### PR TITLE
Whitespace change in code example

### DIFF
--- a/docs/src/asciidocs/embed-authentication.adoc
+++ b/docs/src/asciidocs/embed-authentication.adoc
@@ -47,7 +47,7 @@ init
     ({
         thoughtSpotHost:"https://<hostname>:<port>",
         authType: AuthType.SSO,
-         noRedirect: true
+        noRedirect: true
         
     });
 


### PR DESCRIPTION
Deleted one character of whitespace to reformat the JavaScript example. This is mainly just a test of the process of pull requests