### PR TITLE
[SCAL-92387] add filter removal param

### DIFF
--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -57,6 +57,11 @@ export interface SearchViewConfig extends ViewConfig {
      */
     forceTable?: boolean;
     /**
+     * If set to true, all filter chips from a
+     * pinboard page will be read-only (no X buttons)
+     */
+    preventPinboardFilterRemoval?: boolean;
+    /**
      * The array of data source GUIDs to set on load.
      */
     dataSources?: string[];
@@ -125,6 +130,7 @@ export class SearchEmbed extends TsEmbed {
             hideResults,
             enableSearchAssist,
             forceTable,
+            preventPinboardFilterRemoval,
             searchOptions,
         } = this.viewConfig;
         const answerPath = answerId ? `saved-answer/${answerId}` : 'answer';
@@ -161,6 +167,9 @@ export class SearchEmbed extends TsEmbed {
         }
         if (forceTable) {
             queryParams[Param.ForceTable] = true;
+        }
+        if (preventPinboardFilterRemoval) {
+            queryParams[Param.preventPinboardFilterRemoval] = true;
         }
 
         queryParams[Param.DataSourceMode] = this.getDataSourceMode();

--- a/src/types.ts
+++ b/src/types.ts
@@ -345,6 +345,7 @@ export enum Param {
     DisableActions = 'disableAction',
     DisableActionReason = 'disableHint',
     ForceTable = 'forceTable',
+    preventPinboardFilterRemoval = 'preventPinboardFilterRemoval',
     SearchQuery = 'searchQuery',
     HideActions = 'hideAction',
     EnableVizTransformations = 'enableVizTransform',


### PR DESCRIPTION
If set to true, all filter chips from a pinboard page will be read-only (no X buttons)