### PR TITLE
Corrected error in import_objects format

### DIFF
--- a/docs/src/asciidocs/tml-api.adoc
+++ b/docs/src/asciidocs/tml-api.adoc
@@ -33,7 +33,7 @@ If in YAML format within the JSON array, use escape characters for YAML quotes, 
 For example:
 
 * To import a single object, `["guid: 3729c085-8659-48fd-9479-a67bd7307496\npinboard:\n  name: …"]`
-* To import multiple objects, `["guid: 3729c085-8659-48fd-9479-a67bd7307496\npinboard:\n  name: …“, “["guid: 3729c085-8659-48fd-9479-a67bd7307496\npinboard:\n  name: "4f3827f2-ee0c-4771-848a-29e449901c86”]`
+* To import multiple objects, `["guid: 3729c085-8659-48fd-9479-a67bd7307496\npinboard:\n  name: …“, "guid: 5739d025-8659-48fd-9479-a67bd7704212\npinboard:\n  name: …”]`
 |None
 |`import_policy`|string a|Policy to follow during import. The allowed values are:
 


### PR DESCRIPTION
There was an extra square bracket and parenthesis that was incorrect in the example. I also changed the guid property of the second element since it was an exact repeat of the first one, to remove confusion