### PR TITLE
Update to clarify rules around new GUIDs

### DIFF
--- a/docs/src/asciidocs/tml-api.adoc
+++ b/docs/src/asciidocs/tml-api.adoc
@@ -44,7 +44,11 @@ Imports the objects that validate successfully.
 * `VALIDATE_ONLY`
 Validates the objects but does not import them.|`PARTIAL`
 
-|`force_create`| boolean|Specifies if you are updating or creating objects. To create new objects, specify `true`. By default, ThoughtSpot updates existing objects that have the same GUID as the objects you are importing. When set to `true`, the GUID property in the imported TML is replaced on the server, and the response headers will include the `id_guid` property with the GUID of the new object.|`false`|
+|`force_create`| boolean|Specifies if you are updating or creating objects. To create new objects, specify `true`. 
+
+By default, ThoughtSpot updates existing objects that have the same GUID as the objects you are importing. When set to `true`, the GUID property in the imported TML is replaced on the server, and the response headers will include the `id_guid` property with the GUID of the new object. 
+
+The new object will be assigned a new GUID, even if the imported TML file included a `guid` value. Thus, there is no need to include the `guid` in the TML file if you are using `force_create=true`. |`false`|
 |====
 
 === Example request


### PR DESCRIPTION
Question arose around whether you can specify the GUID for a newly created TML object. Testing showed that the system always generates a new guid. Clarified just slightly and formatted the explanation of force_create a little more.