### PR TITLE
Added info about runtime filters

### DIFF
--- a/docs/src/asciidocs/pinboarddata.adoc
+++ b/docs/src/asciidocs/pinboarddata.adoc
@@ -17,7 +17,7 @@ Using this API, you can fetch the following information:
 ----
 POST /tspublic/v1/pinboarddata
 ----
-=== Request Parameters
+=== Request parameters
 
 [width="100%" cols="1,1,4"]
 [options='header']
@@ -31,6 +31,9 @@ POST /tspublic/v1/pinboarddata
          `1-based indexingOffset = (pageNumber - 1)` * batchSize
 |`formattype`|string|Valid values are `COMPACT` or `FULL JSON`. The system default is `COMPACT`.
 |====
+
+=== Runtime filters
+The pinboarddata REST API accept runtime filters as parameters in the request URL. Please see the full documentation of runtime filters link:https://cloud-docs.thoughtspot.com/admin/ts-cloud/about-runtime-filters.html[here, window=_blank].
 
 === Example requests
 

--- a/docs/src/asciidocs/pinboarddata.adoc
+++ b/docs/src/asciidocs/pinboarddata.adoc
@@ -32,9 +32,6 @@ POST /tspublic/v1/pinboarddata
 |`formattype`|string|Valid values are `COMPACT` or `FULL JSON`. The system default is `COMPACT`.
 |====
 
-=== Runtime filters
-The pinboarddata REST API accept runtime filters as parameters in the request URL. Please see the full documentation of runtime filters link:https://cloud-docs.thoughtspot.com/admin/ts-cloud/about-runtime-filters.html[here, window=_blank].
-
 === Example requests
 
 ==== Pinboard data
@@ -185,6 +182,97 @@ If you make a call to obtain data for a specific visualization on a pinboard, Th
   }
 }
 ----
+
+=== Runtime filters
+You can modify the API's output by passing runtime filters as parameters in the resource URL.
+
+For example:
+
+----
+https://<ThoughtSpot-host>/callosum/v1/tspublic/v1/pinboarddata?id=f4533461-caa5-4efa-a189-13815ab86770&batchsize=-1&col1=COL_NAME1&op1=OP_TYPE1&val1=VALUE1&coln=COL_NAMEn&opn=OP_TYPEn&valn=VALUEn
+----
+
+You can add more than one filter by specifying `col2`, `op2`, `val2`, and so on.
+[width="100%" cols="1,5"]
+[options='header']
+|===
+| Parameter | Definition
+
+| col<__n__>
+| Name of the column to filter on.
+
+| op<__n__>
+| {IN, EQ, NE, LT, LE...}
+
+| val<__n__>
+| Value of the column to filter on.
+|===
+
+[NOTE]
+These parameters are case-insensitive. For example, `EQ`, `eq`, and `eQ` have the same result.
+
+==== Runtime filter operators
+[width="100%" cols="1,2,1"]
+[options='header']
+|===
+| Operator | Description | Number of Values
+
+| `EQ`
+| equals
+| 1
+
+| `NE`
+| does not equal
+| 1
+
+| `LT`
+| less than
+| 1
+
+| `LE`
+| less than or equal to
+| 1
+
+| `GT`
+| greater than
+| 1
+
+| `GE`
+| greater than or equal to
+| 1
+
+| `CONTAINS`
+| contains
+| 1
+
+| `BEGINS_WITH`
+| begins with
+| 1
+
+| `ENDS_WITH`
+| ends with
+| 1
+
+| `BW_INC_MAX`
+| between inclusive of the higher value
+| 2
+
+| `BW_INC_MIN`
+| between inclusive of the lower value
+| 2
+
+| `BW_INC`
+| between inclusive
+| 2
+
+| `BW`
+| between non-inclusive
+| 2
+
+| `IN`
+| is included in this list of values
+| multiple
+|===
 
 === Response codes
 


### PR DESCRIPTION
This REST API supports runtime filters but the documentation of that feature is in the main cloud-docs and would be difficult to find. Added direct link (and fixed a section header to be sentence case per style guidelines)