### PR TITLE
Sitemap docs

### DIFF
--- a/docs/src/configs/doc-configs.js
+++ b/docs/src/configs/doc-configs.js
@@ -1,4 +1,5 @@
 module.exports = {
+    SITE_URL: 'https://developers.thoughtspot.com/docs/',
     DOC_REPO_NAME: '',
     DOC_NAV_PAGE_ID: 'nav',
     TS_HOST_PARAM: 'tshost',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,9 @@ const config = require('./docs/src/configs/doc-configs');
 const buildEnv = process.env.BUILD_ENV || config.BUILD_ENVS.LOCAL; // Default build env
 
 const getPathPrefix = () => {
+    if(buildEnv === config.BUILD_ENVS.LOCAL) {
+        return null;
+    }
     return 'docs';
 };
 
@@ -87,6 +90,7 @@ module.exports = {
     pathPrefix: getPath(config.DOC_REPO_NAME),
     siteMetadata: {
         title: 'tseverywhere-docs',
+        siteUrl: 'https://developers.thoughtspot.com/docs/',
     },
     plugins: [
         'gatsby-plugin-sass',
@@ -177,6 +181,7 @@ module.exports = {
               apiKey: process.env.ALGOLIA_ADMIN_KEY,
               queries: require(`${__dirname}/docs/src/utils/algolia-queries`)
             },
-        }
+        },
+        'gatsby-plugin-sitemap',
     ],
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -90,7 +90,6 @@ module.exports = {
     pathPrefix: getPath(config.DOC_REPO_NAME),
     siteMetadata: {
         title: 'tseverywhere-docs',
-        siteUrl: 'https://developers.thoughtspot.com/docs/',
     },
     plugins: [
         'gatsby-plugin-sass',
@@ -182,6 +181,43 @@ module.exports = {
               queries: require(`${__dirname}/docs/src/utils/algolia-queries`)
             },
         },
-        'gatsby-plugin-sitemap',
+        {
+            resolve:'gatsby-plugin-sitemap',
+            options: {
+                query: `
+                {   
+                    allAsciidoc {
+                        edges {
+                            node {
+                                pageAttributes {
+                                    pageid
+                                }
+                            }
+                        }
+                    }
+                }`,
+                resolveSiteUrl: () => config.SITE_URL,
+                resolvePages: ({
+                    allAsciidoc: { edges },
+                }) => {
+                    const asciiNodeSet = new Set();
+                    edges.forEach(edge => {
+                        if(edge.node && edge.node.pageAttributes && edge.node.pageAttributes.pageid) {
+                            asciiNodeSet.add(edge.node.pageAttributes.pageid);
+                        }
+                    });
+                    let paths = [];
+                    for (let item of asciiNodeSet) {
+                        paths.push({path:`?pageid=${item}`});
+                    }
+                    return paths;
+                },
+                serialize: ({ path }) => {
+                    return {
+                      url: path,
+                    }
+                },
+            }
+        },
     ],
 };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     },
     "dependencies": {
         "algoliasearch": "^4.10.5",
+        "gatsby-plugin-sitemap": "^4.10.0",
         "mixpanel-browser": "^2.41.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     },
     "dependencies": {
         "algoliasearch": "^4.10.5",
-        "gatsby-plugin-sitemap": "^4.10.0",
         "mixpanel-browser": "^2.41.0"
     },
     "devDependencies": {
@@ -82,6 +81,7 @@
         "gatsby-plugin-manifest": "^3.2.0",
         "gatsby-plugin-output": "^0.1.3",
         "gatsby-plugin-sass": "4.1.0",
+        "gatsby-plugin-sitemap": "^4.10.0",
         "gatsby-source-filesystem": "3.1.0",
         "gatsby-transformer-asciidoc": "2.1.0",
         "gatsby-transformer-rehype": "2.0.0",


### PR DESCRIPTION
For Algolia federated search, we need to provide a sitemap file.
Added 'gatsby-plugin-sitemap' plugin to generate XML file for all the pageId's
current URL format:  https://developers.thoughtspot.com/docs/?pageid={pageID}
the XML file can be accessed from {docs-url}/sitemap/sitemap-0.xml in production
