### PR TITLE
app actions and slack update removal

### DIFF
--- a/docs/src/asciidocs/common/nav.adoc
+++ b/docs/src/asciidocs/common/nav.adoc
@@ -55,8 +55,12 @@
 ** link:{{navprefix}}=custom-action-url[URL actions]
 ** link:{{navprefix}}=custom-action-callback[Callback actions]
 ** link:{{navprefix}}=custom-action-payload[Callback response payload]
+
+////
 ** link:{{navprefix}}=app-actions[App actions]
 ** link:{{navprefix}}=slack-integration[Push data to a Slack workspace]
+////
+
 
 * link:{{navprefix}}=customization-intro[Customization and rebranding]
 ** link:{{navprefix}}=customize-style[Customize layout and styles]

--- a/docs/src/asciidocs/custom-actions-callback.adoc
+++ b/docs/src/asciidocs/custom-actions-callback.adoc
@@ -43,7 +43,7 @@ The callback ID is used as a unique reference for the callback custom action in 
 
 . To add this action to all visualizations and saved answer pages, select *On by default on all visualizations*. 
 +
-If you do not select this checkbox, the app action will be set as a *Local* action.  
+If you do not select this checkbox, the callback action will be set as a *Local* action.
 
 . To restrict action availability to specific user groups, click *Show advanced availability settings*, and select the groups.    
 

--- a/docs/src/asciidocs/custom-actions-url.adoc
+++ b/docs/src/asciidocs/custom-actions-url.adoc
@@ -19,7 +19,7 @@ ThoughtSpot allows you to add a custom action to trigger a data payload to a spe
 * Developers can limit custom action access to a specific user group. 
 * To access a URL action, users must have the **New Answer Experience** enabled.
 * For URL actions to work in the embedded mode, you must add the URL domain to the CORS and CSP connect-src allowlist.
-* Only ThoughtSpot users with edit permissions to a worksheet or visualization can add an app action to a worksheet, visualization, or saved answer. 
+* Only ThoughtSpot users with edit permissions to a worksheet or visualization can add a URL action to a worksheet, visualization, or saved answer.
 --
 
 [#creUrlAction]
@@ -64,7 +64,7 @@ Select this authentication method if you want ThoughtSpot to use an API key duri
  
 . To add this action to all visualizations and saved answer pages, select *On by default on all visualizations*. 
 +
-If you do not select this checkbox, the app action will be set as a *Local* action.  
+If you do not select this checkbox, the URL action will be set as a *Local* action.
 
 . To restrict action availability to specific user groups, click *Show advanced availability settings*, and select the groups.      
  

--- a/docs/src/asciidocs/custom-actions.adoc
+++ b/docs/src/asciidocs/custom-actions.adoc
@@ -14,7 +14,7 @@ Similarly, if you have embedded ThoughtSpot in another app, you can add a custom
 If your user account has the `Developer` privilege, you can create custom actions in the ThoughtSpot Developer portal. Users with edit access to a visualization or worksheet can add a custom action as a primary button or menu item on a visualization page.
 ////
 
-
+////
 ++++
 <div class="row">
 
@@ -60,7 +60,43 @@ Trigger a callback to the host app and push a response payload</p>
 </div>
 
 ++++
+////
 
+
+++++
+<div class="row">
+
+<h2 align="center">Types of custom actions</h2>
+
+<div class="col-md-6">
+	<a href="?pageid=custom-action-url"><div class="boxHalfWidth">
+<h5>URL actions</h5>
+<p class="boxBody">
+Push data to a specific web page or URL destination</p>
+
+
+<p class="boxBody"><em>Available on all ThoughtSpot instances</em> </p>
+<p class="boxBody"><a href="?pageid=custom-action-url">Learn more -></a></p>
+</div>
+</a>
+</div>
+
+<div class="col-md-6">
+	<a href="?pageid=custom-action-callback">	<div class="boxHalfWidth">
+<h5>Callback actions</h5>
+<p class="boxBody">
+Trigger a callback to the host app and push a response payload</p>
+
+
+<p class="boxBody"><em>Available on embedded ThoughtSpot instances only</em> </p>
+<p><a href="?pageid=custom-action-callback">Learn more -></a></p>
+</div>
+</a>
+</div>
+
+</div>
+
+++++
 
 
 ++++

--- a/docs/src/asciidocs/customize-actions-menu.adoc
+++ b/docs/src/asciidocs/customize-actions-menu.adoc
@@ -31,8 +31,11 @@ The *Custom actions* page displays the **Create action** button, and the *Overvi
 
 The *Create action* button allows you to create the following types of actions:
 
+////
 App actions::
 An xref:app-actions.adoc[app action] connects a ThoughtSpot instance to an external app and pushes  data to a user's business workspace; for example, Slack. 
+////
+
 
 Callback actions::
 A xref:custom-actions-callback.adoc[callback action] triggers a callback event to the parent application and then pushes the answer or visualization data in a response payload. 

--- a/docs/src/asciidocs/whats-new.adoc
+++ b/docs/src/asciidocs/whats-new.adoc
@@ -8,10 +8,19 @@
 
 This page provides information about new features, enhancements, and deprecated functionality in ThoughtSpot Everywhere.
 
+== Upcoming features
+
+* App actions for Slack integration 
+
++
+This feature will provide the ability to integrate ThoughtSpot with your Slack workspace and push insights directly to Slack channels.
+
+
 == Version 8.1.0.cl
 
 The ThoughtSpot 8.1.0.cl release version is now available with the following new features and enhancements.
 
+////
 === Custom actions
 
 [width="100%" cols="1,4"]
@@ -25,6 +34,7 @@ Users with developer or admin privileges can create an app action for Slack in t
 
 For more information, see xref:app-actions.adoc[App actions] and xref:push-data-to-slack.adoc[Push data to a Slack workspace].
 |====
+////
 
 === Visual Embed SDK version 1.9.0 
 


### PR DESCRIPTION
Commented out all app action and send-to-slack content in 8.1.0 docs