### PR TITLE
ALL event type

### DIFF
--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -279,9 +279,10 @@ export class TsEmbed {
      * will be removed for ts7.oct.cl
      * @hidden
      */
-    private formatEventData(event: MessageEvent) {
+    private formatEventData(event: MessageEvent, eventType: string) {
         const eventData = {
             ...event.data,
+            type: eventType,
         };
         if (!eventData.data) {
             eventData.data = event.data.payload;
@@ -299,7 +300,7 @@ export class TsEmbed {
         window.addEventListener('message', (event) => {
             const eventType = this.getEventType(event);
             const eventPort = this.getEventPort(event);
-            const eventData = this.formatEventData(event);
+            const eventData = this.formatEventData(event, eventType);
             if (event.source === this.iFrame.contentWindow) {
                 this.executeCallbacks(
                     eventType,
@@ -457,6 +458,7 @@ export class TsEmbed {
                 data: {
                     timestamp: initTimestamp,
                 },
+                type: EmbedEvent.Init,
             });
 
             uploadMixpanelEvent(MIXPANEL_EVENT.VISUAL_SDK_RENDER_START);
@@ -505,6 +507,7 @@ export class TsEmbed {
                             data: {
                                 timestamp: loadTimestamp,
                             },
+                            type: EmbedEvent.Load,
                         });
                         uploadMixpanelEvent(
                             MIXPANEL_EVENT.VISUAL_SDK_IFRAME_LOAD_PERFORMANCE,
@@ -558,6 +561,8 @@ export class TsEmbed {
         eventPort?: MessagePort | void,
     ): void {
         const callbacks = this.eventHandlerMap.get(eventType) || [];
+        const allHandlers = this.eventHandlerMap.get(EmbedEvent.ALL) || [];
+        callbacks.push(...allHandlers);
         const dataStatus = data?.status || embedEventStatus.END;
         callbacks.forEach((callbackObj) => {
             if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,7 +419,7 @@ export enum EmbedEvent {
     /**
      * This can be used to register an event listener which
      * is triggered on all events.
-     * @version 1.9.9 or later
+     * @version SDK: 1.10.0 | ThoughtSpot: any
      */
     ALL = '*',
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,12 @@ export enum EmbedEvent {
      */
     LiveboardRendered = 'PinboardRendered',
     /**
+     * This can be used to register an event listener which
+     * is triggered on all events.
+     * @version 1.9.9 or later
+     */
+    ALL = '*',
+    /**
      * Emitted when answer is saved in the app
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl
      */


### PR DESCRIPTION
This provides a way to listen to all events emitted from an embed, without enumerating each and every event listener.