### PR TITLE
Fix ThoughtSpot react component re-render issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "classnames": "^2.3.1",
         "eventemitter3": "^4.0.7",
         "html-react-parser": "^1.4.12",
-        "mixpanel-browser": "^2.45.0"
+        "mixpanel-browser": "^2.45.0",
+        "use-deep-compare-effect": "^1.8.1"
     },
     "devDependencies": {
         "@mdx-js/mdx": "^1.6.22",

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -41,7 +41,7 @@ const componentFactory = <
                     // eslint-disable-next-line no-param-reassign
                     forwardedRef.current = tsEmbed;
                 }
-            }, [viewConfig]);
+            }, [viewConfig, listeners]);
 
             return (
                 <div

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import { SearchEmbed as _SearchEmbed, SearchViewConfig } from '../embed/search';
 import { AppEmbed as _AppEmbed, AppViewConfig } from '../embed/app';
 import {
@@ -25,7 +26,7 @@ const componentFactory = <
                 Omit<U, 'className'>,
                 V
             >(embedProps);
-            React.useEffect(() => {
+            useDeepCompareEffect(() => {
                 const tsEmbed = new EmbedConstructor(ref!.current, {
                     ...viewConfig,
                 });
@@ -40,7 +41,7 @@ const componentFactory = <
                     // eslint-disable-next-line no-param-reassign
                     forwardedRef.current = tsEmbed;
                 }
-            }, [embedProps]);
+            }, [viewConfig]);
 
             return (
                 <div


### PR DESCRIPTION
Use deep comparison instead of ref comparison useEffect dependency to prevent unnecessary re-render