### PR TITLE
FrameParams interface declaration

### DIFF
--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -75,7 +75,7 @@ export interface FrameParams {
      * This parameters will be passed on the iframe
      * as is.
      */
-    [key: string]: string | number | boolean;
+    [key: string]: string | number | boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
Adding undefined return type on the index type as width and height are optional on the FrameParams interface. This is otherwise causing issues in Angular builds