### PR TITLE
Trusted auth updates 2

### DIFF
--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -84,37 +84,42 @@ Because the requirements around matching domain hosting can be difficult to set 
 
 == Authenticator service / back-end
 
-The authenticator service should exist at the web application tier of your networks, with secure access to the ThoughtSpot `secret_key` and the credentials of a ThoughtSpot administrator user (typically a service account). It performs the following functions:
-
-* Authenticate users who request access to the embedded content
-* Request a token from ThoughtSpot on a user’s behalf, using the `secret_key` for the ThoughtSpot instance
-* Return the token to the user's web browser
+The authenticator service should exist at the web application tier of your networks, with secure access to the ThoughtSpot `secret_key` and the credentials of a ThoughtSpot administrator user (typically a service account).
 
 There are no requirements to how the authenticator service is built or hosted, other than being able to issue REST API commands to the ThoughtSpot instance and having access to the `secret_key`. When using ThoughtSpot Cloud, the authenticator service will need outbound request access to the hosted ThoughtSpot cloud instance.
 
-The authenticator service can also issue REST API commands to xref:auth-overview.adoc[create users and set additional authentication properties].
+The simplest *authenticator service* does the following steps, assuming ThoughtSpot users already exist from another process:
 
-=== Implement an authenticator service
+1. Verify and parse the authentication message to retrieve the ThoughtSpot username
+2. Request a login token from ThoughtSpot using the V1 REST API
+3. Return the token to the user's web browser
 
-The following illustration depicts the authentication workflow with the authenticator service:
+If user creation and group assignment needs to also be performed at the time of the login token request, the *authenticator service* can follow this pattern:
 
-image::./images/trusted-auth-workflow.png[Trusted Authentication Workflow]
+1. Make a REST API request for the user and group details for the user
+2. If the user doesn't exist (Error Response), create the user and the user to Groups in this step
+3. If user already exists, compare the "assignedGroups" property for the User with the Groups they SHOULD belong to
+4. If user should belong to Groups they do not belong to, issue the appropriate Add User to Groups REST API command
+5. Request a login token from ThoughtSpot using the V1 REST API
+6. Return the token to the user's web browser
 
-[NOTE]
-====
-The authenticator service makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the authenticator service must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot as a *server administrator* acting as a service account. The authenticator service code will need logic to log in if there is no active session, and secure access to the service account credentials.
-====
+=== Verify and parse the authentication message
+As mentioned above, the exact way you send the authentication details will vary with your implementation. The *authenticator service* must verify the request and then parse out the details (at minimum, the *ThoughtSpot username* value) so that they can be used in the subsequent REST API requests to ThoughtSpot.
 
+The *authenticator service* will need access to whatever code and other services are necessary to parse out the authentication details. For example, if you are sending through an OAuth token from an IdP, the IdP may provide a library or set of instructions using standard libraries. If using the application's existing session system, there will be some way to retrieve the username based on the session details from the request. You can also define your own JWT or some other secure way for your web application to send the message securely.
 
-The user authentication workflow with an authenticator service involves the following steps:
+If your *authenticator service* must also create users and give them access, you must parse out additional details from the request:
 
-. A user logs into the web application through the web application's authentication mechanism.
-. When the user requests access to embedded ThoughtSpot content, the web application sends a request for a login token to the authenticator service.
-+
-To proceed with authentication, the authenticator service must do the following:
+- user email address
+- user display name
+- ThoughtSpot group names to add user to
 
- * Authenticate the request from the web application: it is essential that the request to the authenticator service be valid and only come from the web application.
- * Retrieve the ThoughtSpot username from the request.
+User password is never required - it is unnecessary in the login token request, and it can be randomly generated if creating a user account in ThoughtSpot, so that the user can only sign in via the embedding application.
+
+=== REST API session sign-in
+The *authenticator service* makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the authenticator service must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot as a *server administrator* acting as a service account. The authenticator service code will need logic to log in if there is no active session, and secure access to the service account credentials.
+
+=== Login token request
  * [Optional] Determine the ID of a specific ThoughtSpot object from the request: you can request a limited token using the `access_level=REPORT_BOOK_VIEW` option, but this is rarely used.
 . Authenticator service sends a POST request to the ThoughtSpot server with the `secret_key` and `username` attributes to obtain an authentication token on the user's behalf.
 +
@@ -151,7 +156,10 @@ Allows access to only one object at a time. The token request for this access mo
 __String__. The GUID of the Liveboard or answer.
 This parameter is required only for the `REPORT_BOOK_VIEW` access mode.
 
+==== Create user request
 
+
+==== Add user to groups request
 
 [#trusted-auth-enable]
 == Enable trusted authentication

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -97,7 +97,7 @@ The simplest *authenticator service* does the following steps, assuming ThoughtS
 If user creation and group assignment needs to also be performed at the time of the login token request, the *authenticator service* can follow this pattern:
 
 1. Make a REST API request for the user and group details for the user
-2. If the user doesn't exist (Error Response), create the user and the user to Groups in this step
+2. If the user doesn't exist (Error Response), create the user and add the user to Groups in this step
 3. If user already exists, compare the "assignedGroups" property for the User with the Groups they SHOULD belong to
 4. If user should belong to Groups they do not belong to, issue the appropriate Add User to Groups REST API command
 5. Request a login token from ThoughtSpot using the V1 REST API
@@ -117,49 +117,32 @@ If your *authenticator service* must also create users and give them access, you
 User password is never required - it is unnecessary in the login token request, and it can be randomly generated if creating a user account in ThoughtSpot, so that the user can only sign in via the embedding application.
 
 === REST API session sign-in
-The *authenticator service* makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the authenticator service must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot as a *server administrator* acting as a service account. The authenticator service code will need logic to log in if there is no active session, and secure access to the service account credentials.
+The *authenticator service* makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the *authenticator service* must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot user with *server administrator* privileges, typically a service account created only for use by the *authenticator service*.
+
+The authenticator service code will need logic to log in if there is no active session, and secure access to the service account credentials. How you protect and securely access the service account credentials is up to you in the design of the service. Any examples with a username and password entered directly in the code are for *testing purposes only*.
 
 === Login token request
- * [Optional] Determine the ID of a specific ThoughtSpot object from the request: you can request a limited token using the `access_level=REPORT_BOOK_VIEW` option, but this is rarely used.
-. Authenticator service sends a POST request to the ThoughtSpot server with the `secret_key` and `username` attributes to obtain an authentication token on the user's behalf.
-+
-----
-POST /tspublic/v1/session/auth/token
-----
-+
-This POST request body includes the following `formData` attributes:
+The only other REST API call *necessary* after sign-in is the xref:session-api.adoc#session-authToken[request for the login token]. This is the call that utilizes the `secret_key`, which the *authenticator service* must also securely store and access along with the service account user credentials.
 
-* `secret_key`
-+
+When a token has been requested in `FULL` mode, it will create a full ThoughtSpot session in the browser and application. The token for `Full` access mode persists through several sessions and stays valid until another token is generated.
 
-__String__. The `secret_key` obtained from ThoughtSpot.
+There is the option to request a limited token using the `access_level=REPORT_BOOK_VIEW` option, but this is rarely used and not recommended. Access control in ThoughtSpot (called Sharing) will prohibit a signed-in user from loading any content they aren't assigned access to.
 
-* `username`
-+
-__String__. The `username` of the ThoughtSpot user.
+Access control (sharing) can be granted during the login token request process by adding the user to the appropriate ThoughtSpot groups (see below).
 
-* `access_level`
-+
-__String__. Mode of access. Valid values are:
+=== Create user and add to groups requests
+Many people choose to create the user in ThoughtSpot the first time they request a login token (otherwise the user must be created in ThoughtSpot via another process before the login token can be requested). This is accomplished using the xref:user-api.adoc#create-user[create user REST API].
 
-** `FULL`
-+
-Allows access to the entire ThoughtSpot application. When a token has been requested in `FULL` mode, it will create a full ThoughtSpot session in the browser and application. The token for `Full` access mode persists through several sessions and stays valid until another token is generated.
+The typical flow of REST API commands for user creation is actually as follows:
 
+1. Make a REST API request for the xref:user-api.adoc#get-user-detail[user details] and xref:group-api.adoc#get-ug-details[group details for the user]
+2. If the user doesn't exist from the Get User Details request, xref:user-api.adoc#create-user[create the user] and add the user to groups in this step
+3. If user already exists, compare the "assignedGroups" property for the user with the groups they SHOULD belong to
+4. If user should belong to groups they do not belong to, issue the appropriate xref:group-api.adoc#add-user-to-group[Add User to Groups REST API request]
 
-** `REPORT_BOOK_VIEW`
-+
-Allows access to only one object at a time. The token request for this access mode requires you to specify the GUID of the Liveboard or answer. If your application user requires access to another object, a new token request must be sent.
+=== Additional REST API requests
+Because all of ThoughtSpot administration is possible via the REST API, you can incorporate even more functionality into the *authenticator service* if necessary, building it into an authentication and authorization service. The xref:api-user-management.adoc[user and group privileges] REST API documentation covers the additional requests related to authorization.
 
-* `id`
-+
-__String__. The GUID of the Liveboard or answer.
-This parameter is required only for the `REPORT_BOOK_VIEW` access mode.
-
-==== Create user request
-
-
-==== Add user to groups request
 
 [#trusted-auth-enable]
 == Enable trusted authentication
@@ -222,7 +205,12 @@ All SSO methods in ThoughtSpot create a ThoughtSpot session using cookies. Pleas
 ====
 
 == Implement without Visual Embed SDK
-The Visual Embed SDK handles the final REST API request to create the session, but it is possible to perform the login using the REST API command directly:
+The Visual Embed SDK handles the final REST API request to create the session, but it is possible to perform the login using the xref:session-api.adoc#session-loginToken[/session/login/token endpoint] directly:
+
+[NOTE]
+====
+The V1 REST API login token is not used for establishing a REST API session for backend processes or administration scripts. Use the xref:session-api.adoc#session-login[/session/login] endpoint with username and password to create a REST API session. The V2 REST API does have an OAuth token mechanism, which is also separate from V1 login token and not part of the trusted authenitcation flow at this time.
+====
 
 +
 . The client application constructs a fully encoded URL with the authentication token and the resource endpoint, and sends these as attributes in the API request to the ThoughtSpot application server.

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -6,6 +6,7 @@
 :page-pageid: trusted-auth
 :page-description: You can configure support for token-based authentication service on ThoughtSpot.
 
+== Overview
 Trusted authentication establishes a ThoughtSpot session in the browser without requiring a user to sign-in directly to ThoughtSpot or be redirected to a third-party IdP. It is the most seamless method of single sign-on, but requires more of the application developer to secure the process.
 
 Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
@@ -22,24 +23,21 @@ The process for trusted authentication is as follows:
  4. The *authenticator service* returns the *login token* to the browser and the Visual Embed SDK
  5. The Visual Embed SDK issues requests to establish ThoughtSpot session in the browser
 
-
-== Key components
-
-The trusted authentication workflow involves several entities, such as the web browser, web application, authenticator service, and the ThoughtSpot application server.
+image::./images/trusted-auth-workflow.png[Trusted Authentication Workflow]
 
 [#trusted-auth-sdk]
-=== Visual Embed SDK
+== Visual Embed SDK / front-end
 
 The Visual Embed SDK automates the login token request and subsequent login request using the returned login token.
 
 The request to the *authenticator service* is defined in the `init()` function of the Visual Embed SDK. When `init()` is called, the SDK checks if there is an existing ThoughtSpot session for the instance in the browser. If not, it will request a *login token* from either the `authEndpoint` URL or the `getAuthToken` callback function. The xref:embed-authentication.adoc#trusted-auth-embed[Embed user authentication page] shows the exact forms to use for these two properties.
 
-==== Secure the authentication details request
+=== Secure the authentication details request
 For the request to the *authenticator service* to be secure, the user in the browser cannot modify the request or make their own valid request to the *authenticator service*.
 
 How your particular application can most easily securely request the *login token* is up to you, but how you choose to send the message will constrain your choice between `authEndpoint` or `getAuthToken`.
 
-When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the callback function you have the freedom to define the request to the *authenticator service* with far greater control than the automated GET request to a URL used by the `authEndpoint` option.
+When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the callback function you have the freedom to define the request to the *authenticator service* with far greater control than the automated GET request to a URL used by the `authEndpoint` option. `getAuthToken` is the preferred method for production deployments unless your *authenticator service* is implemented within the existing API endpoints of your existing application and a simple GET request provides the necessary authentication details (see below).
 
 The example below shows an example of a callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, target=_blank], which returns a Promise. You can also use link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest[XHR, target=_blank] and build the link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise, target=_blank] manually.
 
@@ -79,19 +77,14 @@ function async getAuthToken {
 }
 ----
 
-
-
 If you choose `authEndpoint`, a GET request is made directly to the provided URL. The authentication details must be included by the browser in this automated GET request, typically in the cookies. Cookies are not sent across domains (only to sub-domains), so your *authenticator service* must be *hosted in the same domain* as the embedding application.
 
 Because the requirements around matching domain hosting can be difficult to set up during a quick testing phase, you may see examples of a trusted authentication flow using `authEndpoint` with the username sent in the clear as a URL parameter, but this it is *only for testing purposes* and *is not secure*.
 
 
+== Authenticator service / back-end
 
-
-
-=== Authenticator service
-
-The authenticator service should exist at the web application tier of your networks, with secure access to the ThoughtSpot `secret_key`. It performs the following functions:
+The authenticator service should exist at the web application tier of your networks, with secure access to the ThoughtSpot `secret_key` and the credentials of a ThoughtSpot administrator user (typically a service account). It performs the following functions:
 
 * Authenticate users who request access to the embedded content
 * Request a token from ThoughtSpot on a user’s behalf, using the `secret_key` for the ThoughtSpot instance
@@ -101,28 +94,7 @@ There are no requirements to how the authenticator service is built or hosted, o
 
 The authenticator service can also issue REST API commands to xref:auth-overview.adoc[create users and set additional authentication properties].
 
-=== ThoughtSpot server
-
-For a token-based authentication method, ThoughtSpot administrators must xref:trusted-authentication.adoc#trusted-auth-enable[enable Trusted authentication] in the *Develop* > *Customization* > *Security settings* page of the ThoughtSpot UI. This setting allows ThoughtSpot administrators to obtain a `secret_key`, which is required for requesting access to ThoughtSpot on a user’s behalf.
-
-The `secret_key` must be stored in a secure fashion such that only the trusted authenticator service can use it.
-
-=== Login token
-
-The login token, also referred to as the authentication token, allows users to access the requested object.
-
-Tokens stay valid for a length of time based on the following rules:
-
-* A token stays valid indefinitely until another token for any user is generated.
-* When a new token is generated using the same `secret_key`, the previous token will expire after five minutes.
-* When a new `secret_key` is generated for the ThoughtSpot server and the first new login token is obtained using the new `secret_key`, all tokens generated using the previous `secret_key` become invalid.
-* If users make multiple attempts to log in to ThoughtSpot using an invalid or expired token, they may get locked out of their accounts.
-
-To set a consistent five minute expiration time, you can generate a second token to start the expiration clock for the previous login token that is sent to the user's browser.
-
-
-
-== Implement an authenticator service
+=== Implement an authenticator service
 
 The following illustration depicts the authentication workflow with the authenticator service:
 
@@ -133,7 +105,6 @@ image::./images/trusted-auth-workflow.png[Trusted Authentication Workflow]
 The authenticator service makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the authenticator service must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot as a *server administrator* acting as a service account. The authenticator service code will need logic to log in if there is no active session, and secure access to the service account credentials.
 ====
 
-=== Authentication workflow
 
 The user authentication workflow with an authenticator service involves the following steps:
 
@@ -180,49 +151,6 @@ Allows access to only one object at a time. The token request for this access mo
 __String__. The GUID of the Liveboard or answer.
 This parameter is required only for the `REPORT_BOOK_VIEW` access mode.
 
-. ThoughtSpot verifies the authentication server's request and returns a token.
-. The authentication server returns the token to the user's web browser.
-
-+
-[NOTE]
-====
-If you are using the Visual Embed SDK, steps 7 and 8 are handled automatically by the *init* function, where you specify the authenticator service via a URL (`authEndpoint`) or a callback function (`getAuthToken`). For more information, see  xref:trusted-authentication.adoc#trusted-auth-sdk[Trusted authentication workflow with Visual Embed SDK].
-====
-
-+
-. The client application constructs a fully encoded URL with the authentication token and the resource endpoint, and sends these as attributes in the API request to the ThoughtSpot application server.
-+
-[source, HTML]
-----
-GET https://<ThoughtSpot-host>/callosum/v1/tspublic/v1/session/login/token?username=<user>&auth_token=<token>&redirect_url=<full-encoded-url-with-auth-token>
-----
-
-The request URL includes the following attributes:
-
-
-* `username`
-+
-_String_. The `username` of the user requesting access to the embedded ThoughtSpot content.
-
-* `auth_token`
-+
-_String_. The authentication token obtained for the user in step 5.
-
-* `redirect_url`
-+
-_String_. The URL to which the user is redirected after successful authentication. The URL is fully encoded and includes the authentication token obtained for the user.
-+
-For example, if the user has requested access to a specific visualization on a Liveboard, the redirect URL includes the domain to which the user is redirected, the auth token string obtained for the user, visualization ID, and Liveboard ID.
-+
-[source, HTML]
-----
-https://<redirect-domain>/?authtoken=<user_auth_token>&embedApp=true&primaryNavHidden=true#/embed/viz/<Liveboard_id>/<visualization_id>
-----
-[NOTE]
-The request URL includes the `auth_token` attribute and the redirect URL uses the `authtoken` attribute.
-
-. ThoughtSpot validates the request and allows access to the requested content.
-
 
 
 [#trusted-auth-enable]
@@ -264,12 +192,61 @@ A pop-up window appears and prompts you to confirm the disable action.
 When you disable trusted authentication, the validity of your existing secret key expires. Your application will become inoperable until you add a secret key to the authenticator service.
 You must re-enable trusted authentication and then obtain a new secret key.
 
+[#login-token]
+== Login token expiration
+
+The login token, also referred to as the authentication token, allows users to access the requested object. It is a proprietary token format that cannot be decoded or used for any purpose other than to create a ThoughtSpot session.
+
+Tokens stay valid for a length of time based on the following rules:
+
+* A token stays valid indefinitely until another token for any user is generated.
+* When a new token is generated using the same `secret_key`, the previous token will expire after five minutes.
+* When a new `secret_key` is generated for the ThoughtSpot server and the first new login token is obtained using the new `secret_key`, all tokens generated using the previous `secret_key` become invalid.
+* If users make multiple attempts to log in to ThoughtSpot using an invalid or expired token, they may get locked out of their accounts.
+
+To set a consistent five-minute expiration time, you can generate a second token to start the expiration clock for the previous login token that is sent to the user's browser.
+
 == Troubleshoot trusted authentication
 
 [NOTE]
 ====
 All SSO methods in ThoughtSpot create a ThoughtSpot session using cookies. Please confirm that your browser is set to allow "third-party cookies" when testing trusted authentication. Chrome now blocks third-party cookies in Incognito mode by default, while Safari blocks them by default even in standard mode.
 ====
+
+== Implement without Visual Embed SDK
+The Visual Embed SDK handles the final REST API request to create the session, but it is possible to perform the login using the REST API command directly:
+
++
+. The client application constructs a fully encoded URL with the authentication token and the resource endpoint, and sends these as attributes in the API request to the ThoughtSpot application server.
++
+[source, HTML]
+----
+GET https://<ThoughtSpot-host>/callosum/v1/tspublic/v1/session/login/token?username=<user>&auth_token=<token>&redirect_url=<full-encoded-url-with-auth-token>
+----
+
+The request URL includes the following attributes:
+
+
+* `username`
++
+_String_. The `username` of the user requesting access to the embedded ThoughtSpot content.
+
+* `auth_token`
++
+_String_. The authentication token obtained for the user in step 5.
+
+* `redirect_url`
++
+_String_. The URL to which the user is redirected after successful authentication. The URL is fully encoded and includes the authentication token obtained for the user.
++
+For example, if the user has requested access to a specific visualization on a Liveboard, the redirect URL includes the domain to which the user is redirected, the auth token string obtained for the user, visualization ID, and Liveboard ID.
++
+[source, HTML]
+----
+https://<redirect-domain>/?authtoken=<user_auth_token>&embedApp=true&primaryNavHidden=true#/embed/viz/<Liveboard_id>/<visualization_id>
+----
+[NOTE]
+The request URL includes the `auth_token` attribute and the redirect URL uses the `authtoken` attribute.
 
 
 == Additional resources

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -143,6 +143,8 @@ The typical flow of REST API commands for user creation is actually as follows:
 === Additional REST API requests
 Because all of ThoughtSpot administration is possible via the REST API, you can incorporate even more functionality into the *authenticator service* if necessary, building it into an authentication and authorization service. The xref:api-user-management.adoc[user and group privileges] REST API documentation covers the additional requests related to authorization.
 
+For example, you could implement the xref:group-api.adoc#create-group[create group] REST API for ThoughtSpot groups that are intended for use in Row Level Security (RLS) rules. For these groups, the group name must match exactly with a value in a column in the data warehouse, so the name of the group itself serves as a "data entitlement". You could adjust the flow in the section above to create any group for RLS that did not already exist and assign it to the user, which would bring the process closer to an RBAC or ABAC pattern.
+
 
 [#trusted-auth-enable]
 == Enable trusted authentication

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -246,5 +246,5 @@ The request URL includes the `auth_token` attribute and the redirect URL uses th
 
 
 == Additional resources
-A simple Python Flask implementation of an Authenticator Service is available in the link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[ts_everywhere_resources GitHub repository, target=_blank].  +
-The token_auth directory contains a link:https://github.com/thoughtspot/ts_everywhere_resources/blob/master/examples/token_auth/trusted_auth_tester.html[trusted_auth_tester.html, target=_blank] page to help verify each step of the trusted authentication process.
+A simple Python Flask implementation of an Authenticator Service is available in the link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[ts_everywhere_resources GitHub repository, window=_blank].  +
+The token_auth directory contains a link:https://github.com/thoughtspot/ts_everywhere_resources/blob/master/examples/token_auth/trusted_auth_tester.html[trusted_auth_tester.html, window=_blank] page to help verify each step of the trusted authentication process.

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -9,19 +9,19 @@
 Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
 
 == Overview
-Trusted authentication establishes a ThoughtSpot session in the browser without requiring a user to sign-in directly to ThoughtSpot or be redirected to a third-party IdP. It is the most seamless method of single sign-on, but requires more of the application developer to secure the process.
+Trusted authentication establishes a ThoughtSpot session in the browser without requiring a user to sign in directly to ThoughtSpot or be redirected to a third-party IdP. It is the most seamless method of single sign-on (SSO), but requires more of the application developer to secure the process.
 
 The *login token* from the ThoughtSpot V1 REST API is a simple, proprietary token. The authentication token of the V2 REST API is not currently used in the trusted authentication flow.
 
-*Securely requesting the login token* requires passing authentication details from the embedding application securely to an *authenticator service* with access to the `secret_key` for the ThoughtSpot instance and an ThoughtSpot admin level user's credentials.
+*Securely requesting the login token* requires passing authentication details from the embedding application securely to an *authenticator service* with access to the `secret_key` for the ThoughtSpot instance and ThoughtSpot admin user's credentials.
 
 The process for trusted authentication is as follows:
 
- 1. The Visual Embed SDK, loaded within the embedded application page, calls the `init()` function with the correct set of parameters to request a *login token*
- 2. The request for the *login token* securely provides the username and any additional details to the *authenticator service*
- 3. The *authenticator service* verifies and parses the username and other details, and issues REST API commands to ThoughtSpot, at minimum requesting a *login token* for the provided username
- 4. The *authenticator service* returns the *login token* to the browser and the Visual Embed SDK
- 5. The Visual Embed SDK issues requests to establish ThoughtSpot session in the browser
+ 1. The Visual Embed SDK, loaded within the embedded application page, calls the `init()` function with the correct set of parameters to request a *login token*.
+ 2. The request for the *login token* securely provides the username and any additional details to the *authenticator service*.
+ 3. The *authenticator service* verifies and parses the username and other details, and issues REST API commands to ThoughtSpot, at minimum requesting a *login token* for the provided username.
+ 4. The *authenticator service* returns the *login token* to the browser and the Visual Embed SDK.
+ 5. The Visual Embed SDK issues requests to establish ThoughtSpot session in the browser.
 
 image::./images/trusted-auth-workflow.png[Trusted Authentication Workflow]
 
@@ -37,9 +37,9 @@ For the request to the *authenticator service* to be secure, the user in the bro
 
 How your particular application can most easily securely request the *login token* is up to you, but how you choose to send the message will constrain your choice between `authEndpoint` or `getAuthToken`.
 
-When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the callback function you have the freedom to define the request to the *authenticator service* with far greater control than the automated GET request to a URL used by the `authEndpoint` option. `getAuthToken` is the preferred method for production deployments unless your *authenticator service* is implemented within the existing API endpoints of your existing application and a simple GET request provides the necessary authentication details (see below).
+When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the callback function, you can define the request to the *authenticator service* with far greater control than the automated `GET` request to a URL used by the `authEndpoint` option. `getAuthToken` is the preferred method for production deployments unless your *authenticator service* is implemented within the existing API endpoints of your application and a simple GET request provides the necessary authentication details as shown here.
 
-The example below shows an example of a callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, target=_blank], which returns a Promise. You can also use link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest[XHR, target=_blank] and build the link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise, target=_blank] manually.
+The following example shows a callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, window=_blank], which returns a Promise. You can also use link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest[XHR, window=_blank] and build the link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise, window=_blank] manually.
 
 [source,javascript]
 ----
@@ -79,7 +79,7 @@ function async getAuthToken {
 
 If you choose `authEndpoint`, a GET request is made directly to the provided URL. The authentication details must be included by the browser in this automated GET request, typically in the cookies. Cookies are not sent across domains (only to sub-domains), so your *authenticator service* must be *hosted in the same domain* as the embedding application.
 
-Because the requirements around matching domain hosting can be difficult to set up during a quick testing phase, you may see examples of a trusted authentication flow using `authEndpoint` with the username sent in the clear as a URL parameter, but this it is *only for testing purposes* and *is not secure*.
+Because the requirements around matching domain hosting can be difficult to set up during a quick testing phase, you may see examples of a trusted authentication flow using `authEndpoint` with the username sent in the clear as a URL parameter. Note that this is *only for testing purposes* and *is not secure*.
 
 
 == Authenticator service / back-end
@@ -90,21 +90,21 @@ There are no requirements to how the authenticator service is built or hosted, o
 
 The simplest *authenticator service* does the following steps, assuming ThoughtSpot users already exist from another process:
 
-1. Verify and parse the authentication message to retrieve the ThoughtSpot username
-2. Request a login token from ThoughtSpot using the V1 REST API
-3. Return the token to the user's web browser
+1. Verify and parse the authentication message to retrieve the ThoughtSpot username.
+2. Request a login token from ThoughtSpot using the V1 REST API.
+3. Return the token to the user's web browser.
 
-If user creation and group assignment needs to also be performed at the time of the login token request, the *authenticator service* can follow this pattern:
+If user creation and group assignment must be performed at the time of the login token request, the *authenticator service* can follow this pattern:
 
-1. Make a REST API request for the user and group details for the user
-2. If the user doesn't exist (Error Response), create the user and add the user to Groups in this step
-3. If user already exists, compare the "assignedGroups" property for the User with the Groups they SHOULD belong to
-4. If user should belong to Groups they do not belong to, issue the appropriate Add User to Groups REST API command
-5. Request a login token from ThoughtSpot using the V1 REST API
-6. Return the token to the user's web browser
+1. Make a REST API request for the user and group details for the user.
+2. If the user doesn't exist (Error Response), create the user and add the user to groups in this step.
+3. If the user already exists, compare the `assignedGroups` property for the user with the groups they should belong to.
+4. If the user should belong to other groups, issue the appropriate `Add User to Groups REST API` command.
+5. Request a login token from ThoughtSpot using the V1 REST API.
+6. Return the token to the user's web browser.
 
 === Verify and parse the authentication message
-As mentioned above, the exact way you send the authentication details will vary with your implementation. The *authenticator service* must verify the request and then parse out the details (at minimum, the *ThoughtSpot username* value) so that they can be used in the subsequent REST API requests to ThoughtSpot.
+As mentioned above, the exact way you send the authentication details varies with your implementation. The *authenticator service* must verify the request and then parse out the details (at minimum, the *ThoughtSpot username* value) so that they can be used in the subsequent REST API requests to ThoughtSpot.
 
 The *authenticator service* will need access to whatever code and other services are necessary to parse out the authentication details. For example, if you are sending through an OAuth token from an IdP, the IdP may provide a library or set of instructions using standard libraries. If using the application's existing session system, there will be some way to retrieve the username based on the session details from the request. You can also define your own JWT or some other secure way for your web application to send the message securely.
 
@@ -112,9 +112,9 @@ If your *authenticator service* must also create users and give them access, you
 
 - user email address
 - user display name
-- ThoughtSpot group names to add user to
+- ThoughtSpot group names to add a user to
 
-User password is never required - it is unnecessary in the login token request, and it can be randomly generated if creating a user account in ThoughtSpot, so that the user can only sign in via the embedding application.
+User password is not required in the login token request. It can be randomly generated if creating a user account in ThoughtSpot, so that the user can only sign in via the embedding application.
 
 === REST API session sign-in
 The *authenticator service* makes REST API requests to ThoughtSpot. To make a REST API request for a login token, the *authenticator service* must have xref:api-auth-session.adoc[created an active session] with ThoughtSpot user with *server administrator* privileges, typically a service account created only for use by the *authenticator service*.
@@ -124,26 +124,26 @@ The authenticator service code will need logic to log in if there is no active s
 === Login token request
 The only other REST API call *necessary* after sign-in is the xref:session-api.adoc#session-authToken[request for the login token]. This is the call that utilizes the `secret_key`, which the *authenticator service* must also securely store and access along with the service account user credentials.
 
-When a token has been requested in `FULL` mode, it will create a full ThoughtSpot session in the browser and application. The token for `Full` access mode persists through several sessions and stays valid until another token is generated.
+When a token has been requested in `FULL` mode, it will create a full ThoughtSpot session in the browser and application. The token for `FULL` access mode persists through several sessions and stays valid until another token is generated.
 
-There is the option to request a limited token using the `access_level=REPORT_BOOK_VIEW` option, but this is rarely used and not recommended. Access control in ThoughtSpot (called Sharing) will prohibit a signed-in user from loading any content they aren't assigned access to.
+There is the option to request a limited token using the `access_level=REPORT_BOOK_VIEW` option, but this is rarely used and not recommended. Access control in ThoughtSpot (called Sharing) prohibits a signed-in user from loading any content they aren't assigned access to.
 
-Access control (sharing) can be granted during the login token request process by adding the user to the appropriate ThoughtSpot groups (see below).
+Access control (sharing) can be granted during the login token request process by adding the user to the appropriate ThoughtSpot groups.
 
 === Create user and add to groups requests
-Many people choose to create the user in ThoughtSpot the first time they request a login token (otherwise the user must be created in ThoughtSpot via another process before the login token can be requested). This is accomplished using the xref:user-api.adoc#create-user[create user REST API].
+You can choose to create the user in ThoughtSpot the first time they request a login token. Otherwise, the user must be created in ThoughtSpot via another process before the login token can be requested. This is accomplished using the xref:user-api.adoc#create-user[create user REST API].
 
 The typical flow of REST API commands for user creation is actually as follows:
 
 1. Make a REST API request for the xref:user-api.adoc#get-user-detail[user details] and xref:group-api.adoc#get-ug-details[group details for the user]
-2. If the user doesn't exist from the Get User Details request, xref:user-api.adoc#create-user[create the user] and add the user to groups in this step
-3. If user already exists, compare the "assignedGroups" property for the user with the groups they SHOULD belong to
-4. If user should belong to groups they do not belong to, issue the appropriate xref:group-api.adoc#add-user-to-group[Add User to Groups REST API request]
+2. If the user doesn't exist from the `Get User Details` request, xref:user-api.adoc#create-user[create the user] and add the user to groups in this step
+3. If the user already exists, compare the `assignedGroups` property for the user with the groups they should belong to
+4. If the user should belong to other groups, issue the appropriate xref:group-api.adoc#add-user-to-group[Add User to Groups REST API request]. 
 
 === Additional REST API requests
 Because all of ThoughtSpot administration is possible via the REST API, you can incorporate even more functionality into the *authenticator service* if necessary, building it into an authentication and authorization service. The xref:api-user-management.adoc[user and group privileges] REST API documentation covers the additional requests related to authorization.
 
-For example, you could implement the xref:group-api.adoc#create-group[create group] REST API for ThoughtSpot groups that are intended for use in Row Level Security (RLS) rules. For these groups, the group name must match exactly with a value in a column in the data warehouse, so the name of the group itself serves as a "data entitlement". You could adjust the flow in the section above to create any group for RLS that did not already exist and assign it to the user, which would bring the process closer to an RBAC or ABAC pattern.
+For example, you could implement the xref:group-api.adoc#create-group[create group] REST API for ThoughtSpot groups that are intended for use in Row Level Security (RLS) rules. For these groups, the group name must match exactly with a value in a column in the data warehouse, so the name of the group itself serves as a __data entitlement__. You could adjust the flow in the section above to create any group for RLS that did not already exist and assign it to the user, which would bring the process closer to a Role-based access control (RBAC) or Attribute-based access control (ABAC) pattern.
 
 
 [#trusted-auth-enable]
@@ -211,12 +211,11 @@ The Visual Embed SDK handles the final REST API request to create the session, b
 
 [NOTE]
 ====
-The V1 REST API login token is not used for establishing a REST API session for backend processes or administration scripts. Use the xref:session-api.adoc#session-login[/session/login] endpoint with username and password to create a REST API session. The V2 REST API does have an OAuth token mechanism, which is also separate from V1 login token and not part of the trusted authenitcation flow at this time.
+The REST API v1 login token is not used for establishing a REST API session for backend processes or administration scripts. Use the xref:session-api.adoc#session-login[/session/login] endpoint with username and password to create a REST API session. The REST API v2 does have an OAuth token mechanism, which is also separate from the REST API v1 login token and not part of the trusted authentication flow at this time.
 ====
 
-+
-. The client application constructs a fully encoded URL with the authentication token and the resource endpoint, and sends these as attributes in the API request to the ThoughtSpot application server.
-+
+In this method, the client application constructs a fully encoded URL with the authentication token and the resource endpoint, and sends these as attributes in the API request to the ThoughtSpot application server.
+
 [source, HTML]
 ----
 GET https://<ThoughtSpot-host>/callosum/v1/tspublic/v1/session/login/token?username=<user>&auth_token=<token>&redirect_url=<full-encoded-url-with-auth-token>
@@ -224,28 +223,28 @@ GET https://<ThoughtSpot-host>/callosum/v1/tspublic/v1/session/login/token?usern
 
 The request URL includes the following attributes:
 
-
-* `username`
-+
+* `username` +
 _String_. The `username` of the user requesting access to the embedded ThoughtSpot content.
 
-* `auth_token`
-+
+* `auth_token` +
 _String_. The authentication token obtained for the user in step 5.
 
-* `redirect_url`
-+
+* `redirect_url` +
 _String_. The URL to which the user is redirected after successful authentication. The URL is fully encoded and includes the authentication token obtained for the user.
+
 +
 For example, if the user has requested access to a specific visualization on a Liveboard, the redirect URL includes the domain to which the user is redirected, the auth token string obtained for the user, visualization ID, and Liveboard ID.
+
 +
 [source, HTML]
 ----
 https://<redirect-domain>/?authtoken=<user_auth_token>&embedApp=true&primaryNavHidden=true#/embed/viz/<Liveboard_id>/<visualization_id>
 ----
++
 [NOTE]
 The request URL includes the `auth_token` attribute and the redirect URL uses the `authtoken` attribute.
 
 
 == Additional resources
-There is an simple Python Flask implementation of an Authenticator Service available in the  link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[ts_everywhere_resources repository, target=_blank]. The token_auth directory contains a link:https://github.com/thoughtspot/ts_everywhere_resources/blob/master/examples/token_auth/trusted_auth_tester.html[trusted_auth_tester.html, target=_blank] page to help verify each step of the trusted authentication process.
+A simple Python Flask implementation of an Authenticator Service is available in the link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[ts_everywhere_resources GitHub repository, target=_blank].  +
+The token_auth directory contains a link:https://github.com/thoughtspot/ts_everywhere_resources/blob/master/examples/token_auth/trusted_auth_tester.html[trusted_auth_tester.html, target=_blank] page to help verify each step of the trusted authentication process.

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -20,14 +20,28 @@ The process for trusted authentication is as follows:
  4. The *authenticator service* returns the *login token* to the browser and the Visual Embed SDK
  5. The Visual Embed SDK issues requests to establish ThoughtSpot session in the browser
 
-[NOTE]
-====
-All SSO methods in ThoughtSpot create a ThoughtSpot session using cookies. Please confirm that your browser is set to allow "third-party cookies" when testing trusted authentication. Chrome now blocks third-party cookies in Incognito mode by default, while Safari blocks them by default even in standard mode. 
-====
 
 == Key components
 
 The trusted authentication workflow involves several entities, such as the web browser, web application, authenticator service, and the ThoughtSpot application server.
+
+[#trusted-auth-sdk]
+=== Visual Embed SDK
+
+The Visual Embed SDK automates the login token request and subsequent login request using the returned login token.
+
+The request to the *authenticator service* is defined in the `init()` function of the Visual Embed SDK. When `init()` is called, the SDK checks if there is an existing ThoughtSpot session for the instance in the browser. If not, it will request a *login token* from either the `authEndpoint` URL or the `getAuthToken` callback function. The xref:embed-authentication.adoc#trusted-auth-embed[Embed user authentication] shows the exact forms to use for these two properties.
+
+==== Secure the authentication details request
+For the request to the *authenticator service* to be secure, the user in the browser cannot modify or more their own request to the *authenticator service* and specify a different username than their own (which they already used to sign-in to the embedding application itself).
+
+How your particular application can most easily securely request the *login token* is up to you, but how you choose to send the message will constrain your choices between `authEndpoint` or `getAuthToken`.
+
+If you choose `authEndpoint`, a GET request is made directly to the provided URL, so the authentication details must be part of the cookies or other headers of the general embedding application page prior to calling the `init()`. 
+
+When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the function you build, you have the freedom to craft the request to the *authenticator service* with far greater control. 
+
+
 
 === Authenticator service
 
@@ -37,7 +51,7 @@ The authenticator service should exist at the web application tier of your netwo
 * Request a token from ThoughtSpot on a user’s behalf, using the `secret_key` for the ThoughtSpot instance
 * Return the token to the user's web browser
 
-There are no requirements to how the authenticator service is built or hosted, other than being able to issue REST API commands to the ThoughtSpot instance and having access to the `secret_key`. When using ThoughtSpot Cloud, the authenticator service will need outbound request access to the hosted ThoughtSpot cloud instance. 
+There are no requirements to how the authenticator service is built or hosted, other than being able to issue REST API commands to the ThoughtSpot instance and having access to the `secret_key`. When using ThoughtSpot Cloud, the authenticator service will need outbound request access to the hosted ThoughtSpot cloud instance.
 
 The authenticator service can also issue REST API commands to xref:auth-overview.adoc[create users and set additional authentication properties].
 
@@ -60,29 +74,7 @@ Tokens stay valid for a length of time based on the following rules:
 
 To set a consistent five minute expiration time, you can generate a second token to start the expiration clock for the previous login token that is sent to the user's browser.
 
-[#trusted-auth-enable]
-== Enable trusted authentication
-You need ThoughtSpot admin privileges to enable trusted authentication.
 
-. Log in to the ThoughtSpot.
-. Click the *Develop* tab.
-. Under *Customizations*, click *Settings*.
-. To enable trusted authentication, turn on the toggle.
-+
-A `secret_key` for trusted authentication is generated. This `secret_key` is required for obtaining an authentication token for a ThoughtSpot user.
-
-. Click the clipboard icon to copy the token.
-+
-The following example shows a ThoughtSpot-generated secret key string.
-
-+
-----
-b0cb26a0-351e-40b4-9e42-00fa2265d50c
-----
-This key is required for making API calls to get a token for ThoughtSpot users.
-
-. Store the key in a secure location.
-. Click *Save Changes*.
 
 == Implement an authenticator service
 
@@ -185,18 +177,31 @@ The request URL includes the `auth_token` attribute and the redirect URL uses th
 
 . ThoughtSpot validates the request and allows access to the requested content.
 
-[#trusted-auth-sdk]
-=== Authentication workflow with Visual Embed SDK
 
-The Visual Embed SDK simplifies and automates the trusted authentication workflow.
 
-. A user logs into the host application and requests access to the embedded ThoughtSpot content.
-. The SDK checks for an existing user session in the browser.
-. If there is no session, it obtains a token either from the specified `authEndpoint` URL or by using the `getAuthToken` callback method.
-. The SDK uses the obtained auth token and `username` in the `GET` request to the `/tspublic/v1/session/login/token` endpoint.
-. If the request is successful, the SDK renders the embedded content.
+[#trusted-auth-enable]
+== Enable trusted authentication
+You need ThoughtSpot admin privileges to enable trusted authentication.
 
-For more information, see xref:embed-authentication.adoc[Embed user authentication].
+. Log in to the ThoughtSpot.
+. Click the *Develop* tab.
+. Under *Customizations*, click *Settings*.
+. To enable trusted authentication, turn on the toggle.
++
+A `secret_key` for trusted authentication is generated. This `secret_key` is required for obtaining an authentication token for a ThoughtSpot user.
+
+. Click the clipboard icon to copy the token.
++
+The following example shows a ThoughtSpot-generated secret key string.
+
++
+----
+b0cb26a0-351e-40b4-9e42-00fa2265d50c
+----
+This key is required for making API calls to get a token for ThoughtSpot users.
+
+. Store the key in a secure location.
+. Click *Save Changes*.
 
 == Disable trusted authentication
 
@@ -212,6 +217,14 @@ A pop-up window appears and prompts you to confirm the disable action.
 +
 When you disable trusted authentication, the validity of your existing secret key expires. Your application will become inoperable until you add a secret key to the authenticator service.
 You must re-enable trusted authentication and then obtain a new secret key.
+
+== Troubleshoot trusted authentication
+
+[NOTE]
+====
+All SSO methods in ThoughtSpot create a ThoughtSpot session using cookies. Please confirm that your browser is set to allow "third-party cookies" when testing trusted authentication. Chrome now blocks third-party cookies in Incognito mode by default, while Safari blocks them by default even in standard mode.
+====
+
 
 == Additional resources
 There is an simple Python Flask implementation of an Authenticator Service available in the  link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[ts_everywhere_resources repository, target=_blank]. The token_auth directory contains a link:https://github.com/thoughtspot/ts_everywhere_resources/blob/master/examples/token_auth/trusted_auth_tester.html[trusted_auth_tester.html, target=_blank] page to help verify each step of the trusted authentication process.

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -6,11 +6,11 @@
 :page-pageid: trusted-auth
 :page-description: You can configure support for token-based authentication service on ThoughtSpot.
 
-The trusted authentication mode of single sign-on specifies a method for an *authenticator service* to programmatically request __login tokens__ from ThoughtSpot, which can then be used to sign in a user to the ThoughtSpot instance. The login token is only necessary during the login process, after which ThoughtSpot establishes a user session using cookies.
+Trusted authentication establishes a ThoughtSpot session in the browser without requiring a user to sign-in directly to ThoughtSpot or be redirected to a third-party IdP. It is the most seamless method of single sign-on, but requires more of the application developer to secure the process.
 
-_You_ must implement the actual authentication of the inbound request for a token within the authenticator service. This is why the method is called trusted authentication; ThoughtSpot trusts the authenticator service to request a login token for any user.
+Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
 
-The authenticator service must have secure access to the `secret_key` for the ThoughtSpot instance. With that `secret_key`, the authenticator service can make a REST API request for a login token for any existing user within ThoughtSpot. This login token is then sent to the user's web browser, where it is used in the login process.
+*Securely requesting the login token* requires passing authentication details from the embedding application securely to an *authenticator service* with access to the `secret_key` for the ThoughtSpot instance and an ThoughtSpot admin level user's credentials.
 
 [NOTE]
 ====

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -6,10 +6,10 @@
 :page-pageid: trusted-auth
 :page-description: You can configure support for token-based authentication service on ThoughtSpot.
 
+Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
+
 == Overview
 Trusted authentication establishes a ThoughtSpot session in the browser without requiring a user to sign-in directly to ThoughtSpot or be redirected to a third-party IdP. It is the most seamless method of single sign-on, but requires more of the application developer to secure the process.
-
-Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
 
 The *login token* from the ThoughtSpot V1 REST API is a simple, proprietary token. The authentication token of the V2 REST API is not currently used in the trusted authentication flow.
 

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -10,6 +10,8 @@ Trusted authentication establishes a ThoughtSpot session in the browser without 
 
 Trusted authentication defines a *method* for requesting *login tokens* using the ThoughtSpot REST API. The login token is only necessary during the login process, after which any request to ThoughtSpot will include session cookies identifying the signed-in user.
 
+The *login token* from the ThoughtSpot V1 REST API is a simple, proprietary token. The authentication token of the V2 REST API is not currently used in the trusted authentication flow.
+
 *Securely requesting the login token* requires passing authentication details from the embedding application securely to an *authenticator service* with access to the `secret_key` for the ThoughtSpot instance and an ThoughtSpot admin level user's credentials.
 
 The process for trusted authentication is as follows:
@@ -30,16 +32,60 @@ The trusted authentication workflow involves several entities, such as the web b
 
 The Visual Embed SDK automates the login token request and subsequent login request using the returned login token.
 
-The request to the *authenticator service* is defined in the `init()` function of the Visual Embed SDK. When `init()` is called, the SDK checks if there is an existing ThoughtSpot session for the instance in the browser. If not, it will request a *login token* from either the `authEndpoint` URL or the `getAuthToken` callback function. The xref:embed-authentication.adoc#trusted-auth-embed[Embed user authentication] shows the exact forms to use for these two properties.
+The request to the *authenticator service* is defined in the `init()` function of the Visual Embed SDK. When `init()` is called, the SDK checks if there is an existing ThoughtSpot session for the instance in the browser. If not, it will request a *login token* from either the `authEndpoint` URL or the `getAuthToken` callback function. The xref:embed-authentication.adoc#trusted-auth-embed[Embed user authentication page] shows the exact forms to use for these two properties.
 
 ==== Secure the authentication details request
-For the request to the *authenticator service* to be secure, the user in the browser cannot modify or more their own request to the *authenticator service* and specify a different username than their own (which they already used to sign-in to the embedding application itself).
+For the request to the *authenticator service* to be secure, the user in the browser cannot modify the request or make their own valid request to the *authenticator service*.
 
-How your particular application can most easily securely request the *login token* is up to you, but how you choose to send the message will constrain your choices between `authEndpoint` or `getAuthToken`.
+How your particular application can most easily securely request the *login token* is up to you, but how you choose to send the message will constrain your choice between `authEndpoint` or `getAuthToken`.
 
-If you choose `authEndpoint`, a GET request is made directly to the provided URL, so the authentication details must be part of the cookies or other headers of the general embedding application page prior to calling the `init()`. 
+When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the callback function you have the freedom to define the request to the *authenticator service* with far greater control than the automated GET request to a URL used by the `authEndpoint` option.
 
-When using `getAuthToken`, you specify a function that returns a Promise that resolves with the *login token*. Within the function you build, you have the freedom to craft the request to the *authenticator service* with far greater control. 
+The example below shows an example of a callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, target=_blank], which returns a Promise. You can also use link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest[XHR, target=_blank] and build the link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise, target=_blank] manually.
+
+[source,javascript]
+----
+init({
+    thoughtSpotHost: tsURL,
+    authType: AuthType.AuthServer,
+    getAuthToken: getAuthToken,
+    username: username
+  });
+}
+
+function async getAuthToken {
+  const tokenURL = tokenServiceURL + "/gettoken/";
+  console.log("calling token server at " + tokenURL);
+
+  const timeoutSecs = 5 * 1000; // seconds to milliseconds
+
+  const response = await timeout(timeoutSecs, fetch(
+    tokenURL,
+    {
+      method: 'POST',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': "text/plain",
+        'X-TS-Auth-Token': tsAuthJWT
+      },
+      credentials: 'include'
+    }
+  ))
+
+  // Have to return a promise for the auth SDK.
+  //console.log(await response.text());
+  return response.text()
+}
+----
+
+
+
+If you choose `authEndpoint`, a GET request is made directly to the provided URL. The authentication details must be included by the browser in this automated GET request, typically in the cookies. Cookies are not sent across domains (only to sub-domains), so your *authenticator service* must be *hosted in the same domain* as the embedding application.
+
+Because the requirements around matching domain hosting can be difficult to set up during a quick testing phase, you may see examples of a trusted authentication flow using `authEndpoint` with the username sent in the clear as a URL parameter, but this it is *only for testing purposes* and *is not secure*.
+
+
 
 
 

--- a/docs/src/asciidocs/trusted-authentication.adoc
+++ b/docs/src/asciidocs/trusted-authentication.adoc
@@ -12,6 +12,14 @@ Trusted authentication defines a *method* for requesting *login tokens* using th
 
 *Securely requesting the login token* requires passing authentication details from the embedding application securely to an *authenticator service* with access to the `secret_key` for the ThoughtSpot instance and an ThoughtSpot admin level user's credentials.
 
+The process for trusted authentication is as follows:
+
+ 1. The Visual Embed SDK, loaded within the embedded application page, calls the `init()` function with the correct set of parameters to request a *login token*
+ 2. The request for the *login token* securely provides the username and any additional details to the *authenticator service*
+ 3. The *authenticator service* verifies and parses the username and other details, and issues REST API commands to ThoughtSpot, at minimum requesting a *login token* for the provided username
+ 4. The *authenticator service* returns the *login token* to the browser and the Visual Embed SDK
+ 5. The Visual Embed SDK issues requests to establish ThoughtSpot session in the browser
+
 [NOTE]
 ====
 All SSO methods in ThoughtSpot create a ThoughtSpot session using cookies. Please confirm that your browser is set to allow "third-party cookies" when testing trusted authentication. Chrome now blocks third-party cookies in Incognito mode by default, while Safari blocks them by default even in standard mode. 


### PR DESCRIPTION
Rework of trusted auth to reflect the conversations I've been having with customers lately - much more clarity around front-end, back-end separation, what parts they must do and what needs to happen to be secure, and additional REST API command for user management and authentication at the sign-in time. I anticipate we'll do another update at some point to add in more examples or code based on this full workflow