### PR TITLE
Fetch examples

### DIFF
--- a/docs/src/asciidocs/api-auth-session.adoc
+++ b/docs/src/asciidocs/api-auth-session.adoc
@@ -10,7 +10,7 @@ To create, access, and modify ThoughtSpot objects and resources through the REST
 
 When using the REST API through a web browser, ThoughtSpot recommends that you use the xref:configure-saml.adoc[SAML SSO] or xref:trusted-authentication.adoc[trusted authentication] service to authenticate to ThoughtSpot. A successful log-in using the Visual Embed SDK via either of those two methods will establish the session within the web browser. 
 
-Once the session is established in the browser, you can set the `withCredentials: true` property for any `XMLHttpRequest` object or `credentials: "include"` as part of a `Fetch` object to pass the cookies along when making REST API requests or:
+Once the session is established in the browser, you can set the `withCredentials: true` property for any `XMLHttpRequest` object or `credentials: "include"` as part of a `Fetch` object to pass the cookies along when making REST API requests:
 
 [source,javascript]
 ----

--- a/docs/src/asciidocs/api-auth-session.adoc
+++ b/docs/src/asciidocs/api-auth-session.adoc
@@ -10,12 +10,26 @@ To create, access, and modify ThoughtSpot objects and resources through the REST
 
 When using the REST API through a web browser, ThoughtSpot recommends that you use the xref:configure-saml.adoc[SAML SSO] or xref:trusted-authentication.adoc[trusted authentication] service to authenticate to ThoughtSpot. A successful log-in using the Visual Embed SDK via either of those two methods will establish the session within the web browser. 
 
-Once the session is established in the browser, the *withCredentials* property tells any `XMLHttpRequest` object to pass the cookies along when making REST API requests:
+Once the session is established in the browser, you can set the `withCredentials: true` property for any `XMLHttpRequest` object or `credentials: "include"` as part of a `Fetch` object to pass the cookies along when making REST API requests or:
 
+[source,javascript]
 ----
+// Simple XMLHttpRequest
 var xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
+
+// Using Fetch with Promises
+return async fetch(
+            apiFullEndpoint, {
+            method: 'GET',
+            headers: {
+                "Accept": "application/json",
+                "X-Requested-By": "ThoughtSpot"
+            },
+            credentials: "include"
+            })
 ----
+
 
 [TIP]
 ====

--- a/docs/src/asciidocs/custom-viz-rest-api.adoc
+++ b/docs/src/asciidocs/custom-viz-rest-api.adoc
@@ -92,6 +92,25 @@ Now you can make the API request. The following is an example using `XMLHttpRequ
  }
 ----
 
+A more modern form, using Fetch and Promises, would look like:
+
+[source,javascript]
+----
+fetch(
+    liveboardDataFullEndpoint, {
+       method: 'GET',
+       headers: {
+           "Accept": "application/json",
+           "X-Requested-By": "ThoughtSpot"
+    },
+    credentials: "include"
+    })
+.then(response =>  response.text())
+.catch(error => {
+    console.error("Unable to get the response: " + error)
+});
+----
+
 The JSON object created by the code above will match the format documented in the  xref:pinboarddata.adoc[Liveboard data API].  
 
 == Transform the REST API response
@@ -122,7 +141,35 @@ After you have transformed the data into the input format, you can render the ch
 
 [source,javascript]
 ----
- var xhr = new XMLHttpRequest();
+
+function transformVizData(responseFromApi){
+
+   return finalChartingData;
+}
+
+function renderCustomChart(){
+
+}
+
+// Using Fetch and Promises
+fetch(
+    liveboardDataFullEndpoint, {
+       method: 'GET',
+       headers: {
+           "Accept": "application/json",
+           "X-Requested-By": "ThoughtSpot"
+    },
+    credentials: "include"
+    })
+.then(response =>  response.text())
+.then(transformVizData)
+.then(renderCustomChart)
+.catch(error => {
+    console.error("Unable to get the response: " + error)
+});
+
+// Using XMLHttpRequest
+var xhr = new XMLHttpRequest();
  xhr.open('POST', encodeURI(liveboardDataFullEndpoint), true);
  // .withCredentials = true is important - this is what sends the cookies from the browser session
  // without that, the APIs will reject you as not being signed in

--- a/docs/src/asciidocs/custom-viz-rest-api.adoc
+++ b/docs/src/asciidocs/custom-viz-rest-api.adoc
@@ -143,15 +143,29 @@ After you have transformed the data into the input format, you can render the ch
 ----
 
 function transformVizData(responseFromApi){
+   // Using the LiveboardData class from dataclasses.js to make operations on the data easier
+   let lbDataObj = LiveboardData.createFromJSON(JSON.parse(responseFromApi));
+   console.log(lbDataObj);
+    // Just one viz in this case, API Liveboard can return data from ALL or specified few
+   let vizData = lbDataObj.vizData[vizIds[0]];
+   // Array of column names
+   let colNames = vizData.columnNames;
+   // Column data
+   let colName = 'Column A';
+   let colData = vizData.data[colName];
 
+   /* Any other transformations to get data in the right format for your charting library */
+
+   // Return the data in the format necessary for the charting library to go to the rendering function
    return finalChartingData;
 }
 
-function renderCustomChart(){
-
+function renderCustomChart(dataInChartingLibraryFormat){
+    let chartDiv = document.getElementById('chartingDivSpace');
+    /* Use your charting library to render the data in place in the page /*
 }
 
-// Using Fetch and Promises
+// Using Fetch and Promises to call API, send to data transform function, then to the charting rendering function
 fetch(
     liveboardDataFullEndpoint, {
        method: 'GET',
@@ -167,6 +181,7 @@ fetch(
 .catch(error => {
     console.error("Unable to get the response: " + error)
 });
+
 
 // Using XMLHttpRequest
 var xhr = new XMLHttpRequest();


### PR DESCRIPTION
Added in examples in using the REST API from the browser using the more modern Fetch / Promises pattern which Bill uses in his examples. There are numerous benefits to showing this pattern. All of it is based on the existing examples which I have also left in the documentation there.