### PR TITLE
SCAL-131371  enableVizTranformations param update

### DIFF
--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -41,7 +41,7 @@ export interface LiveboardViewConfig extends ViewConfig {
      */
     defaultHeight?: number;
     /**
-     * If set to true, the context menu in visualizations will be enabled.
+     * @Deprecated If set to true, the context menu in visualizations will be enabled.
      */
     enableVizTransformations?: boolean;
     /**

--- a/static/typedoc/classes/AppEmbed.html
+++ b/static/typedoc/classes/AppEmbed.html
@@ -220,7 +220,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides V1Embed.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L109">embed/app.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L108">embed/app.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -250,7 +250,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from V1Embed.getThoughtSpotPostUrlParams</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L750">embed/ts-embed.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L751">embed/ts-embed.ts:751</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L209">embed/app.ts:209</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L210">embed/app.ts:210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -325,7 +325,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from V1Embed.on</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L796">embed/ts-embed.ts:796</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L797">embed/ts-embed.ts:797</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -355,6 +355,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides V1Embed.render</p>
 								<ul>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L238">embed/app.ts:238</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -377,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from V1Embed.trigger</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L721">embed/ts-embed.ts:721</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L721">embed/ts-embed.ts:721</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/static/typedoc/classes/LiveboardEmbed.html
+++ b/static/typedoc/classes/LiveboardEmbed.html
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides V1Embed.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L100">embed/liveboard.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L102">embed/liveboard.ts:102</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from V1Embed.getThoughtSpotPostUrlParams</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L750">embed/ts-embed.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L751">embed/ts-embed.ts:751</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from V1Embed.on</p>
 								<ul>
-				<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L796">embed/ts-embed.ts:796</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L797">embed/ts-embed.ts:797</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides V1Embed.render</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L227">embed/liveboard.ts:227</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L231">embed/liveboard.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -329,7 +329,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides V1Embed.trigger</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L214">embed/liveboard.ts:214</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L218">embed/liveboard.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/static/typedoc/classes/SearchEmbed.html
+++ b/static/typedoc/classes/SearchEmbed.html
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides TsEmbed.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L103">embed/search.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L103">embed/search.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from TsEmbed.getThoughtSpotPostUrlParams</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L750">embed/ts-embed.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L751">embed/ts-embed.ts:751</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from TsEmbed.on</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L678">embed/ts-embed.ts:678</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L678">embed/ts-embed.ts:678</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides TsEmbed.render</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L185">embed/search.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L185">embed/search.ts:185</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from TsEmbed.trigger</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L721">embed/ts-embed.ts:721</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L721">embed/ts-embed.ts:721</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/Action.html
+++ b/static/typedoc/enums/Action.html
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;addFilter&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L904">types.ts:904</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L904">types.ts:904</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -360,7 +360,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<wbr>ToFavorites<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;addToFavorites&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1009">types.ts:1009</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1009">types.ts:1009</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -377,7 +377,7 @@
 					<div class="tsd-signature tsd-kind-icon">Answer<wbr>Chart<wbr>Switcher<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;answerChartSwitcher&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1005">types.ts:1005</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1005">types.ts:1005</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -394,7 +394,7 @@
 					<div class="tsd-signature tsd-kind-icon">Answer<wbr>Delete<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;onDeleteAnswer&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1001">types.ts:1001</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1001">types.ts:1001</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -411,7 +411,7 @@
 					<div class="tsd-signature tsd-kind-icon">Configure<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;configureFilter&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L905">types.ts:905</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L905">types.ts:905</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -421,7 +421,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>And<wbr>Edit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-copy-and-edit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L985">types.ts:985</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L985">types.ts:985</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -431,7 +431,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>Link<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;embedDocument&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L896">types.ts:896</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L896">types.ts:896</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -441,7 +441,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>ToClipboard<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-copy-to-clipboard&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L984">types.ts:984</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L984">types.ts:984</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -451,7 +451,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<wbr>Monitor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;createMonitor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1017">types.ts:1017</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1017">types.ts:1017</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -468,7 +468,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;download&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L929">types.ts:929</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L929">types.ts:929</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -478,7 +478,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsCsv<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsCSV&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L931">types.ts:931</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L931">types.ts:931</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -488,7 +488,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsPdf<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsPdf&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L930">types.ts:930</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L930">types.ts:930</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -498,7 +498,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsXlsx<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsXLSX&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L932">types.ts:932</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L932">types.ts:932</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -508,7 +508,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drill<wbr>Exclude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-exclude&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L983">types.ts:983</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L983">types.ts:983</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -518,7 +518,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drill<wbr>Include<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-include&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L982">types.ts:982</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L982">types.ts:982</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -528,7 +528,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;edit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L943">types.ts:943</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L943">types.ts:943</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -538,7 +538,7 @@
 					<div class="tsd-signature tsd-kind-icon">EditACopy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editACopy&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L895">types.ts:895</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L895">types.ts:895</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -548,7 +548,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<wbr>Details<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editDetails&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1013">types.ts:1013</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1013">types.ts:1013</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -565,7 +565,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<wbr>Measure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-edit-measure&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L990">types.ts:990</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L990">types.ts:990</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -575,7 +575,7 @@
 					<div class="tsd-signature tsd-kind-icon">EditTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L940">types.ts:940</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L940">types.ts:940</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -585,7 +585,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<wbr>Title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editTitle&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L944">types.ts:944</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L944">types.ts:944</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -595,7 +595,7 @@
 					<div class="tsd-signature tsd-kind-icon">Explore<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;explore&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L981">types.ts:981</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L981">types.ts:981</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -605,7 +605,7 @@
 					<div class="tsd-signature tsd-kind-icon">ExportTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;exportTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L937">types.ts:937</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L937">types.ts:937</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -615,7 +615,7 @@
 					<div class="tsd-signature tsd-kind-icon">ImportTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;importTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L938">types.ts:938</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L938">types.ts:938</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -625,7 +625,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liveboard<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pinboardInfo&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L966">types.ts:966</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L966">types.ts:966</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -635,7 +635,7 @@
 					<div class="tsd-signature tsd-kind-icon">MakeACopy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;makeACopy&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L894">types.ts:894</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L894">types.ts:894</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -645,7 +645,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L975">types.ts:975</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L975">types.ts:975</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -655,7 +655,7 @@
 					<div class="tsd-signature tsd-kind-icon">Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;present&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L941">types.ts:941</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L941">types.ts:941</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -665,7 +665,7 @@
 					<div class="tsd-signature tsd-kind-icon">Query<wbr>Details<wbr>Buttons<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;queryDetailsButtons&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L997">types.ts:997</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L997">types.ts:997</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -675,7 +675,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;delete&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L945">types.ts:945</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L945">types.ts:945</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -685,7 +685,7 @@
 					<div class="tsd-signature tsd-kind-icon">Report<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;reportError&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L1021">types.ts:1021</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L1021">types.ts:1021</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -702,7 +702,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request<wbr>Access<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;requestAccess&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L996">types.ts:996</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L996">types.ts:996</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -712,7 +712,7 @@
 					<div class="tsd-signature tsd-kind-icon">Save<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;save&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L884">types.ts:884</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L884">types.ts:884</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -722,7 +722,7 @@
 					<div class="tsd-signature tsd-kind-icon">Save<wbr>AsView<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;saveAsView&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L893">types.ts:893</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L893">types.ts:893</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -732,7 +732,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedule<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;subscription&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L901">types.ts:901</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L901">types.ts:901</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -742,7 +742,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedules<wbr>List<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;schedule-list&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L902">types.ts:902</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L902">types.ts:902</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -752,7 +752,7 @@
 					<div class="tsd-signature tsd-kind-icon">Separator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-separator&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L991">types.ts:991</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L991">types.ts:991</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -762,7 +762,7 @@
 					<div class="tsd-signature tsd-kind-icon">Share<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;share&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L903">types.ts:903</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L903">types.ts:903</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -772,7 +772,7 @@
 					<div class="tsd-signature tsd-kind-icon">Share<wbr>Viz<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;shareViz&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L923">types.ts:923</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L923">types.ts:923</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -782,7 +782,7 @@
 					<div class="tsd-signature tsd-kind-icon">Show<wbr>Underlying<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;showUnderlyingData&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L928">types.ts:928</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L928">types.ts:928</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -792,7 +792,7 @@
 					<div class="tsd-signature tsd-kind-icon">SpotIQAnalyze<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;spotIQAnalyze&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L914">types.ts:914</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L914">types.ts:914</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -802,7 +802,7 @@
 					<div class="tsd-signature tsd-kind-icon">Subscription<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;subscription&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L980">types.ts:980</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L980">types.ts:980</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -812,7 +812,7 @@
 					<div class="tsd-signature tsd-kind-icon">Toggle<wbr>Size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;toggleSize&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L942">types.ts:942</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L942">types.ts:942</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -822,7 +822,7 @@
 					<div class="tsd-signature tsd-kind-icon">UpdateTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;updateTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L939">types.ts:939</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L939">types.ts:939</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/static/typedoc/enums/AuthFailureType.html
+++ b/static/typedoc/enums/AuthFailureType.html
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">EXPIRY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;EXPIRY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L40">auth.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L40">auth.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">NO_<wbr>COOKIE_<wbr>ACCESS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;NO_COOKIE_ACCESS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L39">auth.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L39">auth.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">OTHER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;OTHER&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L41">auth.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L41">auth.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">SDK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SDK&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L38">auth.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L38">auth.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/static/typedoc/enums/AuthStatus.html
+++ b/static/typedoc/enums/AuthStatus.html
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">FAILURE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;FAILURE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L48">auth.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L48">auth.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">LOGOUT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;LOGOUT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L60">auth.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L60">auth.ts:60</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">SDK_<wbr>SUCCESS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SDK_SUCCESS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L52">auth.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L52">auth.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">SUCCESS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SUCCESS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/auth.ts#L56">auth.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/auth.ts#L56">auth.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/AuthType.html
+++ b/static/typedoc/enums/AuthType.html
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">Auth<wbr>Server<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;AuthServer&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L36">types.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L36">types.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Basic&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L43">types.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L43">types.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;None&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L19">types.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L19">types.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">OIDC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SSO_OIDC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L32">types.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L32">types.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">SAML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SSO_SAML&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L28">types.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L28">types.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">SSO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SSO_SAML&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L24">types.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L24">types.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/DataSourceVisualMode.html
+++ b/static/typedoc/enums/DataSourceVisualMode.html
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">Collapsed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;collapse&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L831">types.ts:831</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L831">types.ts:831</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">Expanded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;expand&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L835">types.ts:835</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L835">types.ts:835</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hidden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;hide&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L827">types.ts:827</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L827">types.ts:827</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/EmbedEvent.html
+++ b/static/typedoc/enums/EmbedEvent.html
@@ -373,7 +373,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;*&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L497">types.ts:497</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L497">types.ts:497</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -394,7 +394,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<wbr>Remove<wbr>Columns<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;addRemoveColumns&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L398">types.ts:398</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L398">types.ts:398</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -417,7 +417,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<wbr>ToFavorites<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;addToFavorites&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L607">types.ts:607</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L607">types.ts:607</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 					<div class="tsd-signature tsd-kind-icon">Alert<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;alert&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L426">types.ts:426</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L426">types.ts:426</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 					<div class="tsd-signature tsd-kind-icon">Answer<wbr>Chart<wbr>Switcher<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;answerChartSwitcher&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L592">types.ts:592</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L592">types.ts:592</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 					<div class="tsd-signature tsd-kind-icon">Answer<wbr>Delete<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;answerDelete&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L527">types.ts:527</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L527">types.ts:527</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -497,7 +497,7 @@
 					<div class="tsd-signature tsd-kind-icon">Auth<wbr>Expire<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ThoughtspotAuthExpired&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L430">types.ts:430</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L430">types.ts:430</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -512,7 +512,7 @@
 					<div class="tsd-signature tsd-kind-icon">Auth<wbr>Init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;authInit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L361">types.ts:361</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L361">types.ts:361</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -532,7 +532,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cancel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;cancel&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L642">types.ts:642</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L642">types.ts:642</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -552,7 +552,7 @@
 					<div class="tsd-signature tsd-kind-icon">CopyAEdit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;copyAEdit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L582">types.ts:582</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L582">types.ts:582</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -572,7 +572,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>Link<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;embedDocument&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L652">types.ts:652</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L652">types.ts:652</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -592,7 +592,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>ToClipboard<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-copy-to-clipboard&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L557">types.ts:557</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L557">types.ts:557</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -612,7 +612,7 @@
 					<div class="tsd-signature tsd-kind-icon">Custom<wbr>Action<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;customAction&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L404">types.ts:404</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L404">types.ts:404</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -635,7 +635,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;data&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L371">types.ts:371</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L371">types.ts:371</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -655,7 +655,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<wbr>Source<wbr>Selected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;dataSourceSelected&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L392">types.ts:392</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L392">types.ts:392</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -675,7 +675,7 @@
 					<div class="tsd-signature tsd-kind-icon">Delete<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;delete&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L632">types.ts:632</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L632">types.ts:632</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -695,7 +695,7 @@
 					<div class="tsd-signature tsd-kind-icon">Dialog<wbr>Close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;dialog-close&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L484">types.ts:484</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L484">types.ts:484</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -715,7 +715,7 @@
 					<div class="tsd-signature tsd-kind-icon">Dialog<wbr>Open<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;dialog-open&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L479">types.ts:479</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L479">types.ts:479</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -735,7 +735,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;download&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L507">types.ts:507</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L507">types.ts:507</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -755,7 +755,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsCsv<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsCsv&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L517">types.ts:517</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L517">types.ts:517</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -775,7 +775,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsPdf<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsPdf&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L512">types.ts:512</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L512">types.ts:512</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -795,7 +795,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsXlsx<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsXlsx&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L522">types.ts:522</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L522">types.ts:522</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -815,7 +815,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drill<wbr>Exclude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-exclude&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L552">types.ts:552</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L552">types.ts:552</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -835,7 +835,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drill<wbr>Include<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;context-menu-item-include&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L547">types.ts:547</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L547">types.ts:547</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -855,7 +855,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drilldown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;drillDown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L387">types.ts:387</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L387">types.ts:387</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -881,7 +881,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;edit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L617">types.ts:617</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L617">types.ts:617</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -901,7 +901,7 @@
 					<div class="tsd-signature tsd-kind-icon">EditTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L567">types.ts:567</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L567">types.ts:567</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -921,7 +921,7 @@
 					<div class="tsd-signature tsd-kind-icon">Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Error&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L421">types.ts:421</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L421">types.ts:421</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -941,7 +941,7 @@
 					<div class="tsd-signature tsd-kind-icon">Explore<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;explore&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L647">types.ts:647</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L647">types.ts:647</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -961,7 +961,7 @@
 					<div class="tsd-signature tsd-kind-icon">ExportTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;exportTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L572">types.ts:572</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L572">types.ts:572</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -981,7 +981,7 @@
 					<div class="tsd-signature tsd-kind-icon">Init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;init&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L356">types.ts:356</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L356">types.ts:356</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1001,7 +1001,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liveboard<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pinboardInfo&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L602">types.ts:602</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L602">types.ts:602</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liveboard<wbr>Rendered<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;PinboardRendered&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L491">types.ts:491</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L491">types.ts:491</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1043,7 +1043,7 @@
 					<div class="tsd-signature tsd-kind-icon">Load<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;load&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L366">types.ts:366</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L366">types.ts:366</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1063,7 +1063,7 @@
 					<div class="tsd-signature tsd-kind-icon">MakeACopy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;makeACopy&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L622">types.ts:622</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L622">types.ts:622</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1083,7 +1083,7 @@
 					<div class="tsd-signature tsd-kind-icon">No<wbr>Cookie<wbr>Access<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;noCookieAccess&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L468">types.ts:468</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L468">types.ts:468</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1104,7 +1104,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L532">types.ts:532</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L532">types.ts:532</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1124,7 +1124,7 @@
 					<div class="tsd-signature tsd-kind-icon">Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;present&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L627">types.ts:627</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L627">types.ts:627</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1144,7 +1144,7 @@
 					<div class="tsd-signature tsd-kind-icon">Query<wbr>Changed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;queryChanged&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L380">types.ts:380</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L380">types.ts:380</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1159,7 +1159,7 @@
 					<div class="tsd-signature tsd-kind-icon">Route<wbr>Change<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ROUTE_CHANGE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L456">types.ts:456</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L456">types.ts:456</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1174,7 +1174,7 @@
 					<div class="tsd-signature tsd-kind-icon">Save<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;save&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L502">types.ts:502</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L502">types.ts:502</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1194,7 +1194,7 @@
 					<div class="tsd-signature tsd-kind-icon">Save<wbr>AsView<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;saveAsView&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L577">types.ts:577</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L577">types.ts:577</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1214,7 +1214,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedule<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;subscription&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L612">types.ts:612</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L612">types.ts:612</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1234,7 +1234,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedules<wbr>List<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;schedule-list&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L637">types.ts:637</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L637">types.ts:637</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1254,7 +1254,7 @@
 					<div class="tsd-signature tsd-kind-icon">Share<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;share&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L542">types.ts:542</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L542">types.ts:542</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1274,7 +1274,7 @@
 					<div class="tsd-signature tsd-kind-icon">Show<wbr>Underlying<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;showUnderlyingData&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L587">types.ts:587</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L587">types.ts:587</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1294,7 +1294,7 @@
 					<div class="tsd-signature tsd-kind-icon">SpotIQAnalyze<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;spotIQAnalyze&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L537">types.ts:537</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L537">types.ts:537</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1314,7 +1314,7 @@
 					<div class="tsd-signature tsd-kind-icon">UpdateTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;updateTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L562">types.ts:562</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L562">types.ts:562</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1334,7 +1334,7 @@
 					<div class="tsd-signature tsd-kind-icon">Viz<wbr>Point<wbr>Click<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;vizPointClick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L416">types.ts:416</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L416">types.ts:416</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1357,7 +1357,7 @@
 					<div class="tsd-signature tsd-kind-icon">Viz<wbr>Point<wbr>Double<wbr>Click<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;vizPointDoubleClick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L410">types.ts:410</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L410">types.ts:410</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/HostEvent.html
+++ b/static/typedoc/enums/HostEvent.html
@@ -264,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">Copy<wbr>Link<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;embedDocument&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L805">types.ts:805</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L805">types.ts:805</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<wbr>Monitor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;createMonitor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L779">types.ts:779</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L779">types.ts:779</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -315,7 +315,7 @@
 					<div class="tsd-signature tsd-kind-icon">Download<wbr>AsPdf<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;downloadAsPdf&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L756">types.ts:756</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L756">types.ts:756</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drill<wbr>Down<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;triggerDrillDown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L678">types.ts:678</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L678">types.ts:678</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<div class="tsd-signature tsd-kind-icon">Edit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;edit&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L795">types.ts:795</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L795">types.ts:795</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 					<div class="tsd-signature tsd-kind-icon">EditTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;editTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L746">types.ts:746</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L746">types.ts:746</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -411,7 +411,7 @@
 					<div class="tsd-signature tsd-kind-icon">Explore<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;explore&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L773">types.ts:773</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L773">types.ts:773</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -435,7 +435,7 @@
 					<div class="tsd-signature tsd-kind-icon">ExportTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;exportTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L741">types.ts:741</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L741">types.ts:741</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -455,7 +455,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liveboard<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pinboardInfo&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L726">types.ts:726</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L726">types.ts:726</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -475,7 +475,7 @@
 					<div class="tsd-signature tsd-kind-icon">MakeACopy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;makeACopy&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L761">types.ts:761</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L761">types.ts:761</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -495,7 +495,7 @@
 					<div class="tsd-signature tsd-kind-icon">Manage<wbr>Monitor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;manageMonitor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L785">types.ts:785</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L785">types.ts:785</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -518,7 +518,7 @@
 					<div class="tsd-signature tsd-kind-icon">Navigate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Navigate&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L709">types.ts:709</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L709">types.ts:709</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -542,7 +542,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;pin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L721">types.ts:721</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L721">types.ts:721</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 					<div class="tsd-signature tsd-kind-icon">Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;present&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L815">types.ts:815</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L815">types.ts:815</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -594,7 +594,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;delete&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L766">types.ts:766</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L766">types.ts:766</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -614,7 +614,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedule<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;subscription&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L731">types.ts:731</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L731">types.ts:731</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -634,7 +634,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schedules<wbr>List<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;schedule-list&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L736">types.ts:736</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L736">types.ts:736</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -654,7 +654,7 @@
 					<div class="tsd-signature tsd-kind-icon">Search<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;search&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L669">types.ts:669</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L669">types.ts:669</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -677,7 +677,7 @@
 					<div class="tsd-signature tsd-kind-icon">Set<wbr>Visible<wbr>Vizs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SetPinboardVisibleVizs&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L695">types.ts:695</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L695">types.ts:695</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -701,7 +701,7 @@
 					<div class="tsd-signature tsd-kind-icon">Update<wbr>Runtime<wbr>Filters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;UpdateRuntimeFilters&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L702">types.ts:702</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L702">types.ts:702</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -725,7 +725,7 @@
 					<div class="tsd-signature tsd-kind-icon">UpdateTML<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;updateTSL&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L751">types.ts:751</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L751">types.ts:751</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -745,7 +745,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Export<wbr>Request<wbr>For<wbr>Current<wbr>Pinboard<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;getExportRequestForCurrentPinboard&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L714">types.ts:714</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L714">types.ts:714</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/Page.html
+++ b/static/typedoc/enums/Page.html
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">Answers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;answers&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L32">embed/app.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L32">embed/app.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;data&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L44">embed/app.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L44">embed/app.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">Home<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;home&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L24">embed/app.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L24">embed/app.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">Liveboards<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;liveboards&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L36">embed/app.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L36">embed/app.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">Search<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;search&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L28">embed/app.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L28">embed/app.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">SpotIQ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;spotiq&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L48">embed/app.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L48">embed/app.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/enums/RuntimeFilterOp.html
+++ b/static/typedoc/enums/RuntimeFilterOp.html
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">BEGINS_<wbr>WITH<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;BEGINS_WITH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L300">types.ts:300</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L300">types.ts:300</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">BW<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;BW&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L320">types.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">BW_<wbr>INC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;BW_INC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L316">types.ts:316</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L316">types.ts:316</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 					<div class="tsd-signature tsd-kind-icon">BW_<wbr>INC_<wbr>MAX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;BW_INC_MAX&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L308">types.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L308">types.ts:308</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -289,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">BW_<wbr>INC_<wbr>MIN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;BW_INC_MIN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L312">types.ts:312</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L312">types.ts:312</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTAINS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CONTAINS&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L296">types.ts:296</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L296">types.ts:296</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENDS_<wbr>WITH<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ENDS_WITH&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L304">types.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 					<div class="tsd-signature tsd-kind-icon">EQ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;EQ&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L272">types.ts:272</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L272">types.ts:272</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -349,7 +349,7 @@
 					<div class="tsd-signature tsd-kind-icon">GE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;GE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L292">types.ts:292</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L292">types.ts:292</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -364,7 +364,7 @@
 					<div class="tsd-signature tsd-kind-icon">GT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;GT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L288">types.ts:288</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L288">types.ts:288</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -379,7 +379,7 @@
 					<div class="tsd-signature tsd-kind-icon">IN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;IN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L324">types.ts:324</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L324">types.ts:324</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -394,7 +394,7 @@
 					<div class="tsd-signature tsd-kind-icon">LE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;LE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L284">types.ts:284</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L284">types.ts:284</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@
 					<div class="tsd-signature tsd-kind-icon">LT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;LT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L280">types.ts:280</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L280">types.ts:280</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -424,7 +424,7 @@
 					<div class="tsd-signature tsd-kind-icon">NE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;NE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L276">types.ts:276</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L276">types.ts:276</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/interfaces/AppViewConfig.html
+++ b/static/typedoc/interfaces/AppViewConfig.html
@@ -251,7 +251,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.additionalFlags</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 					<div class="tsd-signature tsd-kind-icon">disable<wbr>Profile<wbr>And<wbr>Help<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L65">embed/app.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L65">embed/app.ts:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActionReason</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -317,7 +317,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -333,7 +333,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Search<wbr>Assist<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L98">embed/app.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L97">embed/app.ts:97</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -354,7 +354,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.frameParams</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -370,7 +370,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.hiddenActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -386,7 +386,7 @@
 					<div class="tsd-signature tsd-kind-icon">hide<wbr>Objects<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L85">embed/app.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L85">embed/app.ts:85</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -402,7 +402,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.locale</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -422,7 +422,7 @@
 					<div class="tsd-signature tsd-kind-icon">page<wbr>Id<span class="tsd-signature-symbol">:</span> <a href="../enums/Page.html" class="tsd-signature-type" data-tsd-kind="Enumeration">Page</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L76">embed/app.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L76">embed/app.ts:76</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -438,7 +438,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L71">embed/app.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L71">embed/app.ts:71</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -456,7 +456,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.runtimeFilters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -473,7 +473,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.showAlerts</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -493,7 +493,7 @@
 					<div class="tsd-signature tsd-kind-icon">show<wbr>Primary<wbr>Navbar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L60">embed/app.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L60">embed/app.ts:60</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -509,7 +509,7 @@
 					<div class="tsd-signature tsd-kind-icon">tag<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/app.ts#L81">embed/app.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/app.ts#L81">embed/app.ts:81</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.visibleActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/interfaces/EmbedConfig.html
+++ b/static/typedoc/interfaces/EmbedConfig.html
@@ -265,7 +265,7 @@
 					<div class="tsd-signature tsd-kind-icon">auth<wbr>Endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L92">types.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L92">types.ts:92</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 					<div class="tsd-signature tsd-kind-icon">auth<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/AuthType.html" class="tsd-signature-type" data-tsd-kind="Enumeration">AuthType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L84">types.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L84">types.ts:84</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 					<div class="tsd-signature tsd-kind-icon">auto<wbr>Login<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L161">types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L161">types.ts:161</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">call<wbr>Prefetch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L181">types.ts:181</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L181">types.ts:181</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -339,7 +339,7 @@
 					<div class="tsd-signature tsd-kind-icon">custom<wbr>Css<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L198">types.ts:198</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L198">types.ts:198</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<div class="tsd-signature tsd-kind-icon">customisations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CustomisationsInterface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L218">types.ts:218</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L218">types.ts:218</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -383,7 +383,7 @@
 					<div class="tsd-signature tsd-kind-icon">detect<wbr>Cookie<wbr>Access<wbr>Slow<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L206">types.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L206">types.ts:206</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -405,7 +405,7 @@
 					<div class="tsd-signature tsd-kind-icon">disable<wbr>Login<wbr>Redirect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L169">types.ts:169</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L169">types.ts:169</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -429,7 +429,7 @@
 					<div class="tsd-signature tsd-kind-icon">login<wbr>Failed<wbr>Message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L175">types.ts:175</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L175">types.ts:175</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -449,7 +449,7 @@
 					<div class="tsd-signature tsd-kind-icon">no<wbr>Redirect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L125">types.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L125">types.ts:125</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -470,7 +470,7 @@
 					<div class="tsd-signature tsd-kind-icon">password<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L117">types.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L117">types.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -487,7 +487,7 @@
 					<div class="tsd-signature tsd-kind-icon">queue<wbr>Multi<wbr>Renders<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L190">types.ts:190</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L190">types.ts:190</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -512,7 +512,7 @@
 					<div class="tsd-signature tsd-kind-icon">redirect<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L135">types.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L135">types.ts:135</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -535,7 +535,7 @@
 					<div class="tsd-signature tsd-kind-icon">should<wbr>Encode<wbr>Url<wbr>Query<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L146">types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L146">types.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -557,7 +557,7 @@
 					<div class="tsd-signature tsd-kind-icon">suppress<wbr>NoCookie<wbr>Access<wbr>Alert<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L155">types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L155">types.ts:155</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -580,7 +580,7 @@
 					<div class="tsd-signature tsd-kind-icon">suppress<wbr>Search<wbr>Embed<wbr>Beta<wbr>Warning<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L212">types.ts:212</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L212">types.ts:212</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -600,7 +600,7 @@
 					<div class="tsd-signature tsd-kind-icon">thought<wbr>Spot<wbr>Host<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L80">types.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L80">types.ts:80</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -615,7 +615,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L109">types.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L109">types.ts:109</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -638,7 +638,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L104">types.ts:104</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L104">types.ts:104</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/static/typedoc/interfaces/LiveboardViewConfig.html
+++ b/static/typedoc/interfaces/LiveboardViewConfig.html
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Tab<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L87">embed/liveboard.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L89">embed/liveboard.ts:89</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.additionalFlags</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L41">embed/liveboard.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L42">embed/liveboard.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -338,7 +338,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActionReason</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -354,7 +354,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -370,13 +370,15 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Viz<wbr>Transformations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L45">embed/liveboard.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L46">embed/liveboard.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>If set to true, the context menu in visualizations will be enabled.</p>
-						</div>
+						<dl class="tsd-comment-tags">
+							<dt class="deprecated">deprecated</dt>
+							<dd><p>If set to true, the context menu in visualizations will be enabled.</p>
+							</dd>
+						</dl>
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited">
@@ -386,7 +388,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.frameParams</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -401,7 +403,7 @@
 					<div class="tsd-signature tsd-kind-icon">full<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L33">embed/liveboard.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L34">embed/liveboard.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -423,7 +425,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.hiddenActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -439,7 +441,7 @@
 					<div class="tsd-signature tsd-kind-icon">liveboard<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L50">embed/liveboard.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L52">embed/liveboard.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -460,7 +462,7 @@
 					<div class="tsd-signature tsd-kind-icon">liveboard<wbr>V2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L82">embed/liveboard.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L84">embed/liveboard.ts:84</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -468,9 +470,6 @@
 							<p>Render embedded Liveboards and visualizations in the new Liveboard experience mode</p>
 						</div>
 						<dl class="tsd-comment-tags">
-							<dt class="default">default</dt>
-							<dd><p>false</p>
-							</dd>
 							<dt class="version">version</dt>
 							<dd><p>SDK: 1.14.0 | ThoughtSpot: 8.6.0.cl, 8.8.1-sw</p>
 							</dd>
@@ -484,7 +483,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.locale</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -504,7 +503,7 @@
 					<div class="tsd-signature tsd-kind-icon">prevent<wbr>Liveboard<wbr>Filter<wbr>Removal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L64">embed/liveboard.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L67">embed/liveboard.ts:67</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -526,7 +525,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.runtimeFilters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -543,7 +542,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.showAlerts</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -564,7 +563,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.visibleActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -585,7 +584,7 @@
 					<div class="tsd-signature tsd-kind-icon">visible<wbr>Vizs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L71">embed/liveboard.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L74">embed/liveboard.ts:74</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -607,7 +606,7 @@
 					<div class="tsd-signature tsd-kind-icon">viz<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/liveboard.ts#L59">embed/liveboard.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/liveboard.ts#L61">embed/liveboard.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/interfaces/RuntimeFilter.html
+++ b/static/typedoc/interfaces/RuntimeFilter.html
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">column<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L335">types.ts:335</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L335">types.ts:335</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">operator<span class="tsd-signature-symbol">:</span> <a href="../enums/RuntimeFilterOp.html" class="tsd-signature-type" data-tsd-kind="Enumeration">RuntimeFilterOp</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L339">types.ts:339</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L339">types.ts:339</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 					<div class="tsd-signature tsd-kind-icon">values<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/types.ts#L344">types.ts:344</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/types.ts#L344">types.ts:344</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/interfaces/SearchViewConfig.html
+++ b/static/typedoc/interfaces/SearchViewConfig.html
@@ -259,7 +259,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.additionalFlags</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L148">embed/ts-embed.ts:148</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">answer<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L81">embed/search.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L81">embed/search.ts:81</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">collapse<wbr>Data<wbr>Sources<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L44">embed/search.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L44">embed/search.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -323,7 +323,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<wbr>Sources<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L68">embed/search.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L68">embed/search.ts:68</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -339,7 +339,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActionReason</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L112">embed/ts-embed.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -355,7 +355,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.disabledActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L108">embed/ts-embed.ts:108</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -371,7 +371,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Search<wbr>Assist<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L59">embed/search.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L59">embed/search.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 					<div class="tsd-signature tsd-kind-icon">force<wbr>Table<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L64">embed/search.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L64">embed/search.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -408,7 +408,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.frameParams</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L94">embed/ts-embed.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -424,7 +424,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.hiddenActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L117">embed/ts-embed.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -440,7 +440,7 @@
 					<div class="tsd-signature tsd-kind-icon">hide<wbr>Data<wbr>Sources<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L48">embed/search.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L48">embed/search.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -455,7 +455,7 @@
 					<div class="tsd-signature tsd-kind-icon">hide<wbr>Results<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L54">embed/search.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L54">embed/search.ts:54</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -473,7 +473,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.locale</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L138">embed/ts-embed.ts:138</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -494,7 +494,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.runtimeFilters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L133">embed/ts-embed.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -510,7 +510,7 @@
 					<div class="tsd-signature tsd-kind-icon">search<wbr>Options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SearchOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L77">embed/search.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L77">embed/search.ts:77</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -525,7 +525,7 @@
 					<div class="tsd-signature tsd-kind-icon">search<wbr>Query<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/search.ts#L73">embed/search.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/search.ts#L73">embed/search.ts:73</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -546,7 +546,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.showAlerts</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L128">embed/ts-embed.ts:128</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -567,7 +567,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ViewConfig.visibleActions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/ts-embed.ts#L123">embed/ts-embed.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/static/typedoc/modules.html
+++ b/static/typedoc/modules.html
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/base.ts#L116">embed/base.ts:116</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/base.ts#L116">embed/base.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/base.ts#L151">embed/base.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/base.ts#L151">embed/base.ts:151</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/e51948bb/src/embed/base.ts#L90">embed/base.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/thoughtspot/visual-embed-sdk/blob/32fc1db0/src/embed/base.ts#L91">embed/base.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">


### PR DESCRIPTION
Added deprecated tag to enableVizTranformations in the SDK docs. This attribute has also been removed from the developer docs in the upcoming [8.8.0 version](https://developers.thoughtspot.com/docs/?pageid=embed-sdk-changelog). 