### PR TITLE
fix: add missing comma after pair in object (#791)

### DIFF
--- a/docs/src/asciidocs/embed-pinboard.adoc
+++ b/docs/src/asciidocs/embed-pinboard.adoc
@@ -58,7 +58,7 @@ const liveboardEmbed = new LiveboardEmbed(document.getElementById('ts-embed'), {
     liveboardId: '<%=liveboardGUID%>',
     enableVizTransformations: true,
     preventLiveboardFilterRemoval: true,
-    visibleVizs: []
+    visibleVizs: [],
     runtimeFilters: [],
 });
 ----


### PR DESCRIPTION
There's a missing comma after the value for key visibleVizs in this [file](https://github.com/thoughtspot/visual-embed-sdk/blob/38cce8ab8ca771310dec0e7252bae81487bfde2f/docs/src/asciidocs/embed-pinboard.adoc), came across the error using your [docs](https://my1.thoughtspot.cloud/#/develop/documentation/en/?pageid=embed-liveboard) to embed a liveboard.