### PR TITLE
SCAL-183676 SCAL-186974 Remove embedded content when token fetch fails or logout is called

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -472,6 +472,12 @@ export const logout = async (embedConfig: EmbedConfig): Promise<boolean> => {
     const { thoughtSpotHost } = embedConfig;
     await fetchLogoutService(thoughtSpotHost);
     resetCachedAuthToken();
+    const thoughtspotIframes = document.querySelectorAll('[data-ts-iframe=\'true\']');
+    if (thoughtspotIframes?.length) {
+        thoughtspotIframes.forEach((el) => {
+            el.parentElement.innerHTML = embedConfig.loginFailedMessage;
+        });
+    }
     loggedInStatus = false;
     return loggedInStatus;
 };

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -147,7 +147,8 @@ export interface LiveboardViewConfig extends Omit<ViewConfig, 'hiddenHomepageMod
 
 /**
  * Embed a ThoughtSpot Liveboard or visualization. When rendered it already
- * waits for the authentication to complete, so you need not wait for `AuthStatus.SUCCESS`.
+ * waits for the authentication to complete, so you need not wait for
+ * `AuthStatus.SUCCESS`.
  *
  * @example
  * ```js

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -411,4 +411,17 @@ describe('Search embed tests', () => {
             );
         });
     });
+    test('should set hideSearchBar to true if hideSearchBar flag is true', async () => {
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            hideSearchBar: true,
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&dataSourceMode=expand&enableDataPanelV2=false&useLastSelectedSources=false&hideSearchBar=true${prefixParams}#/embed/saved-answer/${answerId}`,
+            );
+        });
+    });
 });

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -199,6 +199,7 @@ export class SearchEmbed extends TsEmbed {
             dataSource,
             dataSources,
             excludeRuntimeFiltersfromURL,
+            hideSearchBar,
             dataPanelV2 = false,
             useLastSelectedSources = false,
             runtimeParameters,
@@ -233,6 +234,10 @@ export class SearchEmbed extends TsEmbed {
         }
         if (forceTable) {
             queryParams[Param.ForceTable] = true;
+        }
+
+        if (hideSearchBar) {
+            queryParams[Param.HideSearchBar] = true;
         }
 
         queryParams[Param.DataPanelV2Enabled] = dataPanelV2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2815,7 +2815,8 @@ export enum Param {
     LiveboardHeaderSticky = 'isLiveboardHeaderSticky',
     IsProductTour = 'isProductTour',
     HideSearchBarTitle = 'hideSearchBarTitle',
-    HideSageAnswerHeader = 'hideSageAnswerHeader'
+    HideSageAnswerHeader = 'hideSageAnswerHeader',
+    HideSearchBar = 'hideSearchBar',
 }
 
 /**

--- a/src/utils/processData.ts
+++ b/src/utils/processData.ts
@@ -8,6 +8,7 @@ import {
 import { AuthFailureType, initSession } from '../auth';
 import { AuthType, CustomActionPayload, EmbedEvent } from '../types';
 import { AnswerService } from './graphql/answerService/answerService';
+import { resetCachedAuthToken } from '../authToken';
 
 /**
  *
@@ -77,13 +78,14 @@ function processNoCookieAccess(e: any, containerEl: Element) {
  * @param e
  * @param containerEl
  */
-function processAuthFailure(e: any, containerEl: Element) {
+export function processAuthFailure(e: any, containerEl: Element) {
     const { loginFailedMessage, authType } = getEmbedConfig();
     if (authType !== AuthType.None) {
         // eslint-disable-next-line no-param-reassign
         containerEl.innerHTML = loginFailedMessage;
         notifyAuthFailure(AuthFailureType.OTHER);
     }
+    resetCachedAuthToken();
     return e;
 }
 
@@ -96,6 +98,7 @@ function processAuthLogout(e: any, containerEl: Element) {
     const { loginFailedMessage } = getEmbedConfig();
     // eslint-disable-next-line no-param-reassign
     containerEl.innerHTML = loginFailedMessage;
+    resetCachedAuthToken();
     disableAutoLogin();
     notifyLogout();
     return e;


### PR DESCRIPTION
### Changes

- Remove iframe and show Not logged in message if token fetch fails during app_init
- Remove iframe and show Not logged in message if update token fails during auth expiry
- Remove all TS iframes and show Not logged in message if logout SDK function is called
- Added `HideSearchBar` param
