### PR TITLE
SCAL-178305 : make excludeRuntimeFiltersfromURL true by default, unhide it from jsdocs and add description

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -213,6 +213,7 @@ describe('App embed tests', () => {
                     values: [1000],
                 },
             ],
+            excludeRuntimeFiltersfromURL: false,
         } as AppViewConfig);
 
         appEmbed.render();
@@ -224,7 +225,7 @@ describe('App embed tests', () => {
         });
     });
 
-    test('should not apply runtime filters if excludeRuntimeFiltersfromURL is true', async () => {
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is true', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,
             showPrimaryNavbar: true,
@@ -236,6 +237,28 @@ describe('App embed tests', () => {
                 },
             ],
             excludeRuntimeFiltersfromURL: true,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=false&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is undefined', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showPrimaryNavbar: true,
+            runtimeFilters: [
+                {
+                    columnName: 'sales',
+                    operator: RuntimeFilterOp.EQ,
+                    values: [1000],
+                },
+            ],
         } as AppViewConfig);
 
         appEmbed.render();

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -182,6 +182,7 @@ describe('Liveboard/viz embed tests', () => {
                     values: [1000],
                 },
             ],
+            excludeRuntimeFiltersfromURL: false,
         } as LiveboardViewConfig);
         liveboardEmbed.render();
         await executeAfterWait(() => {
@@ -208,7 +209,29 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
-    test('should not apply runtime filters if excludeRuntimeFiltersfromURL is true', async () => {
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is true', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            vizId,
+            runtimeFilters: [
+                {
+                    columnName: 'sales',
+                    operator: RuntimeFilterOp.EQ,
+                    values: [1000],
+                },
+            ],
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}${prefixParamsVizEmbed}#/embed/viz/${liveboardId}/${vizId}`,
+            );
+        });
+    });
+
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is undefined', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,
             liveboardId,

--- a/src/embed/pinboard.spec.ts
+++ b/src/embed/pinboard.spec.ts
@@ -169,6 +169,7 @@ describe('Pinboard/viz embed tests', () => {
                     values: [1000],
                 },
             ],
+            excludeRuntimeFiltersfromURL: false,
         } as LiveboardViewConfig);
         pinboardEmbed.render();
         await executeAfterWait(() => {
@@ -179,7 +180,7 @@ describe('Pinboard/viz embed tests', () => {
         });
     });
 
-    test('should not apply runtime filters if excludeRuntimeFiltersfromURL is true', async () => {
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is true', async () => {
         const pinboardEmbed = new PinboardEmbed(getRootEl(), {
             ...defaultViewConfig,
             pinboardId,
@@ -194,6 +195,28 @@ describe('Pinboard/viz embed tests', () => {
             excludeRuntimeFiltersfromURL: true,
         } as LiveboardViewConfig);
         pinboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}${prefixParamsVizEmbed}#/embed/viz/${pinboardId}/${vizId}`,
+            );
+        });
+    });
+
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is undefined', async () => {
+        const liveboardEmbed = new PinboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            pinboardId,
+            vizId,
+            runtimeFilters: [
+                {
+                    columnName: 'sales',
+                    operator: RuntimeFilterOp.EQ,
+                    values: [1000],
+                },
+            ],
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -178,6 +178,7 @@ describe('Search embed tests', () => {
                     values: ['berkeley'],
                 },
             ],
+            excludeRuntimeFiltersfromURL: false,
         });
         searchEmbed.render();
         await executeAfterWait(() => {
@@ -188,7 +189,7 @@ describe('Search embed tests', () => {
         });
     });
 
-    test('should not add runtime filters if excludeRuntimeFiltersfromURL is true', async () => {
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is true', async () => {
         const dataSources = ['data-source-1'];
         const searchOptions = {
             searchTokenString: '[commit date][revenue]',
@@ -206,6 +207,33 @@ describe('Search embed tests', () => {
                 },
             ],
             excludeRuntimeFiltersfromURL: true,
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&dataSources=[%22data-source-1%22]&searchTokenString=%5Bcommit%20date%5D%5Brevenue%5D&dataSourceMode=hide&useLastSelectedSources=false${prefixParams}#/embed/answer`,
+            );
+        });
+    });
+
+    test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is undefined', async () => {
+        const dataSources = ['data-source-1'];
+        const searchOptions = {
+            searchTokenString: '[commit date][revenue]',
+        };
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            hideDataSources: true,
+            dataSources,
+            searchOptions,
+            runtimeFilters: [
+                {
+                    columnName: 'city',
+                    operator: RuntimeFilterOp.EQ,
+                    values: ['berkeley'],
+                },
+            ],
         });
         searchEmbed.render();
         await executeAfterWait(() => {

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -196,7 +196,7 @@ export class SearchEmbed extends TsEmbed {
             runtimeFilters,
             dataSource,
             dataSources,
-            excludeRuntimeFiltersfromURL,
+            excludeRuntimeFiltersfromURL = true,
             hideSearchBar,
             dataPanelV2 = false,
             useLastSelectedSources = false,

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -317,6 +317,46 @@ describe('Unit test case for ts embed', () => {
             });
         });
 
+        test('Runtime filters from view Config should be part of app_init payload when excludeRuntimeFiltersfromURL is undefined', async () => {
+            const mockEmbedEventPayload = {
+                type: EmbedEvent.APP_INIT,
+                data: {},
+            };
+            const mockRuntimeFilters: RuntimeFilter[] = [
+                {
+                    columnName: 'color',
+                    operator: RuntimeFilterOp.EQ,
+                    values: ['blue'],
+                },
+            ];
+
+            const searchEmbed = new SearchEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                excludeRuntimeFiltersfromURL: true,
+                runtimeFilters: mockRuntimeFilters,
+            });
+            searchEmbed.render();
+            const mockPort: any = {
+                postMessage: jest.fn(),
+            };
+            await executeAfterWait(() => {
+                const iframe = getIFrameEl();
+                postMessageToParent(iframe.contentWindow, mockEmbedEventPayload, mockPort);
+            });
+            expect(mockPort.postMessage).toHaveBeenCalledWith({
+                type: EmbedEvent.APP_INIT,
+                data: {
+                    customisations,
+                    authToken: '',
+                    runtimeFilterParams: 'col1=color&op1=EQ&val1=blue',
+                    hiddenHomeLeftNavItems: [],
+                    hiddenHomepageModules: [],
+                    hostConfig: undefined,
+                    reorderedHomepageModules: [],
+                },
+            });
+        });
+
         test('Runtime filters from view Config should not be part of app_init payload when excludeRuntimeFiltersfromURL is false', async () => {
             const mockEmbedEventPayload = {
                 type: EmbedEvent.APP_INIT,

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -170,7 +170,7 @@ export class TsEmbed {
         this.thoughtSpotV2Base = getV2BasePath(this.embedConfig);
         this.eventHandlerMap = new Map();
         this.isError = false;
-        this.viewConfig = viewConfig;
+        this.viewConfig = { excludeRuntimeFiltersfromURL: true, ...viewConfig };
         this.shouldEncodeUrlQueryParams = this.embedConfig.shouldEncodeUrlQueryParams;
         this.registerAppInit();
         uploadMixpanelEvent(MIXPANEL_EVENT.VISUAL_SDK_EMBED_CREATE, {
@@ -1235,7 +1235,7 @@ export class V1Embed extends TsEmbed {
 
     constructor(domSelector: DOMSelector, viewConfig: ViewConfig) {
         super(domSelector, viewConfig);
-        this.viewConfig = viewConfig;
+        this.viewConfig = { excludeRuntimeFiltersfromURL: true, ...viewConfig };
     }
 
     /**

--- a/src/react/index.spec.tsx
+++ b/src/react/index.spec.tsx
@@ -135,6 +135,7 @@ describe('React Components', () => {
                             values: [100],
                         },
                     ]}
+                    excludeRuntimeFiltersfromURL={false}
                 />,
             );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -741,9 +741,14 @@ export interface ViewConfig {
     usePrerenderedIfAvailable?: boolean;
     /**
      * Boolean to exclude runtimeFilters in the URL
+     * By default it is true, this flag removes runtime filters from the URL
+     * when set to false, runtime filters will be included in the URL.
      *
-     * @default false
-     * @hidden
+     * Irrespective of this flag, runtime filters ( if passed ) will be applied to the
+     * embedded view.
+     *
+     * @default true
+     * @version SDK: 1.24.0 | ThoughtSpot: 9.5.0.cl
      */
     excludeRuntimeFiltersfromURL?: boolean;
     /**


### PR DESCRIPTION
- make excludeRuntimeFiltersfromURL true by default
- unhide it from jsdocs and add description
- Tests modified to include runtime filters in url only when excludeRuntimeFiltersfromURL is false.
- Test added to check runtime filters should not be part of URL when excludeRuntimeFiltersfromURL is not defined by user
- Test added to check runtime filters should be part of app_init cb payload when excludeRuntimeFiltersfromURL is not defined by user