### PR TITLE
[SCAL-203325] Add collapseSearchBarInitially flag

### DIFF
--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -352,6 +352,13 @@ export interface AppViewConfig extends Omit<ViewConfig, 'visibleTabs'> {
      * @default false
      */
     enableAskSage?: boolean;
+    /**
+     * To set the initial state of the search bar in case of saved-answers.
+     *
+     * @version SDK: 1.32.0 | Thoughtspot: 10.0.0.cl
+     * @default false
+     */
+    collapseSearchBarInitially?: boolean;
 }
 
 /**
@@ -398,6 +405,7 @@ export class AppEmbed extends V1Embed {
             modularHomeExperience = false,
             isLiveboardHeaderSticky = true,
             enableAskSage,
+            collapseSearchBarInitially = false,
         } = this.viewConfig;
 
         let params = {};
@@ -438,6 +446,7 @@ export class AppEmbed extends V1Embed {
         params[Param.DataPanelV2Enabled] = dataPanelV2;
         params[Param.HideHomepageLeftNav] = hideHomepageLeftNav;
         params[Param.ModularHomeExperienceEnabled] = modularHomeExperience;
+        params[Param.CollapseSearchBarInitially] = collapseSearchBarInitially;
         const queryParams = getQueryParamString(params, true);
 
         return queryParams;

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -356,12 +356,13 @@ describe('Search embed tests', () => {
         const searchEmbed = new SearchEmbed(getRootEl(), {
             ...defaultViewConfig,
             answerId,
+            collapseSearchBarInitially: true,
         });
         searchEmbed.render();
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/saved-answer/${answerId}`,
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&dataSourceMode=expand&useLastSelectedSources=false&collapseSearchBarInitially=true${prefixParams}#/embed/saved-answer/${answerId}`,
             );
         });
     });

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -238,6 +238,13 @@ export interface SearchViewConfig
      * @version: SDK: 1.24.0
      */
     useLastSelectedSources?: boolean;
+    /**
+     * To set the initial state of the search bar in case of saved-answers.
+     *
+     * @default false
+     * @version SDK: 1.32.0 | Thoughtspot: 10.0.0.cl
+     */
+    collapseSearchBarInitially?: boolean;
 }
 
 export const HiddenActionItemByDefaultForSearchEmbed = [
@@ -294,6 +301,7 @@ export class SearchEmbed extends TsEmbed {
             dataPanelV2 = false,
             useLastSelectedSources = false,
             runtimeParameters,
+            collapseSearchBarInitially = false,
         } = this.viewConfig;
         const queryParams = this.getBaseQueryParams();
 
@@ -340,6 +348,7 @@ export class SearchEmbed extends TsEmbed {
         }
 
         queryParams[Param.searchEmbed] = true;
+        queryParams[Param.CollapseSearchBarInitially] = collapseSearchBarInitially;
         let query = '';
         const queryParamsString = getQueryParamString(queryParams, true);
         if (queryParamsString) {

--- a/src/react/index.spec.tsx
+++ b/src/react/index.spec.tsx
@@ -49,7 +49,7 @@ describe('React Components', () => {
                 ),
             ).toBe(true);
             expect(getIFrameSrc(container)).toBe(
-                `http://${thoughtSpotHost}/?hostAppUrl=local-host&viewPortHeight=768&viewPortWidth=1024&sdkVersion=${version}&authType=None&blockNonEmbedFullAppAccess=true&hideAction=[%22${Action.ReportError}%22,%22editACopy%22,%22saveAsView%22,%22updateTSL%22,%22editTSL%22,%22onDeleteAnswer%22]&overrideConsoleLogs=true&clientLogLevel=ERROR&enableDataPanelV2=false&dataSourceMode=hide&useLastSelectedSources=false&isSearchEmbed=true#/embed/answer`,
+                `http://${thoughtSpotHost}/?hostAppUrl=local-host&viewPortHeight=768&viewPortWidth=1024&sdkVersion=${version}&authType=None&blockNonEmbedFullAppAccess=true&hideAction=[%22${Action.ReportError}%22,%22editACopy%22,%22saveAsView%22,%22updateTSL%22,%22editTSL%22,%22onDeleteAnswer%22]&overrideConsoleLogs=true&clientLogLevel=ERROR&enableDataPanelV2=false&dataSourceMode=hide&useLastSelectedSources=false&isSearchEmbed=true&collapseSearchBarInitially=false#/embed/answer`,
             );
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3082,6 +3082,7 @@ export enum Param {
     ClientLogLevel = 'clientLogLevel',
     OverrideNativeConsole = 'overrideConsoleLogs',
     enableAskSage = 'enableAskSage',
+    CollapseSearchBarInitially= 'collapseSearchBarInitially',
 }
 
 /**


### PR DESCRIPTION
This flag controls the behavior of the search bar. If this flag is set to true, the saved-answer will open with the search bar collapsed initially to give more space for the visualization in the answer.