### PR TITLE
SCAL-216965 Change enum representation to camel-case

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3912,7 +3912,7 @@ export enum Action {
      * disabledActions: [Action.ManageMonitor]
      * ```
      */
-    ManageMonitor = 'ManageMonitor',
+    ManageMonitor = 'manageMonitor',
     /**
      * Action ID for Liveboard Personalised Views dropdown
      *  @example


### PR DESCRIPTION
If it were `ManageMonitor` it would also be encoded as such in query parameter. This would cause a mismatch while comparing it in Blink, partially causing the bug SCAL-216965