### PR TITLE
SCAL-220702 Created flags to control Liveboard Compact header

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -375,6 +375,51 @@ describe('App embed tests', () => {
         });
     });
 
+    test('Should add isLiveboardCompactHeaderEnabled flag to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            isLiveboardCompactHeaderEnabled: false,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&isLiveboardHeaderV2Enabled=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
+    test('Should add showLiveboardReverifyBanner flag to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showLiveboardReverifyBanner: false,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&showLiveboardReverifyBanner=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
+    test('Should add showLiveboardVerifiedBadge flag to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showLiveboardVerifiedBadge: false,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&showLiveboardVerifiedBadge=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('Should add default values of flags to the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -402,6 +402,48 @@ export interface AppViewConfig extends Omit<ViewConfig, 'visibleTabs'> {
      * @version SDK : 1.33.0 | Thoughtspot : 10.2.0.cl
      */
     homePageSearchBarMode?: HomePageSearchBarMode;
+    /**
+     * This flag is used to enable the compact header in liveboard
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.3.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#embed-container', {
+     *    ... // other options
+     *    isLiveboardHeaderV2Enabled: true,
+     * })
+     * ```
+     */
+    isLiveboardHeaderV2Enabled?: boolean;
+    /**
+     * This flag is used to show/hide verified Icon in liveboard compact header
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#embed-container', {
+     *    ... // other options
+     *    showLiveboardVerifiedBadge: true,
+     * })
+     * ```
+     */
+    showLiveboardVerifiedBadge?: boolean;
+    /**
+     * This flag is used to show/hide re-verify banner in liveboard compact header
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#embed-container', {
+     *    ... // other options
+     *    showLiveboardReverifyBanner: true,
+     * })
+     * ```
+     */
+    showLiveboardReverifyBanner?: boolean;
 }
 
 /**
@@ -454,6 +496,9 @@ export class AppEmbed extends V1Embed {
             /* eslint-disable-next-line max-len */
             dataPanelCustomGroupsAccordionInitialState = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL,
             collapseSearchBar = true,
+            isLiveboardHeaderV2Enabled = true,
+            showLiveboardVerifiedBadge = true,
+            showLiveboardReverifyBanner = true,
             homePageSearchBarMode,
         } = this.viewConfig;
 
@@ -468,6 +513,9 @@ export class AppEmbed extends V1Embed {
         params[Param.ShowLiveboardDescription] = !!showLiveboardDescription;
         params[Param.LiveboardHeaderSticky] = isLiveboardHeaderSticky;
         params[Param.IsFullAppEmbed] = true;
+        params[Param.LiveboardHeaderV2] = isLiveboardHeaderV2Enabled;
+        params[Param.ShowLiveboardVerifiedBadge] = showLiveboardVerifiedBadge;
+        params[Param.ShowLiveboardReverifyBanner] = showLiveboardReverifyBanner;
 
         params = this.getBaseQueryParams(params);
 

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -406,21 +406,21 @@ export interface AppViewConfig extends Omit<ViewConfig, 'visibleTabs'> {
      * This flag is used to enable the compact header in liveboard
      * @type {boolean}
      * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.3.0.cl
+     * @version SDK: 1.35.0 | ThoughtSpot:10.3.0.cl
      * @example
      * ```js
      * const embed = new AppEmbed('#embed-container', {
      *    ... // other options
-     *    isLiveboardHeaderV2Enabled: true,
+     *    isLiveboardCompactHeaderEnabled: true,
      * })
      * ```
      */
-    isLiveboardHeaderV2Enabled?: boolean;
+    isLiveboardCompactHeaderEnabled?: boolean;
     /**
      * This flag is used to show/hide verified Icon in liveboard compact header
      * @type {boolean}
-     * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @default true
+     * @version SDK: 1.35.0 | ThoughtSpot:10.4.0.cl
      * @example
      * ```js
      * const embed = new AppEmbed('#embed-container', {
@@ -433,8 +433,8 @@ export interface AppViewConfig extends Omit<ViewConfig, 'visibleTabs'> {
     /**
      * This flag is used to show/hide re-verify banner in liveboard compact header
      * @type {boolean}
-     * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @default true
+     * @version SDK: 1.35.0 | ThoughtSpot:10.4.0.cl
      * @example
      * ```js
      * const embed = new AppEmbed('#embed-container', {
@@ -496,7 +496,7 @@ export class AppEmbed extends V1Embed {
             /* eslint-disable-next-line max-len */
             dataPanelCustomGroupsAccordionInitialState = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL,
             collapseSearchBar = true,
-            isLiveboardHeaderV2Enabled = true,
+            isLiveboardCompactHeaderEnabled = false,
             showLiveboardVerifiedBadge = true,
             showLiveboardReverifyBanner = true,
             homePageSearchBarMode,
@@ -513,7 +513,7 @@ export class AppEmbed extends V1Embed {
         params[Param.ShowLiveboardDescription] = !!showLiveboardDescription;
         params[Param.LiveboardHeaderSticky] = isLiveboardHeaderSticky;
         params[Param.IsFullAppEmbed] = true;
-        params[Param.LiveboardHeaderV2] = isLiveboardHeaderV2Enabled;
+        params[Param.LiveboardHeaderV2] = isLiveboardCompactHeaderEnabled;
         params[Param.ShowLiveboardVerifiedBadge] = showLiveboardVerifiedBadge;
         params[Param.ShowLiveboardReverifyBanner] = showLiveboardReverifyBanner;
 

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -241,6 +241,54 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
+    test('Should add isLiveboardCompactHeaderEnabled flag to the iframe src', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            isLiveboardCompactHeaderEnabled: false,
+        } as LiveboardViewConfig);
+
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&isLiveboardHeaderV2Enabled=false${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
+    test('Should add showLiveboardReverifyBanner flag to the iframe src', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            showLiveboardReverifyBanner: false,
+        } as LiveboardViewConfig);
+
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&showLiveboardReverifyBanner=false${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
+    test('Should add showLiveboardVerifiedBadge flag to the iframe src', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            showLiveboardVerifiedBadge: false,
+        } as LiveboardViewConfig);
+
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&showLiveboardVerifiedBadge=false${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
     test('should not append runtime filters in URL if excludeRuntimeFiltersfromURL is true', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -284,6 +284,48 @@ export interface LiveboardViewConfig
      * @version SDK: 1.32.0 | ThoughtSpot: 10.0.0.cl
      */
     showPreviewLoader?: boolean;
+    /**
+     * This flag is used to enable the compact header in liveboard
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.3.0.cl
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#embed-container', {
+     *    ... // other options
+     *    isLiveboardHeaderV2Enabled: true,
+     * })
+     * ```
+     */
+    isLiveboardHeaderV2Enabled?: boolean;
+    /**
+     * This flag is used to show/hide verified Icon in liveboard compact header
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#embed-container', {
+     *    ... // other options
+     *    showLiveboardVerifiedBadge: true,
+     * })
+     * ```
+     */
+    showLiveboardVerifiedBadge?: boolean;
+    /**
+     * This flag is used to show/hide re-verify banner in liveboard compact header
+     * @type {boolean}
+     * @default false
+     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#embed-container', {
+     *    ... // other options
+     *    showLiveboardReverifyBanner: true,
+     * })
+     * ```
+     */
+    showLiveboardReverifyBanner?: boolean;
 }
 
 /**
@@ -338,6 +380,9 @@ export class LiveboardEmbed extends V1Embed {
             showLiveboardDescription,
             showLiveboardTitle,
             isLiveboardHeaderSticky = true,
+            isLiveboardHeaderV2Enabled = true,
+            showLiveboardVerifiedBadge = true,
+            showLiveboardReverifyBanner = true,
             enableAskSage,
             enable2ColumnLayout,
             dataPanelV2 = true,
@@ -388,6 +433,9 @@ export class LiveboardEmbed extends V1Embed {
         }
 
         params[Param.LiveboardHeaderSticky] = isLiveboardHeaderSticky;
+        params[Param.LiveboardHeaderV2] = isLiveboardHeaderV2Enabled;
+        params[Param.ShowLiveboardVerifiedBadge] = showLiveboardVerifiedBadge;
+        params[Param.ShowLiveboardReverifyBanner] = showLiveboardReverifyBanner;
 
         params[Param.DataPanelV2Enabled] = dataPanelV2;
         const queryParams = getQueryParamString(params, true);

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -288,21 +288,21 @@ export interface LiveboardViewConfig
      * This flag is used to enable the compact header in liveboard
      * @type {boolean}
      * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.3.0.cl
+     * @version SDK: 1.35.0 | ThoughtSpot:10.3.0.cl
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#embed-container', {
      *    ... // other options
-     *    isLiveboardHeaderV2Enabled: true,
+     *    isLiveboardCompactHeaderEnabled: true,
      * })
      * ```
      */
-    isLiveboardHeaderV2Enabled?: boolean;
+    isLiveboardCompactHeaderEnabled?: boolean;
     /**
      * This flag is used to show/hide verified Icon in liveboard compact header
      * @type {boolean}
-     * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @default true
+     * @version SDK: 1.35.0 | ThoughtSpot:10.4.0.cl
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#embed-container', {
@@ -315,8 +315,8 @@ export interface LiveboardViewConfig
     /**
      * This flag is used to show/hide re-verify banner in liveboard compact header
      * @type {boolean}
-     * @default false
-     * @version SDK: 1.34.0 | ThoughtSpot:10.4.0.cl
+     * @default true
+     * @version SDK: 1.35.0 | ThoughtSpot:10.4.0.cl
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#embed-container', {
@@ -380,7 +380,7 @@ export class LiveboardEmbed extends V1Embed {
             showLiveboardDescription,
             showLiveboardTitle,
             isLiveboardHeaderSticky = true,
-            isLiveboardHeaderV2Enabled = true,
+            isLiveboardCompactHeaderEnabled = false,
             showLiveboardVerifiedBadge = true,
             showLiveboardReverifyBanner = true,
             enableAskSage,
@@ -433,7 +433,7 @@ export class LiveboardEmbed extends V1Embed {
         }
 
         params[Param.LiveboardHeaderSticky] = isLiveboardHeaderSticky;
-        params[Param.LiveboardHeaderV2] = isLiveboardHeaderV2Enabled;
+        params[Param.LiveboardHeaderV2] = isLiveboardCompactHeaderEnabled;
         params[Param.ShowLiveboardVerifiedBadge] = showLiveboardVerifiedBadge;
         params[Param.ShowLiveboardReverifyBanner] = showLiveboardReverifyBanner;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3139,6 +3139,9 @@ export enum Param {
     FocusSearchBarOnRender = 'focusSearchBarOnRender',
     DisableRedirectionLinksInNewTab = 'disableRedirectionLinksInNewTab',
     HomePageSearchBarMode = 'homePageSearchBarMode',
+    ShowLiveboardVerifiedBadge = 'showLiveboardVerifiedBadge',
+    ShowLiveboardReverifyBanner = 'showLiveboardReverifyBanner',
+    LiveboardHeaderV2 = 'isLiveboardHeaderV2Enabled',
 }
 
 /**


### PR DESCRIPTION
Added new variables to control liveboard compact header  in TSE

- `isLiveboardCompactHeaderEnabled` - to enable or disable the compact header [SCAL-220702](https://thoughtspot.atlassian.net/browse/SCAL-220702)
- `showLiveboardVerifiedBadge` - to show/hide the verfied badge [SCAL-220703](https://thoughtspot.atlassian.net/browse/SCAL-220703)
- `showLiveboardReverifyBanner` - to show/hide the request re-verification banner in compact header [SCAL-220704](https://thoughtspot.atlassian.net/browse/SCAL-220704)

[SCAL-220702]: https://thoughtspot.atlassian.net/browse/SCAL-220702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCAL-220703]: https://thoughtspot.atlassian.net/browse/SCAL-220703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCAL-220704]: https://thoughtspot.atlassian.net/browse/SCAL-220704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ