### PR TITLE
SCAL-230828 Add Accept and Content-type headers for tokenized fetch

### DIFF
--- a/src/tokenizedFetch.ts
+++ b/src/tokenizedFetch.ts
@@ -29,6 +29,8 @@ export const tokenizedFetch: typeof fetch = async (input, init): Promise<Respons
     }
 
     const req = new Request(input, init);
+    req.headers.append('Content-Type', 'application/json');
+    req.headers.append('Accept', 'application/json');
     const authToken = await getAuthenticationToken(embedConfig);
     if (authToken) {
         req.headers.append('Authorization', `Bearer ${authToken}`);


### PR DESCRIPTION
- Without these headers the results for v2 APIs are wrong