### PR TITLE
SCAL-240652 Passing forceSAMLAutoRedirect true in OIDC redirect

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -452,7 +452,8 @@ export const doOIDCAuth = async (embedConfig: EmbedConfig) => {
         );
 
     // bring back the page to the same URL
-    const ssoEndPoint = `${EndPoints.OIDC_LOGIN_TEMPLATE(encodeURIComponent(ssoRedirectUrl))}`;
+    const baseEndpoint = `${EndPoints.OIDC_LOGIN_TEMPLATE(encodeURIComponent(ssoRedirectUrl))}`;
+    const ssoEndPoint = `${baseEndpoint}${baseEndpoint.includes('?') ? '&' : '?'}forceSAMLAutoRedirect=true`;
 
     await doSSOAuth(embedConfig, ssoEndPoint);
     return loggedInStatus;


### PR DESCRIPTION
This is honored only in IAMv2 enabled clusters and sends directly to IDP.