### PR TITLE
SCAL-243177 : Remove execute search from behind flag

### DIFF
--- a/src/embed/search-bar.tsx
+++ b/src/embed/search-bar.tsx
@@ -143,10 +143,12 @@ export class SearchBarEmbed extends TsEmbed {
         if (dataSource) {
             queryParams[Param.DataSources] = `["${dataSource}"]`;
         }
-        if (searchOptions?.searchTokenString && !excludeSearchTokenStringFromURL) {
-            queryParams[Param.searchTokenString] = encodeURIComponent(
-                searchOptions.searchTokenString,
-            );
+        if (searchOptions?.searchTokenString) {
+            if (!excludeSearchTokenStringFromURL) {
+                queryParams[Param.searchTokenString] = encodeURIComponent(
+                    searchOptions.searchTokenString,
+                );
+            }
 
             if (searchOptions.executeSearch) {
                 queryParams[Param.executeSearch] = true;

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -392,11 +392,12 @@ export class SearchEmbed extends TsEmbed {
         if (dataSource) {
             queryParams[Param.DataSources] = `["${dataSource}"]`;
         }
-        if (searchOptions?.searchTokenString && !excludeSearchTokenStringFromURL) {
-            queryParams[Param.searchTokenString] = encodeURIComponent(
-                searchOptions.searchTokenString,
-            );
-
+        if (searchOptions?.searchTokenString) {
+            if (!excludeSearchTokenStringFromURL) {
+                queryParams[Param.searchTokenString] = encodeURIComponent(
+                    searchOptions.searchTokenString,
+                );
+            }
             if (searchOptions.executeSearch) {
                 queryParams[Param.executeSearch] = true;
             }


### PR DESCRIPTION
# Summary
When adding the feature flag for keeping the searchToken not in the URL 
the execute search param was also wrapped inside the same flag

## Fix : 
Move the flag outside the feature flag and keep it separate

# Tests covered as part of this  

## Manual testing done for : 
1. execute:true  without this flag -> token should be filled and execute should be done, token should be in url
![Screenshot 2025-02-17 at 5 45 27 PM](https://github.com/user-attachments/assets/b886d708-6d09-4036-8e1f-636eb0ae222a)

2.  execute:true with this flag -> token should be filled and execute should be done and token should not be url.
![Screenshot 2025-02-17 at 5 46 10 PM](https://github.com/user-attachments/assets/82fd6b13-0deb-4518-93ad-9085927fccbd)

3. execute:false  without this flag -> token should be filled and execute should not be done
![Screenshot 2025-02-17 at 5 48 21 PM](https://github.com/user-attachments/assets/f5f6af4e-6e07-44cd-8fc5-e1285efe03cf)

4.  execute:false with this flag -> token should be filled and execute not be done and token should not be url.
![Screenshot 2025-02-17 at 5 47 31 PM](https://github.com/user-attachments/assets/f241feae-c76e-43aa-b582-83c21ae922c8)

## UTs added/updated

1. with excludeSearchTokenStringFromURL, execute as false
2. with excludeSearchTokenStringFromURL with execute true
3. without excludeSearchTokenStringFromURL with execute search as false
4. without excludeSearchTokenStringFromURL with executeSearch as false