### PR TITLE
SCAL-243504 : Update dompurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "algoliasearch": "^4.10.5",
                 "classnames": "^2.3.1",
-                "dompurify": "^3.2.4",
                 "eventemitter3": "^4.0.7",
                 "gatsby-plugin-vercel": "^1.0.3",
                 "html-react-parser": "^1.4.12",
@@ -4673,13 +4672,6 @@
                 "@types/jest": "*"
             }
         },
-        "node_modules/@types/trusted-types": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@types/unist": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -7633,15 +7625,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/dompurify": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-            "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-            "license": "(MPL-2.0 OR Apache-2.0)",
-            "optionalDependencies": {
-                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/domutils": {
@@ -23812,12 +23795,6 @@
                 "@types/jest": "*"
             }
         },
-        "@types/trusted-types": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "optional": true
-        },
         "@types/unist": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -25991,14 +25968,6 @@
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "requires": {
                 "domelementtype": "^2.2.0"
-            }
-        },
-        "dompurify": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-            "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-            "requires": {
-                "@types/trusted-types": "^2.0.7"
             }
         },
         "domutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "@thoughtspot/visual-embed-sdk",
-    "version": "1.33.8",
+    "version": "1.35.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@thoughtspot/visual-embed-sdk",
-            "version": "1.33.8",
+            "version": "1.35.13",
             "license": "ThoughtSpot Development Tools End User License Agreement",
             "dependencies": {
                 "algoliasearch": "^4.10.5",
                 "classnames": "^2.3.1",
-                "dompurify": "^2.3.4",
+                "dompurify": "^3.2.4",
                 "eventemitter3": "^4.0.7",
                 "gatsby-plugin-vercel": "^1.0.3",
                 "html-react-parser": "^1.4.12",
@@ -4673,6 +4673,13 @@
                 "@types/jest": "*"
             }
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/unist": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -7629,9 +7636,13 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
-            "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+            "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/domutils": {
             "version": "2.8.0",
@@ -23801,6 +23812,12 @@
                 "@types/jest": "*"
             }
         },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "optional": true
+        },
         "@types/unist": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -25977,9 +25994,12 @@
             }
         },
         "dompurify": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
-            "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+            "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+            "requires": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "domutils": {
             "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "dependencies": {
         "algoliasearch": "^4.10.5",
         "classnames": "^2.3.1",
-        "dompurify": "^3.2.4",
         "eventemitter3": "^4.0.7",
         "gatsby-plugin-vercel": "^1.0.3",
         "html-react-parser": "^1.4.12",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "dependencies": {
         "algoliasearch": "^4.10.5",
         "classnames": "^2.3.1",
-        "dompurify": "^2.3.4",
+        "dompurify": "^3.2.4",
         "eventemitter3": "^4.0.7",
         "gatsby-plugin-vercel": "^1.0.3",
         "html-react-parser": "^1.4.12",


### PR DESCRIPTION
## SCAL-243504: Update dompurify  

### Why?  
`dompurify` v2.3.4 had a **conditional and config-dependent mXSS-style bypass** reported. While this might not have directly impacted us, it posed a potential security risk.  

Relevant links : 
https://github.com/cure53/DOMPurify/releases/tag/3.2.4
https://github.com/advisories/GHSA-vhxf-7vqr-mrjg

### Solution  
- **Removed `dompurify`** since it was **unused** and originally intended for the docs repo.  
- This ensures we don’t carry unnecessary dependencies or security risks.  

### Tests  
- Manually **checked basic embed flows** to confirm no regressions.  
- Since `dompurify` was unused, its removal has no impact on functionality.  
