### PR TITLE
SCAL-245513 : Reset session info cache on init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@thoughtspot/visual-embed-sdk",
-    "version": "1.36.1",
+    "version": "1.36.2",
     "description": "ThoughtSpot Embed SDK",
     "module": "lib/src/index.js",
     "main": "dist/tsembed.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -15,7 +15,7 @@ import {
 } from './utils/authService';
 import { isActiveService } from './utils/authService/tokenizedAuthService';
 import { logger } from './utils/logger';
-import { getSessionInfo, getPreauthInfo } from './utils/sessionInfoService';
+import { getSessionInfo, getPreauthInfo, resetCachedSessionInfo } from './utils/sessionInfoService';
 import { ERROR_MESSAGE } from './errors';
 
 // eslint-disable-next-line import/no-mutable-exports
@@ -471,6 +471,7 @@ export const logout = async (embedConfig: EmbedConfig): Promise<boolean> => {
     const { thoughtSpotHost } = embedConfig;
     await fetchLogoutService(thoughtSpotHost);
     resetCachedAuthToken();
+    resetCachedSessionInfo();
     const thoughtspotIframes = document.querySelectorAll("[data-ts-iframe='true']");
     if (thoughtspotIframes?.length) {
         thoughtspotIframes.forEach((el) => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'eventemitter3';
-import { getAuthenticationToken, resetCachedAuthToken } from './authToken';
+import { getAuthenticationToken } from './authToken';
 import { getEmbedConfig } from './embed/embedConfig';
 import { initMixpanel } from './mixpanel-service';
 import {
@@ -15,8 +15,9 @@ import {
 } from './utils/authService';
 import { isActiveService } from './utils/authService/tokenizedAuthService';
 import { logger } from './utils/logger';
-import { getSessionInfo, getPreauthInfo, resetCachedSessionInfo } from './utils/sessionInfoService';
+import { getSessionInfo, getPreauthInfo } from './utils/sessionInfoService';
 import { ERROR_MESSAGE } from './errors';
+import { resetAllServices } from './utils/resetServices';
 
 // eslint-disable-next-line import/no-mutable-exports
 export let loggedInStatus = false;
@@ -470,8 +471,7 @@ export const doOIDCAuth = async (embedConfig: EmbedConfig) => {
 export const logout = async (embedConfig: EmbedConfig): Promise<boolean> => {
     const { thoughtSpotHost } = embedConfig;
     await fetchLogoutService(thoughtSpotHost);
-    resetCachedAuthToken();
-    resetCachedSessionInfo();
+    resetAllServices();
     const thoughtspotIframes = document.querySelectorAll("[data-ts-iframe='true']");
     if (thoughtspotIframes?.length) {
         thoughtspotIframes.forEach((el) => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -17,7 +17,7 @@ import { isActiveService } from './utils/authService/tokenizedAuthService';
 import { logger } from './utils/logger';
 import { getSessionInfo, getPreauthInfo } from './utils/sessionInfoService';
 import { ERROR_MESSAGE } from './errors';
-import { resetAllServices } from './utils/resetServices';
+import { resetAllCachedServices } from './utils/resetServices';
 
 // eslint-disable-next-line import/no-mutable-exports
 export let loggedInStatus = false;
@@ -471,7 +471,7 @@ export const doOIDCAuth = async (embedConfig: EmbedConfig) => {
 export const logout = async (embedConfig: EmbedConfig): Promise<boolean> => {
     const { thoughtSpotHost } = embedConfig;
     await fetchLogoutService(thoughtSpotHost);
-    resetAllServices();
+    resetAllCachedServices();
     const thoughtspotIframes = document.querySelectorAll("[data-ts-iframe='true']");
     if (thoughtspotIframes?.length) {
         thoughtspotIframes.forEach((el) => {

--- a/src/embed/base.spec.ts
+++ b/src/embed/base.spec.ts
@@ -9,7 +9,7 @@ import * as authTokenService from '../authToken';
 import * as index from '../index';
 import * as base from './base';
 import * as embedConfigInstance from './embedConfig';
-import * as sessionInfoService from '../utils/sessionInfoService';
+import * as resetService from '../utils/resetServices';
 
 import {
     executeAfterWait,
@@ -416,19 +416,16 @@ describe('Base TS Embed', () => {
     });
 
     test('Logout method should reset caches', async () => {
-        jest.spyOn(authTokenService, 'resetCachedAuthToken');
-        jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
         jest.spyOn(tokenAuthServices, 'fetchLogoutService').mockResolvedValueOnce({});
+        jest.spyOn(resetService, 'resetAllServices');
         index.init({
             thoughtSpotHost,
             authType: index.AuthType.None,
             autoLogin: true,
         });
-        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalled();
-        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalled();
+        expect(resetService.resetAllServices).toHaveBeenCalledTimes(1);
         await index.logout();
-        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalledTimes(2);
-        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalledTimes(2);
+        expect(resetService.resetAllServices).toHaveBeenCalledTimes(2);
     });
 
     test('config sanity, no ts host', () => {
@@ -502,15 +499,11 @@ describe('Base without init', () => {
 
 describe('Init tests', () => {
     test('clear caches on init', () => {
-        jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
-        jest.spyOn(authTokenService, 'resetCachedAuthToken');
-
+        jest.spyOn(resetService, 'resetAllServices');
         base.init({
             thoughtSpotHost,
             authType: index.AuthType.None,
         });
-        expect(sessionInfoService.getCachedSessionInfo()).toBeNull();
-        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalled();
-        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalled();
+        expect(resetService.resetAllServices).toBeCalled();
     });
 });

--- a/src/embed/base.spec.ts
+++ b/src/embed/base.spec.ts
@@ -417,15 +417,15 @@ describe('Base TS Embed', () => {
 
     test('Logout method should reset caches', async () => {
         jest.spyOn(tokenAuthServices, 'fetchLogoutService').mockResolvedValueOnce({});
-        jest.spyOn(resetService, 'resetAllServices');
+        jest.spyOn(resetService, 'resetAllCachedServices');
         index.init({
             thoughtSpotHost,
             authType: index.AuthType.None,
             autoLogin: true,
         });
-        expect(resetService.resetAllServices).toHaveBeenCalledTimes(1);
+        expect(resetService.resetAllCachedServices).toHaveBeenCalledTimes(1);
         await index.logout();
-        expect(resetService.resetAllServices).toHaveBeenCalledTimes(2);
+        expect(resetService.resetAllCachedServices).toHaveBeenCalledTimes(2);
     });
 
     test('config sanity, no ts host', () => {
@@ -499,11 +499,11 @@ describe('Base without init', () => {
 
 describe('Init tests', () => {
     test('clear caches on init', () => {
-        jest.spyOn(resetService, 'resetAllServices');
+        jest.spyOn(resetService, 'resetAllCachedServices');
         base.init({
             thoughtSpotHost,
             authType: index.AuthType.None,
         });
-        expect(resetService.resetAllServices).toBeCalled();
+        expect(resetService.resetAllCachedServices).toBeCalled();
     });
 });

--- a/src/embed/base.spec.ts
+++ b/src/embed/base.spec.ts
@@ -8,6 +8,7 @@ import * as authTokenService from '../authToken';
 import * as index from '../index';
 import * as base from './base';
 import * as embedConfigInstance from './embedConfig';
+import * as sessionInfoService from '../utils/sessionInfoService';
 
 import {
     executeAfterWait,
@@ -479,5 +480,20 @@ describe('Base without init', () => {
         base.notifyLogout();
         base.notifyAuthSDKSuccess();
         expect(logger.error).toHaveBeenCalledTimes(4);
+    });
+});
+
+describe('Init tests', () => {
+    test('clear caches on init', () => {
+        jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
+        jest.spyOn(authTokenService, 'resetCachedAuthToken');
+
+        base.init({
+            thoughtSpotHost,
+            authType: index.AuthType.None,
+        });
+        expect(sessionInfoService.getCachedSessionInfo()).toBeNull();
+        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalled();
+        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalled();
     });
 });

--- a/src/embed/base.spec.ts
+++ b/src/embed/base.spec.ts
@@ -4,6 +4,7 @@ import EventEmitter from 'eventemitter3';
 import { EmbedConfig } from '../index';
 import * as auth from '../auth';
 import * as authService from '../utils/authService/authService';
+import * as tokenAuthServices from '../utils/authService/tokenizedAuthService';
 import * as authTokenService from '../authToken';
 import * as index from '../index';
 import * as base from './base';
@@ -412,6 +413,22 @@ describe('Base TS Embed', () => {
             },
         );
         expect(embedConfigInstance.getEmbedConfig().autoLogin).toBe(false);
+    });
+
+    test('Logout method should reset caches', async () => {
+        jest.spyOn(authTokenService, 'resetCachedAuthToken');
+        jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
+        jest.spyOn(tokenAuthServices, 'fetchLogoutService').mockResolvedValueOnce({});
+        index.init({
+            thoughtSpotHost,
+            authType: index.AuthType.None,
+            autoLogin: true,
+        });
+        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalled();
+        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalled();
+        await index.logout();
+        expect(authTokenService.resetCachedAuthToken).toHaveBeenCalledTimes(2);
+        expect(sessionInfoService.resetCachedSessionInfo).toHaveBeenCalledTimes(2);
     });
 
     test('config sanity, no ts host', () => {

--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -33,7 +33,7 @@ import {
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { getEmbedConfig, setEmbedConfig } from './embedConfig';
 import { getQueryParamString } from '../utils';
-import { resetAllServices } from '../utils/resetServices';
+import { resetAllCachedServices } from '../utils/resetServices';
 
 const CONFIG_DEFAULTS: Partial<EmbedConfig> = {
     loginFailedMessage: 'Not logged in',
@@ -193,7 +193,7 @@ function backwardCompat(embedConfig: EmbedConfig): EmbedConfig {
  */
 export const init = (embedConfig: EmbedConfig): AuthEventEmitter => {
     sanity(embedConfig);
-    resetAllServices();
+    resetAllCachedServices();
     embedConfig = setEmbedConfig(
         backwardCompat({
             ...CONFIG_DEFAULTS,

--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -34,6 +34,7 @@ import {
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { getEmbedConfig, setEmbedConfig } from './embedConfig';
 import { getQueryParamString } from '../utils';
+import { resetCachedSessionInfo } from '../utils/sessionInfoService';
 
 const CONFIG_DEFAULTS: Partial<EmbedConfig> = {
     loginFailedMessage: 'Not logged in',
@@ -194,6 +195,7 @@ function backwardCompat(embedConfig: EmbedConfig): EmbedConfig {
 export const init = (embedConfig: EmbedConfig): AuthEventEmitter => {
     sanity(embedConfig);
     resetCachedAuthToken();
+    resetCachedSessionInfo();
     embedConfig = setEmbedConfig(
         backwardCompat({
             ...CONFIG_DEFAULTS,

--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -9,7 +9,6 @@
  */
 import EventEmitter from 'eventemitter3';
 import { registerReportingObserver } from '../utils/reporting';
-import { resetCachedAuthToken } from '../authToken';
 import { logger, setGlobalLogLevelOverride } from '../utils/logger';
 import { tokenizedFetch } from '../tokenizedFetch';
 import { EndPoints } from '../utils/authService/authService';
@@ -34,7 +33,7 @@ import {
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { getEmbedConfig, setEmbedConfig } from './embedConfig';
 import { getQueryParamString } from '../utils';
-import { resetCachedSessionInfo } from '../utils/sessionInfoService';
+import { resetAllServices } from '../utils/resetServices';
 
 const CONFIG_DEFAULTS: Partial<EmbedConfig> = {
     loginFailedMessage: 'Not logged in',
@@ -194,8 +193,7 @@ function backwardCompat(embedConfig: EmbedConfig): EmbedConfig {
  */
 export const init = (embedConfig: EmbedConfig): AuthEventEmitter => {
     sanity(embedConfig);
-    resetCachedAuthToken();
-    resetCachedSessionInfo();
+    resetAllServices();
     embedConfig = setEmbedConfig(
         backwardCompat({
             ...CONFIG_DEFAULTS,

--- a/src/utils/resetServices.spec.ts
+++ b/src/utils/resetServices.spec.ts
@@ -1,0 +1,13 @@
+import * as authToken from '../authToken';
+import { resetAllServices } from './resetServices';
+import * as sessionInfoService from './sessionInfoService';
+
+describe('resetAllServices', () => {
+    it('should reset all services', () => {
+        const resetCachedAuthTokenSpy = jest.spyOn(authToken, 'resetCachedAuthToken');
+        const resetCachedSessionInfoSpy = jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
+        resetAllServices();
+        expect(resetCachedAuthTokenSpy).toHaveBeenCalled();
+        expect(resetCachedSessionInfoSpy).toHaveBeenCalled();
+    });
+});

--- a/src/utils/resetServices.spec.ts
+++ b/src/utils/resetServices.spec.ts
@@ -1,13 +1,15 @@
 import * as authToken from '../authToken';
-import { resetAllServices } from './resetServices';
+import { resetAllCachedServices } from './resetServices';
 import * as sessionInfoService from './sessionInfoService';
 
 describe('resetAllServices', () => {
     it('should reset all services', () => {
         const resetCachedAuthTokenSpy = jest.spyOn(authToken, 'resetCachedAuthToken');
         const resetCachedSessionInfoSpy = jest.spyOn(sessionInfoService, 'resetCachedSessionInfo');
-        resetAllServices();
+        const resetCachedPreauthInfoSpy = jest.spyOn(sessionInfoService, 'resetCachedPreauthInfo');
+        resetAllCachedServices();
         expect(resetCachedAuthTokenSpy).toHaveBeenCalled();
         expect(resetCachedSessionInfoSpy).toHaveBeenCalled();
+        expect(resetCachedPreauthInfoSpy).toHaveBeenCalled();
     });
 });

--- a/src/utils/resetServices.ts
+++ b/src/utils/resetServices.ts
@@ -1,5 +1,5 @@
 import { resetCachedAuthToken } from '../authToken';
-import { resetCachedSessionInfo } from './sessionInfoService';
+import { resetCachedPreauthInfo, resetCachedSessionInfo } from './sessionInfoService';
 
 /**
  * This function resets all the services that are cached in the SDK.
@@ -7,7 +7,8 @@ import { resetCachedSessionInfo } from './sessionInfoService';
  * when init is called again.
  * @version SDK: 1.30.2 | ThoughtSpot: *
  */
-export function resetAllServices(): void {
+export function resetAllCachedServices(): void {
     resetCachedAuthToken();
     resetCachedSessionInfo();
+    resetCachedPreauthInfo();
 }

--- a/src/utils/resetServices.ts
+++ b/src/utils/resetServices.ts
@@ -1,0 +1,13 @@
+import { resetCachedAuthToken } from '../authToken';
+import { resetCachedSessionInfo } from './sessionInfoService';
+
+/**
+ * This function resets all the services that are cached in the SDK.
+ * This is to be called when the user logs out of the application and also
+ * when init is called again.
+ * @version SDK: 1.30.2 | ThoughtSpot: *
+ */
+export function resetAllServices(): void {
+    resetCachedAuthToken();
+    resetCachedSessionInfo();
+}

--- a/src/utils/sessionInfoService.ts
+++ b/src/utils/sessionInfoService.ts
@@ -153,9 +153,23 @@ export const getSessionDetails = (sessionInfoResp: any): SessionInfo => {
  * const sessionInfo = await getSessionInfo();
  * console.log(sessionInfo);
  * ```
- * @version SDK: 1.28.3 | ThoughtSpot ts7.april.cl, 7.2.1
+ * @version SDK: 1.28.3 | ThoughtSpot: *
  * @returns {void}
  */
 export function resetCachedSessionInfo(): void {
     sessionInfo = null;
+}
+
+/**
+ * Resets the cached preauth info object and forces a new fetch on the next call.
+ * @example ```js
+ * resetCachedPreauthInfo();
+ * const preauthInfo = await getPreauthInfo();
+ * console.log(preauthInfo);
+ * ```
+ * @version SDK: 1.28.3 | ThoughtSpot: *
+ * @returns {void}
+ */
+export function resetCachedPreauthInfo(): void {
+    preauthInfo = null;
 }

--- a/src/utils/sessionInfoService.ts
+++ b/src/utils/sessionInfoService.ts
@@ -79,9 +79,10 @@ export async function getPreauthInfo(allowCache = true): Promise<PreauthInfo> {
 }
 
 /**
- * Returns the session info object and caches it for future use.
+ * Returns the cached session info object and caches it for future use.
  * Once fetched the session info object is cached and returned from the cache on
  * subsequent calls.
+ * This cache is cleared when inti is called OR resetCachedSessionInfo is called.
  * @example ```js
  * const sessionInfo = await getSessionInfo();
  * console.log(sessionInfo);


### PR DESCRIPTION
Tested scenario : 

init with user - justin.mathew-dev

init again with new user - justin.mathew

Before : 
![Screenshot 2025-03-04 at 12 53 24 PM](https://github.com/user-attachments/assets/e5325dd9-0530-4323-94c6-aad628b80f33)


After fix : 
![Screenshot 2025-03-04 at 12 56 52 PM](https://github.com/user-attachments/assets/5d455f6e-56e8-4461-9e45-8693d6093105)

