### PR TITLE
SCAL-267334 When the Navigation v3 is enabled in Launch darkly, nine …

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -610,6 +610,20 @@ describe('App embed tests', () => {
         });
     });
 
+    test('Should add navigationVersion=v2 when primaryNavbarVersion is not added to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('Should add enableAskSage flag to the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -740,6 +740,12 @@ export class AppEmbed extends V1Embed {
             params[Param.DataPanelCustomGroupsAccordionInitialState] = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL;
         }
 
+        // Set navigation to v2 by default to avoid problems like the app
+        // switcher (9-dot menu) not showing when v3 navigation is turned on
+        // at the cluster level.
+        // To use v3 navigation, we must manually set the discoveryExperience
+        // settings.
+        params[Param.NavigationVersion] = 'v2';
         if (discoveryExperience) {
             // primaryNavbarVersion v3 will enabled the new left navigation
             if (discoveryExperience.primaryNavbarVersion === PrimaryNavbarVersion.Sliding) {

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -11530,7 +11530,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 917,
+							"line": 923,
 							"character": 11
 						}
 					],
@@ -11647,7 +11647,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 786,
+							"line": 792,
 							"character": 11
 						}
 					],
@@ -11984,7 +11984,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 891,
+							"line": 897,
 							"character": 11
 						}
 					],
@@ -12348,7 +12348,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 946,
+							"line": 952,
 							"character": 17
 						}
 					],


### PR DESCRIPTION
…dot navigation should support

If we don’t set the discoveryExperience config, it should automatically use navigationVersion = v2. This is important because if v3 is turned on through LaunchDarkly and there’s no fallback, the application switcher (9-dot menu) won’t appear.

We didn’t create an enum for v2 because it’s just used internally and not shared outside.

Note: 
v2 mainly represents the global navigation (9-dot menu). From an implementation point of view, we don’t need to do anything special for v2, it’s already handled by the existing modularHomeExperience config. It simply indicates that navigation v3 is not activated.