### PR TITLE
SCAL-267334 Setting the modularHomeExperience for navigation v3

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -593,9 +593,10 @@ describe('App embed tests', () => {
         });
     });
 
-    test('Should add navigationVersion=v3 & modularHomeExperience=false when primaryNavbarVersion is Sliding to the iframe src', async () => {
+    test('Should add navigationVersion=v3 & modularHomeExperience=true when primaryNavbarVersion is Sliding to the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,
+            // Not included the homePage v2 config under discoveryExperience.
             discoveryExperience: {
                 primaryNavbarVersion: PrimaryNavbarVersion.Sliding,
             },
@@ -605,7 +606,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v3${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=true&navigationVersion=v3${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -750,6 +750,8 @@ export class AppEmbed extends V1Embed {
             // primaryNavbarVersion v3 will enabled the new left navigation
             if (discoveryExperience.primaryNavbarVersion === PrimaryNavbarVersion.Sliding) {
                 params[Param.NavigationVersion] = discoveryExperience.primaryNavbarVersion;
+                // Enable the modularHomeExperience when Sliding is enabled.
+                params[Param.ModularHomeExperienceEnabled] = true;
             }
 
             // homePage v2 will enable the modular home page

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -11530,7 +11530,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 923,
+							"line": 925,
 							"character": 11
 						}
 					],
@@ -11647,7 +11647,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 792,
+							"line": 794,
 							"character": 11
 						}
 					],
@@ -11984,7 +11984,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 897,
+							"line": 899,
 							"character": 11
 						}
 					],
@@ -12348,7 +12348,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 952,
+							"line": 954,
 							"character": 17
 						}
 					],


### PR DESCRIPTION
When Sliding navigation is enabled, the system will now enable the modularHomeExperience to display the V3 navigation without using the homePage property under the discoveryExperience.

Previously, in order to show the V3 navigation for TSE, we had to explicitly configure both the primaryNavbarVersion and the homePage values, like this:
discoveryExperience: {
    primaryNavbarVersion: PrimaryNavbarVersion.Sliding,
    homePage: HomePage.Modular,
},

With the current update, showing the V3 navigation now only requires the following configuration:
discoveryExperience: {
    primaryNavbarVersion: PrimaryNavbarVersion.Sliding,
},

The homePage configuration is no longer mandatory for enabling V3 navigation
it will now specifically be used only when configuring the modular homepage or new V3 homepage layout.

The below configuration enables the global navigation and the modular homepage,
it will set modularHomeExperience to true.
discoveryExperience: {
    homePage: HomePage.Modular,
},

A simple TSE configuration document:
https://docs.google.com/document/d/1gzx0zb6ypYBmGsZgtMto4Z2-ne6ftrSKIICc7xXLALM/edit?tab=t.0