### PR TITLE
 SCAL-249159 ensuring the token type is a string before proceeding token validation

### DIFF
--- a/src/authToken.spec.ts
+++ b/src/authToken.spec.ts
@@ -1,6 +1,7 @@
 import { getAuthenticationToken, resetCachedAuthToken, validateAuthToken } from './authToken';
 import * as authServiceInstance from './utils/authService/authService';
 import { EmbedConfig } from './types';
+import { formatTemplate } from './utils';
 import { logger } from './utils/logger';
 import { ERROR_MESSAGE } from './errors';
 
@@ -36,6 +37,10 @@ describe('AuthToken Unit tests', () => {
         const loggerSpy = jest.spyOn(logger, 'error');
 
         const authToken = (123 as unknown) as string;
+        const errorMessage = formatTemplate(ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR, {
+            invalidType: typeof authToken,
+        });
+
         await expect(
             validateAuthToken(
                 {
@@ -43,10 +48,8 @@ describe('AuthToken Unit tests', () => {
                 } as EmbedConfig,
                 authToken,
             ),
-        ).rejects.toThrow(`${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`);
-        expect(loggerSpy).toHaveBeenCalledWith(
-            `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`,
-        );
+        ).rejects.toThrow(errorMessage);
+        expect(loggerSpy).toHaveBeenCalledWith(errorMessage);
 
         loggerSpy.mockRestore();
     });
@@ -56,6 +59,10 @@ describe('AuthToken Unit tests', () => {
         const loggerSpy = jest.spyOn(logger, 'error');
 
         const authToken = ({} as unknown) as string;
+        const errorMessage = formatTemplate(ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR, {
+            invalidType: typeof authToken,
+        });
+
         await expect(
             validateAuthToken(
                 {
@@ -63,10 +70,8 @@ describe('AuthToken Unit tests', () => {
                 } as EmbedConfig,
                 authToken,
             ),
-        ).rejects.toThrow(`${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`);
-        expect(loggerSpy).toHaveBeenCalledWith(
-            `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`,
-        );
+        ).rejects.toThrow(errorMessage);
+        expect(loggerSpy).toHaveBeenCalledWith(errorMessage);
 
         loggerSpy.mockRestore();
     });

--- a/src/authToken.spec.ts
+++ b/src/authToken.spec.ts
@@ -1,6 +1,8 @@
-import { getAuthenticationToken, resetCachedAuthToken } from './authToken';
+import { getAuthenticationToken, resetCachedAuthToken, validateAuthToken } from './authToken';
 import * as authServiceInstance from './utils/authService/authService';
 import { EmbedConfig } from './types';
+import { logger } from './utils/logger';
+import { ERROR_MESSAGE } from './errors';
 
 describe('AuthToken Unit tests', () => {
     test('getAuthenticationToken: When verification is disabled', async () => {
@@ -27,5 +29,45 @@ describe('AuthToken Unit tests', () => {
 
         expect(token).toBe('abc2');
         expect(authServiceInstance.verifyTokenService).toBeCalledWith('test', 'abc2');
+    });
+
+    test('validateAuthToken : When token is invalid by type number', async () => {
+        jest.spyOn(logger, 'error').mockImplementation(() => {});
+        const loggerSpy = jest.spyOn(logger, 'error');
+
+        const authToken = (123 as unknown) as string;
+        await expect(
+            validateAuthToken(
+                {
+                    thoughtSpotHost: 'test',
+                } as EmbedConfig,
+                authToken,
+            ),
+        ).rejects.toThrow(`${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`);
+        expect(loggerSpy).toHaveBeenCalledWith(
+            `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`,
+        );
+
+        loggerSpy.mockRestore();
+    });
+
+    test('validateAuthToken : When token is invalid by type object', async () => {
+        jest.spyOn(logger, 'error').mockImplementation(() => {});
+        const loggerSpy = jest.spyOn(logger, 'error');
+
+        const authToken = ({} as unknown) as string;
+        await expect(
+            validateAuthToken(
+                {
+                    thoughtSpotHost: 'test',
+                } as EmbedConfig,
+                authToken,
+            ),
+        ).rejects.toThrow(`${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`);
+        expect(loggerSpy).toHaveBeenCalledWith(
+            `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`,
+        );
+
+        loggerSpy.mockRestore();
     });
 });

--- a/src/authToken.ts
+++ b/src/authToken.ts
@@ -1,6 +1,6 @@
 import { ERROR_MESSAGE } from './errors';
 import { EmbedConfig } from './types';
-import { getValueFromWindow, storeValueInWindow } from './utils';
+import { getValueFromWindow, storeValueInWindow, formatTemplate } from './utils';
 import { fetchAuthTokenService, verifyTokenService } from './utils/authService/authService';
 import { logger } from './utils/logger';
 
@@ -59,10 +59,12 @@ export const validateAuthToken = async (
     suppressAlert?: boolean,
 ): Promise<boolean> => {
     const cachedAuthToken = getCacheAuthToken();
-    // even if token verification is disabled, we will still validate 
+    // even if token verification is disabled, we will still validate
     // that the token is a string before proceeding.
     if (typeof authToken !== 'string') {
-        const errorMessage = `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`;
+        const errorMessage = formatTemplate(ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR, {
+            invalidType: typeof authToken,
+        });
         logger.error(errorMessage);
         throw new Error(errorMessage);
     }

--- a/src/authToken.ts
+++ b/src/authToken.ts
@@ -59,6 +59,14 @@ const validateAuthToken = async (
     suppressAlert?: boolean,
 ): Promise<boolean> => {
     const cachedAuthToken = getCacheAuthToken();
+    // even if token verification is disabled, we will still validate 
+    // that the token is a string before proceeding.
+    if (typeof authToken !== 'string') {
+        const errorMessage = `${ERROR_MESSAGE.INVALID_TOKEN_TYPE_ERROR} ${typeof authToken}.`;
+        logger.error(errorMessage);
+        throw new Error(errorMessage);
+    }
+
     if (embedConfig.disableTokenVerification) {
         logger.info('Token verification is disabled. Assuming token is valid.');
         return true;

--- a/src/authToken.ts
+++ b/src/authToken.ts
@@ -53,7 +53,7 @@ export async function getAuthenticationToken(embedConfig: EmbedConfig): Promise<
     return authToken;
 }
 
-const validateAuthToken = async (
+export const validateAuthToken = async (
     embedConfig: EmbedConfig,
     authToken: string,
     suppressAlert?: boolean,

--- a/src/authToken.ts
+++ b/src/authToken.ts
@@ -58,7 +58,6 @@ export const validateAuthToken = async (
     authToken: string,
     suppressAlert?: boolean,
 ): Promise<boolean> => {
-    const cachedAuthToken = getCacheAuthToken();
     // even if token verification is disabled, we will still validate
     // that the token is a string before proceeding.
     if (typeof authToken !== 'string') {
@@ -68,6 +67,8 @@ export const validateAuthToken = async (
         logger.error(errorMessage);
         throw new Error(errorMessage);
     }
+
+    const cachedAuthToken = getCacheAuthToken();
 
     if (embedConfig.disableTokenVerification) {
         logger.info('Token verification is disabled. Assuming token is valid.');

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,7 @@ export const ERROR_MESSAGE = {
     SDK_NOT_INITIALIZED: 'SDK not initialized',
     SESSION_INFO_FAILED: 'Failed to get session information',
     INVALID_TOKEN_ERROR: 'Received invalid token from getAuthToken callback or authToken endpoint.',
+    INVALID_TOKEN_TYPE_ERROR: 'Expected getAuthToken to return a string, but received a ',
     MIXPANEL_TOKEN_NOT_FOUND: 'Mixpanel token not found in session info',
     PRERENDER_ID_MISSING: 'PreRender ID is required for preRender',
     SYNC_STYLE_CALLED_BEFORE_RENDER: 'PreRender should be called before using syncPreRenderStyle',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,7 +10,7 @@ export const ERROR_MESSAGE = {
     SDK_NOT_INITIALIZED: 'SDK not initialized',
     SESSION_INFO_FAILED: 'Failed to get session information',
     INVALID_TOKEN_ERROR: 'Received invalid token from getAuthToken callback or authToken endpoint.',
-    INVALID_TOKEN_TYPE_ERROR: 'Expected getAuthToken to return a string, but received a ',
+    INVALID_TOKEN_TYPE_ERROR: 'Expected getAuthToken to return a string, but received a',
     MIXPANEL_TOKEN_NOT_FOUND: 'Mixpanel token not found in session info',
     PRERENDER_ID_MISSING: 'PreRender ID is required for preRender',
     SYNC_STYLE_CALLED_BEFORE_RENDER: 'PreRender should be called before using syncPreRenderStyle',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,7 +10,7 @@ export const ERROR_MESSAGE = {
     SDK_NOT_INITIALIZED: 'SDK not initialized',
     SESSION_INFO_FAILED: 'Failed to get session information',
     INVALID_TOKEN_ERROR: 'Received invalid token from getAuthToken callback or authToken endpoint.',
-    INVALID_TOKEN_TYPE_ERROR: 'Expected getAuthToken to return a string, but received a',
+    INVALID_TOKEN_TYPE_ERROR: 'Expected getAuthToken to return a string, but received a {invalidType}.',
     MIXPANEL_TOKEN_NOT_FOUND: 'Mixpanel token not found in session info',
     PRERENDER_ID_MISSING: 'PreRender ID is required for preRender',
     SYNC_STYLE_CALLED_BEFORE_RENDER: 'PreRender should be called before using syncPreRenderStyle',

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -18,6 +18,7 @@ import {
     getTypeFromValue,
     arrayIncludesString,
     calculateVisibleElementData,
+    formatTemplate,
 } from './utils';
 import { RuntimeFilterOp } from './types';
 import { logger } from './utils/logger';
@@ -716,5 +717,22 @@ describe('calculateVisibleElementData', () => {
             left: 0, // Not clipped from left
             width: 1200, // Full viewport width
         });
+    });
+});
+
+describe('formatTemplate', () => {
+    it('should replace placeholders with provided values', () => {
+        expect(
+            formatTemplate('Hello {name}, you are {age} years old', { name: 'John', age: 30 }),
+        ).toBe('Hello John, you are 30 years old');
+        expect(
+            formatTemplate('Expected {type}, but received {actual}', {
+                type: 'string',
+                actual: 'number',
+            }),
+        ).toBe('Expected string, but received number');
+        expect(
+            formatTemplate('Hello {name}, you are {age} years old', { name: 'John' }),
+        ).toBe('Hello John, you are {age} years old');
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -499,3 +499,24 @@ export const calculateVisibleElementData = (element: HTMLElement) => {
 
     return data;
 }
+
+/**
+ * Replaces placeholders in a template string with provided values.
+ * Placeholders should be in the format {key}.
+ * @param template - The template string with placeholders
+ * @param values - An object containing key-value pairs to replace placeholders
+ * @returns The template string with placeholders replaced
+ * @example
+ * formatTemplate('Hello {name}, you are {age} years old', { name: 'John', age: 30 })
+ * // Returns: 'Hello John, you are 30 years old'
+ *
+ * formatTemplate('Expected {type}, but received {actual}', { type: 'string', actual: 'number' })
+ * // Returns: 'Expected string, but received number'
+ */
+export const formatTemplate = (template: string, values: Record<string, any>): string => {
+    // This regex /\{(\w+)\}/g finds all placeholders in the format {word} 
+    // and captures the word inside the braces for replacement.
+    return template.replace(/\{(\w+)\}/g, (match, key) => {
+        return values[key] !== undefined ? String(values[key]) : match;
+    });
+};


### PR DESCRIPTION
- Ensuring the token type is a string before proceeding token validation
- Added unit tests for token type validation