### PR TITLE
SCAL-284011 Added embed flag to control visibility of maskedfilterchip

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -542,6 +542,53 @@ describe('App embed tests', () => {
         });
     });
 
+    test('Should add showMaskedFilterChip true to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showPrimaryNavbar: false,
+            showMaskedFilterChip: true,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&showMaskedFilterChip=true${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
+    test('Should add showMaskedFilterChip false to the iframe src', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showPrimaryNavbar: false,
+            showMaskedFilterChip: false,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&showMaskedFilterChip=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
+    test('Should add default showMaskedFilterChip false when not specified', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showPrimaryNavbar: false,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&showMaskedFilterChip=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('Should add enableSearchAssist flagto the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -672,6 +672,7 @@ export class AppEmbed extends V1Embed {
             hideLiveboardHeader = false,
             showLiveboardTitle = true,
             showLiveboardDescription = true,
+            showMaskedFilterChip = false,
             hideHomepageLeftNav = false,
             modularHomeExperience = false,
             isLiveboardHeaderSticky = true,
@@ -707,6 +708,7 @@ export class AppEmbed extends V1Embed {
         params[Param.HideLiveboardHeader] = hideLiveboardHeader;
         params[Param.ShowLiveboardTitle] = showLiveboardTitle;
         params[Param.ShowLiveboardDescription] = !!showLiveboardDescription;
+        params[Param.ShowMaskedFilterChip] = showMaskedFilterChip;
         params[Param.LiveboardHeaderSticky] = isLiveboardHeaderSticky;
         params[Param.IsFullAppEmbed] = true;
         params[Param.LiveboardHeaderV2] = isLiveboardCompactHeaderEnabled;

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -407,6 +407,38 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
+    test('Should add showMaskedFilterChip flag set to true to the iframe src', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            showMaskedFilterChip: true,
+        } as LiveboardViewConfig);
+
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&showMaskedFilterChip=true${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
+    test('Should add showMaskedFilterChip flag set to false to the iframe src', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            showMaskedFilterChip: false,
+        } as LiveboardViewConfig);
+
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&showMaskedFilterChip=false${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
     test('Should add hideIrrelevantFiltersAtTabLevel flag to the iframe src', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -480,6 +480,7 @@ export class LiveboardEmbed extends V1Embed {
             showLiveboardVerifiedBadge = true,
             showLiveboardReverifyBanner = true,
             hideIrrelevantChipsInLiveboardTabs = false,
+            showMaskedFilterChip = false,
             isEnhancedFilterInteractivityEnabled = false,
             enableAskSage,
             enable2ColumnLayout,
@@ -589,6 +590,7 @@ export class LiveboardEmbed extends V1Embed {
         params[Param.ShowLiveboardVerifiedBadge] = showLiveboardVerifiedBadge;
         params[Param.ShowLiveboardReverifyBanner] = showLiveboardReverifyBanner;
         params[Param.HideIrrelevantFiltersInTab] = hideIrrelevantChipsInLiveboardTabs;
+        params[Param.ShowMaskedFilterChip] = showMaskedFilterChip;
         params[Param.IsEnhancedFilterInteractivityEnabled] = isEnhancedFilterInteractivityEnabled;
         params[Param.DataPanelV2Enabled] = dataPanelV2;
         params[Param.EnableCustomColumnGroups] = enableCustomColumnGroups;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1575,6 +1575,22 @@ export interface LiveboardAppEmbedViewConfig {
      * ```
      */
     isEnhancedFilterInteractivityEnabled?: boolean;
+    /**
+     * Show or hide masked filter chips
+     *
+     * Supported embed types: `AppEmbed`, `LiveboardEmbed`
+     * @version SDK: 1.43.0 | Thoughtspot: 26.2.0.cl
+     * @default false
+     * @example
+     * ```js
+     * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
+     * const embed = new <EmbedComponent>('#tsEmbed', {
+     *    ... // other embed view config
+     *    showMaskedFilterChip: true,
+     * })
+     * ```
+     */
+    showMaskedFilterChip?: boolean;
 }
 
 export interface AllEmbedViewConfig
@@ -4534,6 +4550,7 @@ export enum Param {
     HideLiveboardHeader = 'hideLiveboardHeader',
     ShowLiveboardDescription = 'showLiveboardDescription',
     ShowLiveboardTitle = 'showLiveboardTitle',
+    ShowMaskedFilterChip = 'showMaskedFilterChip',
     HiddenTabs = 'hideTabs',
     VisibleTabs = 'visibleTabs',
     HideTabPanel = 'hideTabPanel',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1579,7 +1579,7 @@ export interface LiveboardAppEmbedViewConfig {
      * Show or hide masked filter chips
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
-     * @version SDK: 1.43.0 | Thoughtspot: 26.2.0.cl
+     * @version SDK: 1.45.0 | Thoughtspot: 26.2.0.cl
      * @default false
      * @example
      * ```js

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2170,
+			"id": 2167,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2283,
+					"id": 2280,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -48,14 +48,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5659,
+							"line": 5676,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2190,
+					"id": 2187,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -76,14 +76,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4805,
+							"line": 4822,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2183,
+					"id": 2180,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -104,14 +104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4734,
+							"line": 4751,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2182,
+					"id": 2179,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -128,14 +128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4723,
+							"line": 4740,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2188,
+					"id": 2185,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -152,14 +152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4786,
+							"line": 4803,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2189,
+					"id": 2186,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -176,14 +176,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4795,
+							"line": 4812,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2191,
+					"id": 2188,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -204,14 +204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4815,
+							"line": 4832,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2265,
+					"id": 2262,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -232,14 +232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5453,
+							"line": 5470,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2238,
+					"id": 2235,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -260,14 +260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5175,
+							"line": 5192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2280,
+					"id": 2277,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -288,14 +288,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5626,
+							"line": 5643,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2237,
+					"id": 2234,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -316,14 +316,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5163,
+							"line": 5180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2236,
+					"id": 2233,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -344,14 +344,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5151,
+							"line": 5168,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2279,
+					"id": 2276,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5615,
+							"line": 5632,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2249,
+					"id": 2246,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -401,14 +401,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5288,
+							"line": 5305,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2252,
+					"id": 2249,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -429,14 +429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5322,
+							"line": 5339,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2257,
+					"id": 2254,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -457,14 +457,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5377,
+							"line": 5394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2251,
+					"id": 2248,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -485,14 +485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5311,
+							"line": 5328,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2254,
+					"id": 2251,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -513,14 +513,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5345,
+							"line": 5362,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2258,
+					"id": 2255,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -541,14 +541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5387,
+							"line": 5404,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2255,
+					"id": 2252,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -569,14 +569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5356,
+							"line": 5373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2260,
+					"id": 2257,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -597,14 +597,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5409,
+							"line": 5426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2256,
+					"id": 2253,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -625,14 +625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5366,
+							"line": 5383,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2253,
+					"id": 2250,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -653,14 +653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5333,
+							"line": 5350,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2259,
+					"id": 2256,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -681,14 +681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5397,
+							"line": 5414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2250,
+					"id": 2247,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -709,14 +709,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5299,
+							"line": 5316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2292,
+					"id": 2289,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -737,14 +737,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5757,
+							"line": 5774,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2187,
+					"id": 2184,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -761,14 +761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4777,
+							"line": 4794,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2186,
+					"id": 2183,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -789,14 +789,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4768,
+							"line": 4785,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2185,
+					"id": 2182,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -817,14 +817,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4756,
+							"line": 4773,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2299,
+					"id": 2296,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -845,14 +845,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5833,
+							"line": 5850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2184,
+					"id": 2181,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -869,14 +869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4745,
+							"line": 4762,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2229,
+					"id": 2226,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -884,14 +884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5102,
+							"line": 5119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2177,
+					"id": 2174,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -908,14 +908,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4682,
+							"line": 4699,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2228,
+					"id": 2225,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -932,14 +932,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5101,
+							"line": 5118,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2300,
+					"id": 2297,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -960,14 +960,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5843,
+							"line": 5860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2277,
+					"id": 2307,
+					"name": "CreateGroup",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Create Group** menu action on a Liveboard.\nAllows creating a new group.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.CreateGroup]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.44.0 | ThoughtSpot Cloud: 26.2.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 5972,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"createGroup\""
+				},
+				{
+					"id": 2274,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -988,14 +1016,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5590,
+							"line": 5607,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2240,
+					"id": 2237,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1016,14 +1044,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5195,
+							"line": 5212,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2245,
+					"id": 2242,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1044,14 +1072,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5246,
+							"line": 5263,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2297,
+					"id": 2294,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1072,14 +1100,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5814,
+							"line": 5831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2289,
+					"id": 2286,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1100,14 +1128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5726,
+							"line": 5743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2291,
+					"id": 2288,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1128,14 +1156,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5745,
+							"line": 5762,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2199,
+					"id": 2196,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1152,14 +1180,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4865,
+							"line": 4882,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2202,
+					"id": 2199,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1176,14 +1204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4898,
+							"line": 4915,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2201,
+					"id": 2198,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1201,14 +1229,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4888,
+							"line": 4905,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2200,
+					"id": 2197,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1225,14 +1253,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4875,
+							"line": 4892,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2203,
+					"id": 2200,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1249,14 +1277,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4908,
+							"line": 4925,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2233,
+					"id": 2230,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1273,14 +1301,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5118,
+							"line": 5135,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2227,
+					"id": 2224,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1297,14 +1325,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5091,
+							"line": 5108,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2226,
+					"id": 2223,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1321,14 +1349,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5082,
+							"line": 5099,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2211,
+					"id": 2208,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1345,14 +1373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4984,
+							"line": 5001,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2176,
+					"id": 2173,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1369,14 +1397,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4673,
+							"line": 4690,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2239,
+					"id": 2236,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1397,14 +1425,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5184,
+							"line": 5201,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2231,
+					"id": 2228,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1412,14 +1440,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5107,
+							"line": 5124,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2296,
+					"id": 2293,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1440,14 +1468,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5803,
+							"line": 5820,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2269,
+					"id": 2266,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1468,14 +1496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5497,
+							"line": 5514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2284,
+					"id": 2281,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1496,14 +1524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5672,
+							"line": 5689,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2208,
+					"id": 2205,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1520,14 +1548,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4952,
+							"line": 4969,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2212,
+					"id": 2209,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1544,14 +1572,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4992,
+							"line": 5009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2298,
+					"id": 2295,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1572,14 +1600,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5824,
+							"line": 5841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2266,
+					"id": 2263,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1600,14 +1628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5463,
+							"line": 5480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2267,
+					"id": 2264,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1628,14 +1656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5474,
+							"line": 5491,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2225,
+					"id": 2222,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1652,14 +1680,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5071,
+							"line": 5088,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2205,
+					"id": 2202,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1677,14 +1705,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4924,
+							"line": 4941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2206,
+					"id": 2203,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1701,14 +1729,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4934,
+							"line": 4951,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2301,
+					"id": 2298,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1729,14 +1757,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5859,
+							"line": 5876,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2290,
+					"id": 2287,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1757,14 +1785,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5736,
+							"line": 5753,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2219,
+					"id": 2216,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1781,14 +1809,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5033,
+							"line": 5050,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2307,
+					"id": 2304,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1809,14 +1837,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5925,
+							"line": 5942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2275,
+					"id": 2272,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1837,14 +1865,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5558,
+							"line": 5575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2175,
+					"id": 2172,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1861,14 +1889,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4664,
+							"line": 4681,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2273,
+					"id": 2270,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1885,14 +1913,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5538,
+							"line": 5555,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2244,
+					"id": 2241,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1913,14 +1941,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5236,
+							"line": 5253,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2288,
+					"id": 2285,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1941,14 +1969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5715,
+							"line": 5732,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2264,
+					"id": 2261,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1969,14 +1997,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5443,
+							"line": 5460,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2271,
+					"id": 2268,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1996,14 +2024,70 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5518,
+							"line": 5535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2272,
+					"id": 2306,
+					"name": "MoveOutOfGroup",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Move out of Group** menu action on a Liveboard.\nAllows moving a visualization out of a group.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.MoveOutOfGroup]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.44.0 | ThoughtSpot Cloud: 26.2.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 5962,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"moveOutOfGroup\""
+				},
+				{
+					"id": 2305,
+					"name": "MoveToGroup",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Move to Group** menu action on a Liveboard.\nAllows moving a visualization to a different group.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.MoveToGroup]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.44.0 | ThoughtSpot Cloud: 26.2.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 5952,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"moveToGroup\""
+				},
+				{
+					"id": 2269,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2020,14 +2104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5527,
+							"line": 5544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2282,
+					"id": 2279,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2048,14 +2132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5648,
+							"line": 5665,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2285,
+					"id": 2282,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2076,14 +2160,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5683,
+							"line": 5700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2274,
+					"id": 2271,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2104,14 +2188,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5548,
+							"line": 5565,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2222,
+					"id": 2219,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2128,14 +2212,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5050,
+							"line": 5067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2305,
+					"id": 2302,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2152,14 +2236,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5903,
+							"line": 5920,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2209,
+					"id": 2206,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2176,14 +2260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4962,
+							"line": 4979,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2293,
+					"id": 2290,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2204,14 +2288,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5769,
+							"line": 5786,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2235,
+					"id": 2232,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2229,14 +2313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5141,
+							"line": 5158,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2213,
+					"id": 2210,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2253,14 +2337,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5002,
+							"line": 5019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2306,
+					"id": 2303,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2281,14 +2365,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5915,
+							"line": 5932,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2248,
+					"id": 2245,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2309,14 +2393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5277,
+							"line": 5294,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2281,
+					"id": 2278,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2337,14 +2421,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5637,
+							"line": 5654,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2262,
+					"id": 2259,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2365,14 +2449,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5423,
+							"line": 5440,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2241,
+					"id": 2238,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2396,14 +2480,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5205,
+							"line": 5222,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2234,
+					"id": 2231,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2420,14 +2504,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5127,
+							"line": 5144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2263,
+					"id": 2260,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2448,14 +2532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5433,
+							"line": 5450,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2294,
+					"id": 2291,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2476,14 +2560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5781,
+							"line": 5798,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2270,
+					"id": 2267,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2504,14 +2588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5509,
+							"line": 5526,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2171,
+					"id": 2168,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2528,14 +2612,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4633,
+							"line": 4650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2174,
+					"id": 2171,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2552,14 +2636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4651,
+							"line": 4668,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2179,
+					"id": 2176,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2576,14 +2660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4696,
+							"line": 4713,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2180,
+					"id": 2177,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2600,14 +2684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4705,
+							"line": 4722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2232,
+					"id": 2229,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2615,14 +2699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5108,
+							"line": 5125,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2181,
+					"id": 2178,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2639,14 +2723,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4714,
+							"line": 4731,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2196,
+					"id": 2193,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2657,14 +2741,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4840,
+							"line": 4857,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2268,
+					"id": 2265,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2685,14 +2769,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5484,
+							"line": 5501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2198,
+					"id": 2195,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2709,14 +2793,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4855,
+							"line": 4872,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2193,
+					"id": 2190,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2733,14 +2817,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4828,
+							"line": 4845,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2295,
+					"id": 2292,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2761,14 +2845,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5792,
+							"line": 5809,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2304,
+					"id": 2301,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2789,14 +2873,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5892,
+							"line": 5909,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2302,
+					"id": 2299,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2817,14 +2901,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5870,
+							"line": 5887,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2303,
+					"id": 2300,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2845,14 +2929,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5881,
+							"line": 5898,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2224,
+					"id": 2221,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2869,14 +2953,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5063,
+							"line": 5080,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2243,
+					"id": 2240,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2897,14 +2981,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5226,
+							"line": 5243,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2242,
+					"id": 2239,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2925,14 +3009,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5215,
+							"line": 5232,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2246,
+					"id": 2243,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2953,14 +3037,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5256,
+							"line": 5273,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2247,
+					"id": 2244,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2981,14 +3065,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5266,
+							"line": 5283,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2276,
+					"id": 2273,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3013,14 +3097,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5577,
+							"line": 5594,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2210,
+					"id": 2207,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3037,14 +3121,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4974,
+							"line": 4991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2287,
+					"id": 2308,
+					"name": "UngroupLiveboardGroup",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Ungroup Liveboard Group** menu action on a Liveboard.\nAllows ungrouping a liveboard group.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.UngroupLiveboardGroup]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.44.0 | ThoughtSpot Cloud: 26.2.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 5982,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"ungroupLiveboardGroup\""
+				},
+				{
+					"id": 2284,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3065,14 +3177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5705,
+							"line": 5722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2207,
+					"id": 2204,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3089,14 +3201,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4943,
+							"line": 4960,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2278,
+					"id": 2275,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3117,14 +3229,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5601,
+							"line": 5618,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2286,
+					"id": 2283,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3145,7 +3257,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5694,
+							"line": 5711,
 							"character": 4
 						}
 					],
@@ -3157,138 +3269,142 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2283,
-						2190,
-						2183,
-						2182,
-						2188,
-						2189,
-						2191,
-						2265,
-						2238,
 						2280,
-						2237,
-						2236,
-						2279,
+						2187,
+						2180,
+						2179,
+						2185,
+						2186,
+						2188,
+						2262,
+						2235,
+						2277,
+						2234,
+						2233,
+						2276,
+						2246,
 						2249,
+						2254,
+						2248,
+						2251,
+						2255,
 						2252,
 						2257,
-						2251,
-						2254,
-						2258,
-						2255,
-						2260,
-						2256,
 						2253,
-						2259,
 						2250,
-						2292,
-						2187,
-						2186,
-						2185,
-						2299,
-						2184,
-						2229,
-						2177,
-						2228,
-						2300,
-						2277,
-						2240,
-						2245,
-						2297,
-						2289,
-						2291,
-						2199,
-						2202,
-						2201,
-						2200,
-						2203,
-						2233,
-						2227,
-						2226,
-						2211,
-						2176,
-						2239,
-						2231,
-						2296,
-						2269,
-						2284,
-						2208,
-						2212,
-						2298,
-						2266,
-						2267,
-						2225,
-						2205,
-						2206,
-						2301,
-						2290,
-						2219,
-						2307,
-						2275,
-						2175,
-						2273,
-						2244,
-						2288,
-						2264,
-						2271,
-						2272,
-						2282,
-						2285,
-						2274,
-						2222,
-						2305,
-						2209,
-						2293,
-						2235,
-						2213,
-						2306,
-						2248,
-						2281,
-						2262,
-						2241,
-						2234,
-						2263,
-						2294,
-						2270,
-						2171,
-						2174,
-						2179,
-						2180,
-						2232,
-						2181,
-						2196,
-						2268,
-						2198,
-						2193,
-						2295,
-						2304,
-						2302,
-						2303,
-						2224,
-						2243,
-						2242,
-						2246,
+						2256,
 						2247,
-						2276,
-						2210,
+						2289,
+						2184,
+						2183,
+						2182,
+						2296,
+						2181,
+						2226,
+						2174,
+						2225,
+						2297,
+						2307,
+						2274,
+						2237,
+						2242,
+						2294,
+						2286,
+						2288,
+						2196,
+						2199,
+						2198,
+						2197,
+						2200,
+						2230,
+						2224,
+						2223,
+						2208,
+						2173,
+						2236,
+						2228,
+						2293,
+						2266,
+						2281,
+						2205,
+						2209,
+						2295,
+						2263,
+						2264,
+						2222,
+						2202,
+						2203,
+						2298,
 						2287,
-						2207,
+						2216,
+						2304,
+						2272,
+						2172,
+						2270,
+						2241,
+						2285,
+						2261,
+						2268,
+						2306,
+						2305,
+						2269,
+						2279,
+						2282,
+						2271,
+						2219,
+						2302,
+						2206,
+						2290,
+						2232,
+						2210,
+						2303,
+						2245,
 						2278,
-						2286
+						2259,
+						2238,
+						2231,
+						2260,
+						2291,
+						2267,
+						2168,
+						2171,
+						2176,
+						2177,
+						2229,
+						2178,
+						2193,
+						2265,
+						2195,
+						2190,
+						2292,
+						2301,
+						2299,
+						2300,
+						2221,
+						2240,
+						2239,
+						2243,
+						2244,
+						2273,
+						2207,
+						2308,
+						2284,
+						2204,
+						2275,
+						2283
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4624,
+					"line": 4641,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1817,
+			"id": 1814,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3304,7 +3420,7 @@
 			},
 			"children": [
 				{
-					"id": 1818,
+					"id": 1815,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3327,7 +3443,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1818
+						1815
 					]
 				}
 			],
@@ -3340,7 +3456,7 @@
 			]
 		},
 		{
-			"id": 1802,
+			"id": 1799,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3356,7 +3472,7 @@
 			},
 			"children": [
 				{
-					"id": 1805,
+					"id": 1802,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3371,7 +3487,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1807,
+					"id": 1804,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3386,7 +3502,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1804,
+					"id": 1801,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3401,7 +3517,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1806,
+					"id": 1803,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3416,7 +3532,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1803,
+					"id": 1800,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3431,7 +3547,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1808,
+					"id": 1805,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3451,12 +3567,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1805,
-						1807,
+						1802,
 						1804,
-						1806,
+						1801,
 						1803,
-						1808
+						1800,
+						1805
 					]
 				}
 			],
@@ -3469,7 +3585,7 @@
 			]
 		},
 		{
-			"id": 1809,
+			"id": 1806,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3485,7 +3601,7 @@
 			},
 			"children": [
 				{
-					"id": 1810,
+					"id": 1807,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3503,7 +3619,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1814,
+					"id": 1811,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3521,7 +3637,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1816,
+					"id": 1813,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3539,7 +3655,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1811,
+					"id": 1808,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3557,7 +3673,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1813,
+					"id": 1810,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3575,7 +3691,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1815,
+					"id": 1812,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3604,12 +3720,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1810,
-						1814,
-						1816,
+						1807,
 						1811,
 						1813,
-						1815
+						1808,
+						1810,
+						1812
 					]
 				}
 			],
@@ -3622,7 +3738,7 @@
 			]
 		},
 		{
-			"id": 1964,
+			"id": 1961,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3638,7 +3754,7 @@
 			},
 			"children": [
 				{
-					"id": 1975,
+					"id": 1972,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3657,7 +3773,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1966,
+					"id": 1963,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3686,7 +3802,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1965,
+					"id": 1962,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3710,7 +3826,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1971,
+					"id": 1968,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3728,7 +3844,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1969,
+					"id": 1966,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3761,7 +3877,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1973,
+					"id": 1970,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3785,7 +3901,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1974,
+					"id": 1971,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3818,13 +3934,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1975,
+						1972,
+						1963,
+						1962,
+						1968,
 						1966,
-						1965,
-						1971,
-						1969,
-						1973,
-						1974
+						1970,
+						1971
 					]
 				}
 			],
@@ -3837,7 +3953,7 @@
 			]
 		},
 		{
-			"id": 2308,
+			"id": 2309,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3847,7 +3963,7 @@
 			},
 			"children": [
 				{
-					"id": 2311,
+					"id": 2312,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3855,14 +3971,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5946,
+							"line": 6002,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2309,
+					"id": 2310,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3870,14 +3986,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5944,
+							"line": 6000,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2310,
+					"id": 2311,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3885,7 +4001,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5945,
+							"line": 6001,
 							"character": 4
 						}
 					],
@@ -3897,22 +4013,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2311,
-						2309,
-						2310
+						2312,
+						2310,
+						2311
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5943,
+					"line": 5999,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2994,
+			"id": 2997,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3922,7 +4038,7 @@
 			},
 			"children": [
 				{
-					"id": 2997,
+					"id": 3000,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3930,14 +4046,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6031,
+							"line": 6087,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 2995,
+					"id": 2998,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3945,14 +4061,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6029,
+							"line": 6085,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 2998,
+					"id": 3001,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3960,14 +4076,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6032,
+							"line": 6088,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 2996,
+					"id": 2999,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3975,7 +4091,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6030,
+							"line": 6086,
 							"character": 4
 						}
 					],
@@ -3987,23 +4103,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2997,
-						2995,
+						3000,
 						2998,
-						2996
+						3001,
+						2999
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6028,
+					"line": 6084,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2990,
+			"id": 2993,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4013,7 +4129,7 @@
 			},
 			"children": [
 				{
-					"id": 2993,
+					"id": 2996,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4021,14 +4137,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6022,
+							"line": 6078,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 2992,
+					"id": 2995,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4036,14 +4152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6021,
+							"line": 6077,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 2991,
+					"id": 2994,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4051,7 +4167,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6020,
+							"line": 6076,
 							"character": 4
 						}
 					],
@@ -4063,22 +4179,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2993,
-						2992,
-						2991
+						2996,
+						2995,
+						2994
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6019,
+					"line": 6075,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2986,
+			"id": 2989,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4088,7 +4204,7 @@
 			},
 			"children": [
 				{
-					"id": 2988,
+					"id": 2991,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4106,7 +4222,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 2987,
+					"id": 2990,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4124,7 +4240,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 2989,
+					"id": 2992,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4147,9 +4263,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2988,
-						2987,
-						2989
+						2991,
+						2990,
+						2992
 					]
 				}
 			],
@@ -4162,7 +4278,7 @@
 			]
 		},
 		{
-			"id": 2166,
+			"id": 2163,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4172,7 +4288,7 @@
 			},
 			"children": [
 				{
-					"id": 2168,
+					"id": 2165,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4183,14 +4299,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4454,
+							"line": 4470,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2169,
+					"id": 2166,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4201,14 +4317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4458,
+							"line": 4474,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2167,
+					"id": 2164,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4219,7 +4335,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4450,
+							"line": 4466,
 							"character": 4
 						}
 					],
@@ -4231,22 +4347,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2168,
-						2169,
-						2167
+						2165,
+						2166,
+						2164
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4446,
+					"line": 4462,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1996,
+			"id": 1993,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4271,7 +4387,7 @@
 			},
 			"children": [
 				{
-					"id": 2032,
+					"id": 2029,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4292,14 +4408,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2320,
+							"line": 2336,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2024,
+					"id": 2021,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4320,14 +4436,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2205,
+							"line": 2221,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2004,
+					"id": 2001,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4352,14 +4468,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1971,
+							"line": 1987,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2049,
+					"id": 2046,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4380,14 +4496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2527,
+							"line": 2543,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2009,
+					"id": 2006,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4412,14 +4528,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2063,
+							"line": 2079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2045,
+					"id": 2042,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4440,14 +4556,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2495,
+							"line": 2511,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2031,
+					"id": 2028,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4468,14 +4584,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2309,
+							"line": 2325,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2091,
+					"id": 2088,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4497,14 +4613,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3065,
+							"line": 3081,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2072,
+					"id": 2069,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4537,14 +4653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2736,
+							"line": 2752,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2010,
+					"id": 2007,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4565,14 +4681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2076,
+							"line": 2092,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 1998,
+					"id": 1995,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4597,14 +4713,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1873,
+							"line": 1889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2056,
+					"id": 2053,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4625,14 +4741,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2603,
+							"line": 2619,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2043,
+					"id": 2040,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4653,14 +4769,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2473,
+							"line": 2489,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2058,
+					"id": 2055,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4681,14 +4797,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2623,
+							"line": 2639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2038,
+					"id": 2035,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4709,14 +4825,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2410,
+							"line": 2426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2066,
+					"id": 2063,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4733,14 +4849,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2687,
+							"line": 2703,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2077,
+					"id": 2074,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4758,14 +4874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2871,
+							"line": 2887,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2078,
+					"id": 2075,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4782,14 +4898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2876,
+							"line": 2892,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2071,
+					"id": 2068,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4806,14 +4922,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2727,
+							"line": 2743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2059,
+					"id": 2056,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4834,14 +4950,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2634,
+							"line": 2650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2005,
+					"id": 2002,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4870,14 +4986,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1988,
+							"line": 2004,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2000,
+					"id": 1997,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4906,14 +5022,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1901,
+							"line": 1917,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2003,
+					"id": 2000,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4938,14 +5054,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1959,
+							"line": 1975,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2054,
+					"id": 2051,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4966,14 +5082,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2585,
+							"line": 2601,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2070,
+					"id": 2067,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4998,14 +5114,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2722,
+							"line": 2738,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2022,
+					"id": 2019,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5026,14 +5142,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2172,
+							"line": 2188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2021,
+					"id": 2018,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5054,14 +5170,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2161,
+							"line": 2177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2026,
+					"id": 2023,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5083,14 +5199,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2239,
+							"line": 2255,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2029,
+					"id": 2026,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5111,14 +5227,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2281,
+							"line": 2297,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2028,
+					"id": 2025,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5139,14 +5255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2267,
+							"line": 2283,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2027,
+					"id": 2024,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5167,14 +5283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2253,
+							"line": 2269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2030,
+					"id": 2027,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5195,14 +5311,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2295,
+							"line": 2311,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2037,
+					"id": 2034,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5223,14 +5339,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2399,
+							"line": 2415,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2036,
+					"id": 2033,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5251,14 +5367,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2387,
+							"line": 2403,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2002,
+					"id": 1999,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5295,14 +5411,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1947,
+							"line": 1963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2051,
+					"id": 2048,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5323,14 +5439,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2549,
+							"line": 2565,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2040,
+					"id": 2037,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5351,14 +5467,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2433,
+							"line": 2449,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2008,
+					"id": 2005,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5388,14 +5504,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2053,
+							"line": 2069,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2057,
+					"id": 2054,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5416,14 +5532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2613,
+							"line": 2629,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2041,
+					"id": 2038,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5444,14 +5560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2448,
+							"line": 2464,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2062,
+					"id": 2059,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5468,14 +5584,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2664,
+							"line": 2680,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2016,
+					"id": 2013,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5496,14 +5612,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2118,
+							"line": 2134,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 1997,
+					"id": 1994,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5524,14 +5640,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1861,
+							"line": 1877,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2085,
+					"id": 2082,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5552,14 +5668,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2943,
+							"line": 2959,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2084,
+					"id": 2081,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5580,14 +5696,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2932,
+							"line": 2948,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2048,
+					"id": 2045,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5608,14 +5724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2516,
+							"line": 2532,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2023,
+					"id": 2020,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5640,14 +5756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2194,
+							"line": 2210,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 1999,
+					"id": 1996,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5672,14 +5788,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1887,
+							"line": 1903,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2052,
+					"id": 2049,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5700,14 +5816,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2560,
+							"line": 2576,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2019,
+					"id": 2016,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5728,14 +5844,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2144,
+							"line": 2160,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2074,
+					"id": 2071,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5765,14 +5881,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2804,
+							"line": 2820,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2090,
+					"id": 2087,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5793,14 +5909,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2999,
+							"line": 3015,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2075,
+					"id": 2072,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5817,14 +5933,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2815,
+							"line": 2831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2033,
+					"id": 2030,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5845,14 +5961,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2339,
+							"line": 2355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2053,
+					"id": 2050,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5877,14 +5993,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2575,
+							"line": 2591,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2082,
+					"id": 2079,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5905,14 +6021,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2910,
+							"line": 2926,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2001,
+					"id": 1998,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5933,14 +6049,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1910,
+							"line": 1926,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2073,
+					"id": 2070,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5957,14 +6073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2741,
+							"line": 2757,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2069,
+					"id": 2066,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5997,14 +6113,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2715,
+							"line": 2731,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2086,
+					"id": 2083,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6025,14 +6141,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2954,
+							"line": 2970,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2017,
+					"id": 2014,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6053,14 +6169,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2128,
+							"line": 2144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2063,
+					"id": 2060,
 					"name": "SageEmbedQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6077,14 +6193,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2670,
+							"line": 2686,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageEmbedQuery\""
 				},
 				{
-					"id": 2064,
+					"id": 2061,
 					"name": "SageWorksheetUpdated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6101,14 +6217,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2677,
+							"line": 2693,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageWorksheetUpdated\""
 				},
 				{
-					"id": 2025,
+					"id": 2022,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6129,14 +6245,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2223,
+							"line": 2239,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2042,
+					"id": 2039,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6157,14 +6273,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2459,
+							"line": 2475,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2068,
+					"id": 2065,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6197,14 +6313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2706,
+							"line": 2722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2050,
+					"id": 2047,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6225,14 +6341,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2538,
+							"line": 2554,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2055,
+					"id": 2052,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6253,14 +6369,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2594,
+							"line": 2610,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2035,
+					"id": 2032,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6281,14 +6397,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2375,
+							"line": 2391,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2044,
+					"id": 2041,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6309,14 +6425,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2484,
+							"line": 2500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2034,
+					"id": 2031,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6337,14 +6453,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2357,
+							"line": 2373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2081,
+					"id": 2078,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6365,14 +6481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2899,
+							"line": 2915,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2087,
+					"id": 2084,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6393,14 +6509,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2965,
+							"line": 2981,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2088,
+					"id": 2085,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6421,14 +6537,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2976,
+							"line": 2992,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2083,
+					"id": 2080,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6449,14 +6565,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2921,
+							"line": 2937,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2076,
+					"id": 2073,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6478,14 +6594,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2858,
+							"line": 2874,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2065,
+					"id": 2062,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6502,14 +6618,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2682,
+							"line": 2698,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2067,
+					"id": 2064,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6542,14 +6658,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2697,
+							"line": 2713,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2039,
+					"id": 2036,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6570,14 +6686,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2421,
+							"line": 2437,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2007,
+					"id": 2004,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6606,14 +6722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2019,
+							"line": 2035,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2006,
+					"id": 2003,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6638,14 +6754,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2000,
+							"line": 2016,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2060,
+					"id": 2057,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6666,7 +6782,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2645,
+							"line": 2661,
 							"character": 4
 						}
 					],
@@ -6678,101 +6794,101 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2032,
-						2024,
-						2004,
-						2049,
-						2009,
-						2045,
-						2031,
-						2091,
-						2072,
-						2010,
-						1998,
-						2056,
-						2043,
-						2058,
-						2038,
-						2066,
-						2077,
-						2078,
-						2071,
-						2059,
-						2005,
-						2000,
-						2003,
-						2054,
-						2070,
-						2022,
-						2021,
-						2026,
 						2029,
-						2028,
-						2027,
-						2030,
-						2037,
-						2036,
-						2002,
-						2051,
-						2040,
-						2008,
-						2057,
-						2041,
-						2062,
-						2016,
-						1997,
-						2085,
-						2084,
-						2048,
-						2023,
-						1999,
-						2052,
-						2019,
-						2074,
-						2090,
-						2075,
-						2033,
-						2053,
-						2082,
+						2021,
 						2001,
-						2073,
-						2069,
-						2086,
-						2017,
-						2063,
-						2064,
-						2025,
+						2046,
+						2006,
 						2042,
-						2068,
-						2050,
+						2028,
+						2088,
+						2069,
+						2007,
+						1995,
+						2053,
+						2040,
 						2055,
 						2035,
-						2044,
-						2034,
-						2081,
-						2087,
-						2088,
-						2083,
-						2076,
-						2065,
+						2063,
+						2074,
+						2075,
+						2068,
+						2056,
+						2002,
+						1997,
+						2000,
+						2051,
 						2067,
+						2019,
+						2018,
+						2023,
+						2026,
+						2025,
+						2024,
+						2027,
+						2034,
+						2033,
+						1999,
+						2048,
+						2037,
+						2005,
+						2054,
+						2038,
+						2059,
+						2013,
+						1994,
+						2082,
+						2081,
+						2045,
+						2020,
+						1996,
+						2049,
+						2016,
+						2071,
+						2087,
+						2072,
+						2030,
+						2050,
+						2079,
+						1998,
+						2070,
+						2066,
+						2083,
+						2014,
+						2060,
+						2061,
+						2022,
 						2039,
-						2007,
-						2006,
-						2060
+						2065,
+						2047,
+						2052,
+						2032,
+						2041,
+						2031,
+						2078,
+						2084,
+						2085,
+						2080,
+						2073,
+						2062,
+						2064,
+						2036,
+						2004,
+						2003,
+						2057
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1848,
+					"line": 1864,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2692,
+			"id": 2695,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6782,7 +6898,7 @@
 			},
 			"children": [
 				{
-					"id": 2696,
+					"id": 2699,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6805,7 +6921,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2700,
+					"id": 2703,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6829,7 +6945,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2702,
+					"id": 2705,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6853,7 +6969,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2694,
+					"id": 2697,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6876,7 +6992,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2699,
+					"id": 2702,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6899,7 +7015,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2695,
+					"id": 2698,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6922,7 +7038,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2697,
+					"id": 2700,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6945,7 +7061,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2693,
+					"id": 2696,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6968,7 +7084,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2698,
+					"id": 2701,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6991,7 +7107,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2701,
+					"id": 2704,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7020,16 +7136,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2696,
-						2700,
-						2702,
-						2694,
 						2699,
-						2695,
+						2703,
+						2705,
 						2697,
-						2693,
+						2702,
 						2698,
-						2701
+						2700,
+						2696,
+						2701,
+						2704
 					]
 				}
 			],
@@ -7042,7 +7158,7 @@
 			]
 		},
 		{
-			"id": 2943,
+			"id": 2946,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7058,7 +7174,7 @@
 			},
 			"children": [
 				{
-					"id": 2944,
+					"id": 2947,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7076,7 +7192,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 2945,
+					"id": 2948,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7099,8 +7215,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2944,
-						2945
+						2947,
+						2948
 					]
 				}
 			],
@@ -7113,14 +7229,14 @@
 			]
 		},
 		{
-			"id": 2937,
+			"id": 2940,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2939,
+					"id": 2942,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7135,7 +7251,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 2940,
+					"id": 2943,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7150,7 +7266,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 2938,
+					"id": 2941,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7170,9 +7286,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2939,
-						2940,
-						2938
+						2942,
+						2943,
+						2941
 					]
 				}
 			],
@@ -7185,7 +7301,7 @@
 			]
 		},
 		{
-			"id": 2703,
+			"id": 2706,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7201,7 +7317,7 @@
 			},
 			"children": [
 				{
-					"id": 2706,
+					"id": 2709,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7212,14 +7328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1729,
+							"line": 1745,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2709,
+					"id": 2712,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7230,14 +7346,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1741,
+							"line": 1757,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2707,
+					"id": 2710,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7248,14 +7364,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1733,
+							"line": 1749,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2704,
+					"id": 2707,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7266,14 +7382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1721,
+							"line": 1737,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2708,
+					"id": 2711,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7284,14 +7400,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1737,
+							"line": 1753,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2705,
+					"id": 2708,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7302,7 +7418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1725,
+							"line": 1741,
 							"character": 4
 						}
 					],
@@ -7314,25 +7430,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2706,
 						2709,
+						2712,
+						2710,
 						2707,
-						2704,
-						2708,
-						2705
+						2711,
+						2708
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1717,
+					"line": 1733,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2092,
+			"id": 2089,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7361,7 +7477,7 @@
 			},
 			"children": [
 				{
-					"id": 2114,
+					"id": 2111,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7382,14 +7498,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3511,
+							"line": 3527,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2103,
+					"id": 2100,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7415,14 +7531,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3316,
+							"line": 3332,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2159,
+					"id": 2156,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7448,14 +7564,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4368,
+							"line": 4384,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2144,
+					"id": 2141,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7476,14 +7592,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4161,
+							"line": 4177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2162,
+					"id": 2159,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7509,14 +7625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4406,
+							"line": 4422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2121,
+					"id": 2118,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7542,14 +7658,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3647,
+							"line": 3663,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2118,
+					"id": 2115,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7579,14 +7695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3585,
+							"line": 3601,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2125,
+					"id": 2122,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7612,14 +7728,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3731,
+							"line": 3747,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2158,
+					"id": 2155,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7640,14 +7756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4353,
+							"line": 4369,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2164,
+					"id": 2161,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7668,14 +7784,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4426,
+							"line": 4442,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2127,
+					"id": 2124,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7705,14 +7821,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3777,
+							"line": 3793,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2129,
+					"id": 2126,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7738,14 +7854,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3828,
+							"line": 3844,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2113,
+					"id": 2110,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7775,14 +7891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3501,
+							"line": 3517,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2128,
+					"id": 2125,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7803,14 +7919,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3801,
+							"line": 3817,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2130,
+					"id": 2127,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7836,14 +7952,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3855,
+							"line": 3871,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2094,
+					"id": 2091,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7893,14 +8009,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3193,
+							"line": 3209,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2120,
+					"id": 2117,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7936,14 +8052,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3630,
+							"line": 3646,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2155,
+					"id": 2152,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7969,14 +8085,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4326,
+							"line": 4342,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2111,
+					"id": 2108,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7997,14 +8113,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3465,
+							"line": 3481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2117,
+					"id": 2114,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8030,14 +8146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3568,
+							"line": 3584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2110,
+					"id": 2107,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8058,14 +8174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3455,
+							"line": 3471,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2143,
+					"id": 2140,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8091,14 +8207,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4151,
+							"line": 4167,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2137,
+					"id": 2134,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8119,14 +8235,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3978,
+							"line": 3994,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2097,
+					"id": 2094,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8147,14 +8263,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3213,
+							"line": 3229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2148,
+					"id": 2145,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8176,14 +8292,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4226,
+							"line": 4242,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2123,
+					"id": 2120,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8208,14 +8324,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3695,
+							"line": 3711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2139,
+					"id": 2136,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8236,14 +8352,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4081,
+							"line": 4097,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2107,
+					"id": 2104,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8264,14 +8380,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3427,
+							"line": 3443,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2115,
+					"id": 2112,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8308,14 +8424,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3544,
+							"line": 3560,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2119,
+					"id": 2116,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8349,14 +8465,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3606,
+							"line": 3622,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2135,
+					"id": 2132,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8382,14 +8498,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3955,
+							"line": 3971,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2101,
+					"id": 2098,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8415,14 +8531,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3286,
+							"line": 3302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2102,
+					"id": 2099,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8452,14 +8568,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3306,
+							"line": 3322,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2106,
+					"id": 2103,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8520,14 +8636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3417,
+							"line": 3433,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2122,
+					"id": 2119,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8553,14 +8669,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3664,
+							"line": 3680,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2156,
+					"id": 2153,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8581,14 +8697,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4335,
+							"line": 4351,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2116,
+					"id": 2113,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8613,14 +8729,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3558,
+							"line": 3574,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2104,
+					"id": 2101,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8646,14 +8762,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3326,
+							"line": 3342,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2146,
+					"id": 2143,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8674,14 +8790,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4186,
+							"line": 4202,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2136,
+					"id": 2133,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8702,14 +8818,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3967,
+							"line": 3983,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2157,
+					"id": 2154,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8730,14 +8846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4344,
+							"line": 4360,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2132,
+					"id": 2129,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8763,14 +8879,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3908,
+							"line": 3924,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2151,
+					"id": 2148,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8810,14 +8926,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4276,
+							"line": 4292,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2108,
+					"id": 2105,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8838,14 +8954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3436,
+							"line": 3452,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2109,
+					"id": 2106,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8866,14 +8982,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3445,
+							"line": 3461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2093,
+					"id": 2090,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8905,14 +9021,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3142,
+							"line": 3158,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2099,
+					"id": 2096,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8938,14 +9054,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3238,
+							"line": 3254,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2141,
+					"id": 2138,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8971,14 +9087,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4107,
+							"line": 4123,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2140,
+					"id": 2137,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9004,14 +9120,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4094,
+							"line": 4110,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2098,
+					"id": 2095,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9037,14 +9153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3226,
+							"line": 3242,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2131,
+					"id": 2128,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9065,14 +9181,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3868,
+							"line": 3884,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2124,
+					"id": 2121,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9098,14 +9214,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3714,
+							"line": 3730,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2126,
+					"id": 2123,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9131,14 +9247,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3751,
+							"line": 3767,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2154,
+					"id": 2151,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9169,14 +9285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4316,
+							"line": 4332,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2165,
+					"id": 2162,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9193,14 +9309,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4438,
+							"line": 4454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2134,
+					"id": 2131,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9226,14 +9342,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3939,
+							"line": 3955,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2133,
+					"id": 2130,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9259,14 +9375,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3923,
+							"line": 3939,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2153,
+					"id": 2150,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9292,14 +9408,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4301,
+							"line": 4317,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2145,
+					"id": 2142,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9320,14 +9436,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4177,
+							"line": 4193,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2138,
+					"id": 2135,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9370,14 +9486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4068,
+							"line": 4084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2147,
+					"id": 2144,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9408,14 +9524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4206,
+							"line": 4222,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2149,
+					"id": 2146,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9432,14 +9548,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4234,
+							"line": 4250,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2100,
+					"id": 2097,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9470,14 +9586,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3274,
+							"line": 3290,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2142,
+					"id": 2139,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9508,14 +9624,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4121,
+							"line": 4137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2112,
+					"id": 2109,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9536,14 +9652,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3474,
+							"line": 3490,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2105,
+					"id": 2102,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9564,7 +9680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3342,
+							"line": 3358,
 							"character": 4
 						}
 					],
@@ -9576,85 +9692,85 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2114,
-						2103,
-						2159,
-						2144,
-						2162,
-						2121,
-						2118,
-						2125,
-						2158,
-						2164,
-						2127,
-						2129,
-						2113,
-						2128,
-						2130,
-						2094,
-						2120,
-						2155,
 						2111,
-						2117,
-						2110,
-						2143,
-						2137,
-						2097,
-						2148,
-						2123,
-						2139,
-						2107,
-						2115,
-						2119,
-						2135,
-						2101,
-						2102,
-						2106,
-						2122,
+						2100,
 						2156,
-						2116,
-						2104,
-						2146,
-						2136,
-						2157,
-						2132,
-						2151,
-						2108,
-						2109,
-						2093,
-						2099,
 						2141,
-						2140,
-						2098,
-						2131,
+						2159,
+						2118,
+						2115,
+						2122,
+						2155,
+						2161,
 						2124,
 						2126,
-						2154,
-						2165,
+						2110,
+						2125,
+						2127,
+						2091,
+						2117,
+						2152,
+						2108,
+						2114,
+						2107,
+						2140,
 						2134,
-						2133,
-						2153,
+						2094,
 						2145,
-						2138,
-						2147,
-						2149,
-						2100,
-						2142,
+						2120,
+						2136,
+						2104,
 						2112,
-						2105
+						2116,
+						2132,
+						2098,
+						2099,
+						2103,
+						2119,
+						2153,
+						2113,
+						2101,
+						2143,
+						2133,
+						2154,
+						2129,
+						2148,
+						2105,
+						2106,
+						2090,
+						2096,
+						2138,
+						2137,
+						2095,
+						2128,
+						2121,
+						2123,
+						2151,
+						2162,
+						2131,
+						2130,
+						2150,
+						2142,
+						2135,
+						2144,
+						2146,
+						2097,
+						2139,
+						2109,
+						2102
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 3122,
+					"line": 3138,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2999,
+			"id": 3002,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9664,7 +9780,7 @@
 			},
 			"children": [
 				{
-					"id": 3001,
+					"id": 3004,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9675,14 +9791,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6148,
+							"line": 6204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3000,
+					"id": 3003,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9693,14 +9809,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6144,
+							"line": 6200,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3002,
+					"id": 3005,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9711,7 +9827,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6152,
+							"line": 6208,
 							"character": 4
 						}
 					],
@@ -9723,22 +9839,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3001,
-						3000,
-						3002
+						3004,
+						3003,
+						3005
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6140,
+					"line": 6196,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2946,
+			"id": 2949,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9754,7 +9870,7 @@
 			},
 			"children": [
 				{
-					"id": 2947,
+					"id": 2950,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9772,7 +9888,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 2948,
+					"id": 2951,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9795,8 +9911,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2947,
-						2948
+						2950,
+						2951
 					]
 				}
 			],
@@ -9809,7 +9925,7 @@
 			]
 		},
 		{
-			"id": 2980,
+			"id": 2983,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9825,7 +9941,7 @@
 			},
 			"children": [
 				{
-					"id": 2983,
+					"id": 2986,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9836,14 +9952,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1762,
+							"line": 1778,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 2984,
+					"id": 2987,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9854,14 +9970,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1766,
+							"line": 1782,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 2981,
+					"id": 2984,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9872,14 +9988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1754,
+							"line": 1770,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 2985,
+					"id": 2988,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9890,14 +10006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1770,
+							"line": 1786,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 2982,
+					"id": 2985,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9908,7 +10024,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1758,
+							"line": 1774,
 							"character": 4
 						}
 					],
@@ -9920,24 +10036,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2983,
+						2986,
+						2987,
 						2984,
-						2981,
-						2985,
-						2982
+						2988,
+						2985
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1750,
+					"line": 1766,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2914,
+			"id": 2917,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9947,7 +10063,7 @@
 			},
 			"children": [
 				{
-					"id": 2919,
+					"id": 2922,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9968,14 +10084,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6106,
+							"line": 6162,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 2916,
+					"id": 2919,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9996,14 +10112,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6067,
+							"line": 6123,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 2918,
+					"id": 2921,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10024,14 +10140,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6092,
+							"line": 6148,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 2915,
+					"id": 2918,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10052,14 +10168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6055,
+							"line": 6111,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 2920,
+					"id": 2923,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10080,14 +10196,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6118,
+							"line": 6174,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 2917,
+					"id": 2920,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10108,7 +10224,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6079,
+							"line": 6135,
 							"character": 4
 						}
 					],
@@ -10120,25 +10236,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2922,
 						2919,
-						2916,
+						2921,
 						2918,
-						2915,
-						2920,
-						2917
+						2923,
+						2920
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6042,
+					"line": 6098,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1955,
+			"id": 1952,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10148,7 +10264,7 @@
 			},
 			"children": [
 				{
-					"id": 1958,
+					"id": 1955,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10166,7 +10282,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1961,
+					"id": 1958,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10184,7 +10300,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1956,
+					"id": 1953,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10202,7 +10318,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1959,
+					"id": 1956,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10220,7 +10336,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1963,
+					"id": 1960,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10238,7 +10354,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1957,
+					"id": 1954,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10256,7 +10372,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1962,
+					"id": 1959,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10279,13 +10395,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						1955,
 						1958,
-						1961,
+						1953,
 						1956,
-						1959,
-						1963,
-						1957,
-						1962
+						1960,
+						1954,
+						1959
 					]
 				}
 			],
@@ -10298,14 +10414,14 @@
 			]
 		},
 		{
-			"id": 2681,
+			"id": 2684,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2682,
+					"id": 2685,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10313,14 +10429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5933,
+							"line": 5989,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2684,
+					"id": 2687,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10328,14 +10444,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5935,
+							"line": 5991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2683,
+					"id": 2686,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10343,14 +10459,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5934,
+							"line": 5990,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2685,
+					"id": 2688,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10358,7 +10474,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5936,
+							"line": 5992,
 							"character": 4
 						}
 					],
@@ -10370,23 +10486,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2682,
-						2684,
-						2683,
-						2685
+						2685,
+						2687,
+						2686,
+						2688
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5932,
+					"line": 5988,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2941,
+			"id": 2944,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10402,7 +10518,7 @@
 			},
 			"children": [
 				{
-					"id": 2942,
+					"id": 2945,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10425,7 +10541,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2942
+						2945
 					]
 				}
 			],
@@ -10438,7 +10554,7 @@
 			]
 		},
 		{
-			"id": 1980,
+			"id": 1977,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10448,7 +10564,7 @@
 			},
 			"children": [
 				{
-					"id": 1988,
+					"id": 1985,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10459,14 +10575,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1678,
+							"line": 1694,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 1993,
+					"id": 1990,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10477,14 +10593,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1698,
+							"line": 1714,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 1992,
+					"id": 1989,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10495,14 +10611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1694,
+							"line": 1710,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 1990,
+					"id": 1987,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10513,14 +10629,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1686,
+							"line": 1702,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 1991,
+					"id": 1988,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10531,14 +10647,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1690,
+							"line": 1706,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 1987,
+					"id": 1984,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10549,14 +10665,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1674,
+							"line": 1690,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 1989,
+					"id": 1986,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10567,14 +10683,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1682,
+							"line": 1698,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 1981,
+					"id": 1978,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10585,14 +10701,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1650,
+							"line": 1666,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 1986,
+					"id": 1983,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10603,14 +10719,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1670,
+							"line": 1686,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 1985,
+					"id": 1982,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10621,14 +10737,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1666,
+							"line": 1682,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 1994,
+					"id": 1991,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10639,14 +10755,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1702,
+							"line": 1718,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 1984,
+					"id": 1981,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10657,14 +10773,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1662,
+							"line": 1678,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 1983,
+					"id": 1980,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10675,14 +10791,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1658,
+							"line": 1674,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 1982,
+					"id": 1979,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10693,14 +10809,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1654,
+							"line": 1670,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 1995,
+					"id": 1992,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10711,7 +10827,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1706,
+							"line": 1722,
 							"character": 4
 						}
 					],
@@ -10723,41 +10839,41 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1988,
-						1993,
-						1992,
-						1990,
-						1991,
-						1987,
-						1989,
-						1981,
-						1986,
 						1985,
-						1994,
+						1990,
+						1989,
+						1987,
+						1988,
 						1984,
+						1986,
+						1978,
 						1983,
 						1982,
-						1995
+						1991,
+						1981,
+						1980,
+						1979,
+						1992
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1646,
+					"line": 1662,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2972,
+			"id": 2975,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2977,
+					"id": 2980,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10772,7 +10888,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 2976,
+					"id": 2979,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10787,7 +10903,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 2975,
+					"id": 2978,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10802,7 +10918,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 2978,
+					"id": 2981,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10817,7 +10933,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 2979,
+					"id": 2982,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10832,7 +10948,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 2973,
+					"id": 2976,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10847,7 +10963,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 2974,
+					"id": 2977,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10867,13 +10983,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2977,
-						2976,
-						2975,
-						2978,
+						2980,
 						2979,
-						2973,
-						2974
+						2978,
+						2981,
+						2982,
+						2976,
+						2977
 					]
 				}
 			],
@@ -10886,7 +11002,7 @@
 			]
 		},
 		{
-			"id": 1872,
+			"id": 1869,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -10915,7 +11031,7 @@
 			},
 			"children": [
 				{
-					"id": 1873,
+					"id": 1870,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -10932,7 +11048,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1874,
+							"id": 1871,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -10942,7 +11058,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1875,
+									"id": 1872,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -10950,12 +11066,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1945,
+										"id": 1942,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1876,
+									"id": 1873,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -10967,7 +11083,7 @@
 									}
 								},
 								{
-									"id": 1877,
+									"id": 1874,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -10979,7 +11095,7 @@
 									}
 								},
 								{
-									"id": 1878,
+									"id": 1875,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -10993,7 +11109,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2949,
+											"id": 2952,
 											"name": "VizPoint"
 										}
 									}
@@ -11001,14 +11117,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1872,
+								"id": 1869,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1887,
+					"id": 1884,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11024,7 +11140,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1888,
+							"id": 1885,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11035,7 +11151,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1889,
+									"id": 1886,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11064,7 +11180,7 @@
 					]
 				},
 				{
-					"id": 1890,
+					"id": 1887,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11080,7 +11196,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1891,
+							"id": 1888,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11096,7 +11212,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1892,
+									"id": 1889,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11125,7 +11241,7 @@
 					]
 				},
 				{
-					"id": 1939,
+					"id": 1936,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11141,14 +11257,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1940,
+							"id": 1937,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1941,
+									"id": 1938,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11173,7 +11289,7 @@
 					]
 				},
 				{
-					"id": 1893,
+					"id": 1890,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11189,7 +11305,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1894,
+							"id": 1891,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11200,7 +11316,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1895,
+									"id": 1892,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11212,7 +11328,7 @@
 									}
 								},
 								{
-									"id": 1896,
+									"id": 1893,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11220,12 +11336,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1980,
+										"id": 1977,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1897,
+									"id": 1894,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11271,7 +11387,7 @@
 					]
 				},
 				{
-					"id": 1929,
+					"id": 1926,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11287,7 +11403,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1930,
+							"id": 1927,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11298,7 +11414,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1931,
+									"id": 1928,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11312,7 +11428,7 @@
 									}
 								},
 								{
-									"id": 1932,
+									"id": 1929,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11340,7 +11456,7 @@
 					]
 				},
 				{
-					"id": 1907,
+					"id": 1904,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11356,7 +11472,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1908,
+							"id": 1905,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11367,7 +11483,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1909,
+									"id": 1906,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11380,7 +11496,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1910,
+									"id": 1907,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11409,7 +11525,7 @@
 					]
 				},
 				{
-					"id": 1900,
+					"id": 1897,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11425,7 +11541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1901,
+							"id": 1898,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11436,7 +11552,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1902,
+									"id": 1899,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11449,7 +11565,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1903,
+									"id": 1900,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11468,14 +11584,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1904,
+											"id": 1901,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1905,
+													"id": 1902,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -11486,7 +11602,7 @@
 													}
 												},
 												{
-													"id": 1906,
+													"id": 1903,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -11502,8 +11618,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1905,
-														1906
+														1902,
+														1903
 													]
 												}
 											]
@@ -11516,7 +11632,7 @@
 					]
 				},
 				{
-					"id": 1911,
+					"id": 1908,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11532,7 +11648,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1912,
+							"id": 1909,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11543,7 +11659,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1913,
+									"id": 1910,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11556,7 +11672,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1914,
+									"id": 1911,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11571,7 +11687,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1915,
+									"id": 1912,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11600,7 +11716,7 @@
 					]
 				},
 				{
-					"id": 1935,
+					"id": 1932,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11616,7 +11732,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1936,
+							"id": 1933,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11635,7 +11751,7 @@
 					]
 				},
 				{
-					"id": 1916,
+					"id": 1913,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11651,7 +11767,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1917,
+							"id": 1914,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11662,7 +11778,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1918,
+									"id": 1915,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11675,7 +11791,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1919,
+									"id": 1916,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11696,7 +11812,7 @@
 					]
 				},
 				{
-					"id": 1920,
+					"id": 1917,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11712,7 +11828,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1918,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11722,7 +11838,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1919,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11735,7 +11851,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1923,
+									"id": 1920,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11748,7 +11864,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1924,
+									"id": 1921,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11771,7 +11887,7 @@
 					]
 				},
 				{
-					"id": 1898,
+					"id": 1895,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11787,7 +11903,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1899,
+							"id": 1896,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11806,7 +11922,7 @@
 					]
 				},
 				{
-					"id": 1933,
+					"id": 1930,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11822,7 +11938,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1934,
+							"id": 1931,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11833,14 +11949,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1945,
+								"id": 1942,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1882,
+					"id": 1879,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11856,7 +11972,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1883,
+							"id": 1880,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11878,7 +11994,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1934,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11894,7 +12010,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1935,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11913,7 +12029,7 @@
 					]
 				},
 				{
-					"id": 1925,
+					"id": 1922,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11929,7 +12045,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1926,
+							"id": 1923,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11949,7 +12065,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1927,
+									"id": 1924,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11964,7 +12080,7 @@
 									}
 								},
 								{
-									"id": 1928,
+									"id": 1925,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11976,7 +12092,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1952,
+											"id": 1949,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -11987,7 +12103,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -11997,7 +12113,7 @@
 					]
 				},
 				{
-					"id": 1884,
+					"id": 1881,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12013,7 +12129,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1885,
+							"id": 1882,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12024,7 +12140,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1886,
+									"id": 1883,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12053,7 +12169,7 @@
 					]
 				},
 				{
-					"id": 1942,
+					"id": 1939,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12069,14 +12185,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1943,
+							"id": 1940,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1944,
+									"id": 1941,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12100,31 +12216,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1873
+						1870
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1887,
-						1890,
-						1939,
-						1893,
-						1929,
-						1907,
-						1900,
-						1911,
-						1935,
-						1916,
-						1920,
-						1898,
-						1933,
-						1882,
-						1937,
-						1925,
 						1884,
-						1942
+						1887,
+						1936,
+						1890,
+						1926,
+						1904,
+						1897,
+						1908,
+						1932,
+						1913,
+						1917,
+						1895,
+						1930,
+						1879,
+						1934,
+						1922,
+						1881,
+						1939
 					]
 				}
 			],
@@ -12137,7 +12253,7 @@
 			]
 		},
 		{
-			"id": 1024,
+			"id": 1021,
 			"name": "AppEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -12153,7 +12269,7 @@
 			},
 			"children": [
 				{
-					"id": 1025,
+					"id": 1022,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -12161,46 +12277,46 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 640,
+							"line": 641,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1026,
+							"id": 1023,
 							"name": "new AppEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1027,
+									"id": 1024,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2710,
+										"id": 2713,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 1028,
+									"id": 1025,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2594,
+										"id": 2596,
 										"name": "AppViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1024,
+								"id": 1021,
 								"name": "AppEmbed"
 							},
 							"overwrites": {
@@ -12215,7 +12331,7 @@
 					}
 				},
 				{
-					"id": 1062,
+					"id": 1059,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12225,13 +12341,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1024,
+							"line": 1019,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1063,
+							"id": 1060,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12261,7 +12377,7 @@
 					}
 				},
 				{
-					"id": 1238,
+					"id": 1235,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12277,7 +12393,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1239,
+							"id": 1236,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12293,7 +12409,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1240,
+									"id": 1237,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12314,7 +12430,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -12332,7 +12448,7 @@
 					}
 				},
 				{
-					"id": 1039,
+					"id": 1036,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12342,13 +12458,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 893,
+							"line": 888,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1040,
+							"id": 1037,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12364,7 +12480,7 @@
 					]
 				},
 				{
-					"id": 1207,
+					"id": 1204,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12380,7 +12496,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1208,
+							"id": 1205,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12401,7 +12517,7 @@
 					}
 				},
 				{
-					"id": 1233,
+					"id": 1230,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12417,7 +12533,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1234,
+							"id": 1231,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12439,14 +12555,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1235,
+									"id": 1232,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1237,
+											"id": 1234,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -12458,7 +12574,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1236,
+											"id": 1233,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -12475,8 +12591,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1237,
-												1236
+												1234,
+												1233
 											]
 										}
 									]
@@ -12494,7 +12610,7 @@
 					}
 				},
 				{
-					"id": 1215,
+					"id": 1212,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12510,7 +12626,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1216,
+							"id": 1213,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12526,7 +12642,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1217,
+									"id": 1214,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12534,20 +12650,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1218,
+											"id": 1215,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1219,
+												"id": 1216,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1220,
+														"id": 1217,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -12592,7 +12708,7 @@
 					}
 				},
 				{
-					"id": 1221,
+					"id": 1218,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12608,7 +12724,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1222,
+							"id": 1219,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12629,7 +12745,7 @@
 					}
 				},
 				{
-					"id": 1231,
+					"id": 1228,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12645,7 +12761,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1232,
+							"id": 1229,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12669,7 +12785,7 @@
 					}
 				},
 				{
-					"id": 1058,
+					"id": 1055,
 					"name": "navigateToPage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12679,13 +12795,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 998,
+							"line": 993,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1059,
+							"id": 1056,
 							"name": "navigateToPage",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12701,7 +12817,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1060,
+									"id": 1057,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12724,7 +12840,7 @@
 									}
 								},
 								{
-									"id": 1061,
+									"id": 1058,
 									"name": "noReload",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12747,7 +12863,7 @@
 					]
 				},
 				{
-					"id": 1178,
+					"id": 1175,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12763,7 +12879,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1179,
+							"id": 1176,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12779,7 +12895,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1180,
+									"id": 1177,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12789,12 +12905,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1181,
+									"id": 1178,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12804,7 +12920,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -12825,7 +12941,7 @@
 					}
 				},
 				{
-					"id": 1077,
+					"id": 1074,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12841,7 +12957,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1078,
+							"id": 1075,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12864,38 +12980,38 @@
 							},
 							"parameters": [
 								{
-									"id": 1079,
+									"id": 1076,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1080,
+									"id": 1077,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1081,
+									"id": 1078,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -12917,7 +13033,7 @@
 					}
 				},
 				{
-					"id": 1211,
+					"id": 1208,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12933,7 +13049,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1212,
+							"id": 1209,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12943,7 +13059,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1213,
+									"id": 1210,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12958,7 +13074,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1214,
+									"id": 1211,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12992,7 +13108,7 @@
 					}
 				},
 				{
-					"id": 1223,
+					"id": 1220,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13008,7 +13124,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1224,
+							"id": 1221,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13045,7 +13161,7 @@
 					}
 				},
 				{
-					"id": 1070,
+					"id": 1067,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13055,13 +13171,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1053,
+							"line": 1048,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1071,
+							"id": 1068,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13074,7 +13190,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1024,
+										"id": 1021,
 										"name": "AppEmbed"
 									}
 								],
@@ -13092,7 +13208,7 @@
 					}
 				},
 				{
-					"id": 1227,
+					"id": 1224,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13108,7 +13224,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1228,
+							"id": 1225,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13138,7 +13254,7 @@
 					}
 				},
 				{
-					"id": 1229,
+					"id": 1226,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13154,7 +13270,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1230,
+							"id": 1227,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13184,7 +13300,7 @@
 					}
 				},
 				{
-					"id": 1196,
+					"id": 1193,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13200,7 +13316,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1197,
+							"id": 1194,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13211,19 +13327,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1198,
+									"id": 1195,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1199,
+									"id": 1196,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -13232,7 +13348,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1200,
+									"id": 1197,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13246,7 +13362,7 @@
 									}
 								},
 								{
-									"id": 1201,
+									"id": 1198,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13303,7 +13419,7 @@
 					}
 				},
 				{
-					"id": 1202,
+					"id": 1199,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13319,7 +13435,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1203,
+							"id": 1200,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13330,21 +13446,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1204,
+									"id": 1201,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1205,
+									"id": 1202,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13358,7 +13474,7 @@
 									}
 								},
 								{
-									"id": 1206,
+									"id": 1203,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13411,31 +13527,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1025
+						1022
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1062,
-						1238,
-						1039,
-						1207,
-						1233,
-						1215,
-						1221,
-						1231,
-						1058,
-						1178,
-						1077,
-						1211,
-						1223,
-						1070,
-						1227,
-						1229,
-						1196,
-						1202
+						1059,
+						1235,
+						1036,
+						1204,
+						1230,
+						1212,
+						1218,
+						1228,
+						1055,
+						1175,
+						1074,
+						1208,
+						1220,
+						1067,
+						1224,
+						1226,
+						1193,
+						1199
 					]
 				}
 			],
@@ -13454,7 +13570,7 @@
 			]
 		},
 		{
-			"id": 1337,
+			"id": 1334,
 			"name": "BodylessConversation",
 			"kind": 128,
 			"kindString": "Class",
@@ -13478,7 +13594,7 @@
 			},
 			"children": [
 				{
-					"id": 1338,
+					"id": 1335,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -13492,45 +13608,45 @@
 					],
 					"signatures": [
 						{
-							"id": 1339,
+							"id": 1336,
 							"name": "new BodylessConversation",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1340,
+									"id": 1337,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1305,
+										"id": 1302,
 										"name": "BodylessConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1337,
+								"id": 1334,
 								"name": "BodylessConversation"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1243,
+								"id": 1240,
 								"name": "SpotterAgentEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1242,
+						"id": 1239,
 						"name": "SpotterAgentEmbed.constructor"
 					}
 				},
 				{
-					"id": 1341,
+					"id": 1338,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13546,14 +13662,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1342,
+							"id": 1339,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1343,
+									"id": 1340,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13573,14 +13689,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1344,
+													"id": 1341,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1346,
+															"id": 1343,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13591,7 +13707,7 @@
 															}
 														},
 														{
-															"id": 1345,
+															"id": 1342,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13602,7 +13718,7 @@
 															}
 														},
 														{
-															"id": 1347,
+															"id": 1344,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13619,9 +13735,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1346,
-																1345,
-																1347
+																1343,
+																1342,
+																1344
 															]
 														}
 													]
@@ -13630,14 +13746,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1348,
+													"id": 1345,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1349,
+															"id": 1346,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13648,7 +13764,7 @@
 															}
 														},
 														{
-															"id": 1351,
+															"id": 1348,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13659,7 +13775,7 @@
 															}
 														},
 														{
-															"id": 1350,
+															"id": 1347,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13676,9 +13792,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1349,
-																1351,
-																1350
+																1346,
+																1348,
+																1347
 															]
 														}
 													]
@@ -13691,19 +13807,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1247,
+								"id": 1244,
 								"name": "SpotterAgentEmbed.sendMessage"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1246,
+						"id": 1243,
 						"name": "SpotterAgentEmbed.sendMessage"
 					}
 				},
 				{
-					"id": 1352,
+					"id": 1349,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13719,7 +13835,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1353,
+							"id": 1350,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13730,7 +13846,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1354,
+									"id": 1351,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13753,14 +13869,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1355,
+													"id": 1352,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1357,
+															"id": 1354,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13772,7 +13888,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1356,
+															"id": 1353,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13788,8 +13904,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1357,
-																1356
+																1354,
+																1353
 															]
 														}
 													]
@@ -13798,14 +13914,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1358,
+													"id": 1355,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1359,
+															"id": 1356,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13813,14 +13929,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1360,
+																	"id": 1357,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1366,
+																			"id": 1363,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13832,7 +13948,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1365,
+																			"id": 1362,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13844,7 +13960,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1361,
+																			"id": 1358,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13856,7 +13972,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1364,
+																			"id": 1361,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13868,7 +13984,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1362,
+																			"id": 1359,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13880,7 +13996,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1363,
+																			"id": 1360,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13897,12 +14013,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1366,
-																				1365,
-																				1361,
-																				1364,
+																				1363,
 																				1362,
-																				1363
+																				1358,
+																				1361,
+																				1359,
+																				1360
 																			]
 																		}
 																	]
@@ -13911,7 +14027,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1367,
+															"id": 1364,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13927,8 +14043,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1359,
-																1367
+																1356,
+																1364
 															]
 														}
 													]
@@ -13941,14 +14057,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1258,
+								"id": 1255,
 								"name": "SpotterAgentEmbed.sendMessageData"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1257,
+						"id": 1254,
 						"name": "SpotterAgentEmbed.sendMessageData"
 					}
 				}
@@ -13958,15 +14074,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1338
+						1335
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1341,
-						1352
+						1338,
+						1349
 					]
 				}
 			],
@@ -13980,13 +14096,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1241,
+					"id": 1238,
 					"name": "SpotterAgentEmbed"
 				}
 			]
 		},
 		{
-			"id": 1629,
+			"id": 1626,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -14014,7 +14130,7 @@
 			},
 			"children": [
 				{
-					"id": 1630,
+					"id": 1627,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -14022,20 +14138,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 340,
+							"line": 346,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1631,
+							"id": 1628,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1632,
+									"id": 1629,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14046,38 +14162,38 @@
 									}
 								},
 								{
-									"id": 1633,
+									"id": 1630,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1585,
+										"id": 1582,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1629,
+								"id": 1626,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1370,
+								"id": 1367,
 								"name": "SpotterEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1369,
+						"id": 1366,
 						"name": "SpotterEmbed.constructor"
 					}
 				},
 				{
-					"id": 1780,
+					"id": 1777,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14093,7 +14209,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1781,
+							"id": 1778,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14113,19 +14229,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1520,
+								"id": 1517,
 								"name": "SpotterEmbed.destroy"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1516,
 						"name": "SpotterEmbed.destroy"
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1796,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14141,7 +14257,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1797,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14157,7 +14273,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1801,
+									"id": 1798,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14178,7 +14294,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -14186,19 +14302,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1539,
+								"id": 1536,
 								"name": "SpotterEmbed.getAnswerService"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1538,
+						"id": 1535,
 						"name": "SpotterEmbed.getAnswerService"
 					}
 				},
 				{
-					"id": 1637,
+					"id": 1634,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14208,13 +14324,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 273,
+							"line": 279,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1638,
+							"id": 1635,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14225,19 +14341,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1377,
+								"id": 1374,
 								"name": "SpotterEmbed.getIframeSrc"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1376,
+						"id": 1373,
 						"name": "SpotterEmbed.getIframeSrc"
 					}
 				},
 				{
-					"id": 1794,
+					"id": 1791,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14253,7 +14369,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1795,
+							"id": 1792,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14275,14 +14391,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1796,
+									"id": 1793,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1798,
+											"id": 1795,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -14294,7 +14410,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1797,
+											"id": 1794,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -14311,8 +14427,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1798,
-												1797
+												1795,
+												1794
 											]
 										}
 									]
@@ -14320,19 +14436,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1534,
+								"id": 1531,
 								"name": "SpotterEmbed.getPreRenderIds"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1533,
+						"id": 1530,
 						"name": "SpotterEmbed.getPreRenderIds"
 					}
 				},
 				{
-					"id": 1774,
+					"id": 1771,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14348,7 +14464,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1775,
+							"id": 1772,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14364,7 +14480,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1776,
+									"id": 1773,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14372,20 +14488,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1777,
+											"id": 1774,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1778,
+												"id": 1775,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1779,
+														"id": 1776,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -14420,19 +14536,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1514,
+								"id": 1511,
 								"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1513,
+						"id": 1510,
 						"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 					}
 				},
 				{
-					"id": 1782,
+					"id": 1779,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14448,7 +14564,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1783,
+							"id": 1780,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14459,19 +14575,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1522,
+								"id": 1519,
 								"name": "SpotterEmbed.getUnderlyingFrameElement"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1521,
+						"id": 1518,
 						"name": "SpotterEmbed.getUnderlyingFrameElement"
 					}
 				},
 				{
-					"id": 1792,
+					"id": 1789,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14487,7 +14603,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1793,
+							"id": 1790,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14501,19 +14617,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1532,
+								"id": 1529,
 								"name": "SpotterEmbed.hidePreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1531,
+						"id": 1528,
 						"name": "SpotterEmbed.hidePreRender"
 					}
 				},
 				{
-					"id": 1739,
+					"id": 1736,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14529,7 +14645,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1740,
+							"id": 1737,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14545,7 +14661,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1741,
+									"id": 1738,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14555,12 +14671,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1742,
+									"id": 1739,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14570,7 +14686,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -14581,19 +14697,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1479,
+								"id": 1476,
 								"name": "SpotterEmbed.off"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1478,
+						"id": 1475,
 						"name": "SpotterEmbed.off"
 					}
 				},
 				{
-					"id": 1733,
+					"id": 1730,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14609,7 +14725,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1734,
+							"id": 1731,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14629,7 +14745,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1735,
+									"id": 1732,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14639,12 +14755,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1736,
+									"id": 1733,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14654,12 +14770,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1737,
+									"id": 1734,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14669,13 +14785,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1738,
+									"id": 1735,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14694,19 +14810,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1473,
+								"id": 1470,
 								"name": "SpotterEmbed.on"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1472,
+						"id": 1469,
 						"name": "SpotterEmbed.on"
 					}
 				},
 				{
-					"id": 1770,
+					"id": 1767,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14722,7 +14838,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1771,
+							"id": 1768,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14732,7 +14848,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1772,
+									"id": 1769,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14747,7 +14863,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1773,
+									"id": 1770,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14771,19 +14887,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1510,
+								"id": 1507,
 								"name": "SpotterEmbed.preRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1509,
+						"id": 1506,
 						"name": "SpotterEmbed.preRender"
 					}
 				},
 				{
-					"id": 1784,
+					"id": 1781,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14799,7 +14915,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1785,
+							"id": 1782,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14826,19 +14942,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1524,
+								"id": 1521,
 								"name": "SpotterEmbed.prerenderGeneric"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1523,
+						"id": 1520,
 						"name": "SpotterEmbed.prerenderGeneric"
 					}
 				},
 				{
-					"id": 1639,
+					"id": 1636,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14848,13 +14964,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 313,
+							"line": 319,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1640,
+							"id": 1637,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14864,7 +14980,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1368,
+										"id": 1365,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -14872,19 +14988,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1379,
+								"id": 1376,
 								"name": "SpotterEmbed.render"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1378,
+						"id": 1375,
 						"name": "SpotterEmbed.render"
 					}
 				},
 				{
-					"id": 1788,
+					"id": 1785,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14900,7 +15016,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1789,
+							"id": 1786,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14920,19 +15036,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1528,
+								"id": 1525,
 								"name": "SpotterEmbed.showPreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1527,
+						"id": 1524,
 						"name": "SpotterEmbed.showPreRender"
 					}
 				},
 				{
-					"id": 1790,
+					"id": 1787,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14948,7 +15064,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1791,
+							"id": 1788,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14968,19 +15084,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1530,
+								"id": 1527,
 								"name": "SpotterEmbed.syncPreRenderStyle"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1529,
+						"id": 1526,
 						"name": "SpotterEmbed.syncPreRenderStyle"
 					}
 				},
 				{
-					"id": 1757,
+					"id": 1754,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14996,7 +15112,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1758,
+							"id": 1755,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15007,19 +15123,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1759,
+									"id": 1756,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1760,
+									"id": 1757,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -15028,7 +15144,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1761,
+									"id": 1758,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15042,7 +15158,7 @@
 									}
 								},
 								{
-									"id": 1762,
+									"id": 1759,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15089,19 +15205,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1497,
+								"id": 1494,
 								"name": "SpotterEmbed.trigger"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1496,
+						"id": 1493,
 						"name": "SpotterEmbed.trigger"
 					}
 				},
 				{
-					"id": 1763,
+					"id": 1760,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15117,7 +15233,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1764,
+							"id": 1761,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15128,21 +15244,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1765,
+									"id": 1762,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1766,
+									"id": 1763,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15156,7 +15272,7 @@
 									}
 								},
 								{
-									"id": 1767,
+									"id": 1764,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15194,14 +15310,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1503,
+								"id": 1500,
 								"name": "SpotterEmbed.triggerUIPassThrough"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1502,
+						"id": 1499,
 						"name": "SpotterEmbed.triggerUIPassThrough"
 					}
 				}
@@ -15211,49 +15327,49 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1630
+						1627
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1780,
-						1799,
-						1637,
-						1794,
-						1774,
-						1782,
-						1792,
-						1739,
-						1733,
-						1770,
-						1784,
-						1639,
-						1788,
-						1790,
-						1757,
-						1763
+						1777,
+						1796,
+						1634,
+						1791,
+						1771,
+						1779,
+						1789,
+						1736,
+						1730,
+						1767,
+						1781,
+						1636,
+						1785,
+						1787,
+						1754,
+						1760
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 339,
+					"line": 345,
 					"character": 13
 				}
 			],
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1368,
+					"id": 1365,
 					"name": "SpotterEmbed"
 				}
 			]
 		},
 		{
-			"id": 611,
+			"id": 608,
 			"name": "LiveboardEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -15273,7 +15389,7 @@
 			},
 			"children": [
 				{
-					"id": 612,
+					"id": 609,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -15281,46 +15397,46 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 438,
+							"line": 437,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 613,
+							"id": 610,
 							"name": "new LiveboardEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 614,
+									"id": 611,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2710,
+										"id": 2713,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 615,
+									"id": 612,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2465,
+										"id": 2466,
 										"name": "LiveboardViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 611,
+								"id": 608,
 								"name": "LiveboardEmbed"
 							},
 							"overwrites": {
@@ -15335,7 +15451,7 @@
 					}
 				},
 				{
-					"id": 667,
+					"id": 664,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15345,13 +15461,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 806,
+							"line": 793,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 668,
+							"id": 665,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15381,7 +15497,7 @@
 					}
 				},
 				{
-					"id": 838,
+					"id": 835,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15397,7 +15513,7 @@
 					],
 					"signatures": [
 						{
-							"id": 839,
+							"id": 836,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15413,7 +15529,7 @@
 							},
 							"parameters": [
 								{
-									"id": 840,
+									"id": 837,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15434,7 +15550,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -15452,7 +15568,7 @@
 					}
 				},
 				{
-					"id": 811,
+					"id": 808,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15468,7 +15584,7 @@
 					],
 					"signatures": [
 						{
-							"id": 812,
+							"id": 809,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15489,7 +15605,7 @@
 					}
 				},
 				{
-					"id": 682,
+					"id": 679,
 					"name": "getLiveboardUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15499,13 +15615,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 865,
+							"line": 852,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 683,
+							"id": 680,
 							"name": "getLiveboardUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15522,7 +15638,7 @@
 					]
 				},
 				{
-					"id": 833,
+					"id": 830,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15538,7 +15654,7 @@
 					],
 					"signatures": [
 						{
-							"id": 834,
+							"id": 831,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15560,14 +15676,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 835,
+									"id": 832,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 837,
+											"id": 834,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15579,7 +15695,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 836,
+											"id": 833,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15596,8 +15712,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												837,
-												836
+												834,
+												833
 											]
 										}
 									]
@@ -15615,7 +15731,7 @@
 					}
 				},
 				{
-					"id": 817,
+					"id": 814,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15631,7 +15747,7 @@
 					],
 					"signatures": [
 						{
-							"id": 818,
+							"id": 815,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15647,7 +15763,7 @@
 							},
 							"parameters": [
 								{
-									"id": 819,
+									"id": 816,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15655,20 +15771,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 820,
+											"id": 817,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 821,
+												"id": 818,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 822,
+														"id": 819,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -15713,7 +15829,7 @@
 					}
 				},
 				{
-					"id": 823,
+					"id": 820,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15729,7 +15845,7 @@
 					],
 					"signatures": [
 						{
-							"id": 824,
+							"id": 821,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15750,7 +15866,7 @@
 					}
 				},
 				{
-					"id": 831,
+					"id": 828,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15766,7 +15882,7 @@
 					],
 					"signatures": [
 						{
-							"id": 832,
+							"id": 829,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15790,7 +15906,7 @@
 					}
 				},
 				{
-					"id": 677,
+					"id": 674,
 					"name": "navigateToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15800,20 +15916,20 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 846,
+							"line": 833,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 678,
+							"id": 675,
 							"name": "navigateToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 679,
+									"id": 676,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15824,7 +15940,7 @@
 									}
 								},
 								{
-									"id": 680,
+									"id": 677,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15837,7 +15953,7 @@
 									}
 								},
 								{
-									"id": 681,
+									"id": 678,
 									"name": "activeTabId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15858,7 +15974,7 @@
 					]
 				},
 				{
-					"id": 788,
+					"id": 785,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15874,7 +15990,7 @@
 					],
 					"signatures": [
 						{
-							"id": 789,
+							"id": 786,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15890,7 +16006,7 @@
 							},
 							"parameters": [
 								{
-									"id": 790,
+									"id": 787,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15900,12 +16016,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 791,
+									"id": 788,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15915,7 +16031,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -15936,7 +16052,7 @@
 					}
 				},
 				{
-					"id": 689,
+					"id": 686,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15952,7 +16068,7 @@
 					],
 					"signatures": [
 						{
-							"id": 690,
+							"id": 687,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15975,38 +16091,38 @@
 							},
 							"parameters": [
 								{
-									"id": 691,
+									"id": 688,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 692,
+									"id": 689,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 693,
+									"id": 690,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -16028,7 +16144,7 @@
 					}
 				},
 				{
-					"id": 813,
+					"id": 810,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16044,7 +16160,7 @@
 					],
 					"signatures": [
 						{
-							"id": 814,
+							"id": 811,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16054,7 +16170,7 @@
 							},
 							"parameters": [
 								{
-									"id": 815,
+									"id": 812,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16069,7 +16185,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 816,
+									"id": 813,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16103,7 +16219,7 @@
 					}
 				},
 				{
-					"id": 825,
+					"id": 822,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16119,7 +16235,7 @@
 					],
 					"signatures": [
 						{
-							"id": 826,
+							"id": 823,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16156,7 +16272,7 @@
 					}
 				},
 				{
-					"id": 675,
+					"id": 672,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16166,13 +16282,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 835,
+							"line": 822,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 676,
+							"id": 673,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16185,7 +16301,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 611,
+										"id": 608,
 										"name": "LiveboardEmbed"
 									}
 								],
@@ -16203,7 +16319,7 @@
 					}
 				},
 				{
-					"id": 827,
+					"id": 824,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16219,7 +16335,7 @@
 					],
 					"signatures": [
 						{
-							"id": 828,
+							"id": 825,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16249,7 +16365,7 @@
 					}
 				},
 				{
-					"id": 829,
+					"id": 826,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16265,7 +16381,7 @@
 					],
 					"signatures": [
 						{
-							"id": 830,
+							"id": 827,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16295,7 +16411,7 @@
 					}
 				},
 				{
-					"id": 661,
+					"id": 658,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16305,13 +16421,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 788,
+							"line": 775,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 662,
+							"id": 659,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16322,19 +16438,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 663,
+									"id": 660,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 664,
+									"id": 661,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -16343,7 +16459,7 @@
 							],
 							"parameters": [
 								{
-									"id": 665,
+									"id": 662,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16357,7 +16473,7 @@
 									}
 								},
 								{
-									"id": 666,
+									"id": 663,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16414,7 +16530,7 @@
 					}
 				},
 				{
-					"id": 806,
+					"id": 803,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16430,7 +16546,7 @@
 					],
 					"signatures": [
 						{
-							"id": 807,
+							"id": 804,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16441,21 +16557,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 808,
+									"id": 805,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 809,
+									"id": 806,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16469,7 +16585,7 @@
 									}
 								},
 								{
-									"id": 810,
+									"id": 807,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16522,38 +16638,38 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						612
+						609
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						667,
-						838,
-						811,
-						682,
-						833,
-						817,
-						823,
-						831,
-						677,
-						788,
-						689,
-						813,
-						825,
-						675,
-						827,
-						829,
-						661,
-						806
+						664,
+						835,
+						808,
+						679,
+						830,
+						814,
+						820,
+						828,
+						674,
+						785,
+						686,
+						810,
+						822,
+						672,
+						824,
+						826,
+						658,
+						803
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 433,
+					"line": 431,
 					"character": 13
 				}
 			],
@@ -16565,7 +16681,7 @@
 			]
 		},
 		{
-			"id": 841,
+			"id": 838,
 			"name": "SageEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -16585,7 +16701,7 @@
 			},
 			"children": [
 				{
-					"id": 842,
+					"id": 839,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16599,40 +16715,40 @@
 					],
 					"signatures": [
 						{
-							"id": 843,
+							"id": 840,
 							"name": "new SageEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 844,
+									"id": 841,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2710,
+										"id": 2713,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 845,
+									"id": 842,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2544,
+										"id": 2546,
 										"name": "SageViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 841,
+								"id": 838,
 								"name": "SageEmbed"
 							},
 							"overwrites": {
@@ -16647,7 +16763,7 @@
 					}
 				},
 				{
-					"id": 1002,
+					"id": 999,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16663,7 +16779,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1003,
+							"id": 1000,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16693,7 +16809,7 @@
 					}
 				},
 				{
-					"id": 1021,
+					"id": 1018,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16709,7 +16825,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1022,
+							"id": 1019,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16725,7 +16841,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1023,
+									"id": 1020,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16746,7 +16862,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -16764,7 +16880,7 @@
 					}
 				},
 				{
-					"id": 851,
+					"id": 848,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16780,7 +16896,7 @@
 					],
 					"signatures": [
 						{
-							"id": 852,
+							"id": 849,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16797,7 +16913,7 @@
 					]
 				},
 				{
-					"id": 988,
+					"id": 985,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16813,7 +16929,7 @@
 					],
 					"signatures": [
 						{
-							"id": 989,
+							"id": 986,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16834,7 +16950,7 @@
 					}
 				},
 				{
-					"id": 1016,
+					"id": 1013,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16850,7 +16966,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1017,
+							"id": 1014,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16872,14 +16988,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1018,
+									"id": 1015,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1020,
+											"id": 1017,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -16891,7 +17007,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1019,
+											"id": 1016,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -16908,8 +17024,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1020,
-												1019
+												1017,
+												1016
 											]
 										}
 									]
@@ -16927,7 +17043,7 @@
 					}
 				},
 				{
-					"id": 996,
+					"id": 993,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16943,7 +17059,7 @@
 					],
 					"signatures": [
 						{
-							"id": 997,
+							"id": 994,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16959,7 +17075,7 @@
 							},
 							"parameters": [
 								{
-									"id": 998,
+									"id": 995,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16967,20 +17083,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 999,
+											"id": 996,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1000,
+												"id": 997,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1001,
+														"id": 998,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -17025,7 +17141,7 @@
 					}
 				},
 				{
-					"id": 1004,
+					"id": 1001,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17041,7 +17157,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1005,
+							"id": 1002,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17062,7 +17178,7 @@
 					}
 				},
 				{
-					"id": 1014,
+					"id": 1011,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17078,7 +17194,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1015,
+							"id": 1012,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17102,7 +17218,7 @@
 					}
 				},
 				{
-					"id": 959,
+					"id": 956,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17118,7 +17234,7 @@
 					],
 					"signatures": [
 						{
-							"id": 960,
+							"id": 957,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17134,7 +17250,7 @@
 							},
 							"parameters": [
 								{
-									"id": 961,
+									"id": 958,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17144,12 +17260,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 962,
+									"id": 959,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17159,7 +17275,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -17180,7 +17296,7 @@
 					}
 				},
 				{
-					"id": 860,
+					"id": 857,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17196,7 +17312,7 @@
 					],
 					"signatures": [
 						{
-							"id": 861,
+							"id": 858,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17219,38 +17335,38 @@
 							},
 							"parameters": [
 								{
-									"id": 862,
+									"id": 859,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 863,
+									"id": 860,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 864,
+									"id": 861,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17272,7 +17388,7 @@
 					}
 				},
 				{
-					"id": 992,
+					"id": 989,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17288,7 +17404,7 @@
 					],
 					"signatures": [
 						{
-							"id": 993,
+							"id": 990,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17298,7 +17414,7 @@
 							},
 							"parameters": [
 								{
-									"id": 994,
+									"id": 991,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17313,7 +17429,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 995,
+									"id": 992,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17347,7 +17463,7 @@
 					}
 				},
 				{
-					"id": 1006,
+					"id": 1003,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17363,7 +17479,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1007,
+							"id": 1004,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17400,7 +17516,7 @@
 					}
 				},
 				{
-					"id": 853,
+					"id": 850,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17416,7 +17532,7 @@
 					],
 					"signatures": [
 						{
-							"id": 854,
+							"id": 851,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17430,7 +17546,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 841,
+										"id": 838,
 										"name": "SageEmbed"
 									}
 								],
@@ -17448,7 +17564,7 @@
 					}
 				},
 				{
-					"id": 1010,
+					"id": 1007,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17464,7 +17580,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1011,
+							"id": 1008,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17494,7 +17610,7 @@
 					}
 				},
 				{
-					"id": 1012,
+					"id": 1009,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17510,7 +17626,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1013,
+							"id": 1010,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17540,7 +17656,7 @@
 					}
 				},
 				{
-					"id": 977,
+					"id": 974,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17556,7 +17672,7 @@
 					],
 					"signatures": [
 						{
-							"id": 978,
+							"id": 975,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17567,19 +17683,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 979,
+									"id": 976,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 980,
+									"id": 977,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -17588,7 +17704,7 @@
 							],
 							"parameters": [
 								{
-									"id": 981,
+									"id": 978,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17602,7 +17718,7 @@
 									}
 								},
 								{
-									"id": 982,
+									"id": 979,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17659,7 +17775,7 @@
 					}
 				},
 				{
-					"id": 983,
+					"id": 980,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17675,7 +17791,7 @@
 					],
 					"signatures": [
 						{
-							"id": 984,
+							"id": 981,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17686,21 +17802,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 985,
+									"id": 982,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 986,
+									"id": 983,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17714,7 +17830,7 @@
 									}
 								},
 								{
-									"id": 987,
+									"id": 984,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17767,30 +17883,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						842
+						839
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1002,
-						1021,
-						851,
-						988,
-						1016,
-						996,
-						1004,
-						1014,
-						959,
-						860,
-						992,
-						1006,
-						853,
-						1010,
-						1012,
-						977,
-						983
+						999,
+						1018,
+						848,
+						985,
+						1013,
+						993,
+						1001,
+						1011,
+						956,
+						857,
+						989,
+						1003,
+						850,
+						1007,
+						1009,
+						974,
+						980
 					]
 				}
 			],
@@ -17809,7 +17925,7 @@
 			]
 		},
 		{
-			"id": 238,
+			"id": 235,
 			"name": "SearchBarEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -17829,7 +17945,7 @@
 			},
 			"children": [
 				{
-					"id": 239,
+					"id": 236,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -17843,14 +17959,14 @@
 					],
 					"signatures": [
 						{
-							"id": 240,
+							"id": 237,
 							"name": "new SearchBarEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 241,
+									"id": 238,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17861,21 +17977,21 @@
 									}
 								},
 								{
-									"id": 242,
+									"id": 239,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2420,
+										"id": 2421,
 										"name": "SearchBarViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 238,
+								"id": 235,
 								"name": "SearchBarEmbed"
 							},
 							"overwrites": {
@@ -17890,7 +18006,7 @@
 					}
 				},
 				{
-					"id": 396,
+					"id": 393,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17906,7 +18022,7 @@
 					],
 					"signatures": [
 						{
-							"id": 397,
+							"id": 394,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17936,7 +18052,7 @@
 					}
 				},
 				{
-					"id": 415,
+					"id": 412,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17952,7 +18068,7 @@
 					],
 					"signatures": [
 						{
-							"id": 416,
+							"id": 413,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17968,7 +18084,7 @@
 							},
 							"parameters": [
 								{
-									"id": 417,
+									"id": 414,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17989,7 +18105,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -18007,7 +18123,7 @@
 					}
 				},
 				{
-					"id": 382,
+					"id": 379,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18023,7 +18139,7 @@
 					],
 					"signatures": [
 						{
-							"id": 383,
+							"id": 380,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18044,7 +18160,7 @@
 					}
 				},
 				{
-					"id": 410,
+					"id": 407,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18060,7 +18176,7 @@
 					],
 					"signatures": [
 						{
-							"id": 411,
+							"id": 408,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18082,14 +18198,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 412,
+									"id": 409,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 414,
+											"id": 411,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18101,7 +18217,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 413,
+											"id": 410,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18118,8 +18234,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												414,
-												413
+												411,
+												410
 											]
 										}
 									]
@@ -18137,7 +18253,7 @@
 					}
 				},
 				{
-					"id": 390,
+					"id": 387,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18153,7 +18269,7 @@
 					],
 					"signatures": [
 						{
-							"id": 391,
+							"id": 388,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18169,7 +18285,7 @@
 							},
 							"parameters": [
 								{
-									"id": 392,
+									"id": 389,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18177,20 +18293,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 393,
+											"id": 390,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 394,
+												"id": 391,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 395,
+														"id": 392,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -18235,7 +18351,7 @@
 					}
 				},
 				{
-					"id": 398,
+					"id": 395,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18251,7 +18367,7 @@
 					],
 					"signatures": [
 						{
-							"id": 399,
+							"id": 396,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18272,7 +18388,7 @@
 					}
 				},
 				{
-					"id": 408,
+					"id": 405,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18288,7 +18404,7 @@
 					],
 					"signatures": [
 						{
-							"id": 409,
+							"id": 406,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18312,7 +18428,7 @@
 					}
 				},
 				{
-					"id": 353,
+					"id": 350,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18328,7 +18444,7 @@
 					],
 					"signatures": [
 						{
-							"id": 354,
+							"id": 351,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18344,7 +18460,7 @@
 							},
 							"parameters": [
 								{
-									"id": 355,
+									"id": 352,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18354,12 +18470,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 356,
+									"id": 353,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18369,7 +18485,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -18390,7 +18506,7 @@
 					}
 				},
 				{
-					"id": 347,
+					"id": 344,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18406,7 +18522,7 @@
 					],
 					"signatures": [
 						{
-							"id": 348,
+							"id": 345,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18426,7 +18542,7 @@
 							},
 							"parameters": [
 								{
-									"id": 349,
+									"id": 346,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18436,12 +18552,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 350,
+									"id": 347,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18451,12 +18567,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 351,
+									"id": 348,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18466,13 +18582,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 352,
+									"id": 349,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18501,7 +18617,7 @@
 					}
 				},
 				{
-					"id": 386,
+					"id": 383,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18517,7 +18633,7 @@
 					],
 					"signatures": [
 						{
-							"id": 387,
+							"id": 384,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18527,7 +18643,7 @@
 							},
 							"parameters": [
 								{
-									"id": 388,
+									"id": 385,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18542,7 +18658,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 389,
+									"id": 386,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18576,7 +18692,7 @@
 					}
 				},
 				{
-					"id": 400,
+					"id": 397,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18592,7 +18708,7 @@
 					],
 					"signatures": [
 						{
-							"id": 401,
+							"id": 398,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18629,7 +18745,7 @@
 					}
 				},
 				{
-					"id": 249,
+					"id": 246,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18645,7 +18761,7 @@
 					],
 					"signatures": [
 						{
-							"id": 250,
+							"id": 247,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18658,7 +18774,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 238,
+										"id": 235,
 										"name": "SearchBarEmbed"
 									}
 								],
@@ -18676,7 +18792,7 @@
 					}
 				},
 				{
-					"id": 404,
+					"id": 401,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18692,7 +18808,7 @@
 					],
 					"signatures": [
 						{
-							"id": 405,
+							"id": 402,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18722,7 +18838,7 @@
 					}
 				},
 				{
-					"id": 406,
+					"id": 403,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18738,7 +18854,7 @@
 					],
 					"signatures": [
 						{
-							"id": 407,
+							"id": 404,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18768,7 +18884,7 @@
 					}
 				},
 				{
-					"id": 371,
+					"id": 368,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18784,7 +18900,7 @@
 					],
 					"signatures": [
 						{
-							"id": 372,
+							"id": 369,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18795,19 +18911,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 373,
+									"id": 370,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 374,
+									"id": 371,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -18816,7 +18932,7 @@
 							],
 							"parameters": [
 								{
-									"id": 375,
+									"id": 372,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18830,7 +18946,7 @@
 									}
 								},
 								{
-									"id": 376,
+									"id": 373,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18887,7 +19003,7 @@
 					}
 				},
 				{
-					"id": 377,
+					"id": 374,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18903,7 +19019,7 @@
 					],
 					"signatures": [
 						{
-							"id": 378,
+							"id": 375,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18914,21 +19030,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 379,
+									"id": 376,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 380,
+									"id": 377,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18942,7 +19058,7 @@
 									}
 								},
 								{
-									"id": 381,
+									"id": 378,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18995,29 +19111,29 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						239
+						236
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						396,
-						415,
-						382,
-						410,
-						390,
-						398,
-						408,
-						353,
-						347,
-						386,
-						400,
-						249,
-						404,
-						406,
-						371,
-						377
+						393,
+						412,
+						379,
+						407,
+						387,
+						395,
+						405,
+						350,
+						344,
+						383,
+						397,
+						246,
+						401,
+						403,
+						368,
+						374
 					]
 				}
 			],
@@ -19036,7 +19152,7 @@
 			]
 		},
 		{
-			"id": 55,
+			"id": 52,
 			"name": "SearchEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19052,7 +19168,7 @@
 			},
 			"children": [
 				{
-					"id": 56,
+					"id": 53,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19066,40 +19182,40 @@
 					],
 					"signatures": [
 						{
-							"id": 57,
+							"id": 54,
 							"name": "new SearchEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 58,
+									"id": 55,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2710,
+										"id": 2713,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 59,
+									"id": 56,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2364,
+										"id": 2365,
 										"name": "SearchViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 55,
+								"id": 52,
 								"name": "SearchEmbed"
 							},
 							"overwrites": {
@@ -19114,7 +19230,7 @@
 					}
 				},
 				{
-					"id": 216,
+					"id": 213,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19130,7 +19246,7 @@
 					],
 					"signatures": [
 						{
-							"id": 217,
+							"id": 214,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19160,7 +19276,7 @@
 					}
 				},
 				{
-					"id": 235,
+					"id": 232,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19176,7 +19292,7 @@
 					],
 					"signatures": [
 						{
-							"id": 236,
+							"id": 233,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19192,7 +19308,7 @@
 							},
 							"parameters": [
 								{
-									"id": 237,
+									"id": 234,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19213,7 +19329,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -19231,7 +19347,7 @@
 					}
 				},
 				{
-					"id": 75,
+					"id": 72,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19247,7 +19363,7 @@
 					],
 					"signatures": [
 						{
-							"id": 76,
+							"id": 73,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19263,7 +19379,7 @@
 					]
 				},
 				{
-					"id": 202,
+					"id": 199,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19279,7 +19395,7 @@
 					],
 					"signatures": [
 						{
-							"id": 203,
+							"id": 200,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19300,7 +19416,7 @@
 					}
 				},
 				{
-					"id": 230,
+					"id": 227,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19316,7 +19432,7 @@
 					],
 					"signatures": [
 						{
-							"id": 231,
+							"id": 228,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19338,14 +19454,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 232,
+									"id": 229,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 234,
+											"id": 231,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19357,7 +19473,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 233,
+											"id": 230,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19374,8 +19490,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												234,
-												233
+												231,
+												230
 											]
 										}
 									]
@@ -19393,7 +19509,7 @@
 					}
 				},
 				{
-					"id": 210,
+					"id": 207,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19409,7 +19525,7 @@
 					],
 					"signatures": [
 						{
-							"id": 211,
+							"id": 208,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19425,7 +19541,7 @@
 							},
 							"parameters": [
 								{
-									"id": 212,
+									"id": 209,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19433,20 +19549,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 213,
+											"id": 210,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 214,
+												"id": 211,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 215,
+														"id": 212,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -19491,7 +19607,7 @@
 					}
 				},
 				{
-					"id": 218,
+					"id": 215,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19507,7 +19623,7 @@
 					],
 					"signatures": [
 						{
-							"id": 219,
+							"id": 216,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19528,7 +19644,7 @@
 					}
 				},
 				{
-					"id": 228,
+					"id": 225,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19544,7 +19660,7 @@
 					],
 					"signatures": [
 						{
-							"id": 229,
+							"id": 226,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19568,7 +19684,7 @@
 					}
 				},
 				{
-					"id": 173,
+					"id": 170,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19584,7 +19700,7 @@
 					],
 					"signatures": [
 						{
-							"id": 174,
+							"id": 171,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19600,7 +19716,7 @@
 							},
 							"parameters": [
 								{
-									"id": 175,
+									"id": 172,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19610,12 +19726,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 176,
+									"id": 173,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19625,7 +19741,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -19646,7 +19762,7 @@
 					}
 				},
 				{
-					"id": 167,
+					"id": 164,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19662,7 +19778,7 @@
 					],
 					"signatures": [
 						{
-							"id": 168,
+							"id": 165,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19682,7 +19798,7 @@
 							},
 							"parameters": [
 								{
-									"id": 169,
+									"id": 166,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19692,12 +19808,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 170,
+									"id": 167,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19707,12 +19823,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 171,
+									"id": 168,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19722,13 +19838,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 172,
+									"id": 169,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19757,7 +19873,7 @@
 					}
 				},
 				{
-					"id": 206,
+					"id": 203,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19773,7 +19889,7 @@
 					],
 					"signatures": [
 						{
-							"id": 207,
+							"id": 204,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19783,7 +19899,7 @@
 							},
 							"parameters": [
 								{
-									"id": 208,
+									"id": 205,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19798,7 +19914,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 209,
+									"id": 206,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19832,7 +19948,7 @@
 					}
 				},
 				{
-					"id": 220,
+					"id": 217,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19848,7 +19964,7 @@
 					],
 					"signatures": [
 						{
-							"id": 221,
+							"id": 218,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19885,7 +20001,7 @@
 					}
 				},
 				{
-					"id": 77,
+					"id": 74,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19901,7 +20017,7 @@
 					],
 					"signatures": [
 						{
-							"id": 78,
+							"id": 75,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19914,7 +20030,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 55,
+										"id": 52,
 										"name": "SearchEmbed"
 									}
 								],
@@ -19932,7 +20048,7 @@
 					}
 				},
 				{
-					"id": 224,
+					"id": 221,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19948,7 +20064,7 @@
 					],
 					"signatures": [
 						{
-							"id": 225,
+							"id": 222,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19978,7 +20094,7 @@
 					}
 				},
 				{
-					"id": 226,
+					"id": 223,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19994,7 +20110,7 @@
 					],
 					"signatures": [
 						{
-							"id": 227,
+							"id": 224,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20024,7 +20140,7 @@
 					}
 				},
 				{
-					"id": 191,
+					"id": 188,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20040,7 +20156,7 @@
 					],
 					"signatures": [
 						{
-							"id": 192,
+							"id": 189,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20051,19 +20167,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 193,
+									"id": 190,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 194,
+									"id": 191,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -20072,7 +20188,7 @@
 							],
 							"parameters": [
 								{
-									"id": 195,
+									"id": 192,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20086,7 +20202,7 @@
 									}
 								},
 								{
-									"id": 196,
+									"id": 193,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20143,7 +20259,7 @@
 					}
 				},
 				{
-					"id": 197,
+					"id": 194,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20159,7 +20275,7 @@
 					],
 					"signatures": [
 						{
-							"id": 198,
+							"id": 195,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20170,21 +20286,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 199,
+									"id": 196,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 200,
+									"id": 197,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20198,7 +20314,7 @@
 									}
 								},
 								{
-									"id": 201,
+									"id": 198,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20251,30 +20367,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						56
+						53
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						216,
-						235,
-						75,
-						202,
-						230,
-						210,
-						218,
-						228,
-						173,
-						167,
-						206,
-						220,
-						77,
-						224,
-						226,
-						191,
-						197
+						213,
+						232,
+						72,
+						199,
+						227,
+						207,
+						215,
+						225,
+						170,
+						164,
+						203,
+						217,
+						74,
+						221,
+						223,
+						188,
+						194
 					]
 				}
 			],
@@ -20293,7 +20409,7 @@
 			]
 		},
 		{
-			"id": 1241,
+			"id": 1238,
 			"name": "SpotterAgentEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -20317,7 +20433,7 @@
 			},
 			"children": [
 				{
-					"id": 1242,
+					"id": 1239,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -20331,35 +20447,35 @@
 					],
 					"signatures": [
 						{
-							"id": 1243,
+							"id": 1240,
 							"name": "new SpotterAgentEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1244,
+									"id": 1241,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1273,
+										"id": 1270,
 										"name": "SpotterAgentEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1241,
+								"id": 1238,
 								"name": "SpotterAgentEmbed"
 							}
 						}
 					]
 				},
 				{
-					"id": 1246,
+					"id": 1243,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20375,14 +20491,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1247,
+							"id": 1244,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1248,
+									"id": 1245,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20402,14 +20518,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1249,
+													"id": 1246,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1251,
+															"id": 1248,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20420,7 +20536,7 @@
 															}
 														},
 														{
-															"id": 1250,
+															"id": 1247,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20431,7 +20547,7 @@
 															}
 														},
 														{
-															"id": 1252,
+															"id": 1249,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20448,9 +20564,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1251,
-																1250,
-																1252
+																1248,
+																1247,
+																1249
 															]
 														}
 													]
@@ -20459,14 +20575,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1253,
+													"id": 1250,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1254,
+															"id": 1251,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20477,7 +20593,7 @@
 															}
 														},
 														{
-															"id": 1256,
+															"id": 1253,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20488,7 +20604,7 @@
 															}
 														},
 														{
-															"id": 1255,
+															"id": 1252,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20505,9 +20621,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1254,
-																1256,
-																1255
+																1251,
+																1253,
+																1252
 															]
 														}
 													]
@@ -20522,7 +20638,7 @@
 					]
 				},
 				{
-					"id": 1257,
+					"id": 1254,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20538,7 +20654,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1258,
+							"id": 1255,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20549,7 +20665,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1259,
+									"id": 1256,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20572,14 +20688,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1260,
+													"id": 1257,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1262,
+															"id": 1259,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20591,7 +20707,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1261,
+															"id": 1258,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20607,8 +20723,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1262,
-																1261
+																1259,
+																1258
 															]
 														}
 													]
@@ -20617,14 +20733,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1263,
+													"id": 1260,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1264,
+															"id": 1261,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20632,14 +20748,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1265,
+																	"id": 1262,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1271,
+																			"id": 1268,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20651,7 +20767,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1270,
+																			"id": 1267,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20663,7 +20779,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1266,
+																			"id": 1263,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20675,7 +20791,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1269,
+																			"id": 1266,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20687,7 +20803,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1267,
+																			"id": 1264,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20699,7 +20815,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1268,
+																			"id": 1265,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20716,12 +20832,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1271,
-																				1270,
-																				1266,
-																				1269,
+																				1268,
 																				1267,
-																				1268
+																				1263,
+																				1266,
+																				1264,
+																				1265
 																			]
 																		}
 																	]
@@ -20730,7 +20846,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1272,
+															"id": 1269,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20746,8 +20862,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1264,
-																1272
+																1261,
+																1269
 															]
 														}
 													]
@@ -20767,15 +20883,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1242
+						1239
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1246,
-						1257
+						1243,
+						1254
 					]
 				}
 			],
@@ -20789,13 +20905,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1337,
+					"id": 1334,
 					"name": "BodylessConversation"
 				}
 			]
 		},
 		{
-			"id": 1368,
+			"id": 1365,
 			"name": "SpotterEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -20819,7 +20935,7 @@
 			},
 			"children": [
 				{
-					"id": 1369,
+					"id": 1366,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -20833,14 +20949,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1370,
+							"id": 1367,
 							"name": "new SpotterEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1371,
+									"id": 1368,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20851,21 +20967,21 @@
 									}
 								},
 								{
-									"id": 1372,
+									"id": 1369,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1541,
+										"id": 1538,
 										"name": "SpotterEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1368,
+								"id": 1365,
 								"name": "SpotterEmbed"
 							},
 							"overwrites": {
@@ -20880,7 +20996,7 @@
 					}
 				},
 				{
-					"id": 1519,
+					"id": 1516,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20896,7 +21012,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1520,
+							"id": 1517,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20926,7 +21042,7 @@
 					}
 				},
 				{
-					"id": 1538,
+					"id": 1535,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20942,7 +21058,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1539,
+							"id": 1536,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20958,7 +21074,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1540,
+									"id": 1537,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20979,7 +21095,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1869,
 										"name": "AnswerService"
 									}
 								],
@@ -20997,7 +21113,7 @@
 					}
 				},
 				{
-					"id": 1376,
+					"id": 1373,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21007,13 +21123,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 273,
+							"line": 279,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1377,
+							"id": 1374,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21034,7 +21150,7 @@
 					}
 				},
 				{
-					"id": 1533,
+					"id": 1530,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21050,7 +21166,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1534,
+							"id": 1531,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21072,14 +21188,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1535,
+									"id": 1532,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1537,
+											"id": 1534,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21091,7 +21207,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1536,
+											"id": 1533,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21108,8 +21224,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1537,
-												1536
+												1534,
+												1533
 											]
 										}
 									]
@@ -21127,7 +21243,7 @@
 					}
 				},
 				{
-					"id": 1513,
+					"id": 1510,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21143,7 +21259,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1514,
+							"id": 1511,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21159,7 +21275,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1515,
+									"id": 1512,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21167,20 +21283,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1516,
+											"id": 1513,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1517,
+												"id": 1514,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1518,
+														"id": 1515,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -21225,7 +21341,7 @@
 					}
 				},
 				{
-					"id": 1521,
+					"id": 1518,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21241,7 +21357,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1522,
+							"id": 1519,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21262,7 +21378,7 @@
 					}
 				},
 				{
-					"id": 1531,
+					"id": 1528,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21278,7 +21394,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1532,
+							"id": 1529,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21302,7 +21418,7 @@
 					}
 				},
 				{
-					"id": 1478,
+					"id": 1475,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21318,7 +21434,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1479,
+							"id": 1476,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21334,7 +21450,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1480,
+									"id": 1477,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21344,12 +21460,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1481,
+									"id": 1478,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21359,7 +21475,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								}
@@ -21380,7 +21496,7 @@
 					}
 				},
 				{
-					"id": 1472,
+					"id": 1469,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21396,7 +21512,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1473,
+							"id": 1470,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21416,7 +21532,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1474,
+									"id": 1471,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21426,12 +21542,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1996,
+										"id": 1993,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1475,
+									"id": 1472,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21441,12 +21557,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1476,
+									"id": 1473,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21456,13 +21572,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2711,
+										"id": 2714,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1477,
+									"id": 1474,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21491,7 +21607,7 @@
 					}
 				},
 				{
-					"id": 1509,
+					"id": 1506,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21507,7 +21623,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1510,
+							"id": 1507,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21517,7 +21633,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1511,
+									"id": 1508,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21532,7 +21648,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1512,
+									"id": 1509,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21566,7 +21682,7 @@
 					}
 				},
 				{
-					"id": 1523,
+					"id": 1520,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21582,7 +21698,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1524,
+							"id": 1521,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21619,7 +21735,7 @@
 					}
 				},
 				{
-					"id": 1378,
+					"id": 1375,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21629,13 +21745,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 313,
+							"line": 319,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1379,
+							"id": 1376,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21645,7 +21761,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1368,
+										"id": 1365,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -21663,7 +21779,7 @@
 					}
 				},
 				{
-					"id": 1527,
+					"id": 1524,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21679,7 +21795,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1528,
+							"id": 1525,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21709,7 +21825,7 @@
 					}
 				},
 				{
-					"id": 1529,
+					"id": 1526,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21725,7 +21841,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1530,
+							"id": 1527,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21755,7 +21871,7 @@
 					}
 				},
 				{
-					"id": 1496,
+					"id": 1493,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21771,7 +21887,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1497,
+							"id": 1494,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21782,19 +21898,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1498,
+									"id": 1495,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2092,
+										"id": 2089,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1499,
+									"id": 1496,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -21803,7 +21919,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1500,
+									"id": 1497,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21817,7 +21933,7 @@
 									}
 								},
 								{
-									"id": 1501,
+									"id": 1498,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21874,7 +21990,7 @@
 					}
 				},
 				{
-					"id": 1502,
+					"id": 1499,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21890,7 +22006,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1503,
+							"id": 1500,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21901,21 +22017,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1504,
+									"id": 1501,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2972,
+										"id": 2975,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1505,
+									"id": 1502,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21929,7 +22045,7 @@
 									}
 								},
 								{
-									"id": 1506,
+									"id": 1503,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21982,29 +22098,29 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1369
+						1366
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1519,
-						1538,
-						1376,
-						1533,
-						1513,
-						1521,
-						1531,
-						1478,
-						1472,
-						1509,
-						1523,
-						1378,
-						1527,
-						1529,
-						1496,
-						1502
+						1516,
+						1535,
+						1373,
+						1530,
+						1510,
+						1518,
+						1528,
+						1475,
+						1469,
+						1506,
+						1520,
+						1375,
+						1524,
+						1526,
+						1493,
+						1499
 					]
 				}
 			],
@@ -22024,13 +22140,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1629,
+					"id": 1626,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2594,
+			"id": 2596,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -22046,7 +22162,7 @@
 			},
 			"children": [
 				{
-					"id": 2632,
+					"id": 2634,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22077,20 +22193,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2633,
+							"id": 2635,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2634,
+								"id": 2636,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2635,
+										"id": 2637,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -22126,7 +22242,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2661,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22168,7 +22284,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2616,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22205,7 +22321,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2658,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22235,7 +22351,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2308,
+						"id": 2309,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -22244,7 +22360,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2678,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22282,7 +22398,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2652,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22323,7 +22439,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2638,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22352,7 +22468,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -22361,7 +22477,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2617,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22395,12 +22511,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2986,
+						"id": 2989,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2662,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22442,7 +22558,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2599,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22480,7 +22596,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2646,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22518,7 +22634,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2630,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22556,7 +22672,7 @@
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2629,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22588,7 +22704,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -22598,7 +22714,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2615,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22636,7 +22752,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2642,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22677,7 +22793,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2672,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22719,7 +22835,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2677,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22761,7 +22877,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2663,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22803,7 +22919,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2600,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22839,7 +22955,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2612,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22877,7 +22993,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2643,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22915,7 +23031,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2659,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22953,7 +23069,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2660,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22991,7 +23107,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2645,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23028,7 +23144,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2626,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23058,7 +23174,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -23067,7 +23183,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2613,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23101,7 +23217,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2631,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23137,7 +23253,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -23147,7 +23263,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2667,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23179,7 +23295,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2692,
+							"id": 2695,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -23189,7 +23305,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2665,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23221,7 +23337,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2703,
+							"id": 2706,
 							"name": "HomepageModule"
 						}
 					},
@@ -23231,7 +23347,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2664,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23263,7 +23379,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2980,
+							"id": 2983,
 							"name": "ListPageColumns"
 						}
 					},
@@ -23273,7 +23389,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2604,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23311,7 +23427,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2601,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23349,7 +23465,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2598,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23387,7 +23503,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2675,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23429,7 +23545,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2668,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23471,7 +23587,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2603,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23509,7 +23625,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2602,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23547,7 +23663,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2610,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23584,7 +23700,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2605,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23622,7 +23738,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2609,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23656,7 +23772,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2618,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23682,12 +23798,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2937,
+						"id": 2940,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2639,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23725,7 +23841,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2655,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23748,7 +23864,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -23762,7 +23878,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2654,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23785,7 +23901,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -23802,7 +23918,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2680,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23840,7 +23956,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2682,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23878,7 +23994,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2681,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23916,7 +24032,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2673,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23958,7 +24074,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2671,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23996,7 +24112,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2620,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24030,7 +24146,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2653,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24050,7 +24166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -24064,7 +24180,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2621,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24098,7 +24214,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2619,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24136,7 +24252,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2622,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24173,7 +24289,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2623,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24207,7 +24323,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2648,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24245,7 +24361,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2679,
 					"name": "liveboardXLSXCSVDownload",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24283,7 +24399,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2633,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24321,7 +24437,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2614,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24359,7 +24475,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2647,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24397,7 +24513,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2607,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24427,12 +24543,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1955,
+						"id": 1952,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2606,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24466,7 +24582,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2641,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24504,7 +24620,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2649,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24542,7 +24658,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2666,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24574,7 +24690,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2703,
+							"id": 2706,
 							"name": "HomepageModule"
 						}
 					},
@@ -24584,7 +24700,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2656,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24616,7 +24732,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -24626,7 +24742,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2657,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24658,7 +24774,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -24668,7 +24784,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2651,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24705,7 +24821,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2670,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24747,7 +24863,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2676,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24789,7 +24905,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2669,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24831,7 +24947,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2674,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24873,7 +24989,49 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2683,
+					"name": "showMaskedFilterChip",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Show or hide masked filter chips",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | Thoughtspot: 26.2.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   showMaskedFilterChip: true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1593,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "AllEmbedViewConfig.showMaskedFilterChip"
+					}
+				},
+				{
+					"id": 2597,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24911,7 +25069,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2608,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24945,7 +25103,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2624,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24983,7 +25141,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2632,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25019,7 +25177,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -25034,82 +25192,83 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2632,
-						2659,
-						2614,
-						2656,
-						2676,
-						2650,
-						2636,
-						2615,
-						2660,
-						2597,
-						2644,
-						2628,
-						2627,
-						2613,
-						2640,
-						2670,
-						2675,
+						2634,
 						2661,
-						2598,
-						2610,
-						2641,
-						2657,
-						2658,
-						2643,
-						2624,
-						2611,
-						2629,
-						2665,
-						2663,
-						2662,
-						2602,
-						2599,
-						2596,
-						2673,
-						2666,
-						2601,
-						2600,
-						2608,
-						2603,
-						2607,
 						2616,
-						2637,
-						2653,
-						2652,
+						2658,
 						2678,
-						2680,
-						2679,
-						2671,
-						2669,
-						2618,
-						2651,
-						2619,
+						2652,
+						2638,
 						2617,
-						2620,
-						2621,
+						2662,
+						2599,
 						2646,
-						2677,
-						2631,
-						2612,
-						2645,
-						2605,
-						2604,
-						2639,
-						2647,
-						2664,
-						2654,
-						2655,
-						2649,
-						2668,
-						2674,
-						2667,
+						2630,
+						2629,
+						2615,
+						2642,
 						2672,
-						2595,
-						2606,
+						2677,
+						2663,
+						2600,
+						2612,
+						2643,
+						2659,
+						2660,
+						2645,
+						2626,
+						2613,
+						2631,
+						2667,
+						2665,
+						2664,
+						2604,
+						2601,
+						2598,
+						2675,
+						2668,
+						2603,
+						2602,
+						2610,
+						2605,
+						2609,
+						2618,
+						2639,
+						2655,
+						2654,
+						2680,
+						2682,
+						2681,
+						2673,
+						2671,
+						2620,
+						2653,
+						2621,
+						2619,
 						2622,
-						2630
+						2623,
+						2648,
+						2679,
+						2633,
+						2614,
+						2647,
+						2607,
+						2606,
+						2641,
+						2649,
+						2666,
+						2656,
+						2657,
+						2651,
+						2670,
+						2676,
+						2669,
+						2674,
+						2683,
+						2597,
+						2608,
+						2624,
+						2632
 					]
 				}
 			],
@@ -25128,7 +25287,7 @@
 			]
 		},
 		{
-			"id": 1819,
+			"id": 1816,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -25144,14 +25303,14 @@
 			},
 			"children": [
 				{
-					"id": 1856,
+					"id": 1853,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1857,
+							"id": 1854,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25161,19 +25320,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1858,
+									"id": 1855,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1818,
+										"id": 1815,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1859,
+									"id": 1856,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25197,14 +25356,14 @@
 					]
 				},
 				{
-					"id": 1860,
+					"id": 1857,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1861,
+							"id": 1858,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25214,7 +25373,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1862,
+									"id": 1859,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25222,12 +25381,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1806,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1863,
+									"id": 1860,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25236,21 +25395,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1864,
+											"id": 1861,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1865,
+													"id": 1862,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1866,
+															"id": 1863,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25276,7 +25435,7 @@
 									}
 								},
 								{
-									"id": 1867,
+									"id": 1864,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25288,7 +25447,7 @@
 									}
 								},
 								{
-									"id": 1868,
+									"id": 1865,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25304,21 +25463,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1820,
+					"id": 1817,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1821,
+							"id": 1818,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25328,7 +25487,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1822,
+									"id": 1819,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25336,12 +25495,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1807,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1823,
+									"id": 1820,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25352,28 +25511,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1824,
+											"id": 1821,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1825,
+													"id": 1822,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1826,
+															"id": 1823,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1802,
+																"id": 1799,
 																"name": "AuthFailureType"
 															}
 														}
@@ -25390,12 +25549,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1827,
+							"id": 1824,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25405,7 +25564,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1828,
+									"id": 1825,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25416,29 +25575,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1808,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1814,
+												"id": 1811,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1815,
+												"id": 1812,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1816,
+												"id": 1813,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1829,
+									"id": 1826,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25449,14 +25608,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1830,
+											"id": 1827,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1831,
+													"id": 1828,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -25473,31 +25632,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1832,
+							"id": 1829,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1833,
+									"id": 1830,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1813,
+										"id": 1810,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1834,
+									"id": 1831,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25505,21 +25664,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1835,
+											"id": 1832,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1836,
+													"id": 1833,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1837,
+															"id": 1834,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25542,40 +25701,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1838,
+					"id": 1835,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1839,
+							"id": 1836,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1840,
+									"id": 1837,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1807,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1841,
+									"id": 1838,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25583,28 +25742,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1842,
+											"id": 1839,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1843,
+													"id": 1840,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1844,
+															"id": 1841,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1802,
+																"id": 1799,
 																"name": "AuthFailureType"
 															}
 														}
@@ -25621,19 +25780,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1845,
+							"id": 1842,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1846,
+									"id": 1843,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25643,29 +25802,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1808,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1814,
+												"id": 1811,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1815,
+												"id": 1812,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1816,
+												"id": 1813,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1847,
+									"id": 1844,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25673,14 +25832,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1848,
+											"id": 1845,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1849,
+													"id": 1846,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -25697,31 +25856,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1850,
+							"id": 1847,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1851,
+									"id": 1848,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1813,
+										"id": 1810,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1852,
+									"id": 1849,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25729,21 +25888,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1853,
+											"id": 1850,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1854,
+													"id": 1851,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1855,
+															"id": 1852,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25766,21 +25925,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1869,
+					"id": 1866,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1870,
+							"id": 1867,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25790,7 +25949,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1871,
+									"id": 1868,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25800,14 +25959,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1806,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1816,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -25819,11 +25978,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1856,
-						1860,
-						1820,
-						1838,
-						1869
+						1853,
+						1857,
+						1817,
+						1835,
+						1866
 					]
 				}
 			],
@@ -25836,7 +25995,7 @@
 			]
 		},
 		{
-			"id": 1305,
+			"id": 1302,
 			"name": "BodylessConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -25856,7 +26015,7 @@
 			},
 			"children": [
 				{
-					"id": 1316,
+					"id": 1313,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25887,20 +26046,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1317,
+							"id": 1314,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1318,
+								"id": 1315,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1319,
+										"id": 1316,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -25932,12 +26091,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1284,
+						"id": 1281,
 						"name": "SpotterAgentEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1333,
+					"id": 1330,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25974,12 +26133,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1301,
+						"id": 1298,
 						"name": "SpotterAgentEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1320,
+					"id": 1317,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26008,17 +26167,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1288,
+						"id": 1285,
 						"name": "SpotterAgentEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1328,
+					"id": 1325,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26052,12 +26211,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1296,
+						"id": 1293,
 						"name": "SpotterAgentEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1312,
+					"id": 1309,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26091,12 +26250,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1280,
+						"id": 1277,
 						"name": "SpotterAgentEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1311,
+					"id": 1308,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26128,18 +26287,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1279,
+						"id": 1276,
 						"name": "SpotterAgentEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1324,
+					"id": 1321,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26176,12 +26335,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1292,
+						"id": 1289,
 						"name": "SpotterAgentEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1325,
+					"id": 1322,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26215,12 +26374,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1293,
+						"id": 1290,
 						"name": "SpotterAgentEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1327,
+					"id": 1324,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26253,12 +26412,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1295,
+						"id": 1292,
 						"name": "SpotterAgentEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1308,
+					"id": 1305,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26288,17 +26447,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1276,
+						"id": 1273,
 						"name": "SpotterAgentEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1313,
+					"id": 1310,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26334,18 +26493,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1281,
+						"id": 1278,
 						"name": "SpotterAgentEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1321,
+					"id": 1318,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26379,12 +26538,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1289,
+						"id": 1286,
 						"name": "SpotterAgentEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1336,
+					"id": 1333,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26407,7 +26566,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -26417,12 +26576,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1304,
+						"id": 1301,
 						"name": "SpotterAgentEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1335,
+					"id": 1332,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26445,7 +26604,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -26458,12 +26617,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1303,
+						"id": 1300,
 						"name": "SpotterAgentEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1334,
+					"id": 1331,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26483,7 +26642,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -26493,12 +26652,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1302,
+						"id": 1299,
 						"name": "SpotterAgentEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1330,
+					"id": 1327,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26532,12 +26691,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1298,
+						"id": 1295,
 						"name": "SpotterAgentEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1315,
+					"id": 1312,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26571,12 +26730,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1283,
+						"id": 1280,
 						"name": "SpotterAgentEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1329,
+					"id": 1326,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26610,12 +26769,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1297,
+						"id": 1294,
 						"name": "SpotterAgentEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1323,
+					"id": 1320,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26649,12 +26808,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1291,
+						"id": 1288,
 						"name": "SpotterAgentEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1332,
+					"id": 1329,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26687,12 +26846,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1300,
+						"id": 1297,
 						"name": "SpotterAgentEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1314,
+					"id": 1311,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26728,18 +26887,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1282,
+						"id": 1279,
 						"name": "SpotterAgentEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1306,
+					"id": 1303,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26760,7 +26919,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1274,
+						"id": 1271,
 						"name": "SpotterAgentEmbedViewConfig.worksheetId"
 					}
 				}
@@ -26770,28 +26929,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1316,
-						1333,
-						1320,
-						1328,
-						1312,
-						1311,
-						1324,
-						1325,
-						1327,
-						1308,
 						1313,
-						1321,
-						1336,
-						1335,
-						1334,
 						1330,
-						1315,
-						1329,
-						1323,
+						1317,
+						1325,
+						1309,
+						1308,
+						1321,
+						1322,
+						1324,
+						1305,
+						1310,
+						1318,
+						1333,
 						1332,
-						1314,
-						1306
+						1331,
+						1327,
+						1312,
+						1326,
+						1320,
+						1329,
+						1311,
+						1303
 					]
 				}
 			],
@@ -26805,13 +26964,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1273,
+					"id": 1270,
 					"name": "SpotterAgentEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1585,
+			"id": 1582,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26831,7 +26990,7 @@
 			},
 			"children": [
 				{
-					"id": 1608,
+					"id": 1605,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26862,20 +27021,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1609,
+							"id": 1606,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1610,
+								"id": 1607,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1611,
+										"id": 1608,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -26907,12 +27066,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1564,
+						"id": 1561,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1625,
+					"id": 1622,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26949,12 +27108,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1581,
+						"id": 1578,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1609,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26983,17 +27142,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1568,
+						"id": 1565,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1587,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27031,12 +27190,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1546,
+						"id": 1543,
 						"name": "SpotterEmbedViewConfig.dataPanelV2"
 					}
 				},
 				{
-					"id": 1620,
+					"id": 1617,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27070,12 +27229,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1576,
+						"id": 1573,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1585,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27109,12 +27268,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1544,
+						"id": 1541,
 						"name": "SpotterEmbedViewConfig.disableSourceSelection"
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1601,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27148,12 +27307,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1560,
+						"id": 1557,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1600,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27185,18 +27344,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1559,
+						"id": 1556,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1613,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27233,12 +27392,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1572,
+						"id": 1569,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1594,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27276,12 +27435,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1553,
+						"id": 1550,
 						"name": "SpotterEmbedViewConfig.enablePastConversationsSidebar"
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1614,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27315,12 +27474,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1573,
+						"id": 1570,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1591,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27354,12 +27513,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1550,
+						"id": 1547,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeFiltersfromURL"
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1593,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27393,12 +27552,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1552,
+						"id": 1549,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeParametersfromURL"
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1616,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27431,12 +27590,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1575,
+						"id": 1572,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1597,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27466,17 +27625,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1553,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1602,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27512,18 +27671,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1558,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1592,
+					"id": 1589,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27557,12 +27716,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1548,
+						"id": 1545,
 						"name": "SpotterEmbedViewConfig.hideSampleQuestions"
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1586,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27596,12 +27755,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1545,
+						"id": 1542,
 						"name": "SpotterEmbedViewConfig.hideSourceSelection"
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1610,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27635,12 +27794,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1569,
+						"id": 1566,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1625,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27663,7 +27822,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -27673,12 +27832,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1584,
+						"id": 1581,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1627,
+					"id": 1624,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27701,7 +27860,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -27714,12 +27873,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1583,
+						"id": 1580,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1623,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27739,7 +27898,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -27749,12 +27908,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1582,
+						"id": 1579,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1619,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27788,12 +27947,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1578,
+						"id": 1575,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1607,
+					"id": 1604,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27827,12 +27986,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1563,
+						"id": 1560,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1618,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27866,12 +28025,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1577,
+						"id": 1574,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1612,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27905,12 +28064,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1571,
+						"id": 1568,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1590,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27942,18 +28101,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1549,
+						"id": 1546,
 						"name": "SpotterEmbedViewConfig.runtimeFilters"
 					}
 				},
 				{
-					"id": 1595,
+					"id": 1592,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27985,18 +28144,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1551,
+						"id": 1548,
 						"name": "SpotterEmbedViewConfig.runtimeParameters"
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1584,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28019,12 +28178,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1540,
 						"name": "SpotterEmbedViewConfig.searchOptions"
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1621,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28057,12 +28216,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1580,
+						"id": 1577,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1588,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28096,12 +28255,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1547,
+						"id": 1544,
 						"name": "SpotterEmbedViewConfig.showSpotterLimitations"
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1595,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28139,12 +28298,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1554,
+						"id": 1551,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1603,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28180,18 +28339,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1562,
+						"id": 1559,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1583,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28212,7 +28371,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1542,
+						"id": 1539,
 						"name": "SpotterEmbedViewConfig.worksheetId"
 					}
 				}
@@ -28222,40 +28381,40 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1608,
-						1625,
-						1612,
-						1590,
-						1620,
-						1588,
-						1604,
-						1603,
+						1605,
+						1622,
+						1609,
+						1587,
+						1617,
+						1585,
+						1601,
+						1600,
+						1613,
+						1594,
+						1614,
+						1591,
+						1593,
 						1616,
 						1597,
-						1617,
-						1594,
-						1596,
-						1619,
-						1600,
-						1605,
-						1592,
+						1602,
 						1589,
-						1613,
-						1628,
-						1627,
-						1626,
-						1622,
-						1607,
-						1621,
-						1615,
-						1593,
-						1595,
-						1587,
+						1586,
+						1610,
+						1625,
 						1624,
-						1591,
-						1598,
-						1606,
-						1586
+						1623,
+						1619,
+						1604,
+						1618,
+						1612,
+						1590,
+						1592,
+						1584,
+						1621,
+						1588,
+						1595,
+						1603,
+						1583
 					]
 				}
 			],
@@ -28269,13 +28428,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1541,
+					"id": 1538,
 					"name": "SpotterEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 2952,
+			"id": 2955,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28290,7 +28449,7 @@
 			},
 			"children": [
 				{
-					"id": 2953,
+					"id": 2956,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28300,21 +28459,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5977,
+							"line": 6033,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2954,
+							"id": 2957,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2955,
+									"id": 2958,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28322,18 +28481,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5978,
+											"line": 6034,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 2949,
+										"id": 2952,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 2956,
+									"id": 2959,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28341,7 +28500,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5979,
+											"line": 6035,
 											"character": 8
 										}
 									],
@@ -28349,7 +28508,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2949,
+											"id": 2952,
 											"name": "VizPoint"
 										}
 									}
@@ -28360,8 +28519,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2955,
-										2956
+										2958,
+										2959
 									]
 								}
 							]
@@ -28369,7 +28528,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2960,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28377,21 +28536,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5981,
+							"line": 6037,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2958,
+							"id": 2961,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2966,
+									"id": 2969,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28399,7 +28558,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5989,
+											"line": 6045,
 											"character": 8
 										}
 									],
@@ -28412,7 +28571,7 @@
 									}
 								},
 								{
-									"id": 2967,
+									"id": 2970,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28420,7 +28579,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5990,
+											"line": 6046,
 											"character": 8
 										}
 									],
@@ -28433,7 +28592,7 @@
 									}
 								},
 								{
-									"id": 2960,
+									"id": 2963,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28441,7 +28600,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5983,
+											"line": 6039,
 											"character": 8
 										}
 									],
@@ -28451,7 +28610,7 @@
 									}
 								},
 								{
-									"id": 2959,
+									"id": 2962,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28459,7 +28618,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5982,
+											"line": 6038,
 											"character": 8
 										}
 									],
@@ -28469,7 +28628,7 @@
 									}
 								},
 								{
-									"id": 2961,
+									"id": 2964,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28477,21 +28636,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 5984,
+											"line": 6040,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2962,
+											"id": 2965,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 2963,
+													"id": 2966,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -28499,21 +28658,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 5985,
+															"line": 6041,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 2964,
+															"id": 2967,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 2965,
+																	"id": 2968,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -28521,7 +28680,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 5986,
+																			"line": 6042,
 																			"character": 16
 																		}
 																	],
@@ -28536,7 +28695,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		2965
+																		2968
 																	]
 																}
 															]
@@ -28549,7 +28708,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														2963
+														2966
 													]
 												}
 											]
@@ -28562,23 +28721,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2966,
-										2967,
-										2960,
-										2959,
-										2961
+										2969,
+										2970,
+										2963,
+										2962,
+										2964
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2968,
+								"id": 2971,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2969,
+										"id": 2972,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -28597,7 +28756,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2973,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28605,18 +28764,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5993,
+							"line": 6049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1945,
+						"id": 1942,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2974,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28626,7 +28785,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5994,
+							"line": 6050,
 							"character": 4
 						}
 					],
@@ -28641,23 +28800,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2953,
-						2957,
-						2970,
-						2971
+						2956,
+						2960,
+						2973,
+						2974
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5976,
+					"line": 6032,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2749,
+			"id": 2752,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28667,7 +28826,7 @@
 			},
 			"children": [
 				{
-					"id": 2803,
+					"id": 2806,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28690,7 +28849,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2805,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28713,7 +28872,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2775,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28736,7 +28895,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2776,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28759,7 +28918,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2778,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28782,7 +28941,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2777,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28805,7 +28964,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2757,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28828,7 +28987,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2818,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28851,7 +29010,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2819,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28874,7 +29033,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2816,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28897,7 +29056,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2817,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28920,7 +29079,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2780,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28943,7 +29102,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2785,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28966,7 +29125,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2782,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28989,7 +29148,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2784,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29012,7 +29171,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2783,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29035,7 +29194,7 @@
 					}
 				},
 				{
-					"id": 2778,
+					"id": 2781,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29058,7 +29217,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2790,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29081,7 +29240,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2787,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29104,7 +29263,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2789,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29127,7 +29286,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2788,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29150,7 +29309,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2786,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29173,7 +29332,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2794,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29196,7 +29355,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2793,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29219,7 +29378,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2792,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29242,7 +29401,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2791,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29265,7 +29424,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2779,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29288,7 +29447,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2912,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29311,7 +29470,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2907,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29334,7 +29493,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2902,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29357,7 +29516,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2901,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29380,7 +29539,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2904,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29403,7 +29562,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2903,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29426,7 +29585,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2841,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29449,7 +29608,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2844,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29472,7 +29631,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2839,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29495,7 +29654,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2842,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29518,7 +29677,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2843,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29541,7 +29700,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2838,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29564,7 +29723,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2840,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29587,7 +29746,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2811,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29610,7 +29769,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2810,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29633,7 +29792,7 @@
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2813,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29656,7 +29815,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2812,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29679,7 +29838,7 @@
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2809,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29702,7 +29861,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2807,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29725,7 +29884,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2808,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29748,7 +29907,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2814,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29771,7 +29930,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2815,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29794,7 +29953,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2826,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29817,7 +29976,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2827,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29840,7 +29999,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2830,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29863,7 +30022,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2828,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29886,7 +30045,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2829,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29909,7 +30068,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2837,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29932,7 +30091,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2836,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29955,7 +30114,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2835,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29978,7 +30137,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2834,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30001,7 +30160,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2900,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30024,7 +30183,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2899,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30047,7 +30206,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2898,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30070,7 +30229,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2906,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30093,7 +30252,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2905,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30116,7 +30275,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2832,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30139,7 +30298,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2831,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30162,7 +30321,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2859,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30185,7 +30344,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2872,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30209,7 +30368,7 @@
 					}
 				},
 				{
-					"id": 2868,
+					"id": 2871,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30233,7 +30392,7 @@
 					}
 				},
 				{
-					"id": 2866,
+					"id": 2869,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30257,7 +30416,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2870,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30281,7 +30440,7 @@
 					}
 				},
 				{
-					"id": 2874,
+					"id": 2877,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30304,7 +30463,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2875,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30327,7 +30486,7 @@
 					}
 				},
 				{
-					"id": 2871,
+					"id": 2874,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30350,7 +30509,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2860,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30374,7 +30533,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2861,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30398,7 +30557,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2865,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30422,7 +30581,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2853,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30446,7 +30605,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2868,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30470,7 +30629,7 @@
 					}
 				},
 				{
-					"id": 2864,
+					"id": 2867,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30494,7 +30653,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2858,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30518,7 +30677,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2866,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30542,7 +30701,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2856,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30566,7 +30725,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2857,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30590,7 +30749,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2864,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30614,7 +30773,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2854,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30638,7 +30797,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2855,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30662,7 +30821,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2891,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30685,7 +30844,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2888,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30708,7 +30867,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2889,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30731,7 +30890,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2890,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30754,7 +30913,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2846,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30777,7 +30936,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2897,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30800,7 +30959,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2892,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30823,7 +30982,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2893,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30846,7 +31005,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2896,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30869,7 +31028,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2894,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30892,7 +31051,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2895,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30915,7 +31074,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2847,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30938,7 +31097,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2845,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30961,7 +31120,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2863,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30984,7 +31143,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2862,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31007,7 +31166,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2876,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31030,7 +31189,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2878,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31053,7 +31212,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2879,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31076,7 +31235,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2849,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31099,7 +31258,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2848,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31122,7 +31281,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2850,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31145,7 +31304,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2851,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31168,7 +31327,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2852,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31191,7 +31350,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2880,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31214,7 +31373,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2881,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31237,7 +31396,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2824,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31260,7 +31419,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2821,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31283,7 +31442,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2820,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31306,7 +31465,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2822,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31329,7 +31488,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2825,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31352,7 +31511,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2823,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31375,7 +31534,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2758,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31398,7 +31557,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2759,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31421,7 +31580,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2886,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31444,7 +31603,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2887,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31467,7 +31626,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2882,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31490,7 +31649,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2884,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31513,7 +31672,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2885,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31536,7 +31695,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2883,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31559,7 +31718,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2753,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31582,7 +31741,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2754,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31605,7 +31764,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2755,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31628,7 +31787,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2756,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31651,7 +31810,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2767,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31674,7 +31833,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2771,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31697,7 +31856,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2772,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31720,7 +31879,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2770,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31743,7 +31902,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2766,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31766,7 +31925,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2769,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31789,7 +31948,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2763,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31812,7 +31971,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2764,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31835,7 +31994,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2765,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31858,7 +32017,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2760,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31881,7 +32040,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2761,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31904,7 +32063,7 @@
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2762,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31927,7 +32086,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2768,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31950,7 +32109,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2833,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31973,7 +32132,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2873,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31996,7 +32155,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2911,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32019,7 +32178,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2908,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32042,7 +32201,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2909,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32065,7 +32224,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2910,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32088,7 +32247,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2913,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32111,7 +32270,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2773,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32134,7 +32293,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2774,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32157,7 +32316,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2803,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32180,7 +32339,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2801,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32203,7 +32362,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2802,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32226,7 +32385,7 @@
 					}
 				},
 				{
-					"id": 2795,
+					"id": 2798,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32249,7 +32408,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2799,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32272,7 +32431,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2800,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32295,7 +32454,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2804,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32318,7 +32477,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2795,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32341,7 +32500,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2796,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32364,7 +32523,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2797,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32392,167 +32551,167 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2803,
-						2802,
-						2772,
-						2773,
+						2806,
+						2805,
 						2775,
-						2774,
-						2754,
-						2815,
-						2816,
-						2813,
-						2814,
-						2777,
-						2782,
-						2779,
-						2781,
-						2780,
+						2776,
 						2778,
-						2787,
-						2784,
-						2786,
+						2777,
+						2757,
+						2818,
+						2819,
+						2816,
+						2817,
+						2780,
 						2785,
+						2782,
+						2784,
 						2783,
-						2791,
+						2781,
 						2790,
+						2787,
 						2789,
 						2788,
-						2776,
-						2909,
+						2786,
+						2794,
+						2793,
+						2792,
+						2791,
+						2779,
+						2912,
+						2907,
+						2902,
+						2901,
 						2904,
+						2903,
+						2841,
+						2844,
+						2839,
+						2842,
+						2843,
+						2838,
+						2840,
+						2811,
+						2810,
+						2813,
+						2812,
+						2809,
+						2807,
+						2808,
+						2814,
+						2815,
+						2826,
+						2827,
+						2830,
+						2828,
+						2829,
+						2837,
+						2836,
+						2835,
+						2834,
+						2900,
 						2899,
 						2898,
-						2901,
-						2900,
-						2838,
-						2841,
-						2836,
-						2839,
-						2840,
-						2835,
-						2837,
-						2808,
-						2807,
-						2810,
-						2809,
-						2806,
-						2804,
-						2805,
-						2811,
-						2812,
-						2823,
-						2824,
-						2827,
-						2825,
-						2826,
-						2834,
-						2833,
+						2906,
+						2905,
 						2832,
 						2831,
-						2897,
-						2896,
-						2895,
-						2903,
-						2902,
-						2829,
-						2828,
-						2856,
-						2869,
-						2868,
-						2866,
-						2867,
-						2874,
+						2859,
 						2872,
 						2871,
-						2857,
-						2858,
-						2862,
-						2850,
-						2865,
-						2864,
-						2855,
-						2863,
-						2853,
-						2854,
+						2869,
+						2870,
+						2877,
+						2875,
+						2874,
+						2860,
 						2861,
-						2851,
-						2852,
+						2865,
+						2853,
+						2868,
+						2867,
+						2858,
+						2866,
+						2856,
+						2857,
+						2864,
+						2854,
+						2855,
+						2891,
 						2888,
-						2885,
-						2886,
-						2887,
-						2843,
-						2894,
 						2889,
 						2890,
-						2893,
-						2891,
-						2892,
-						2844,
-						2842,
-						2860,
-						2859,
-						2873,
-						2875,
-						2876,
 						2846,
-						2845,
+						2897,
+						2892,
+						2893,
+						2896,
+						2894,
+						2895,
 						2847,
-						2848,
-						2849,
-						2877,
+						2845,
+						2863,
+						2862,
+						2876,
 						2878,
+						2879,
+						2849,
+						2848,
+						2850,
+						2851,
+						2852,
+						2880,
+						2881,
+						2824,
 						2821,
-						2818,
-						2817,
-						2819,
-						2822,
 						2820,
+						2822,
+						2825,
+						2823,
+						2758,
+						2759,
+						2886,
+						2887,
+						2882,
+						2884,
+						2885,
+						2883,
+						2753,
+						2754,
 						2755,
 						2756,
-						2883,
-						2884,
-						2879,
-						2881,
-						2882,
-						2880,
-						2750,
-						2751,
-						2752,
-						2753,
-						2764,
-						2768,
-						2769,
 						2767,
-						2763,
+						2771,
+						2772,
+						2770,
 						2766,
+						2769,
+						2763,
+						2764,
+						2765,
 						2760,
 						2761,
 						2762,
-						2757,
-						2758,
-						2759,
-						2765,
-						2830,
-						2870,
+						2768,
+						2833,
+						2873,
+						2911,
 						2908,
-						2905,
-						2906,
-						2907,
+						2909,
 						2910,
-						2770,
-						2771,
-						2800,
+						2913,
+						2773,
+						2774,
+						2803,
+						2801,
+						2802,
 						2798,
 						2799,
+						2800,
+						2804,
 						2795,
 						2796,
-						2797,
-						2801,
-						2792,
-						2793,
-						2794
+						2797
 					]
 				}
 			],
@@ -32565,7 +32724,7 @@
 			]
 		},
 		{
-			"id": 2737,
+			"id": 2740,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32575,7 +32734,7 @@
 			},
 			"children": [
 				{
-					"id": 2739,
+					"id": 2742,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32591,12 +32750,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2740,
+						"id": 2743,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2741,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32621,8 +32780,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2739,
-						2738
+						2742,
+						2741
 					]
 				}
 			],
@@ -32635,7 +32794,7 @@
 			]
 		},
 		{
-			"id": 2727,
+			"id": 2730,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32651,7 +32810,7 @@
 			},
 			"children": [
 				{
-					"id": 2729,
+					"id": 2732,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32668,14 +32827,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2730,
+							"id": 2733,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2732,
+									"id": 2735,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32705,7 +32864,7 @@
 									}
 								},
 								{
-									"id": 2733,
+									"id": 2736,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32725,7 +32884,7 @@
 									}
 								},
 								{
-									"id": 2731,
+									"id": 2734,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32768,21 +32927,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2732,
-										2733,
-										2731
+										2735,
+										2736,
+										2734
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2734,
+								"id": 2737,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2735,
+										"id": 2738,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -32801,7 +32960,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2739,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32821,7 +32980,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2731,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32837,7 +32996,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2737,
+						"id": 2740,
 						"name": "CustomStyles"
 					}
 				}
@@ -32847,9 +33006,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2729,
-						2736,
-						2728
+						2732,
+						2739,
+						2731
 					]
 				}
 			],
@@ -32862,7 +33021,7 @@
 			]
 		},
 		{
-			"id": 2312,
+			"id": 2313,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32878,7 +33037,7 @@
 			},
 			"children": [
 				{
-					"id": 2354,
+					"id": 2355,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32908,20 +33067,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2355,
+							"id": 2356,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2356,
+								"id": 2357,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2357,
+										"id": 2358,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -32953,7 +33112,7 @@
 					}
 				},
 				{
-					"id": 2315,
+					"id": 2316,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32976,7 +33135,7 @@
 					}
 				},
 				{
-					"id": 2336,
+					"id": 2337,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33018,7 +33177,7 @@
 					}
 				},
 				{
-					"id": 2338,
+					"id": 2339,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33047,7 +33206,7 @@
 					}
 				},
 				{
-					"id": 2314,
+					"id": 2315,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33064,12 +33223,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1964,
+						"id": 1961,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2327,
+					"id": 2328,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33098,7 +33257,7 @@
 					}
 				},
 				{
-					"id": 2339,
+					"id": 2340,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33131,7 +33290,7 @@
 					}
 				},
 				{
-					"id": 2330,
+					"id": 2331,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33160,7 +33319,7 @@
 					}
 				},
 				{
-					"id": 2363,
+					"id": 2364,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33193,7 +33352,7 @@
 					}
 				},
 				{
-					"id": 2351,
+					"id": 2352,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33222,7 +33381,7 @@
 					}
 				},
 				{
-					"id": 2361,
+					"id": 2362,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33258,7 +33417,7 @@
 					}
 				},
 				{
-					"id": 2358,
+					"id": 2359,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33301,7 +33460,7 @@
 					}
 				},
 				{
-					"id": 2335,
+					"id": 2336,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33326,12 +33485,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2349,
+					"id": 2350,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33360,7 +33519,7 @@
 					}
 				},
 				{
-					"id": 2332,
+					"id": 2333,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33390,7 +33549,7 @@
 					}
 				},
 				{
-					"id": 2360,
+					"id": 2361,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33427,7 +33586,7 @@
 					}
 				},
 				{
-					"id": 2353,
+					"id": 2354,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33456,7 +33615,7 @@
 					}
 				},
 				{
-					"id": 2328,
+					"id": 2329,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33489,7 +33648,7 @@
 					}
 				},
 				{
-					"id": 2359,
+					"id": 2360,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33509,7 +33668,7 @@
 					}
 				},
 				{
-					"id": 2348,
+					"id": 2349,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33538,7 +33697,7 @@
 					}
 				},
 				{
-					"id": 2326,
+					"id": 2327,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33567,7 +33726,7 @@
 					}
 				},
 				{
-					"id": 2321,
+					"id": 2322,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33601,7 +33760,7 @@
 					}
 				},
 				{
-					"id": 2347,
+					"id": 2348,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33634,12 +33793,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2914,
+						"id": 2917,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2329,
+					"id": 2330,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33668,7 +33827,7 @@
 					}
 				},
 				{
-					"id": 2320,
+					"id": 2321,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33701,7 +33860,7 @@
 					}
 				},
 				{
-					"id": 2350,
+					"id": 2351,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33730,7 +33889,7 @@
 					}
 				},
 				{
-					"id": 2319,
+					"id": 2320,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33754,7 +33913,7 @@
 					}
 				},
 				{
-					"id": 2345,
+					"id": 2346,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33783,7 +33942,7 @@
 					}
 				},
 				{
-					"id": 2331,
+					"id": 2332,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33816,7 +33975,7 @@
 					}
 				},
 				{
-					"id": 2322,
+					"id": 2323,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33846,7 +34005,7 @@
 					}
 				},
 				{
-					"id": 2324,
+					"id": 2325,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33875,7 +34034,7 @@
 					}
 				},
 				{
-					"id": 2346,
+					"id": 2347,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33904,7 +34063,7 @@
 					}
 				},
 				{
-					"id": 2325,
+					"id": 2326,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33933,7 +34092,7 @@
 					}
 				},
 				{
-					"id": 2334,
+					"id": 2335,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33956,7 +34115,7 @@
 					}
 				},
 				{
-					"id": 2333,
+					"id": 2334,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33985,7 +34144,7 @@
 					}
 				},
 				{
-					"id": 2313,
+					"id": 2314,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34006,7 +34165,7 @@
 					}
 				},
 				{
-					"id": 2337,
+					"id": 2338,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34029,7 +34188,7 @@
 					}
 				},
 				{
-					"id": 2318,
+					"id": 2319,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34052,7 +34211,7 @@
 					}
 				},
 				{
-					"id": 2362,
+					"id": 2363,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34085,7 +34244,7 @@
 					}
 				},
 				{
-					"id": 2316,
+					"id": 2317,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -34101,7 +34260,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2317,
+							"id": 2318,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -34129,52 +34288,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2354,
-						2315,
-						2336,
-						2338,
-						2314,
-						2327,
-						2339,
-						2330,
-						2363,
-						2351,
-						2361,
-						2358,
-						2335,
-						2349,
-						2332,
-						2360,
-						2353,
-						2328,
-						2359,
-						2348,
-						2326,
-						2321,
-						2347,
-						2329,
-						2320,
-						2350,
-						2319,
-						2345,
-						2331,
-						2322,
-						2324,
-						2346,
-						2325,
-						2334,
-						2333,
-						2313,
+						2355,
+						2316,
 						2337,
-						2318,
-						2362
+						2339,
+						2315,
+						2328,
+						2340,
+						2331,
+						2364,
+						2352,
+						2362,
+						2359,
+						2336,
+						2350,
+						2333,
+						2361,
+						2354,
+						2329,
+						2360,
+						2349,
+						2327,
+						2322,
+						2348,
+						2330,
+						2321,
+						2351,
+						2320,
+						2346,
+						2332,
+						2323,
+						2325,
+						2347,
+						2326,
+						2335,
+						2334,
+						2314,
+						2338,
+						2319,
+						2363
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2316
+						2317
 					]
 				}
 			],
@@ -34187,7 +34346,7 @@
 			]
 		},
 		{
-			"id": 2686,
+			"id": 2689,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34203,7 +34362,7 @@
 			},
 			"children": [
 				{
-					"id": 2688,
+					"id": 2691,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34235,7 +34394,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2692,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34271,7 +34430,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2690,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34308,9 +34467,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2688,
-						2689,
-						2687
+						2691,
+						2692,
+						2690
 					]
 				}
 			],
@@ -34322,7 +34481,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2690,
+				"id": 2693,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -34332,7 +34491,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2691,
+						"id": 2694,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -34366,7 +34525,7 @@
 			}
 		},
 		{
-			"id": 2465,
+			"id": 2466,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34382,7 +34541,7 @@
 			},
 			"children": [
 				{
-					"id": 2476,
+					"id": 2477,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34406,7 +34565,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 192,
+							"line": 190,
 							"character": 4
 						}
 					],
@@ -34416,7 +34575,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2500,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34447,20 +34606,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2500,
+							"id": 2501,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2501,
+								"id": 2502,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2502,
+										"id": 2503,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34496,7 +34655,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2527,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34538,7 +34697,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2524,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34568,7 +34727,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2308,
+						"id": 2309,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -34577,7 +34736,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2540,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34615,7 +34774,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2518,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34656,7 +34815,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2504,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34685,7 +34844,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -34694,7 +34853,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2528,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34736,7 +34895,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2468,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34764,7 +34923,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 79,
+							"line": 77,
 							"character": 4
 						}
 					],
@@ -34774,7 +34933,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2512,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34812,7 +34971,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2496,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34850,7 +35009,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2495,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34882,7 +35041,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -34892,7 +35051,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2508,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34933,7 +35092,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2534,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34975,7 +35134,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2539,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35017,7 +35176,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2529,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35059,7 +35218,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2509,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35097,7 +35256,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2469,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35123,7 +35282,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 91,
+							"line": 89,
 							"character": 4
 						}
 					],
@@ -35133,7 +35292,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2525,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35171,7 +35330,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2526,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35209,7 +35368,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2511,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35246,7 +35405,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2492,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35276,7 +35435,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -35285,7 +35444,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2467,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35309,7 +35468,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 61,
+							"line": 59,
 							"character": 4
 						}
 					],
@@ -35319,7 +35478,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2497,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35355,7 +35514,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -35365,7 +35524,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2483,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35389,7 +35548,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 292,
+							"line": 290,
 							"character": 4
 						}
 					],
@@ -35402,7 +35561,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2537,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35444,7 +35603,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2530,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35486,7 +35645,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2478,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35510,7 +35669,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 206,
+							"line": 204,
 							"character": 4
 						}
 					],
@@ -35520,7 +35679,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2505,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35558,7 +35717,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2521,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35581,7 +35740,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -35595,7 +35754,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2520,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35618,7 +35777,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -35635,7 +35794,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2542,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35673,7 +35832,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2544,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35711,7 +35870,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2543,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35749,7 +35908,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2535,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35791,7 +35950,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2533,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35829,7 +35988,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2485,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35853,7 +36012,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 328,
+							"line": 326,
 							"character": 4
 						}
 					],
@@ -35863,7 +36022,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2519,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35883,7 +36042,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -35897,7 +36056,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2486,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35921,7 +36080,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 344,
+							"line": 342,
 							"character": 4
 						}
 					],
@@ -35931,7 +36090,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2487,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35958,7 +36117,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 361,
+							"line": 359,
 							"character": 4
 						}
 					],
@@ -35968,7 +36127,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2488,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35992,7 +36151,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 384,
+							"line": 382,
 							"character": 4
 						}
 					],
@@ -36002,7 +36161,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2514,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36040,7 +36199,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2470,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36064,7 +36223,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 105,
+							"line": 103,
 							"character": 4
 						}
 					],
@@ -36074,7 +36233,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2476,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36098,7 +36257,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 177,
+							"line": 175,
 							"character": 4
 						}
 					],
@@ -36108,7 +36267,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2541,
 					"name": "liveboardXLSXCSVDownload",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36146,7 +36305,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2499,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36184,7 +36343,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2513,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36222,7 +36381,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2507,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36260,7 +36419,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2473,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36284,7 +36443,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 139,
+							"line": 137,
 							"character": 4
 						}
 					],
@@ -36294,7 +36453,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2515,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36332,7 +36491,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2522,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36364,7 +36523,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -36374,7 +36533,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2523,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36406,7 +36565,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -36416,7 +36575,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2517,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36453,7 +36612,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2532,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36495,7 +36654,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2538,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36537,7 +36696,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2531,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36579,7 +36738,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2536,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36621,7 +36780,49 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2545,
+					"name": "showMaskedFilterChip",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Show or hide masked filter chips",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | Thoughtspot: 26.2.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   showMaskedFilterChip: true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1593,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "LiveboardAppEmbedViewConfig.showMaskedFilterChip"
+					}
+				},
+				{
+					"id": 2479,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36645,7 +36846,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 229,
+							"line": 227,
 							"character": 4
 						}
 					],
@@ -36655,7 +36856,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2489,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36678,7 +36879,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 400,
+							"line": 398,
 							"character": 4
 						}
 					],
@@ -36688,7 +36889,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2490,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36716,7 +36917,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 415,
+							"line": 413,
 							"character": 4
 						}
 					],
@@ -36726,7 +36927,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2498,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,7 +36963,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -36772,7 +36973,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2484,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36796,7 +36997,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 312,
+							"line": 310,
 							"character": 4
 						}
 					],
@@ -36809,7 +37010,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2474,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36833,7 +37034,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 157,
+							"line": 155,
 							"character": 4
 						}
 					],
@@ -36846,7 +37047,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2472,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36870,7 +37071,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 124,
+							"line": 122,
 							"character": 4
 						}
 					],
@@ -36885,77 +37086,78 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2476,
-						2499,
-						2526,
-						2523,
-						2539,
-						2517,
-						2503,
-						2527,
-						2467,
-						2511,
-						2495,
-						2494,
-						2507,
-						2533,
-						2538,
-						2528,
-						2508,
-						2468,
-						2524,
-						2525,
-						2510,
-						2491,
-						2466,
-						2496,
-						2482,
-						2536,
-						2529,
 						2477,
-						2504,
-						2520,
-						2519,
-						2541,
-						2543,
-						2542,
-						2534,
-						2532,
-						2484,
-						2518,
-						2485,
-						2486,
-						2487,
-						2513,
-						2469,
-						2475,
+						2500,
+						2527,
+						2524,
 						2540,
-						2498,
+						2518,
+						2504,
+						2528,
+						2468,
 						2512,
-						2506,
-						2472,
-						2514,
-						2521,
-						2522,
-						2516,
-						2531,
-						2537,
-						2530,
-						2535,
-						2478,
-						2488,
-						2489,
+						2496,
+						2495,
+						2508,
+						2534,
+						2539,
+						2529,
+						2509,
+						2469,
+						2525,
+						2526,
+						2511,
+						2492,
+						2467,
 						2497,
 						2483,
+						2537,
+						2530,
+						2478,
+						2505,
+						2521,
+						2520,
+						2542,
+						2544,
+						2543,
+						2535,
+						2533,
+						2485,
+						2519,
+						2486,
+						2487,
+						2488,
+						2514,
+						2470,
+						2476,
+						2541,
+						2499,
+						2513,
+						2507,
 						2473,
-						2471
+						2515,
+						2522,
+						2523,
+						2517,
+						2532,
+						2538,
+						2531,
+						2536,
+						2545,
+						2479,
+						2489,
+						2490,
+						2498,
+						2484,
+						2474,
+						2472
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 35,
+					"line": 36,
 					"character": 17
 				}
 			],
@@ -36975,7 +37177,7 @@
 			]
 		},
 		{
-			"id": 1976,
+			"id": 1973,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36985,7 +37187,7 @@
 			},
 			"children": [
 				{
-					"id": 1977,
+					"id": 1974,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36996,7 +37198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1781,
+							"line": 1797,
 							"character": 4
 						}
 					],
@@ -37006,7 +37208,7 @@
 					}
 				},
 				{
-					"id": 1978,
+					"id": 1975,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37017,18 +37219,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1785,
+							"line": 1801,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1980,
+						"id": 1977,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 1979,
+					"id": 1976,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37039,7 +37241,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1791,
+							"line": 1807,
 							"character": 4
 						}
 					],
@@ -37074,22 +37276,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1977,
-						1978,
-						1979
+						1974,
+						1975,
+						1976
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1777,
+					"line": 1793,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2911,
+			"id": 2914,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37099,7 +37301,7 @@
 			},
 			"children": [
 				{
-					"id": 2912,
+					"id": 2915,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37110,7 +37312,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1801,
+							"line": 1817,
 							"character": 4
 						}
 					],
@@ -37120,7 +37322,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2916,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37131,7 +37333,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1805,
+							"line": 1821,
 							"character": 4
 						}
 					],
@@ -37159,21 +37361,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2912,
-						2913
+						2915,
+						2916
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1797,
+					"line": 1813,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2544,
+			"id": 2546,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37193,7 +37395,7 @@
 			},
 			"children": [
 				{
-					"id": 2573,
+					"id": 2575,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37224,20 +37426,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2574,
+							"id": 2576,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2575,
+								"id": 2577,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2576,
+										"id": 2578,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -37273,7 +37475,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2563,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37315,7 +37517,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2560,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37345,7 +37547,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2308,
+						"id": 2309,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -37354,7 +37556,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2592,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37395,7 +37597,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2579,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37424,7 +37626,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -37433,7 +37635,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2564,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,7 +37677,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2556,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37498,7 +37700,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2587,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37536,7 +37738,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2551,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37565,7 +37767,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2571,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37603,7 +37805,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2570,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37635,7 +37837,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -37645,7 +37847,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2583,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37686,7 +37888,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2565,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37728,7 +37930,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2584,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37766,7 +37968,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2561,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37804,7 +38006,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2562,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37842,7 +38044,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2586,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37879,7 +38081,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2567,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37909,7 +38111,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -37918,7 +38120,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2572,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37954,7 +38156,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -37964,7 +38166,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2553,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37993,7 +38195,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2550,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38022,7 +38224,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2555,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38056,7 +38258,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2549,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38089,7 +38291,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2552,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38118,7 +38320,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2580,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38156,7 +38358,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2595,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38179,7 +38381,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -38193,7 +38395,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2594,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38216,7 +38418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -38233,7 +38435,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2593,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38253,7 +38455,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -38267,7 +38469,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2589,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38305,7 +38507,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2574,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38343,7 +38545,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2588,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38381,7 +38583,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2582,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38419,7 +38621,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2558,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38451,7 +38653,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -38461,7 +38663,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2559,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38493,7 +38695,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -38503,7 +38705,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2557,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38537,7 +38739,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2591,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38574,7 +38776,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2547,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38603,7 +38805,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2554,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38632,7 +38834,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2573,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38668,7 +38870,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -38683,45 +38885,45 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2573,
-						2561,
-						2558,
-						2590,
-						2577,
-						2562,
-						2554,
-						2585,
-						2549,
-						2569,
-						2568,
-						2581,
+						2575,
 						2563,
-						2582,
-						2559,
 						2560,
-						2584,
-						2565,
-						2570,
-						2551,
-						2548,
-						2553,
-						2547,
-						2550,
-						2578,
-						2593,
 						2592,
-						2591,
-						2587,
-						2572,
-						2586,
-						2580,
+						2579,
+						2564,
 						2556,
-						2557,
+						2587,
+						2551,
+						2571,
+						2570,
+						2583,
+						2565,
+						2584,
+						2561,
+						2562,
+						2586,
+						2567,
+						2572,
+						2553,
+						2550,
 						2555,
-						2589,
-						2545,
+						2549,
 						2552,
-						2571
+						2580,
+						2595,
+						2594,
+						2593,
+						2589,
+						2574,
+						2588,
+						2582,
+						2558,
+						2559,
+						2557,
+						2591,
+						2547,
+						2554,
+						2573
 					]
 				}
 			],
@@ -38775,7 +38977,7 @@
 			]
 		},
 		{
-			"id": 2420,
+			"id": 2421,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -38790,7 +38992,7 @@
 			},
 			"children": [
 				{
-					"id": 2435,
+					"id": 2436,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38821,20 +39023,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2436,
+							"id": 2437,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2437,
+								"id": 2438,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2438,
+										"id": 2439,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -38870,7 +39072,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2463,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38912,7 +39114,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2460,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38942,7 +39144,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2308,
+						"id": 2309,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -38951,7 +39153,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2454,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38992,7 +39194,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2440,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39021,7 +39223,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -39030,7 +39232,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2464,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39072,7 +39274,7 @@
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2423,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39106,7 +39308,7 @@
 					}
 				},
 				{
-					"id": 2421,
+					"id": 2422,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39147,7 +39349,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2448,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39185,7 +39387,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2432,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39223,7 +39425,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2431,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39255,7 +39457,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -39265,7 +39467,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2444,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39306,7 +39508,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2465,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39348,7 +39550,7 @@
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2445,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39386,7 +39588,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2461,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39424,7 +39626,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2462,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39462,7 +39664,7 @@
 					}
 				},
 				{
-					"id": 2425,
+					"id": 2426,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39496,7 +39698,7 @@
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2447,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39533,7 +39735,7 @@
 					}
 				},
 				{
-					"id": 2427,
+					"id": 2428,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39563,7 +39765,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -39572,7 +39774,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2433,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39608,7 +39810,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -39618,7 +39820,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2441,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39656,7 +39858,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2457,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39679,7 +39881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -39693,7 +39895,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2456,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39716,7 +39918,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -39733,7 +39935,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2455,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39753,7 +39955,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -39767,7 +39969,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2450,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39805,7 +40007,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2435,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39843,7 +40045,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2449,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39881,7 +40083,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2443,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39919,7 +40121,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2451,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39957,7 +40159,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2458,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39989,7 +40191,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -39999,7 +40201,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2459,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40031,7 +40233,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -40041,7 +40243,7 @@
 					}
 				},
 				{
-					"id": 2424,
+					"id": 2425,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40075,7 +40277,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2453,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40112,7 +40314,7 @@
 					}
 				},
 				{
-					"id": 2423,
+					"id": 2424,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40146,7 +40348,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2434,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40182,7 +40384,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -40197,41 +40399,41 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2435,
-						2462,
-						2459,
-						2453,
-						2439,
+						2436,
 						2463,
-						2422,
-						2421,
-						2447,
-						2431,
-						2430,
-						2443,
-						2464,
-						2444,
 						2460,
-						2461,
-						2425,
-						2446,
-						2427,
-						2432,
+						2454,
 						2440,
+						2464,
+						2423,
+						2422,
+						2448,
+						2432,
+						2431,
+						2444,
+						2465,
+						2445,
+						2461,
+						2462,
+						2426,
+						2447,
+						2428,
+						2433,
+						2441,
+						2457,
 						2456,
 						2455,
-						2454,
-						2449,
-						2434,
-						2448,
-						2442,
 						2450,
-						2457,
+						2435,
+						2449,
+						2443,
+						2451,
 						2458,
+						2459,
+						2425,
+						2453,
 						2424,
-						2452,
-						2423,
-						2433
+						2434
 					]
 				}
 			],
@@ -40254,7 +40456,7 @@
 			]
 		},
 		{
-			"id": 2364,
+			"id": 2365,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40270,7 +40472,7 @@
 			},
 			"children": [
 				{
-					"id": 2399,
+					"id": 2400,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40301,20 +40503,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2400,
+							"id": 2401,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2401,
+								"id": 2402,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2402,
+										"id": 2403,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -40350,7 +40552,7 @@
 					}
 				},
 				{
-					"id": 2376,
+					"id": 2377,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40384,7 +40586,7 @@
 					}
 				},
 				{
-					"id": 2366,
+					"id": 2367,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40418,7 +40620,7 @@
 					}
 				},
 				{
-					"id": 2365,
+					"id": 2366,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40452,7 +40654,7 @@
 					}
 				},
 				{
-					"id": 2387,
+					"id": 2388,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40494,7 +40696,7 @@
 					}
 				},
 				{
-					"id": 2379,
+					"id": 2380,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40531,7 +40733,7 @@
 					}
 				},
 				{
-					"id": 2384,
+					"id": 2385,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40561,7 +40763,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2308,
+						"id": 2309,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -40570,7 +40772,7 @@
 					}
 				},
 				{
-					"id": 2416,
+					"id": 2417,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40611,7 +40813,7 @@
 					}
 				},
 				{
-					"id": 2403,
+					"id": 2404,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40640,7 +40842,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -40649,7 +40851,7 @@
 					}
 				},
 				{
-					"id": 2380,
+					"id": 2381,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40687,7 +40889,7 @@
 					}
 				},
 				{
-					"id": 2388,
+					"id": 2389,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40729,7 +40931,7 @@
 					}
 				},
 				{
-					"id": 2372,
+					"id": 2373,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40763,7 +40965,7 @@
 					}
 				},
 				{
-					"id": 2371,
+					"id": 2372,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40799,7 +41001,7 @@
 					}
 				},
 				{
-					"id": 2411,
+					"id": 2412,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40837,7 +41039,7 @@
 					}
 				},
 				{
-					"id": 2395,
+					"id": 2396,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40875,7 +41077,7 @@
 					}
 				},
 				{
-					"id": 2394,
+					"id": 2395,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40907,7 +41109,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -40917,7 +41119,7 @@
 					}
 				},
 				{
-					"id": 2407,
+					"id": 2408,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40958,7 +41160,7 @@
 					}
 				},
 				{
-					"id": 2389,
+					"id": 2390,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41000,7 +41202,7 @@
 					}
 				},
 				{
-					"id": 2369,
+					"id": 2370,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41034,7 +41236,7 @@
 					}
 				},
 				{
-					"id": 2408,
+					"id": 2409,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41072,7 +41274,7 @@
 					}
 				},
 				{
-					"id": 2385,
+					"id": 2386,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41110,7 +41312,7 @@
 					}
 				},
 				{
-					"id": 2386,
+					"id": 2387,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41148,7 +41350,7 @@
 					}
 				},
 				{
-					"id": 2375,
+					"id": 2376,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41182,7 +41384,7 @@
 					}
 				},
 				{
-					"id": 2410,
+					"id": 2411,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41219,7 +41421,7 @@
 					}
 				},
 				{
-					"id": 2381,
+					"id": 2382,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41257,7 +41459,7 @@
 					}
 				},
 				{
-					"id": 2370,
+					"id": 2371,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41291,7 +41493,7 @@
 					}
 				},
 				{
-					"id": 2391,
+					"id": 2392,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41321,7 +41523,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -41330,7 +41532,7 @@
 					}
 				},
 				{
-					"id": 2396,
+					"id": 2397,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41366,7 +41568,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -41376,7 +41578,7 @@
 					}
 				},
 				{
-					"id": 2367,
+					"id": 2368,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41410,7 +41612,7 @@
 					}
 				},
 				{
-					"id": 2368,
+					"id": 2369,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41444,7 +41646,7 @@
 					}
 				},
 				{
-					"id": 2377,
+					"id": 2378,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41478,7 +41680,7 @@
 					}
 				},
 				{
-					"id": 2404,
+					"id": 2405,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41516,7 +41718,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2420,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41539,7 +41741,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -41553,7 +41755,7 @@
 					}
 				},
 				{
-					"id": 2418,
+					"id": 2419,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41576,7 +41778,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -41593,7 +41795,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2418,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41613,7 +41815,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -41627,7 +41829,7 @@
 					}
 				},
 				{
-					"id": 2413,
+					"id": 2414,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41665,7 +41867,7 @@
 					}
 				},
 				{
-					"id": 2398,
+					"id": 2399,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41703,7 +41905,7 @@
 					}
 				},
 				{
-					"id": 2412,
+					"id": 2413,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41741,7 +41943,7 @@
 					}
 				},
 				{
-					"id": 2406,
+					"id": 2407,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41779,7 +41981,7 @@
 					}
 				},
 				{
-					"id": 2382,
+					"id": 2383,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41811,7 +42013,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -41821,7 +42023,7 @@
 					}
 				},
 				{
-					"id": 2383,
+					"id": 2384,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41853,7 +42055,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -41863,7 +42065,7 @@
 					}
 				},
 				{
-					"id": 2374,
+					"id": 2375,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41893,7 +42095,7 @@
 					}
 				},
 				{
-					"id": 2373,
+					"id": 2374,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41922,7 +42124,7 @@
 					}
 				},
 				{
-					"id": 2415,
+					"id": 2416,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41959,7 +42161,7 @@
 					}
 				},
 				{
-					"id": 2378,
+					"id": 2379,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41989,7 +42191,7 @@
 					}
 				},
 				{
-					"id": 2397,
+					"id": 2398,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42025,7 +42227,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -42040,52 +42242,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2399,
-						2376,
-						2366,
-						2365,
-						2387,
-						2379,
-						2384,
-						2416,
-						2403,
-						2380,
-						2388,
-						2372,
-						2371,
-						2411,
-						2395,
-						2394,
-						2407,
-						2389,
-						2369,
-						2408,
-						2385,
-						2386,
-						2375,
-						2410,
-						2381,
-						2370,
-						2391,
-						2396,
-						2367,
-						2368,
+						2400,
 						2377,
+						2367,
+						2366,
+						2388,
+						2380,
+						2385,
+						2417,
 						2404,
+						2381,
+						2389,
+						2373,
+						2372,
+						2412,
+						2396,
+						2395,
+						2408,
+						2390,
+						2370,
+						2409,
+						2386,
+						2387,
+						2376,
+						2411,
+						2382,
+						2371,
+						2392,
+						2397,
+						2368,
+						2369,
+						2378,
+						2405,
+						2420,
 						2419,
 						2418,
-						2417,
+						2414,
+						2399,
 						2413,
-						2398,
-						2412,
-						2406,
-						2382,
+						2407,
 						2383,
+						2384,
+						2375,
 						2374,
-						2373,
-						2415,
-						2378,
-						2397
+						2416,
+						2379,
+						2398
 					]
 				}
 			],
@@ -42118,14 +42320,14 @@
 			]
 		},
 		{
-			"id": 1945,
+			"id": 1942,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1948,
+					"id": 1945,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42140,14 +42342,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1949,
+							"id": 1946,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1951,
+									"id": 1948,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42165,7 +42367,7 @@
 									}
 								},
 								{
-									"id": 1950,
+									"id": 1947,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42188,8 +42390,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1951,
-										1950
+										1948,
+										1947
 									]
 								}
 							]
@@ -42197,7 +42399,7 @@
 					}
 				},
 				{
-					"id": 1947,
+					"id": 1944,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42215,7 +42417,7 @@
 					}
 				},
 				{
-					"id": 1946,
+					"id": 1943,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42238,9 +42440,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1948,
-						1947,
-						1946
+						1945,
+						1944,
+						1943
 					]
 				}
 			],
@@ -42253,7 +42455,7 @@
 			]
 		},
 		{
-			"id": 1273,
+			"id": 1270,
 			"name": "SpotterAgentEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42269,7 +42471,7 @@
 			},
 			"children": [
 				{
-					"id": 1284,
+					"id": 1281,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42300,20 +42502,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1285,
+							"id": 1282,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1286,
+								"id": 1283,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1287,
+										"id": 1284,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42349,7 +42551,7 @@
 					}
 				},
 				{
-					"id": 1301,
+					"id": 1298,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42390,7 +42592,7 @@
 					}
 				},
 				{
-					"id": 1288,
+					"id": 1285,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42419,7 +42621,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -42428,7 +42630,7 @@
 					}
 				},
 				{
-					"id": 1296,
+					"id": 1293,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42466,7 +42668,7 @@
 					}
 				},
 				{
-					"id": 1280,
+					"id": 1277,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42504,7 +42706,7 @@
 					}
 				},
 				{
-					"id": 1279,
+					"id": 1276,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42536,7 +42738,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -42546,7 +42748,7 @@
 					}
 				},
 				{
-					"id": 1292,
+					"id": 1289,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42587,7 +42789,7 @@
 					}
 				},
 				{
-					"id": 1293,
+					"id": 1290,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42625,7 +42827,7 @@
 					}
 				},
 				{
-					"id": 1295,
+					"id": 1292,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42662,7 +42864,7 @@
 					}
 				},
 				{
-					"id": 1276,
+					"id": 1273,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42692,7 +42894,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42701,7 +42903,7 @@
 					}
 				},
 				{
-					"id": 1281,
+					"id": 1278,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42737,7 +42939,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -42747,7 +42949,7 @@
 					}
 				},
 				{
-					"id": 1289,
+					"id": 1286,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42785,7 +42987,7 @@
 					}
 				},
 				{
-					"id": 1304,
+					"id": 1301,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42808,7 +43010,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -42822,7 +43024,7 @@
 					}
 				},
 				{
-					"id": 1303,
+					"id": 1300,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42845,7 +43047,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -42862,7 +43064,7 @@
 					}
 				},
 				{
-					"id": 1302,
+					"id": 1299,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42882,7 +43084,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -42896,7 +43098,7 @@
 					}
 				},
 				{
-					"id": 1298,
+					"id": 1295,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42934,7 +43136,7 @@
 					}
 				},
 				{
-					"id": 1283,
+					"id": 1280,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42972,7 +43174,7 @@
 					}
 				},
 				{
-					"id": 1297,
+					"id": 1294,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43010,7 +43212,7 @@
 					}
 				},
 				{
-					"id": 1291,
+					"id": 1288,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43048,7 +43250,7 @@
 					}
 				},
 				{
-					"id": 1300,
+					"id": 1297,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43085,7 +43287,7 @@
 					}
 				},
 				{
-					"id": 1282,
+					"id": 1279,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43121,7 +43323,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -43131,7 +43333,7 @@
 					}
 				},
 				{
-					"id": 1274,
+					"id": 1271,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43157,28 +43359,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1284,
-						1301,
-						1288,
-						1296,
-						1280,
-						1279,
-						1292,
-						1293,
-						1295,
-						1276,
 						1281,
-						1289,
-						1304,
-						1303,
-						1302,
 						1298,
-						1283,
-						1297,
-						1291,
+						1285,
+						1293,
+						1277,
+						1276,
+						1289,
+						1290,
+						1292,
+						1273,
+						1278,
+						1286,
+						1301,
 						1300,
-						1282,
-						1274
+						1299,
+						1295,
+						1280,
+						1294,
+						1288,
+						1297,
+						1279,
+						1271
 					]
 				}
 			],
@@ -43208,13 +43410,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1305,
+					"id": 1302,
 					"name": "BodylessConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1541,
+			"id": 1538,
 			"name": "SpotterEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43230,7 +43432,7 @@
 			},
 			"children": [
 				{
-					"id": 1564,
+					"id": 1561,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43261,20 +43463,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1565,
+							"id": 1562,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1566,
+								"id": 1563,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1567,
+										"id": 1564,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43310,7 +43512,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1578,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43351,7 +43553,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1565,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43380,7 +43582,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2727,
+						"id": 2730,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -43389,7 +43591,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1543,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43427,7 +43629,7 @@
 					}
 				},
 				{
-					"id": 1576,
+					"id": 1573,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43465,7 +43667,7 @@
 					}
 				},
 				{
-					"id": 1544,
+					"id": 1541,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43499,7 +43701,7 @@
 					}
 				},
 				{
-					"id": 1560,
+					"id": 1557,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43537,7 +43739,7 @@
 					}
 				},
 				{
-					"id": 1559,
+					"id": 1556,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43569,7 +43771,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -43579,7 +43781,7 @@
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1569,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43620,7 +43822,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1550,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43658,7 +43860,7 @@
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1570,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43696,7 +43898,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1547,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43730,7 +43932,7 @@
 					}
 				},
 				{
-					"id": 1552,
+					"id": 1549,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43764,7 +43966,7 @@
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1572,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43801,7 +44003,7 @@
 					}
 				},
 				{
-					"id": 1556,
+					"id": 1553,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43831,7 +44033,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2686,
+						"id": 2689,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -43840,7 +44042,7 @@
 					}
 				},
 				{
-					"id": 1561,
+					"id": 1558,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43876,7 +44078,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -43886,7 +44088,7 @@
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1545,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43920,7 +44122,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1542,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43954,7 +44156,7 @@
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1566,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43992,7 +44194,7 @@
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1581,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44015,7 +44217,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6196,
+							"line": 6252,
 							"character": 4
 						}
 					],
@@ -44029,7 +44231,7 @@
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1580,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44052,7 +44254,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6179,
+							"line": 6235,
 							"character": 4
 						}
 					],
@@ -44069,7 +44271,7 @@
 					}
 				},
 				{
-					"id": 1582,
+					"id": 1579,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44089,7 +44291,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6219,
 							"character": 4
 						}
 					],
@@ -44103,7 +44305,7 @@
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1575,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44141,7 +44343,7 @@
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1560,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44179,7 +44381,7 @@
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1574,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44217,7 +44419,7 @@
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1568,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44255,7 +44457,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1546,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44287,13 +44489,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1976,
+							"id": 1973,
 							"name": "RuntimeFilter"
 						}
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1548,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44325,13 +44527,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2911,
+							"id": 2914,
 							"name": "RuntimeParameter"
 						}
 					}
 				},
 				{
-					"id": 1543,
+					"id": 1540,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44354,7 +44556,7 @@
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1577,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44391,7 +44593,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1544,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44425,7 +44627,7 @@
 					}
 				},
 				{
-					"id": 1554,
+					"id": 1551,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44463,7 +44665,7 @@
 					}
 				},
 				{
-					"id": 1562,
+					"id": 1559,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44499,7 +44701,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2170,
+							"id": 2167,
 							"name": "Action"
 						}
 					},
@@ -44509,7 +44711,7 @@
 					}
 				},
 				{
-					"id": 1542,
+					"id": 1539,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44535,40 +44737,40 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1564,
-						1581,
-						1568,
-						1546,
-						1576,
-						1544,
-						1560,
-						1559,
+						1561,
+						1578,
+						1565,
+						1543,
+						1573,
+						1541,
+						1557,
+						1556,
+						1569,
+						1550,
+						1570,
+						1547,
+						1549,
 						1572,
 						1553,
-						1573,
-						1550,
-						1552,
-						1575,
-						1556,
-						1561,
-						1548,
+						1558,
 						1545,
-						1569,
-						1584,
-						1583,
-						1582,
-						1578,
-						1563,
-						1577,
-						1571,
-						1549,
-						1551,
-						1543,
+						1542,
+						1566,
+						1581,
 						1580,
-						1547,
-						1554,
-						1562,
-						1542
+						1579,
+						1575,
+						1560,
+						1574,
+						1568,
+						1546,
+						1548,
+						1540,
+						1577,
+						1544,
+						1551,
+						1559,
+						1539
 					]
 				}
 			],
@@ -44598,20 +44800,20 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1585,
+					"id": 1582,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1952,
+			"id": 1949,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1953,
+					"id": 1950,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44629,7 +44831,7 @@
 					}
 				},
 				{
-					"id": 1954,
+					"id": 1951,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44652,8 +44854,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1953,
-						1954
+						1950,
+						1951
 					]
 				}
 			],
@@ -44666,14 +44868,14 @@
 			]
 		},
 		{
-			"id": 2949,
+			"id": 2952,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2950,
+					"id": 2953,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44681,7 +44883,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5969,
+							"line": 6025,
 							"character": 4
 						}
 					],
@@ -44694,7 +44896,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2954,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44702,7 +44904,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5970,
+							"line": 6026,
 							"character": 4
 						}
 					],
@@ -44720,21 +44922,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2950,
-						2951
+						2953,
+						2954
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5968,
+					"line": 6024,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2740,
+			"id": 2743,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44744,7 +44946,7 @@
 			},
 			"children": [
 				{
-					"id": 2742,
+					"id": 2745,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44774,20 +44976,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2743,
+							"id": 2746,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2744,
+								"id": 2747,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2745,
+										"id": 2748,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -44800,7 +45002,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2746,
+										"id": 2749,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -44813,14 +45015,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2747,
+											"id": 2750,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2748,
+													"id": 2751,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -44842,7 +45044,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2744,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44861,7 +45063,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2749,
+						"id": 2752,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -44871,8 +45073,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2742,
-						2741
+						2745,
+						2744
 					]
 				}
 			],
@@ -45177,7 +45379,7 @@
 			]
 		},
 		{
-			"id": 2710,
+			"id": 2713,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45204,7 +45406,7 @@
 			}
 		},
 		{
-			"id": 2714,
+			"id": 2717,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45212,14 +45414,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1614,
+					"line": 1630,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2715,
+					"id": 2718,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -45236,13 +45438,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1614,
+							"line": 1630,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2716,
+							"id": 2719,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -45252,19 +45454,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2717,
+									"id": 2720,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2722,
+										"id": 2725,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2718,
+									"id": 2721,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -45274,7 +45476,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2719,
+											"id": 2722,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -45282,13 +45484,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 1621,
+													"line": 1637,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2720,
+													"id": 2723,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -45298,7 +45500,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2721,
+															"id": 2724,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -45329,7 +45531,7 @@
 			}
 		},
 		{
-			"id": 2711,
+			"id": 2714,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45346,21 +45548,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1603,
+					"line": 1619,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2712,
+					"id": 2715,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2713,
+							"id": 2716,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45373,7 +45575,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 1608,
+									"line": 1624,
 									"character": 4
 								}
 							],
@@ -45388,14 +45590,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2713
+								2716
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1603,
+							"line": 1619,
 							"character": 29
 						}
 					]
@@ -45403,7 +45605,7 @@
 			}
 		},
 		{
-			"id": 2722,
+			"id": 2725,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45420,21 +45622,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1590,
+					"line": 1606,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2723,
+					"id": 2726,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2725,
+							"id": 2728,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45442,7 +45644,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 1594,
+									"line": 1610,
 									"character": 4
 								}
 							],
@@ -45452,7 +45654,7 @@
 							}
 						},
 						{
-							"id": 2726,
+							"id": 2729,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45462,7 +45664,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 1596,
+									"line": 1612,
 									"character": 4
 								}
 							],
@@ -45472,7 +45674,7 @@
 							}
 						},
 						{
-							"id": 2724,
+							"id": 2727,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45480,7 +45682,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 1592,
+									"line": 1608,
 									"character": 4
 								}
 							],
@@ -45495,16 +45697,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2725,
-								2726,
-								2724
+								2728,
+								2729,
+								2727
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1590,
+							"line": 1606,
 							"character": 29
 						}
 					]
@@ -45512,7 +45714,7 @@
 			}
 		},
 		{
-			"id": 51,
+			"id": 48,
 			"name": "createLiveboardWithAnswers",
 			"kind": 64,
 			"kindString": "Function",
@@ -45528,7 +45730,7 @@
 			],
 			"signatures": [
 				{
-					"id": 52,
+					"id": 49,
 					"name": "createLiveboardWithAnswers",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -45550,7 +45752,7 @@
 					},
 					"parameters": [
 						{
-							"id": 53,
+							"id": 50,
 							"name": "answers",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45562,13 +45764,13 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1872,
+									"id": 1869,
 									"name": "AnswerService"
 								}
 							}
 						},
 						{
-							"id": 54,
+							"id": 51,
 							"name": "name",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45732,7 +45934,7 @@
 			]
 		},
 		{
-			"id": 44,
+			"id": 41,
 			"name": "getAnswerFromQuery",
 			"kind": 64,
 			"kindString": "Function",
@@ -45748,7 +45950,7 @@
 			],
 			"signatures": [
 				{
-					"id": 45,
+					"id": 42,
 					"name": "getAnswerFromQuery",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -45769,7 +45971,7 @@
 					},
 					"parameters": [
 						{
-							"id": 46,
+							"id": 43,
 							"name": "query",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45783,7 +45985,7 @@
 							}
 						},
 						{
-							"id": 47,
+							"id": 44,
 							"name": "worksheetId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45803,14 +46005,14 @@
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 48,
+									"id": 45,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 49,
+											"id": 46,
 											"name": "answer",
 											"kind": 1024,
 											"kindString": "Property",
@@ -45824,12 +46026,12 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1872,
+												"id": 1869,
 												"name": "AnswerService"
 											}
 										},
 										{
-											"id": 50,
+											"id": 47,
 											"name": "suggestion",
 											"kind": 1024,
 											"kindString": "Property",
@@ -45852,8 +46054,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												49,
-												50
+												46,
+												47
 											]
 										}
 									]
@@ -45911,7 +46113,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2312,
+						"id": 2313,
 						"name": "EmbedConfig"
 					}
 				}
@@ -46011,14 +46213,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2312,
+								"id": 2313,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1819,
+						"id": 1816,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -46158,7 +46360,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2681,
+									"id": 2684,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -46230,7 +46432,7 @@
 			]
 		},
 		{
-			"id": 3003,
+			"id": 3006,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -46246,7 +46448,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3004,
+					"id": 3007,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -46361,86 +46563,11 @@
 						],
 						"name": "Promise"
 					}
-				},
-				{
-					"id": 41,
-					"name": "tokenizedFetch",
-					"kind": 4096,
-					"kindString": "Call signature",
-					"flags": {},
-					"comment": {
-						"shortText": "Fetch wrapper that adds the authentication token to the request.\nUse this to call the ThoughtSpot APIs when using the visual embed sdk.\nThe interface for this method is the same as Web `Fetch`.",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\ntokenizedFetch(\"<TS_ORIGIN>/api/rest/2.0/auth/session/user\", {\n  // .. fetch options ..\n});\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.28.0"
-							},
-							{
-								"tag": "group",
-								"text": "Global methods\n"
-							}
-						]
-					},
-					"parameters": [
-						{
-							"id": 42,
-							"name": "input",
-							"kind": 32768,
-							"kindString": "Parameter",
-							"flags": {},
-							"comment": {},
-							"type": {
-								"type": "union",
-								"types": [
-									{
-										"type": "intrinsic",
-										"name": "string"
-									},
-									{
-										"type": "reference",
-										"name": "URL"
-									},
-									{
-										"type": "reference",
-										"name": "globalThis.Request"
-									}
-								]
-							}
-						},
-						{
-							"id": 43,
-							"name": "init",
-							"kind": 32768,
-							"kindString": "Parameter",
-							"flags": {
-								"isOptional": true
-							},
-							"comment": {},
-							"type": {
-								"type": "reference",
-								"name": "RequestInit"
-							}
-						}
-					],
-					"type": {
-						"type": "reference",
-						"typeArguments": [
-							{
-								"type": "reference",
-								"name": "Response"
-							}
-						],
-						"name": "Promise"
-					}
 				}
 			]
 		},
 		{
-			"id": 2921,
+			"id": 2924,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -46454,7 +46581,7 @@
 			],
 			"signatures": [
 				{
-					"id": 2922,
+					"id": 2925,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -46464,7 +46591,7 @@
 					},
 					"parameters": [
 						{
-							"id": 2923,
+							"id": 2926,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -46476,7 +46603,7 @@
 							}
 						},
 						{
-							"id": 2924,
+							"id": 2927,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -46487,7 +46614,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2925,
+									"id": 2928,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -46510,75 +46637,75 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2170,
-				1817,
-				1802,
-				1809,
-				1964,
-				2308,
-				2994,
-				2990,
-				2986,
-				2166,
-				1996,
-				2692,
-				2943,
-				2937,
-				2703,
-				2092,
-				2999,
+				2167,
+				1814,
+				1799,
+				1806,
+				1961,
+				2309,
+				2997,
+				2993,
+				2989,
+				2163,
+				1993,
+				2695,
 				2946,
-				2980,
-				2914,
-				1955,
-				2681,
-				2941,
-				1980,
-				2972
+				2940,
+				2706,
+				2089,
+				3002,
+				2949,
+				2983,
+				2917,
+				1952,
+				2684,
+				2944,
+				1977,
+				2975
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1872,
-				1024,
-				1337,
-				1629,
-				611,
-				841,
-				238,
-				55,
-				1241,
-				1368
+				1869,
+				1021,
+				1334,
+				1626,
+				608,
+				838,
+				235,
+				52,
+				1238,
+				1365
 			]
 		},
 		{
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2594,
-				1819,
-				1305,
-				1585,
-				2952,
-				2749,
-				2737,
-				2727,
-				2312,
-				2686,
-				2465,
-				1976,
-				2911,
-				2544,
-				2420,
-				2364,
-				1945,
-				1273,
-				1541,
-				1952,
-				2949,
+				2596,
+				1816,
+				1302,
+				1582,
+				2955,
+				2752,
 				2740,
+				2730,
+				2313,
+				2689,
+				2466,
+				1973,
+				2914,
+				2546,
+				2421,
+				2365,
+				1942,
+				1270,
+				1538,
+				1949,
+				2952,
+				2743,
 				21,
 				25
 			]
@@ -46587,28 +46714,28 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2710,
+				2713,
+				2717,
 				2714,
-				2711,
-				2722
+				2725
 			]
 		},
 		{
 			"title": "Functions",
 			"kind": 64,
 			"children": [
-				51,
+				48,
 				15,
 				18,
-				44,
+				41,
 				33,
 				35,
 				1,
 				4,
 				7,
-				3003,
+				3006,
 				37,
-				2921
+				2924
 			]
 		}
 	],

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2167,
+			"id": 2170,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2280,
+					"id": 2283,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -55,7 +55,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2187,
+					"id": 2190,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -83,7 +83,7 @@
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2180,
+					"id": 2183,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -111,7 +111,7 @@
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2179,
+					"id": 2182,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -135,7 +135,7 @@
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2185,
+					"id": 2188,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -159,7 +159,7 @@
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2186,
+					"id": 2189,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -183,7 +183,7 @@
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2188,
+					"id": 2191,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -211,7 +211,7 @@
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2262,
+					"id": 2265,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -239,7 +239,7 @@
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2235,
+					"id": 2238,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -267,7 +267,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2277,
+					"id": 2280,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -295,7 +295,7 @@
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2234,
+					"id": 2237,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -323,7 +323,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2233,
+					"id": 2236,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -351,7 +351,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2276,
+					"id": 2279,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -380,7 +380,7 @@
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2246,
+					"id": 2249,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -408,7 +408,7 @@
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2249,
+					"id": 2252,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -436,7 +436,7 @@
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2254,
+					"id": 2257,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -464,7 +464,7 @@
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2248,
+					"id": 2251,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -492,7 +492,7 @@
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2251,
+					"id": 2254,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -520,7 +520,7 @@
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2255,
+					"id": 2258,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -548,7 +548,7 @@
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2252,
+					"id": 2255,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -576,7 +576,7 @@
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2257,
+					"id": 2260,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -604,7 +604,7 @@
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2253,
+					"id": 2256,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -632,7 +632,7 @@
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2250,
+					"id": 2253,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -660,7 +660,7 @@
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2256,
+					"id": 2259,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -688,7 +688,7 @@
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2247,
+					"id": 2250,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -716,7 +716,7 @@
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2289,
+					"id": 2292,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -744,7 +744,7 @@
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2184,
+					"id": 2187,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -768,7 +768,7 @@
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2183,
+					"id": 2186,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -796,7 +796,7 @@
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2182,
+					"id": 2185,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -824,7 +824,7 @@
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2296,
+					"id": 2299,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -852,7 +852,7 @@
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2181,
+					"id": 2184,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -876,7 +876,7 @@
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2226,
+					"id": 2229,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -891,7 +891,7 @@
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2174,
+					"id": 2177,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -915,7 +915,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2225,
+					"id": 2228,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -939,7 +939,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2297,
+					"id": 2300,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -967,7 +967,7 @@
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2307,
+					"id": 2310,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -995,7 +995,7 @@
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2274,
+					"id": 2277,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1023,7 +1023,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2237,
+					"id": 2240,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1051,7 +1051,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2242,
+					"id": 2245,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1079,7 +1079,7 @@
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2294,
+					"id": 2297,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1107,7 +1107,7 @@
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2286,
+					"id": 2289,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1135,7 +1135,7 @@
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2288,
+					"id": 2291,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1163,7 +1163,7 @@
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2196,
+					"id": 2199,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1187,7 +1187,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2199,
+					"id": 2202,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1211,7 +1211,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2198,
+					"id": 2201,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1236,7 +1236,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2197,
+					"id": 2200,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1260,7 +1260,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2200,
+					"id": 2203,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1284,7 +1284,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2230,
+					"id": 2233,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1308,7 +1308,7 @@
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2224,
+					"id": 2227,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1332,7 +1332,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2223,
+					"id": 2226,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1356,7 +1356,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2208,
+					"id": 2211,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1380,7 +1380,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2173,
+					"id": 2176,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1404,7 +1404,7 @@
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2236,
+					"id": 2239,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1432,7 +1432,7 @@
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2228,
+					"id": 2231,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1447,7 +1447,7 @@
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2293,
+					"id": 2296,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1475,7 +1475,7 @@
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2266,
+					"id": 2269,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1503,7 +1503,7 @@
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2281,
+					"id": 2284,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1531,7 +1531,7 @@
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2205,
+					"id": 2208,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1555,7 +1555,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2209,
+					"id": 2212,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1579,7 +1579,7 @@
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2295,
+					"id": 2298,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1607,7 +1607,7 @@
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2263,
+					"id": 2266,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1635,7 +1635,7 @@
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2264,
+					"id": 2267,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1663,7 +1663,7 @@
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2222,
+					"id": 2225,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1687,7 +1687,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2202,
+					"id": 2205,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1712,7 +1712,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2203,
+					"id": 2206,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1736,7 +1736,7 @@
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2298,
+					"id": 2301,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1764,7 +1764,7 @@
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2287,
+					"id": 2290,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1792,7 +1792,7 @@
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2216,
+					"id": 2219,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1816,7 +1816,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2304,
+					"id": 2307,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1844,7 +1844,7 @@
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2272,
+					"id": 2275,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1872,7 +1872,7 @@
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2172,
+					"id": 2175,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1896,7 +1896,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2270,
+					"id": 2273,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1920,7 +1920,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2241,
+					"id": 2244,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1948,7 +1948,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2285,
+					"id": 2288,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1976,7 +1976,7 @@
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2261,
+					"id": 2264,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2004,7 +2004,7 @@
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2268,
+					"id": 2271,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2031,7 +2031,7 @@
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2306,
+					"id": 2309,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2059,7 +2059,7 @@
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2305,
+					"id": 2308,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2087,7 +2087,7 @@
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2269,
+					"id": 2272,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2111,7 +2111,7 @@
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2279,
+					"id": 2282,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2139,7 +2139,7 @@
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2282,
+					"id": 2285,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2167,7 +2167,7 @@
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2271,
+					"id": 2274,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2195,7 +2195,7 @@
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2219,
+					"id": 2222,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2219,7 +2219,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2302,
+					"id": 2305,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2243,7 +2243,7 @@
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2206,
+					"id": 2209,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2267,7 +2267,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2290,
+					"id": 2293,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2295,7 +2295,7 @@
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2232,
+					"id": 2235,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2320,7 +2320,7 @@
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2210,
+					"id": 2213,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2344,7 +2344,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2303,
+					"id": 2306,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2372,7 +2372,7 @@
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2245,
+					"id": 2248,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2400,7 +2400,7 @@
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2278,
+					"id": 2281,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2428,7 +2428,7 @@
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2259,
+					"id": 2262,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2456,7 +2456,7 @@
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2238,
+					"id": 2241,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2487,7 +2487,7 @@
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2231,
+					"id": 2234,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2511,7 +2511,7 @@
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2260,
+					"id": 2263,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2539,7 +2539,7 @@
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2291,
+					"id": 2294,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2567,7 +2567,7 @@
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2267,
+					"id": 2270,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2595,7 +2595,7 @@
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2168,
+					"id": 2171,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2619,7 +2619,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2171,
+					"id": 2174,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2643,7 +2643,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2176,
+					"id": 2179,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2667,7 +2667,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2177,
+					"id": 2180,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2691,7 +2691,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2229,
+					"id": 2232,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2706,7 +2706,7 @@
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2178,
+					"id": 2181,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2730,7 +2730,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2193,
+					"id": 2196,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2748,7 +2748,7 @@
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2265,
+					"id": 2268,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2776,7 +2776,7 @@
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2195,
+					"id": 2198,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2800,7 +2800,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2190,
+					"id": 2193,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2824,7 +2824,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2292,
+					"id": 2295,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2852,7 +2852,7 @@
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2301,
+					"id": 2304,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2880,7 +2880,7 @@
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2299,
+					"id": 2302,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2908,7 +2908,7 @@
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2300,
+					"id": 2303,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2936,7 +2936,7 @@
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2221,
+					"id": 2224,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2960,7 +2960,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2240,
+					"id": 2243,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2988,7 +2988,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2239,
+					"id": 2242,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3016,7 +3016,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2243,
+					"id": 2246,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3044,7 +3044,7 @@
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2244,
+					"id": 2247,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3072,7 +3072,7 @@
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2273,
+					"id": 2276,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3104,7 +3104,7 @@
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2207,
+					"id": 2210,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3128,7 +3128,7 @@
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2308,
+					"id": 2311,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3156,7 +3156,7 @@
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2284,
+					"id": 2287,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3184,7 +3184,7 @@
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2204,
+					"id": 2207,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3208,7 +3208,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2275,
+					"id": 2278,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3236,7 +3236,7 @@
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2283,
+					"id": 2286,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3269,129 +3269,129 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2280,
-						2187,
-						2180,
-						2179,
-						2185,
-						2186,
-						2188,
-						2262,
-						2235,
-						2277,
-						2234,
-						2233,
-						2276,
-						2246,
-						2249,
-						2254,
-						2248,
-						2251,
-						2255,
-						2252,
-						2257,
-						2253,
-						2250,
-						2256,
-						2247,
-						2289,
-						2184,
+						2283,
+						2190,
 						2183,
 						2182,
-						2296,
-						2181,
-						2226,
-						2174,
-						2225,
-						2297,
-						2307,
-						2274,
-						2237,
-						2242,
-						2294,
-						2286,
-						2288,
-						2196,
-						2199,
-						2198,
-						2197,
-						2200,
-						2230,
-						2224,
-						2223,
-						2208,
-						2173,
-						2236,
-						2228,
-						2293,
-						2266,
-						2281,
-						2205,
-						2209,
-						2295,
-						2263,
-						2264,
-						2222,
-						2202,
-						2203,
-						2298,
-						2287,
-						2216,
-						2304,
-						2272,
-						2172,
-						2270,
-						2241,
-						2285,
-						2261,
-						2268,
-						2306,
-						2305,
-						2269,
-						2279,
-						2282,
-						2271,
-						2219,
-						2302,
-						2206,
-						2290,
-						2232,
-						2210,
-						2303,
-						2245,
-						2278,
-						2259,
-						2238,
-						2231,
-						2260,
-						2291,
-						2267,
-						2168,
-						2171,
-						2176,
-						2177,
-						2229,
-						2178,
-						2193,
+						2188,
+						2189,
+						2191,
 						2265,
-						2195,
-						2190,
+						2238,
+						2280,
+						2237,
+						2236,
+						2279,
+						2249,
+						2252,
+						2257,
+						2251,
+						2254,
+						2258,
+						2255,
+						2260,
+						2256,
+						2253,
+						2259,
+						2250,
 						2292,
-						2301,
+						2187,
+						2186,
+						2185,
 						2299,
+						2184,
+						2229,
+						2177,
+						2228,
 						2300,
-						2221,
+						2310,
+						2277,
 						2240,
+						2245,
+						2297,
+						2289,
+						2291,
+						2199,
+						2202,
+						2201,
+						2200,
+						2203,
+						2233,
+						2227,
+						2226,
+						2211,
+						2176,
 						2239,
-						2243,
-						2244,
-						2273,
-						2207,
-						2308,
+						2231,
+						2296,
+						2269,
 						2284,
-						2204,
+						2208,
+						2212,
+						2298,
+						2266,
+						2267,
+						2225,
+						2205,
+						2206,
+						2301,
+						2290,
+						2219,
+						2307,
 						2275,
-						2283
+						2175,
+						2273,
+						2244,
+						2288,
+						2264,
+						2271,
+						2309,
+						2308,
+						2272,
+						2282,
+						2285,
+						2274,
+						2222,
+						2305,
+						2209,
+						2293,
+						2235,
+						2213,
+						2306,
+						2248,
+						2281,
+						2262,
+						2241,
+						2234,
+						2263,
+						2294,
+						2270,
+						2171,
+						2174,
+						2179,
+						2180,
+						2232,
+						2181,
+						2196,
+						2268,
+						2198,
+						2193,
+						2295,
+						2304,
+						2302,
+						2303,
+						2224,
+						2243,
+						2242,
+						2246,
+						2247,
+						2276,
+						2210,
+						2311,
+						2287,
+						2207,
+						2278,
+						2286
 					]
 				}
 			],
@@ -3404,7 +3404,7 @@
 			]
 		},
 		{
-			"id": 1814,
+			"id": 1817,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3420,7 +3420,7 @@
 			},
 			"children": [
 				{
-					"id": 1815,
+					"id": 1818,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3443,7 +3443,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1815
+						1818
 					]
 				}
 			],
@@ -3456,7 +3456,7 @@
 			]
 		},
 		{
-			"id": 1799,
+			"id": 1802,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3472,7 +3472,7 @@
 			},
 			"children": [
 				{
-					"id": 1802,
+					"id": 1805,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3487,7 +3487,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1804,
+					"id": 1807,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3502,7 +3502,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1801,
+					"id": 1804,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3517,7 +3517,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1803,
+					"id": 1806,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3532,7 +3532,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1800,
+					"id": 1803,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3547,7 +3547,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1805,
+					"id": 1808,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3567,12 +3567,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1802,
+						1805,
+						1807,
 						1804,
-						1801,
+						1806,
 						1803,
-						1800,
-						1805
+						1808
 					]
 				}
 			],
@@ -3585,7 +3585,7 @@
 			]
 		},
 		{
-			"id": 1806,
+			"id": 1809,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3601,7 +3601,7 @@
 			},
 			"children": [
 				{
-					"id": 1807,
+					"id": 1810,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3619,7 +3619,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1811,
+					"id": 1814,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3637,7 +3637,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1813,
+					"id": 1816,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3655,7 +3655,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1808,
+					"id": 1811,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3673,7 +3673,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1810,
+					"id": 1813,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3691,7 +3691,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1812,
+					"id": 1815,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3720,12 +3720,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1807,
+						1810,
+						1814,
+						1816,
 						1811,
 						1813,
-						1808,
-						1810,
-						1812
+						1815
 					]
 				}
 			],
@@ -3738,7 +3738,7 @@
 			]
 		},
 		{
-			"id": 1961,
+			"id": 1964,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3754,7 +3754,7 @@
 			},
 			"children": [
 				{
-					"id": 1972,
+					"id": 1975,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3773,7 +3773,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1963,
+					"id": 1966,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3802,7 +3802,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1962,
+					"id": 1965,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3826,7 +3826,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1968,
+					"id": 1971,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3844,7 +3844,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1966,
+					"id": 1969,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3877,7 +3877,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1970,
+					"id": 1973,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3901,7 +3901,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1971,
+					"id": 1974,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3934,13 +3934,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1972,
-						1963,
-						1962,
-						1968,
+						1975,
 						1966,
-						1970,
-						1971
+						1965,
+						1971,
+						1969,
+						1973,
+						1974
 					]
 				}
 			],
@@ -3953,7 +3953,7 @@
 			]
 		},
 		{
-			"id": 2309,
+			"id": 2312,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3963,7 +3963,7 @@
 			},
 			"children": [
 				{
-					"id": 2312,
+					"id": 2315,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3978,7 +3978,7 @@
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2310,
+					"id": 2313,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3993,7 +3993,7 @@
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2311,
+					"id": 2314,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4013,9 +4013,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2312,
-						2310,
-						2311
+						2315,
+						2313,
+						2314
 					]
 				}
 			],
@@ -4028,7 +4028,7 @@
 			]
 		},
 		{
-			"id": 2997,
+			"id": 3000,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4038,7 +4038,7 @@
 			},
 			"children": [
 				{
-					"id": 3000,
+					"id": 3003,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4053,7 +4053,7 @@
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 2998,
+					"id": 3001,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4068,7 +4068,7 @@
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3001,
+					"id": 3004,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4083,7 +4083,7 @@
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 2999,
+					"id": 3002,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4103,10 +4103,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3000,
-						2998,
+						3003,
 						3001,
-						2999
+						3004,
+						3002
 					]
 				}
 			],
@@ -4119,7 +4119,7 @@
 			]
 		},
 		{
-			"id": 2993,
+			"id": 2996,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4129,7 +4129,7 @@
 			},
 			"children": [
 				{
-					"id": 2996,
+					"id": 2999,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4144,7 +4144,7 @@
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 2995,
+					"id": 2998,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4159,7 +4159,7 @@
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 2994,
+					"id": 2997,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4179,9 +4179,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2996,
-						2995,
-						2994
+						2999,
+						2998,
+						2997
 					]
 				}
 			],
@@ -4194,7 +4194,7 @@
 			]
 		},
 		{
-			"id": 2989,
+			"id": 2992,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4204,7 +4204,7 @@
 			},
 			"children": [
 				{
-					"id": 2991,
+					"id": 2994,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4222,7 +4222,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 2990,
+					"id": 2993,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4240,7 +4240,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 2992,
+					"id": 2995,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4263,9 +4263,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2991,
-						2990,
-						2992
+						2994,
+						2993,
+						2995
 					]
 				}
 			],
@@ -4278,7 +4278,7 @@
 			]
 		},
 		{
-			"id": 2163,
+			"id": 2166,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4288,7 +4288,7 @@
 			},
 			"children": [
 				{
-					"id": 2165,
+					"id": 2168,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4306,7 +4306,7 @@
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2166,
+					"id": 2169,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4324,7 +4324,7 @@
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2164,
+					"id": 2167,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4347,9 +4347,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2165,
-						2166,
-						2164
+						2168,
+						2169,
+						2167
 					]
 				}
 			],
@@ -4362,7 +4362,7 @@
 			]
 		},
 		{
-			"id": 1993,
+			"id": 1996,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4387,7 +4387,7 @@
 			},
 			"children": [
 				{
-					"id": 2029,
+					"id": 2032,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4415,7 +4415,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2021,
+					"id": 2024,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4443,7 +4443,7 @@
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2001,
+					"id": 2004,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4475,7 +4475,7 @@
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2046,
+					"id": 2049,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4503,7 +4503,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2006,
+					"id": 2009,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4535,7 +4535,7 @@
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2042,
+					"id": 2045,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4563,7 +4563,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2028,
+					"id": 2031,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4591,7 +4591,7 @@
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2088,
+					"id": 2091,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4620,7 +4620,7 @@
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2069,
+					"id": 2072,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4660,7 +4660,7 @@
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2007,
+					"id": 2010,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4688,7 +4688,7 @@
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 1995,
+					"id": 1998,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4720,7 +4720,7 @@
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2053,
+					"id": 2056,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4748,7 +4748,7 @@
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2040,
+					"id": 2043,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4776,7 +4776,7 @@
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2055,
+					"id": 2058,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4804,7 +4804,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2035,
+					"id": 2038,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4832,7 +4832,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2063,
+					"id": 2066,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4856,7 +4856,7 @@
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2074,
+					"id": 2077,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4881,7 +4881,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2075,
+					"id": 2078,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4905,7 +4905,7 @@
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2068,
+					"id": 2071,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4929,7 +4929,7 @@
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2056,
+					"id": 2059,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4957,7 +4957,7 @@
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2002,
+					"id": 2005,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4993,7 +4993,7 @@
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 1997,
+					"id": 2000,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5029,7 +5029,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2000,
+					"id": 2003,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5061,7 +5061,7 @@
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2051,
+					"id": 2054,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5089,7 +5089,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2067,
+					"id": 2070,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5121,7 +5121,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2019,
+					"id": 2022,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5149,7 +5149,7 @@
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2018,
+					"id": 2021,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5177,7 +5177,7 @@
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2023,
+					"id": 2026,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5206,7 +5206,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2026,
+					"id": 2029,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5234,7 +5234,7 @@
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2025,
+					"id": 2028,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5262,7 +5262,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2024,
+					"id": 2027,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5290,7 +5290,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2027,
+					"id": 2030,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5318,7 +5318,7 @@
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2034,
+					"id": 2037,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5346,7 +5346,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2033,
+					"id": 2036,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5374,7 +5374,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 1999,
+					"id": 2002,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5418,7 +5418,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2048,
+					"id": 2051,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5446,7 +5446,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2037,
+					"id": 2040,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5474,7 +5474,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2005,
+					"id": 2008,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5511,7 +5511,7 @@
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2054,
+					"id": 2057,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5539,7 +5539,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2038,
+					"id": 2041,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5567,7 +5567,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2059,
+					"id": 2062,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5591,7 +5591,7 @@
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2013,
+					"id": 2016,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5619,7 +5619,7 @@
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 1994,
+					"id": 1997,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5647,7 +5647,7 @@
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2082,
+					"id": 2085,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5675,7 +5675,7 @@
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2081,
+					"id": 2084,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5703,7 +5703,7 @@
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2045,
+					"id": 2048,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5731,7 +5731,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2020,
+					"id": 2023,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5763,7 +5763,7 @@
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 1996,
+					"id": 1999,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5795,7 +5795,7 @@
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2049,
+					"id": 2052,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5823,7 +5823,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2016,
+					"id": 2019,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5851,7 +5851,7 @@
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2071,
+					"id": 2074,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5888,7 +5888,7 @@
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2087,
+					"id": 2090,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5916,7 +5916,7 @@
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2072,
+					"id": 2075,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5940,7 +5940,7 @@
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2030,
+					"id": 2033,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5968,7 +5968,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2050,
+					"id": 2053,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6000,7 +6000,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2079,
+					"id": 2082,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6028,7 +6028,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 1998,
+					"id": 2001,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6056,7 +6056,7 @@
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2070,
+					"id": 2073,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6080,7 +6080,7 @@
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2066,
+					"id": 2069,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6120,7 +6120,7 @@
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2083,
+					"id": 2086,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6148,7 +6148,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2014,
+					"id": 2017,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6176,7 +6176,7 @@
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2060,
+					"id": 2063,
 					"name": "SageEmbedQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6200,7 +6200,7 @@
 					"defaultValue": "\"sageEmbedQuery\""
 				},
 				{
-					"id": 2061,
+					"id": 2064,
 					"name": "SageWorksheetUpdated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6224,7 +6224,7 @@
 					"defaultValue": "\"sageWorksheetUpdated\""
 				},
 				{
-					"id": 2022,
+					"id": 2025,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6252,7 +6252,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2039,
+					"id": 2042,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6280,7 +6280,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2065,
+					"id": 2068,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6320,7 +6320,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2047,
+					"id": 2050,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6348,7 +6348,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2052,
+					"id": 2055,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6376,7 +6376,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2032,
+					"id": 2035,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6404,7 +6404,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2041,
+					"id": 2044,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6432,7 +6432,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2031,
+					"id": 2034,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6460,7 +6460,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2078,
+					"id": 2081,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6488,7 +6488,7 @@
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2084,
+					"id": 2087,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6516,7 +6516,7 @@
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2085,
+					"id": 2088,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6544,7 +6544,7 @@
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2080,
+					"id": 2083,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6572,7 +6572,7 @@
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2073,
+					"id": 2076,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6601,7 +6601,7 @@
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2062,
+					"id": 2065,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6625,7 +6625,7 @@
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2064,
+					"id": 2067,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6665,7 +6665,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2036,
+					"id": 2039,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6693,7 +6693,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2004,
+					"id": 2007,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6729,7 +6729,7 @@
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2003,
+					"id": 2006,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6761,7 +6761,7 @@
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2057,
+					"id": 2060,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6794,88 +6794,88 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2029,
+						2032,
+						2024,
+						2004,
+						2049,
+						2009,
+						2045,
+						2031,
+						2091,
+						2072,
+						2010,
+						1998,
+						2056,
+						2043,
+						2058,
+						2038,
+						2066,
+						2077,
+						2078,
+						2071,
+						2059,
+						2005,
+						2000,
+						2003,
+						2054,
+						2070,
+						2022,
 						2021,
-						2001,
-						2046,
-						2006,
-						2042,
+						2026,
+						2029,
 						2028,
-						2088,
-						2069,
-						2007,
-						1995,
-						2053,
+						2027,
+						2030,
+						2037,
+						2036,
+						2002,
+						2051,
 						2040,
+						2008,
+						2057,
+						2041,
+						2062,
+						2016,
+						1997,
+						2085,
+						2084,
+						2048,
+						2023,
+						1999,
+						2052,
+						2019,
+						2074,
+						2090,
+						2075,
+						2033,
+						2053,
+						2082,
+						2001,
+						2073,
+						2069,
+						2086,
+						2017,
+						2063,
+						2064,
+						2025,
+						2042,
+						2068,
+						2050,
 						2055,
 						2035,
-						2063,
-						2074,
-						2075,
-						2068,
-						2056,
-						2002,
-						1997,
-						2000,
-						2051,
-						2067,
-						2019,
-						2018,
-						2023,
-						2026,
-						2025,
-						2024,
-						2027,
+						2044,
 						2034,
-						2033,
-						1999,
-						2048,
-						2037,
-						2005,
-						2054,
-						2038,
-						2059,
-						2013,
-						1994,
-						2082,
 						2081,
-						2045,
-						2020,
-						1996,
-						2049,
-						2016,
-						2071,
 						2087,
-						2072,
-						2030,
-						2050,
-						2079,
-						1998,
-						2070,
-						2066,
+						2088,
 						2083,
-						2014,
-						2060,
-						2061,
-						2022,
-						2039,
+						2076,
 						2065,
-						2047,
-						2052,
-						2032,
-						2041,
-						2031,
-						2078,
-						2084,
-						2085,
-						2080,
-						2073,
-						2062,
-						2064,
-						2036,
-						2004,
-						2003,
-						2057
+						2067,
+						2039,
+						2007,
+						2006,
+						2060
 					]
 				}
 			],
@@ -6888,7 +6888,7 @@
 			]
 		},
 		{
-			"id": 2695,
+			"id": 2698,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6898,7 +6898,7 @@
 			},
 			"children": [
 				{
-					"id": 2699,
+					"id": 2702,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6921,7 +6921,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2703,
+					"id": 2706,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6945,7 +6945,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2705,
+					"id": 2708,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6969,7 +6969,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2697,
+					"id": 2700,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6992,7 +6992,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2702,
+					"id": 2705,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7015,7 +7015,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2698,
+					"id": 2701,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7038,7 +7038,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2700,
+					"id": 2703,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7061,7 +7061,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2696,
+					"id": 2699,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7084,7 +7084,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2701,
+					"id": 2704,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7107,7 +7107,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2704,
+					"id": 2707,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7136,16 +7136,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2699,
-						2703,
-						2705,
-						2697,
 						2702,
-						2698,
+						2706,
+						2708,
 						2700,
-						2696,
+						2705,
 						2701,
-						2704
+						2703,
+						2699,
+						2704,
+						2707
 					]
 				}
 			],
@@ -7158,7 +7158,7 @@
 			]
 		},
 		{
-			"id": 2946,
+			"id": 2949,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7174,7 +7174,7 @@
 			},
 			"children": [
 				{
-					"id": 2947,
+					"id": 2950,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7192,7 +7192,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 2948,
+					"id": 2951,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7215,8 +7215,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2947,
-						2948
+						2950,
+						2951
 					]
 				}
 			],
@@ -7229,14 +7229,14 @@
 			]
 		},
 		{
-			"id": 2940,
+			"id": 2943,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2942,
+					"id": 2945,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7251,7 +7251,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 2943,
+					"id": 2946,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7266,7 +7266,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 2941,
+					"id": 2944,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7286,9 +7286,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2942,
-						2943,
-						2941
+						2945,
+						2946,
+						2944
 					]
 				}
 			],
@@ -7301,7 +7301,7 @@
 			]
 		},
 		{
-			"id": 2706,
+			"id": 2709,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7317,7 +7317,7 @@
 			},
 			"children": [
 				{
-					"id": 2709,
+					"id": 2712,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7335,7 +7335,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2712,
+					"id": 2715,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7353,7 +7353,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2710,
+					"id": 2713,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7371,7 +7371,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2707,
+					"id": 2710,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7389,7 +7389,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2711,
+					"id": 2714,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7407,7 +7407,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2708,
+					"id": 2711,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7430,12 +7430,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2709,
 						2712,
+						2715,
+						2713,
 						2710,
-						2707,
-						2711,
-						2708
+						2714,
+						2711
 					]
 				}
 			],
@@ -7448,7 +7448,7 @@
 			]
 		},
 		{
-			"id": 2089,
+			"id": 2092,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7477,7 +7477,7 @@
 			},
 			"children": [
 				{
-					"id": 2111,
+					"id": 2114,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7505,7 +7505,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2100,
+					"id": 2103,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7538,7 +7538,7 @@
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2156,
+					"id": 2159,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7571,7 +7571,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2141,
+					"id": 2144,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7599,7 +7599,7 @@
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2159,
+					"id": 2162,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7632,7 +7632,7 @@
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2118,
+					"id": 2121,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7665,7 +7665,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2115,
+					"id": 2118,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7702,7 +7702,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2122,
+					"id": 2125,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7735,7 +7735,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2155,
+					"id": 2158,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7763,7 +7763,7 @@
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2161,
+					"id": 2164,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7791,7 +7791,7 @@
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2124,
+					"id": 2127,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7828,7 +7828,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2126,
+					"id": 2129,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7861,7 +7861,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2110,
+					"id": 2113,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7898,7 +7898,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2125,
+					"id": 2128,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7926,7 +7926,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2127,
+					"id": 2130,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7959,7 +7959,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2091,
+					"id": 2094,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8016,7 +8016,7 @@
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2117,
+					"id": 2120,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8059,7 +8059,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2152,
+					"id": 2155,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8092,7 +8092,7 @@
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2108,
+					"id": 2111,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8120,7 +8120,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2114,
+					"id": 2117,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8153,7 +8153,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2107,
+					"id": 2110,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8181,7 +8181,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2140,
+					"id": 2143,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8214,7 +8214,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2134,
+					"id": 2137,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8242,7 +8242,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2094,
+					"id": 2097,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8270,7 +8270,7 @@
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2145,
+					"id": 2148,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8299,7 +8299,7 @@
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2120,
+					"id": 2123,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8331,7 +8331,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2136,
+					"id": 2139,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8359,7 +8359,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2104,
+					"id": 2107,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8387,7 +8387,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2112,
+					"id": 2115,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8431,7 +8431,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2116,
+					"id": 2119,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8472,7 +8472,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2132,
+					"id": 2135,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8505,7 +8505,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2098,
+					"id": 2101,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8538,7 +8538,7 @@
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2099,
+					"id": 2102,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8575,7 +8575,7 @@
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2103,
+					"id": 2106,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8643,7 +8643,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2119,
+					"id": 2122,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8676,7 +8676,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2153,
+					"id": 2156,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8704,7 +8704,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2113,
+					"id": 2116,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8736,7 +8736,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2101,
+					"id": 2104,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8769,7 +8769,7 @@
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2143,
+					"id": 2146,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8797,7 +8797,7 @@
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2133,
+					"id": 2136,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8825,7 +8825,7 @@
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2154,
+					"id": 2157,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8853,7 +8853,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2129,
+					"id": 2132,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8886,7 +8886,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2148,
+					"id": 2151,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8933,7 +8933,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2105,
+					"id": 2108,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8961,7 +8961,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2106,
+					"id": 2109,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8989,7 +8989,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2090,
+					"id": 2093,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9028,7 +9028,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2096,
+					"id": 2099,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9061,7 +9061,7 @@
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2138,
+					"id": 2141,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9094,7 +9094,7 @@
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2137,
+					"id": 2140,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9127,7 +9127,7 @@
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2095,
+					"id": 2098,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9160,7 +9160,7 @@
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2128,
+					"id": 2131,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9188,7 +9188,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2121,
+					"id": 2124,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9221,7 +9221,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2123,
+					"id": 2126,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9254,7 +9254,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2151,
+					"id": 2154,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9292,7 +9292,7 @@
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2162,
+					"id": 2165,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9316,7 +9316,7 @@
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2131,
+					"id": 2134,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9349,7 +9349,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2130,
+					"id": 2133,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9382,7 +9382,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2150,
+					"id": 2153,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9415,7 +9415,7 @@
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2142,
+					"id": 2145,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9443,7 +9443,7 @@
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2135,
+					"id": 2138,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9493,7 +9493,7 @@
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2144,
+					"id": 2147,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9531,7 +9531,7 @@
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2146,
+					"id": 2149,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9555,7 +9555,7 @@
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2097,
+					"id": 2100,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9593,7 +9593,7 @@
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2139,
+					"id": 2142,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9631,7 +9631,7 @@
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2109,
+					"id": 2112,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9659,7 +9659,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2102,
+					"id": 2105,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9692,72 +9692,72 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2111,
-						2100,
-						2156,
-						2141,
+						2114,
+						2103,
 						2159,
+						2144,
+						2162,
+						2121,
 						2118,
-						2115,
-						2122,
+						2125,
+						2158,
+						2164,
+						2127,
+						2129,
+						2113,
+						2128,
+						2130,
+						2094,
+						2120,
 						2155,
-						2161,
+						2111,
+						2117,
+						2110,
+						2143,
+						2137,
+						2097,
+						2148,
+						2123,
+						2139,
+						2107,
+						2115,
+						2119,
+						2135,
+						2101,
+						2102,
+						2106,
+						2122,
+						2156,
+						2116,
+						2104,
+						2146,
+						2136,
+						2157,
+						2132,
+						2151,
+						2108,
+						2109,
+						2093,
+						2099,
+						2141,
+						2140,
+						2098,
+						2131,
 						2124,
 						2126,
-						2110,
-						2125,
-						2127,
-						2091,
-						2117,
-						2152,
-						2108,
-						2114,
-						2107,
-						2140,
-						2134,
-						2094,
-						2145,
-						2120,
-						2136,
-						2104,
-						2112,
-						2116,
-						2132,
-						2098,
-						2099,
-						2103,
-						2119,
-						2153,
-						2113,
-						2101,
-						2143,
-						2133,
 						2154,
-						2129,
-						2148,
-						2105,
-						2106,
-						2090,
-						2096,
+						2165,
+						2134,
+						2133,
+						2153,
+						2145,
 						2138,
-						2137,
-						2095,
-						2128,
-						2121,
-						2123,
-						2151,
-						2162,
-						2131,
-						2130,
-						2150,
+						2147,
+						2149,
+						2100,
 						2142,
-						2135,
-						2144,
-						2146,
-						2097,
-						2139,
-						2109,
-						2102
+						2112,
+						2105
 					]
 				}
 			],
@@ -9770,7 +9770,7 @@
 			]
 		},
 		{
-			"id": 3002,
+			"id": 3005,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9780,7 +9780,7 @@
 			},
 			"children": [
 				{
-					"id": 3004,
+					"id": 3007,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9798,7 +9798,7 @@
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3003,
+					"id": 3006,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9816,7 +9816,7 @@
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3005,
+					"id": 3008,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9839,9 +9839,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3004,
-						3003,
-						3005
+						3007,
+						3006,
+						3008
 					]
 				}
 			],
@@ -9854,7 +9854,7 @@
 			]
 		},
 		{
-			"id": 2949,
+			"id": 2952,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9870,7 +9870,7 @@
 			},
 			"children": [
 				{
-					"id": 2950,
+					"id": 2953,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9888,7 +9888,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 2951,
+					"id": 2954,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9911,8 +9911,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2950,
-						2951
+						2953,
+						2954
 					]
 				}
 			],
@@ -9925,7 +9925,7 @@
 			]
 		},
 		{
-			"id": 2983,
+			"id": 2986,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9941,7 +9941,7 @@
 			},
 			"children": [
 				{
-					"id": 2986,
+					"id": 2989,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9959,7 +9959,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 2987,
+					"id": 2990,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9977,7 +9977,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 2984,
+					"id": 2987,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9995,7 +9995,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 2988,
+					"id": 2991,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10013,7 +10013,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 2985,
+					"id": 2988,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10036,11 +10036,11 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2986,
+						2989,
+						2990,
 						2987,
-						2984,
-						2988,
-						2985
+						2991,
+						2988
 					]
 				}
 			],
@@ -10053,7 +10053,7 @@
 			]
 		},
 		{
-			"id": 2917,
+			"id": 2920,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10063,7 +10063,7 @@
 			},
 			"children": [
 				{
-					"id": 2922,
+					"id": 2925,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10091,7 +10091,7 @@
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 2919,
+					"id": 2922,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10119,7 +10119,7 @@
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 2921,
+					"id": 2924,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10147,7 +10147,7 @@
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 2918,
+					"id": 2921,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10175,7 +10175,7 @@
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 2923,
+					"id": 2926,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10203,7 +10203,7 @@
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 2920,
+					"id": 2923,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10236,12 +10236,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2925,
 						2922,
-						2919,
+						2924,
 						2921,
-						2918,
-						2923,
-						2920
+						2926,
+						2923
 					]
 				}
 			],
@@ -10254,7 +10254,7 @@
 			]
 		},
 		{
-			"id": 1952,
+			"id": 1955,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10264,7 +10264,7 @@
 			},
 			"children": [
 				{
-					"id": 1955,
+					"id": 1958,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10282,7 +10282,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1958,
+					"id": 1961,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10300,7 +10300,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1953,
+					"id": 1956,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10318,7 +10318,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1956,
+					"id": 1959,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10336,7 +10336,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1960,
+					"id": 1963,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10354,7 +10354,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1954,
+					"id": 1957,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10372,7 +10372,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1959,
+					"id": 1962,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10395,13 +10395,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1955,
 						1958,
-						1953,
+						1961,
 						1956,
-						1960,
-						1954,
-						1959
+						1959,
+						1963,
+						1957,
+						1962
 					]
 				}
 			],
@@ -10414,14 +10414,14 @@
 			]
 		},
 		{
-			"id": 2684,
+			"id": 2687,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2685,
+					"id": 2688,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10436,7 +10436,7 @@
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2687,
+					"id": 2690,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10451,7 +10451,7 @@
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2686,
+					"id": 2689,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10466,7 +10466,7 @@
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2688,
+					"id": 2691,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10486,10 +10486,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2685,
-						2687,
-						2686,
-						2688
+						2688,
+						2690,
+						2689,
+						2691
 					]
 				}
 			],
@@ -10502,7 +10502,7 @@
 			]
 		},
 		{
-			"id": 2944,
+			"id": 2947,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10518,7 +10518,7 @@
 			},
 			"children": [
 				{
-					"id": 2945,
+					"id": 2948,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10541,7 +10541,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2945
+						2948
 					]
 				}
 			],
@@ -10554,7 +10554,7 @@
 			]
 		},
 		{
-			"id": 1977,
+			"id": 1980,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10564,7 +10564,7 @@
 			},
 			"children": [
 				{
-					"id": 1985,
+					"id": 1988,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10582,7 +10582,7 @@
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 1990,
+					"id": 1993,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10600,7 +10600,7 @@
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 1989,
+					"id": 1992,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10618,7 +10618,7 @@
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 1987,
+					"id": 1990,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10636,7 +10636,7 @@
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 1988,
+					"id": 1991,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10654,7 +10654,7 @@
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 1984,
+					"id": 1987,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10672,7 +10672,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 1986,
+					"id": 1989,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10690,7 +10690,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 1978,
+					"id": 1981,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10708,7 +10708,7 @@
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 1983,
+					"id": 1986,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10726,7 +10726,7 @@
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 1982,
+					"id": 1985,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10744,7 +10744,7 @@
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 1991,
+					"id": 1994,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10762,7 +10762,7 @@
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 1981,
+					"id": 1984,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10780,7 +10780,7 @@
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 1980,
+					"id": 1983,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10798,7 +10798,7 @@
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 1979,
+					"id": 1982,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10816,7 +10816,7 @@
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 1992,
+					"id": 1995,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10839,21 +10839,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1985,
-						1990,
-						1989,
-						1987,
 						1988,
-						1984,
+						1993,
+						1992,
+						1990,
+						1991,
+						1987,
+						1989,
+						1981,
 						1986,
-						1978,
+						1985,
+						1994,
+						1984,
 						1983,
 						1982,
-						1991,
-						1981,
-						1980,
-						1979,
-						1992
+						1995
 					]
 				}
 			],
@@ -10866,14 +10866,14 @@
 			]
 		},
 		{
-			"id": 2975,
+			"id": 2978,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2980,
+					"id": 2983,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10888,7 +10888,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 2979,
+					"id": 2982,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10903,7 +10903,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 2978,
+					"id": 2981,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10918,7 +10918,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 2981,
+					"id": 2984,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10933,7 +10933,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 2982,
+					"id": 2985,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10948,7 +10948,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 2976,
+					"id": 2979,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10963,7 +10963,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 2977,
+					"id": 2980,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10983,13 +10983,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2980,
-						2979,
-						2978,
-						2981,
+						2983,
 						2982,
-						2976,
-						2977
+						2981,
+						2984,
+						2985,
+						2979,
+						2980
 					]
 				}
 			],
@@ -11002,7 +11002,7 @@
 			]
 		},
 		{
-			"id": 1869,
+			"id": 1872,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -11031,7 +11031,7 @@
 			},
 			"children": [
 				{
-					"id": 1870,
+					"id": 1873,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -11048,7 +11048,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1871,
+							"id": 1874,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -11058,7 +11058,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1872,
+									"id": 1875,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11066,12 +11066,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1942,
+										"id": 1945,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1873,
+									"id": 1876,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11083,7 +11083,7 @@
 									}
 								},
 								{
-									"id": 1874,
+									"id": 1877,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11095,7 +11095,7 @@
 									}
 								},
 								{
-									"id": 1875,
+									"id": 1878,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11109,7 +11109,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2952,
+											"id": 2955,
 											"name": "VizPoint"
 										}
 									}
@@ -11117,14 +11117,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1869,
+								"id": 1872,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1884,
+					"id": 1887,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11140,7 +11140,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1885,
+							"id": 1888,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11151,7 +11151,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1886,
+									"id": 1889,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11180,7 +11180,7 @@
 					]
 				},
 				{
-					"id": 1887,
+					"id": 1890,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11196,7 +11196,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1888,
+							"id": 1891,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11212,7 +11212,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1889,
+									"id": 1892,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11241,7 +11241,7 @@
 					]
 				},
 				{
-					"id": 1936,
+					"id": 1939,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11257,14 +11257,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1937,
+							"id": 1940,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1938,
+									"id": 1941,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11289,7 +11289,7 @@
 					]
 				},
 				{
-					"id": 1890,
+					"id": 1893,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11305,7 +11305,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1891,
+							"id": 1894,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11316,7 +11316,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1892,
+									"id": 1895,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11328,7 +11328,7 @@
 									}
 								},
 								{
-									"id": 1893,
+									"id": 1896,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11336,12 +11336,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1977,
+										"id": 1980,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1894,
+									"id": 1897,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11387,7 +11387,7 @@
 					]
 				},
 				{
-					"id": 1926,
+					"id": 1929,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11403,7 +11403,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1927,
+							"id": 1930,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11414,7 +11414,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1928,
+									"id": 1931,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11428,7 +11428,7 @@
 									}
 								},
 								{
-									"id": 1929,
+									"id": 1932,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11456,7 +11456,7 @@
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1907,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11472,7 +11472,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1908,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11483,7 +11483,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1906,
+									"id": 1909,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11496,7 +11496,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1907,
+									"id": 1910,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11525,7 +11525,7 @@
 					]
 				},
 				{
-					"id": 1897,
+					"id": 1900,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11541,7 +11541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1898,
+							"id": 1901,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11552,7 +11552,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1899,
+									"id": 1902,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11565,7 +11565,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1900,
+									"id": 1903,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11584,14 +11584,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1901,
+											"id": 1904,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1902,
+													"id": 1905,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -11602,7 +11602,7 @@
 													}
 												},
 												{
-													"id": 1903,
+													"id": 1906,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -11618,8 +11618,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1902,
-														1903
+														1905,
+														1906
 													]
 												}
 											]
@@ -11632,7 +11632,7 @@
 					]
 				},
 				{
-					"id": 1908,
+					"id": 1911,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11648,7 +11648,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1909,
+							"id": 1912,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11659,7 +11659,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1910,
+									"id": 1913,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11672,7 +11672,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1911,
+									"id": 1914,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11687,7 +11687,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1912,
+									"id": 1915,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11716,7 +11716,7 @@
 					]
 				},
 				{
-					"id": 1932,
+					"id": 1935,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11732,7 +11732,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1933,
+							"id": 1936,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11751,7 +11751,7 @@
 					]
 				},
 				{
-					"id": 1913,
+					"id": 1916,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11767,7 +11767,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1914,
+							"id": 1917,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11778,7 +11778,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1915,
+									"id": 1918,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11791,7 +11791,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1916,
+									"id": 1919,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11812,7 +11812,7 @@
 					]
 				},
 				{
-					"id": 1917,
+					"id": 1920,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11828,7 +11828,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1918,
+							"id": 1921,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11838,7 +11838,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1919,
+									"id": 1922,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11851,7 +11851,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1920,
+									"id": 1923,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11864,7 +11864,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1921,
+									"id": 1924,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11887,7 +11887,7 @@
 					]
 				},
 				{
-					"id": 1895,
+					"id": 1898,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11903,7 +11903,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1896,
+							"id": 1899,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11922,7 +11922,7 @@
 					]
 				},
 				{
-					"id": 1930,
+					"id": 1933,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11938,7 +11938,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1931,
+							"id": 1934,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11949,14 +11949,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1942,
+								"id": 1945,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1879,
+					"id": 1882,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11972,7 +11972,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1880,
+							"id": 1883,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11994,7 +11994,7 @@
 					]
 				},
 				{
-					"id": 1934,
+					"id": 1937,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12010,7 +12010,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1935,
+							"id": 1938,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12029,7 +12029,7 @@
 					]
 				},
 				{
-					"id": 1922,
+					"id": 1925,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12045,7 +12045,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1923,
+							"id": 1926,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12065,7 +12065,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1924,
+									"id": 1927,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12080,7 +12080,7 @@
 									}
 								},
 								{
-									"id": 1925,
+									"id": 1928,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12092,7 +12092,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1949,
+											"id": 1952,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -12103,7 +12103,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -12113,7 +12113,7 @@
 					]
 				},
 				{
-					"id": 1881,
+					"id": 1884,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12129,7 +12129,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1882,
+							"id": 1885,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12140,7 +12140,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1883,
+									"id": 1886,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12169,7 +12169,7 @@
 					]
 				},
 				{
-					"id": 1939,
+					"id": 1942,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12185,14 +12185,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1940,
+							"id": 1943,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1941,
+									"id": 1944,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12216,31 +12216,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1870
+						1873
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1884,
 						1887,
-						1936,
 						1890,
-						1926,
-						1904,
-						1897,
-						1908,
-						1932,
-						1913,
-						1917,
-						1895,
-						1930,
-						1879,
-						1934,
-						1922,
-						1881,
-						1939
+						1939,
+						1893,
+						1929,
+						1907,
+						1900,
+						1911,
+						1935,
+						1916,
+						1920,
+						1898,
+						1933,
+						1882,
+						1937,
+						1925,
+						1884,
+						1942
 					]
 				}
 			],
@@ -12253,7 +12253,7 @@
 			]
 		},
 		{
-			"id": 1021,
+			"id": 1024,
 			"name": "AppEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -12269,7 +12269,7 @@
 			},
 			"children": [
 				{
-					"id": 1022,
+					"id": 1025,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -12283,40 +12283,40 @@
 					],
 					"signatures": [
 						{
-							"id": 1023,
+							"id": 1026,
 							"name": "new AppEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1024,
+									"id": 1027,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2713,
+										"id": 2716,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 1025,
+									"id": 1028,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2596,
+										"id": 2599,
 										"name": "AppViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1021,
+								"id": 1024,
 								"name": "AppEmbed"
 							},
 							"overwrites": {
@@ -12331,7 +12331,7 @@
 					}
 				},
 				{
-					"id": 1059,
+					"id": 1062,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12347,7 +12347,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1060,
+							"id": 1063,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12377,7 +12377,7 @@
 					}
 				},
 				{
-					"id": 1235,
+					"id": 1238,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12393,7 +12393,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1236,
+							"id": 1239,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12409,7 +12409,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1237,
+									"id": 1240,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12430,7 +12430,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -12448,7 +12448,7 @@
 					}
 				},
 				{
-					"id": 1036,
+					"id": 1039,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12464,7 +12464,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1037,
+							"id": 1040,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12480,7 +12480,7 @@
 					]
 				},
 				{
-					"id": 1204,
+					"id": 1207,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12496,7 +12496,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1205,
+							"id": 1208,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12517,7 +12517,7 @@
 					}
 				},
 				{
-					"id": 1230,
+					"id": 1233,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12533,7 +12533,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1231,
+							"id": 1234,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12555,14 +12555,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1232,
+									"id": 1235,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1234,
+											"id": 1237,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -12574,7 +12574,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1233,
+											"id": 1236,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -12591,8 +12591,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1234,
-												1233
+												1237,
+												1236
 											]
 										}
 									]
@@ -12610,7 +12610,7 @@
 					}
 				},
 				{
-					"id": 1212,
+					"id": 1215,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12626,7 +12626,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1213,
+							"id": 1216,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12642,7 +12642,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1214,
+									"id": 1217,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12650,20 +12650,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1215,
+											"id": 1218,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1216,
+												"id": 1219,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1217,
+														"id": 1220,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -12708,7 +12708,7 @@
 					}
 				},
 				{
-					"id": 1218,
+					"id": 1221,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12724,7 +12724,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1219,
+							"id": 1222,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12745,7 +12745,7 @@
 					}
 				},
 				{
-					"id": 1228,
+					"id": 1231,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12761,7 +12761,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1229,
+							"id": 1232,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12785,7 +12785,7 @@
 					}
 				},
 				{
-					"id": 1055,
+					"id": 1058,
 					"name": "navigateToPage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12801,7 +12801,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1056,
+							"id": 1059,
 							"name": "navigateToPage",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12817,7 +12817,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1057,
+									"id": 1060,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12840,7 +12840,7 @@
 									}
 								},
 								{
-									"id": 1058,
+									"id": 1061,
 									"name": "noReload",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12863,7 +12863,7 @@
 					]
 				},
 				{
-					"id": 1175,
+					"id": 1178,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12879,7 +12879,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1176,
+							"id": 1179,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12895,7 +12895,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1177,
+									"id": 1180,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12905,12 +12905,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1178,
+									"id": 1181,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12920,7 +12920,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -12941,7 +12941,7 @@
 					}
 				},
 				{
-					"id": 1074,
+					"id": 1077,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12957,7 +12957,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1075,
+							"id": 1078,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12980,38 +12980,38 @@
 							},
 							"parameters": [
 								{
-									"id": 1076,
+									"id": 1079,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1077,
+									"id": 1080,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1078,
+									"id": 1081,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -13033,7 +13033,7 @@
 					}
 				},
 				{
-					"id": 1208,
+					"id": 1211,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13049,7 +13049,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1209,
+							"id": 1212,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13059,7 +13059,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1210,
+									"id": 1213,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13074,7 +13074,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1211,
+									"id": 1214,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13108,7 +13108,7 @@
 					}
 				},
 				{
-					"id": 1220,
+					"id": 1223,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13124,7 +13124,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1221,
+							"id": 1224,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13161,7 +13161,7 @@
 					}
 				},
 				{
-					"id": 1067,
+					"id": 1070,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13177,7 +13177,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1068,
+							"id": 1071,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13190,7 +13190,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1021,
+										"id": 1024,
 										"name": "AppEmbed"
 									}
 								],
@@ -13208,7 +13208,7 @@
 					}
 				},
 				{
-					"id": 1224,
+					"id": 1227,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13224,7 +13224,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1225,
+							"id": 1228,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13254,7 +13254,7 @@
 					}
 				},
 				{
-					"id": 1226,
+					"id": 1229,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13270,7 +13270,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1227,
+							"id": 1230,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13300,7 +13300,7 @@
 					}
 				},
 				{
-					"id": 1193,
+					"id": 1196,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13316,7 +13316,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1194,
+							"id": 1197,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13327,19 +13327,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1195,
+									"id": 1198,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1196,
+									"id": 1199,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -13348,7 +13348,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1197,
+									"id": 1200,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13362,7 +13362,7 @@
 									}
 								},
 								{
-									"id": 1198,
+									"id": 1201,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13419,7 +13419,7 @@
 					}
 				},
 				{
-					"id": 1199,
+					"id": 1202,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13435,7 +13435,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1200,
+							"id": 1203,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13446,21 +13446,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1201,
+									"id": 1204,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1202,
+									"id": 1205,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13474,7 +13474,7 @@
 									}
 								},
 								{
-									"id": 1203,
+									"id": 1206,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13527,31 +13527,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1022
+						1025
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1059,
-						1235,
-						1036,
-						1204,
-						1230,
-						1212,
-						1218,
-						1228,
-						1055,
-						1175,
-						1074,
-						1208,
-						1220,
-						1067,
-						1224,
-						1226,
-						1193,
-						1199
+						1062,
+						1238,
+						1039,
+						1207,
+						1233,
+						1215,
+						1221,
+						1231,
+						1058,
+						1178,
+						1077,
+						1211,
+						1223,
+						1070,
+						1227,
+						1229,
+						1196,
+						1202
 					]
 				}
 			],
@@ -13570,7 +13570,7 @@
 			]
 		},
 		{
-			"id": 1334,
+			"id": 1337,
 			"name": "BodylessConversation",
 			"kind": 128,
 			"kindString": "Class",
@@ -13594,7 +13594,7 @@
 			},
 			"children": [
 				{
-					"id": 1335,
+					"id": 1338,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -13608,45 +13608,45 @@
 					],
 					"signatures": [
 						{
-							"id": 1336,
+							"id": 1339,
 							"name": "new BodylessConversation",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1337,
+									"id": 1340,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1302,
+										"id": 1305,
 										"name": "BodylessConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1334,
+								"id": 1337,
 								"name": "BodylessConversation"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1240,
+								"id": 1243,
 								"name": "SpotterAgentEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1239,
+						"id": 1242,
 						"name": "SpotterAgentEmbed.constructor"
 					}
 				},
 				{
-					"id": 1338,
+					"id": 1341,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13662,14 +13662,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1339,
+							"id": 1342,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1340,
+									"id": 1343,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13689,14 +13689,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1341,
+													"id": 1344,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1343,
+															"id": 1346,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13707,7 +13707,7 @@
 															}
 														},
 														{
-															"id": 1342,
+															"id": 1345,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13718,7 +13718,7 @@
 															}
 														},
 														{
-															"id": 1344,
+															"id": 1347,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13735,9 +13735,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1343,
-																1342,
-																1344
+																1346,
+																1345,
+																1347
 															]
 														}
 													]
@@ -13746,14 +13746,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1345,
+													"id": 1348,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1346,
+															"id": 1349,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13764,7 +13764,7 @@
 															}
 														},
 														{
-															"id": 1348,
+															"id": 1351,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13775,7 +13775,7 @@
 															}
 														},
 														{
-															"id": 1347,
+															"id": 1350,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13792,9 +13792,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1346,
-																1348,
-																1347
+																1349,
+																1351,
+																1350
 															]
 														}
 													]
@@ -13807,19 +13807,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1244,
+								"id": 1247,
 								"name": "SpotterAgentEmbed.sendMessage"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1243,
+						"id": 1246,
 						"name": "SpotterAgentEmbed.sendMessage"
 					}
 				},
 				{
-					"id": 1349,
+					"id": 1352,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13835,7 +13835,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1350,
+							"id": 1353,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13846,7 +13846,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1351,
+									"id": 1354,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13869,14 +13869,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1352,
+													"id": 1355,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1354,
+															"id": 1357,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13888,7 +13888,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1353,
+															"id": 1356,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13904,8 +13904,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1354,
-																1353
+																1357,
+																1356
 															]
 														}
 													]
@@ -13914,14 +13914,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1355,
+													"id": 1358,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1356,
+															"id": 1359,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -13929,14 +13929,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1357,
+																	"id": 1360,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1363,
+																			"id": 1366,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13948,7 +13948,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1362,
+																			"id": 1365,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13960,7 +13960,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1358,
+																			"id": 1361,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13972,7 +13972,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1361,
+																			"id": 1364,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13984,7 +13984,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1359,
+																			"id": 1362,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -13996,7 +13996,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1360,
+																			"id": 1363,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -14013,12 +14013,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1363,
-																				1362,
-																				1358,
+																				1366,
+																				1365,
 																				1361,
-																				1359,
-																				1360
+																				1364,
+																				1362,
+																				1363
 																			]
 																		}
 																	]
@@ -14027,7 +14027,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1364,
+															"id": 1367,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14043,8 +14043,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1356,
-																1364
+																1359,
+																1367
 															]
 														}
 													]
@@ -14057,14 +14057,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1255,
+								"id": 1258,
 								"name": "SpotterAgentEmbed.sendMessageData"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1254,
+						"id": 1257,
 						"name": "SpotterAgentEmbed.sendMessageData"
 					}
 				}
@@ -14074,15 +14074,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1335
+						1338
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1338,
-						1349
+						1341,
+						1352
 					]
 				}
 			],
@@ -14096,13 +14096,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1238,
+					"id": 1241,
 					"name": "SpotterAgentEmbed"
 				}
 			]
 		},
 		{
-			"id": 1626,
+			"id": 1629,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -14130,7 +14130,7 @@
 			},
 			"children": [
 				{
-					"id": 1627,
+					"id": 1630,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -14144,14 +14144,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1628,
+							"id": 1631,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1629,
+									"id": 1632,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14162,38 +14162,38 @@
 									}
 								},
 								{
-									"id": 1630,
+									"id": 1633,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1582,
+										"id": 1585,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1626,
+								"id": 1629,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1367,
+								"id": 1370,
 								"name": "SpotterEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1366,
+						"id": 1369,
 						"name": "SpotterEmbed.constructor"
 					}
 				},
 				{
-					"id": 1777,
+					"id": 1780,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14209,7 +14209,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1781,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14229,19 +14229,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1517,
+								"id": 1520,
 								"name": "SpotterEmbed.destroy"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1516,
+						"id": 1519,
 						"name": "SpotterEmbed.destroy"
 					}
 				},
 				{
-					"id": 1796,
+					"id": 1799,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14257,7 +14257,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1797,
+							"id": 1800,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14273,7 +14273,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1798,
+									"id": 1801,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14294,7 +14294,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -14302,19 +14302,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1536,
+								"id": 1539,
 								"name": "SpotterEmbed.getAnswerService"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1535,
+						"id": 1538,
 						"name": "SpotterEmbed.getAnswerService"
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1637,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14330,7 +14330,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1635,
+							"id": 1638,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14341,19 +14341,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1374,
+								"id": 1377,
 								"name": "SpotterEmbed.getIframeSrc"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1373,
+						"id": 1376,
 						"name": "SpotterEmbed.getIframeSrc"
 					}
 				},
 				{
-					"id": 1791,
+					"id": 1794,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14369,7 +14369,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1792,
+							"id": 1795,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14391,14 +14391,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1793,
+									"id": 1796,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1795,
+											"id": 1798,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -14410,7 +14410,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1794,
+											"id": 1797,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -14427,8 +14427,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1795,
-												1794
+												1798,
+												1797
 											]
 										}
 									]
@@ -14436,19 +14436,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1531,
+								"id": 1534,
 								"name": "SpotterEmbed.getPreRenderIds"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1530,
+						"id": 1533,
 						"name": "SpotterEmbed.getPreRenderIds"
 					}
 				},
 				{
-					"id": 1771,
+					"id": 1774,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14464,7 +14464,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1772,
+							"id": 1775,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14480,7 +14480,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1773,
+									"id": 1776,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14488,20 +14488,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1774,
+											"id": 1777,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1775,
+												"id": 1778,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1776,
+														"id": 1779,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -14536,19 +14536,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1511,
+								"id": 1514,
 								"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1510,
+						"id": 1513,
 						"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 					}
 				},
 				{
-					"id": 1779,
+					"id": 1782,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14564,7 +14564,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1780,
+							"id": 1783,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14575,19 +14575,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1519,
+								"id": 1522,
 								"name": "SpotterEmbed.getUnderlyingFrameElement"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1518,
+						"id": 1521,
 						"name": "SpotterEmbed.getUnderlyingFrameElement"
 					}
 				},
 				{
-					"id": 1789,
+					"id": 1792,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14603,7 +14603,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1790,
+							"id": 1793,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14617,19 +14617,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1529,
+								"id": 1532,
 								"name": "SpotterEmbed.hidePreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1528,
+						"id": 1531,
 						"name": "SpotterEmbed.hidePreRender"
 					}
 				},
 				{
-					"id": 1736,
+					"id": 1739,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14645,7 +14645,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1737,
+							"id": 1740,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14661,7 +14661,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1738,
+									"id": 1741,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14671,12 +14671,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1739,
+									"id": 1742,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14686,7 +14686,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -14697,19 +14697,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1476,
+								"id": 1479,
 								"name": "SpotterEmbed.off"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1475,
+						"id": 1478,
 						"name": "SpotterEmbed.off"
 					}
 				},
 				{
-					"id": 1730,
+					"id": 1733,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14725,7 +14725,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1731,
+							"id": 1734,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14745,7 +14745,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1732,
+									"id": 1735,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14755,12 +14755,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1733,
+									"id": 1736,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14770,12 +14770,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1734,
+									"id": 1737,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14785,13 +14785,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1735,
+									"id": 1738,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14810,19 +14810,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1470,
+								"id": 1473,
 								"name": "SpotterEmbed.on"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1469,
+						"id": 1472,
 						"name": "SpotterEmbed.on"
 					}
 				},
 				{
-					"id": 1767,
+					"id": 1770,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14838,7 +14838,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1768,
+							"id": 1771,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14848,7 +14848,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1769,
+									"id": 1772,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14863,7 +14863,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1770,
+									"id": 1773,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14887,19 +14887,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1507,
+								"id": 1510,
 								"name": "SpotterEmbed.preRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1506,
+						"id": 1509,
 						"name": "SpotterEmbed.preRender"
 					}
 				},
 				{
-					"id": 1781,
+					"id": 1784,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14915,7 +14915,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1782,
+							"id": 1785,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14942,19 +14942,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1521,
+								"id": 1524,
 								"name": "SpotterEmbed.prerenderGeneric"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1520,
+						"id": 1523,
 						"name": "SpotterEmbed.prerenderGeneric"
 					}
 				},
 				{
-					"id": 1636,
+					"id": 1639,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14970,7 +14970,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1637,
+							"id": 1640,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14980,7 +14980,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1365,
+										"id": 1368,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -14988,19 +14988,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1376,
+								"id": 1379,
 								"name": "SpotterEmbed.render"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1375,
+						"id": 1378,
 						"name": "SpotterEmbed.render"
 					}
 				},
 				{
-					"id": 1785,
+					"id": 1788,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15016,7 +15016,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1786,
+							"id": 1789,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15036,19 +15036,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1525,
+								"id": 1528,
 								"name": "SpotterEmbed.showPreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1524,
+						"id": 1527,
 						"name": "SpotterEmbed.showPreRender"
 					}
 				},
 				{
-					"id": 1787,
+					"id": 1790,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15064,7 +15064,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1788,
+							"id": 1791,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15084,19 +15084,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1527,
+								"id": 1530,
 								"name": "SpotterEmbed.syncPreRenderStyle"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1526,
+						"id": 1529,
 						"name": "SpotterEmbed.syncPreRenderStyle"
 					}
 				},
 				{
-					"id": 1754,
+					"id": 1757,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15112,7 +15112,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1755,
+							"id": 1758,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15123,19 +15123,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1756,
+									"id": 1759,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1757,
+									"id": 1760,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -15144,7 +15144,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1758,
+									"id": 1761,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15158,7 +15158,7 @@
 									}
 								},
 								{
-									"id": 1759,
+									"id": 1762,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15205,19 +15205,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1494,
+								"id": 1497,
 								"name": "SpotterEmbed.trigger"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1493,
+						"id": 1496,
 						"name": "SpotterEmbed.trigger"
 					}
 				},
 				{
-					"id": 1760,
+					"id": 1763,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15233,7 +15233,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1761,
+							"id": 1764,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15244,21 +15244,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1762,
+									"id": 1765,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1763,
+									"id": 1766,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15272,7 +15272,7 @@
 									}
 								},
 								{
-									"id": 1764,
+									"id": 1767,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15310,14 +15310,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1500,
+								"id": 1503,
 								"name": "SpotterEmbed.triggerUIPassThrough"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1499,
+						"id": 1502,
 						"name": "SpotterEmbed.triggerUIPassThrough"
 					}
 				}
@@ -15327,29 +15327,29 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1627
+						1630
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1777,
-						1796,
-						1634,
-						1791,
-						1771,
-						1779,
-						1789,
-						1736,
-						1730,
-						1767,
-						1781,
-						1636,
-						1785,
-						1787,
-						1754,
-						1760
+						1780,
+						1799,
+						1637,
+						1794,
+						1774,
+						1782,
+						1792,
+						1739,
+						1733,
+						1770,
+						1784,
+						1639,
+						1788,
+						1790,
+						1757,
+						1763
 					]
 				}
 			],
@@ -15363,13 +15363,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1365,
+					"id": 1368,
 					"name": "SpotterEmbed"
 				}
 			]
 		},
 		{
-			"id": 608,
+			"id": 611,
 			"name": "LiveboardEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -15389,7 +15389,7 @@
 			},
 			"children": [
 				{
-					"id": 609,
+					"id": 612,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -15403,40 +15403,40 @@
 					],
 					"signatures": [
 						{
-							"id": 610,
+							"id": 613,
 							"name": "new LiveboardEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 611,
+									"id": 614,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2713,
+										"id": 2716,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 612,
+									"id": 615,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2466,
+										"id": 2469,
 										"name": "LiveboardViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 608,
+								"id": 611,
 								"name": "LiveboardEmbed"
 							},
 							"overwrites": {
@@ -15451,7 +15451,7 @@
 					}
 				},
 				{
-					"id": 664,
+					"id": 667,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15467,7 +15467,7 @@
 					],
 					"signatures": [
 						{
-							"id": 665,
+							"id": 668,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15497,7 +15497,7 @@
 					}
 				},
 				{
-					"id": 835,
+					"id": 838,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15513,7 +15513,7 @@
 					],
 					"signatures": [
 						{
-							"id": 836,
+							"id": 839,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15529,7 +15529,7 @@
 							},
 							"parameters": [
 								{
-									"id": 837,
+									"id": 840,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15550,7 +15550,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -15568,7 +15568,7 @@
 					}
 				},
 				{
-					"id": 808,
+					"id": 811,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15584,7 +15584,7 @@
 					],
 					"signatures": [
 						{
-							"id": 809,
+							"id": 812,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15605,7 +15605,7 @@
 					}
 				},
 				{
-					"id": 679,
+					"id": 682,
 					"name": "getLiveboardUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15621,7 +15621,7 @@
 					],
 					"signatures": [
 						{
-							"id": 680,
+							"id": 683,
 							"name": "getLiveboardUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15638,7 +15638,7 @@
 					]
 				},
 				{
-					"id": 830,
+					"id": 833,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15654,7 +15654,7 @@
 					],
 					"signatures": [
 						{
-							"id": 831,
+							"id": 834,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15676,14 +15676,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 832,
+									"id": 835,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 834,
+											"id": 837,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15695,7 +15695,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 833,
+											"id": 836,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15712,8 +15712,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												834,
-												833
+												837,
+												836
 											]
 										}
 									]
@@ -15731,7 +15731,7 @@
 					}
 				},
 				{
-					"id": 814,
+					"id": 817,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15747,7 +15747,7 @@
 					],
 					"signatures": [
 						{
-							"id": 815,
+							"id": 818,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15763,7 +15763,7 @@
 							},
 							"parameters": [
 								{
-									"id": 816,
+									"id": 819,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15771,20 +15771,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 817,
+											"id": 820,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 818,
+												"id": 821,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 819,
+														"id": 822,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -15829,7 +15829,7 @@
 					}
 				},
 				{
-					"id": 820,
+					"id": 823,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15845,7 +15845,7 @@
 					],
 					"signatures": [
 						{
-							"id": 821,
+							"id": 824,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15866,7 +15866,7 @@
 					}
 				},
 				{
-					"id": 828,
+					"id": 831,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15882,7 +15882,7 @@
 					],
 					"signatures": [
 						{
-							"id": 829,
+							"id": 832,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15906,7 +15906,7 @@
 					}
 				},
 				{
-					"id": 674,
+					"id": 677,
 					"name": "navigateToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15922,14 +15922,14 @@
 					],
 					"signatures": [
 						{
-							"id": 675,
+							"id": 678,
 							"name": "navigateToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 676,
+									"id": 679,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15940,7 +15940,7 @@
 									}
 								},
 								{
-									"id": 677,
+									"id": 680,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15953,7 +15953,7 @@
 									}
 								},
 								{
-									"id": 678,
+									"id": 681,
 									"name": "activeTabId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15974,7 +15974,7 @@
 					]
 				},
 				{
-					"id": 785,
+					"id": 788,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15990,7 +15990,7 @@
 					],
 					"signatures": [
 						{
-							"id": 786,
+							"id": 789,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16006,7 +16006,7 @@
 							},
 							"parameters": [
 								{
-									"id": 787,
+									"id": 790,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16016,12 +16016,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 788,
+									"id": 791,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16031,7 +16031,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -16052,7 +16052,7 @@
 					}
 				},
 				{
-					"id": 686,
+					"id": 689,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16068,7 +16068,7 @@
 					],
 					"signatures": [
 						{
-							"id": 687,
+							"id": 690,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16091,38 +16091,38 @@
 							},
 							"parameters": [
 								{
-									"id": 688,
+									"id": 691,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 689,
+									"id": 692,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 690,
+									"id": 693,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -16144,7 +16144,7 @@
 					}
 				},
 				{
-					"id": 810,
+					"id": 813,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16160,7 +16160,7 @@
 					],
 					"signatures": [
 						{
-							"id": 811,
+							"id": 814,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16170,7 +16170,7 @@
 							},
 							"parameters": [
 								{
-									"id": 812,
+									"id": 815,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16185,7 +16185,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 813,
+									"id": 816,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16219,7 +16219,7 @@
 					}
 				},
 				{
-					"id": 822,
+					"id": 825,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16235,7 +16235,7 @@
 					],
 					"signatures": [
 						{
-							"id": 823,
+							"id": 826,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16272,7 +16272,7 @@
 					}
 				},
 				{
-					"id": 672,
+					"id": 675,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16288,7 +16288,7 @@
 					],
 					"signatures": [
 						{
-							"id": 673,
+							"id": 676,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16301,7 +16301,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 608,
+										"id": 611,
 										"name": "LiveboardEmbed"
 									}
 								],
@@ -16319,7 +16319,7 @@
 					}
 				},
 				{
-					"id": 824,
+					"id": 827,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16335,7 +16335,7 @@
 					],
 					"signatures": [
 						{
-							"id": 825,
+							"id": 828,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16365,7 +16365,7 @@
 					}
 				},
 				{
-					"id": 826,
+					"id": 829,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16381,7 +16381,7 @@
 					],
 					"signatures": [
 						{
-							"id": 827,
+							"id": 830,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16411,7 +16411,7 @@
 					}
 				},
 				{
-					"id": 658,
+					"id": 661,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16427,7 +16427,7 @@
 					],
 					"signatures": [
 						{
-							"id": 659,
+							"id": 662,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16438,19 +16438,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 660,
+									"id": 663,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 661,
+									"id": 664,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -16459,7 +16459,7 @@
 							],
 							"parameters": [
 								{
-									"id": 662,
+									"id": 665,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16473,7 +16473,7 @@
 									}
 								},
 								{
-									"id": 663,
+									"id": 666,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16530,7 +16530,7 @@
 					}
 				},
 				{
-					"id": 803,
+					"id": 806,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16546,7 +16546,7 @@
 					],
 					"signatures": [
 						{
-							"id": 804,
+							"id": 807,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16557,21 +16557,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 805,
+									"id": 808,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 806,
+									"id": 809,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16585,7 +16585,7 @@
 									}
 								},
 								{
-									"id": 807,
+									"id": 810,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16638,31 +16638,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						609
+						612
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						664,
-						835,
-						808,
-						679,
-						830,
-						814,
-						820,
-						828,
-						674,
-						785,
-						686,
-						810,
-						822,
-						672,
-						824,
-						826,
-						658,
-						803
+						667,
+						838,
+						811,
+						682,
+						833,
+						817,
+						823,
+						831,
+						677,
+						788,
+						689,
+						813,
+						825,
+						675,
+						827,
+						829,
+						661,
+						806
 					]
 				}
 			],
@@ -16681,7 +16681,7 @@
 			]
 		},
 		{
-			"id": 838,
+			"id": 841,
 			"name": "SageEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -16701,7 +16701,7 @@
 			},
 			"children": [
 				{
-					"id": 839,
+					"id": 842,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16715,40 +16715,40 @@
 					],
 					"signatures": [
 						{
-							"id": 840,
+							"id": 843,
 							"name": "new SageEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 841,
+									"id": 844,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2713,
+										"id": 2716,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 842,
+									"id": 845,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2546,
+										"id": 2549,
 										"name": "SageViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 838,
+								"id": 841,
 								"name": "SageEmbed"
 							},
 							"overwrites": {
@@ -16763,7 +16763,7 @@
 					}
 				},
 				{
-					"id": 999,
+					"id": 1002,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16779,7 +16779,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1000,
+							"id": 1003,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16809,7 +16809,7 @@
 					}
 				},
 				{
-					"id": 1018,
+					"id": 1021,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16825,7 +16825,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1019,
+							"id": 1022,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16841,7 +16841,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1020,
+									"id": 1023,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16862,7 +16862,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -16880,7 +16880,7 @@
 					}
 				},
 				{
-					"id": 848,
+					"id": 851,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16896,7 +16896,7 @@
 					],
 					"signatures": [
 						{
-							"id": 849,
+							"id": 852,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16913,7 +16913,7 @@
 					]
 				},
 				{
-					"id": 985,
+					"id": 988,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16929,7 +16929,7 @@
 					],
 					"signatures": [
 						{
-							"id": 986,
+							"id": 989,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16950,7 +16950,7 @@
 					}
 				},
 				{
-					"id": 1013,
+					"id": 1016,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16966,7 +16966,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1014,
+							"id": 1017,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16988,14 +16988,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1015,
+									"id": 1018,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1017,
+											"id": 1020,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17007,7 +17007,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1016,
+											"id": 1019,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17024,8 +17024,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1017,
-												1016
+												1020,
+												1019
 											]
 										}
 									]
@@ -17043,7 +17043,7 @@
 					}
 				},
 				{
-					"id": 993,
+					"id": 996,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17059,7 +17059,7 @@
 					],
 					"signatures": [
 						{
-							"id": 994,
+							"id": 997,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17075,7 +17075,7 @@
 							},
 							"parameters": [
 								{
-									"id": 995,
+									"id": 998,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17083,20 +17083,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 996,
+											"id": 999,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 997,
+												"id": 1000,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 998,
+														"id": 1001,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -17141,7 +17141,7 @@
 					}
 				},
 				{
-					"id": 1001,
+					"id": 1004,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17157,7 +17157,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1002,
+							"id": 1005,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17178,7 +17178,7 @@
 					}
 				},
 				{
-					"id": 1011,
+					"id": 1014,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17194,7 +17194,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1012,
+							"id": 1015,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17218,7 +17218,7 @@
 					}
 				},
 				{
-					"id": 956,
+					"id": 959,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17234,7 +17234,7 @@
 					],
 					"signatures": [
 						{
-							"id": 957,
+							"id": 960,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17250,7 +17250,7 @@
 							},
 							"parameters": [
 								{
-									"id": 958,
+									"id": 961,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17260,12 +17260,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 959,
+									"id": 962,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17275,7 +17275,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -17296,7 +17296,7 @@
 					}
 				},
 				{
-					"id": 857,
+					"id": 860,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17312,7 +17312,7 @@
 					],
 					"signatures": [
 						{
-							"id": 858,
+							"id": 861,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17335,38 +17335,38 @@
 							},
 							"parameters": [
 								{
-									"id": 859,
+									"id": 862,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 860,
+									"id": 863,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 861,
+									"id": 864,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17388,7 +17388,7 @@
 					}
 				},
 				{
-					"id": 989,
+					"id": 992,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17404,7 +17404,7 @@
 					],
 					"signatures": [
 						{
-							"id": 990,
+							"id": 993,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17414,7 +17414,7 @@
 							},
 							"parameters": [
 								{
-									"id": 991,
+									"id": 994,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17429,7 +17429,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 992,
+									"id": 995,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17463,7 +17463,7 @@
 					}
 				},
 				{
-					"id": 1003,
+					"id": 1006,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17479,7 +17479,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1004,
+							"id": 1007,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17516,7 +17516,7 @@
 					}
 				},
 				{
-					"id": 850,
+					"id": 853,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17532,7 +17532,7 @@
 					],
 					"signatures": [
 						{
-							"id": 851,
+							"id": 854,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17546,7 +17546,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 838,
+										"id": 841,
 										"name": "SageEmbed"
 									}
 								],
@@ -17564,7 +17564,7 @@
 					}
 				},
 				{
-					"id": 1007,
+					"id": 1010,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17580,7 +17580,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1008,
+							"id": 1011,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17610,7 +17610,7 @@
 					}
 				},
 				{
-					"id": 1009,
+					"id": 1012,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17626,7 +17626,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1010,
+							"id": 1013,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17656,7 +17656,7 @@
 					}
 				},
 				{
-					"id": 974,
+					"id": 977,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17672,7 +17672,7 @@
 					],
 					"signatures": [
 						{
-							"id": 975,
+							"id": 978,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17683,19 +17683,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 976,
+									"id": 979,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 977,
+									"id": 980,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -17704,7 +17704,7 @@
 							],
 							"parameters": [
 								{
-									"id": 978,
+									"id": 981,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17718,7 +17718,7 @@
 									}
 								},
 								{
-									"id": 979,
+									"id": 982,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17775,7 +17775,7 @@
 					}
 				},
 				{
-					"id": 980,
+					"id": 983,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17791,7 +17791,7 @@
 					],
 					"signatures": [
 						{
-							"id": 981,
+							"id": 984,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17802,21 +17802,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 982,
+									"id": 985,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 983,
+									"id": 986,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17830,7 +17830,7 @@
 									}
 								},
 								{
-									"id": 984,
+									"id": 987,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17883,30 +17883,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						839
+						842
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						999,
-						1018,
-						848,
-						985,
-						1013,
-						993,
-						1001,
-						1011,
-						956,
-						857,
-						989,
-						1003,
-						850,
-						1007,
-						1009,
-						974,
-						980
+						1002,
+						1021,
+						851,
+						988,
+						1016,
+						996,
+						1004,
+						1014,
+						959,
+						860,
+						992,
+						1006,
+						853,
+						1010,
+						1012,
+						977,
+						983
 					]
 				}
 			],
@@ -17925,7 +17925,7 @@
 			]
 		},
 		{
-			"id": 235,
+			"id": 238,
 			"name": "SearchBarEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -17945,7 +17945,7 @@
 			},
 			"children": [
 				{
-					"id": 236,
+					"id": 239,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -17959,14 +17959,14 @@
 					],
 					"signatures": [
 						{
-							"id": 237,
+							"id": 240,
 							"name": "new SearchBarEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 238,
+									"id": 241,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17977,21 +17977,21 @@
 									}
 								},
 								{
-									"id": 239,
+									"id": 242,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2421,
+										"id": 2424,
 										"name": "SearchBarViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 235,
+								"id": 238,
 								"name": "SearchBarEmbed"
 							},
 							"overwrites": {
@@ -18006,7 +18006,7 @@
 					}
 				},
 				{
-					"id": 393,
+					"id": 396,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18022,7 +18022,7 @@
 					],
 					"signatures": [
 						{
-							"id": 394,
+							"id": 397,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18052,7 +18052,7 @@
 					}
 				},
 				{
-					"id": 412,
+					"id": 415,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18068,7 +18068,7 @@
 					],
 					"signatures": [
 						{
-							"id": 413,
+							"id": 416,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18084,7 +18084,7 @@
 							},
 							"parameters": [
 								{
-									"id": 414,
+									"id": 417,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18105,7 +18105,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -18123,7 +18123,7 @@
 					}
 				},
 				{
-					"id": 379,
+					"id": 382,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18139,7 +18139,7 @@
 					],
 					"signatures": [
 						{
-							"id": 380,
+							"id": 383,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18160,7 +18160,7 @@
 					}
 				},
 				{
-					"id": 407,
+					"id": 410,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18176,7 +18176,7 @@
 					],
 					"signatures": [
 						{
-							"id": 408,
+							"id": 411,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18198,14 +18198,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 409,
+									"id": 412,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 411,
+											"id": 414,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18217,7 +18217,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 410,
+											"id": 413,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18234,8 +18234,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												411,
-												410
+												414,
+												413
 											]
 										}
 									]
@@ -18253,7 +18253,7 @@
 					}
 				},
 				{
-					"id": 387,
+					"id": 390,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18269,7 +18269,7 @@
 					],
 					"signatures": [
 						{
-							"id": 388,
+							"id": 391,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18285,7 +18285,7 @@
 							},
 							"parameters": [
 								{
-									"id": 389,
+									"id": 392,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18293,20 +18293,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 390,
+											"id": 393,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 391,
+												"id": 394,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 392,
+														"id": 395,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -18351,7 +18351,7 @@
 					}
 				},
 				{
-					"id": 395,
+					"id": 398,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18367,7 +18367,7 @@
 					],
 					"signatures": [
 						{
-							"id": 396,
+							"id": 399,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18388,7 +18388,7 @@
 					}
 				},
 				{
-					"id": 405,
+					"id": 408,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18404,7 +18404,7 @@
 					],
 					"signatures": [
 						{
-							"id": 406,
+							"id": 409,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18428,7 +18428,7 @@
 					}
 				},
 				{
-					"id": 350,
+					"id": 353,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18444,7 +18444,7 @@
 					],
 					"signatures": [
 						{
-							"id": 351,
+							"id": 354,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18460,7 +18460,7 @@
 							},
 							"parameters": [
 								{
-									"id": 352,
+									"id": 355,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18470,12 +18470,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 353,
+									"id": 356,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18485,7 +18485,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -18506,7 +18506,7 @@
 					}
 				},
 				{
-					"id": 344,
+					"id": 347,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18522,7 +18522,7 @@
 					],
 					"signatures": [
 						{
-							"id": 345,
+							"id": 348,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18542,7 +18542,7 @@
 							},
 							"parameters": [
 								{
-									"id": 346,
+									"id": 349,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18552,12 +18552,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 347,
+									"id": 350,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18567,12 +18567,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 348,
+									"id": 351,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18582,13 +18582,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 349,
+									"id": 352,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18617,7 +18617,7 @@
 					}
 				},
 				{
-					"id": 383,
+					"id": 386,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18633,7 +18633,7 @@
 					],
 					"signatures": [
 						{
-							"id": 384,
+							"id": 387,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18643,7 +18643,7 @@
 							},
 							"parameters": [
 								{
-									"id": 385,
+									"id": 388,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18658,7 +18658,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 386,
+									"id": 389,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18692,7 +18692,7 @@
 					}
 				},
 				{
-					"id": 397,
+					"id": 400,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18708,7 +18708,7 @@
 					],
 					"signatures": [
 						{
-							"id": 398,
+							"id": 401,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18745,7 +18745,7 @@
 					}
 				},
 				{
-					"id": 246,
+					"id": 249,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18761,7 +18761,7 @@
 					],
 					"signatures": [
 						{
-							"id": 247,
+							"id": 250,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18774,7 +18774,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 235,
+										"id": 238,
 										"name": "SearchBarEmbed"
 									}
 								],
@@ -18792,7 +18792,7 @@
 					}
 				},
 				{
-					"id": 401,
+					"id": 404,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18808,7 +18808,7 @@
 					],
 					"signatures": [
 						{
-							"id": 402,
+							"id": 405,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18838,7 +18838,7 @@
 					}
 				},
 				{
-					"id": 403,
+					"id": 406,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18854,7 +18854,7 @@
 					],
 					"signatures": [
 						{
-							"id": 404,
+							"id": 407,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18884,7 +18884,7 @@
 					}
 				},
 				{
-					"id": 368,
+					"id": 371,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18900,7 +18900,7 @@
 					],
 					"signatures": [
 						{
-							"id": 369,
+							"id": 372,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18911,19 +18911,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 370,
+									"id": 373,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 371,
+									"id": 374,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -18932,7 +18932,7 @@
 							],
 							"parameters": [
 								{
-									"id": 372,
+									"id": 375,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18946,7 +18946,7 @@
 									}
 								},
 								{
-									"id": 373,
+									"id": 376,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19003,7 +19003,7 @@
 					}
 				},
 				{
-					"id": 374,
+					"id": 377,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19019,7 +19019,7 @@
 					],
 					"signatures": [
 						{
-							"id": 375,
+							"id": 378,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19030,21 +19030,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 376,
+									"id": 379,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 377,
+									"id": 380,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19058,7 +19058,7 @@
 									}
 								},
 								{
-									"id": 378,
+									"id": 381,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19111,29 +19111,29 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						236
+						239
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						393,
-						412,
-						379,
-						407,
-						387,
-						395,
-						405,
-						350,
-						344,
-						383,
-						397,
-						246,
-						401,
-						403,
-						368,
-						374
+						396,
+						415,
+						382,
+						410,
+						390,
+						398,
+						408,
+						353,
+						347,
+						386,
+						400,
+						249,
+						404,
+						406,
+						371,
+						377
 					]
 				}
 			],
@@ -19152,7 +19152,7 @@
 			]
 		},
 		{
-			"id": 52,
+			"id": 55,
 			"name": "SearchEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19168,7 +19168,7 @@
 			},
 			"children": [
 				{
-					"id": 53,
+					"id": 56,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19182,40 +19182,40 @@
 					],
 					"signatures": [
 						{
-							"id": 54,
+							"id": 57,
 							"name": "new SearchEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 55,
+									"id": 58,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2713,
+										"id": 2716,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 56,
+									"id": 59,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2365,
+										"id": 2368,
 										"name": "SearchViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 52,
+								"id": 55,
 								"name": "SearchEmbed"
 							},
 							"overwrites": {
@@ -19230,7 +19230,7 @@
 					}
 				},
 				{
-					"id": 213,
+					"id": 216,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19246,7 +19246,7 @@
 					],
 					"signatures": [
 						{
-							"id": 214,
+							"id": 217,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19276,7 +19276,7 @@
 					}
 				},
 				{
-					"id": 232,
+					"id": 235,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19292,7 +19292,7 @@
 					],
 					"signatures": [
 						{
-							"id": 233,
+							"id": 236,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19308,7 +19308,7 @@
 							},
 							"parameters": [
 								{
-									"id": 234,
+									"id": 237,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19329,7 +19329,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -19347,7 +19347,7 @@
 					}
 				},
 				{
-					"id": 72,
+					"id": 75,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19363,7 +19363,7 @@
 					],
 					"signatures": [
 						{
-							"id": 73,
+							"id": 76,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19379,7 +19379,7 @@
 					]
 				},
 				{
-					"id": 199,
+					"id": 202,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19395,7 +19395,7 @@
 					],
 					"signatures": [
 						{
-							"id": 200,
+							"id": 203,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19416,7 +19416,7 @@
 					}
 				},
 				{
-					"id": 227,
+					"id": 230,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19432,7 +19432,7 @@
 					],
 					"signatures": [
 						{
-							"id": 228,
+							"id": 231,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19454,14 +19454,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 229,
+									"id": 232,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 231,
+											"id": 234,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19473,7 +19473,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 230,
+											"id": 233,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19490,8 +19490,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												231,
-												230
+												234,
+												233
 											]
 										}
 									]
@@ -19509,7 +19509,7 @@
 					}
 				},
 				{
-					"id": 207,
+					"id": 210,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19525,7 +19525,7 @@
 					],
 					"signatures": [
 						{
-							"id": 208,
+							"id": 211,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19541,7 +19541,7 @@
 							},
 							"parameters": [
 								{
-									"id": 209,
+									"id": 212,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19549,20 +19549,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 210,
+											"id": 213,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 211,
+												"id": 214,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 212,
+														"id": 215,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -19607,7 +19607,7 @@
 					}
 				},
 				{
-					"id": 215,
+					"id": 218,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19623,7 +19623,7 @@
 					],
 					"signatures": [
 						{
-							"id": 216,
+							"id": 219,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19644,7 +19644,7 @@
 					}
 				},
 				{
-					"id": 225,
+					"id": 228,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19660,7 +19660,7 @@
 					],
 					"signatures": [
 						{
-							"id": 226,
+							"id": 229,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19684,7 +19684,7 @@
 					}
 				},
 				{
-					"id": 170,
+					"id": 173,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19700,7 +19700,7 @@
 					],
 					"signatures": [
 						{
-							"id": 171,
+							"id": 174,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19716,7 +19716,7 @@
 							},
 							"parameters": [
 								{
-									"id": 172,
+									"id": 175,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19726,12 +19726,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 173,
+									"id": 176,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19741,7 +19741,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -19762,7 +19762,7 @@
 					}
 				},
 				{
-					"id": 164,
+					"id": 167,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19778,7 +19778,7 @@
 					],
 					"signatures": [
 						{
-							"id": 165,
+							"id": 168,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19798,7 +19798,7 @@
 							},
 							"parameters": [
 								{
-									"id": 166,
+									"id": 169,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19808,12 +19808,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 167,
+									"id": 170,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19823,12 +19823,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 168,
+									"id": 171,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19838,13 +19838,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 169,
+									"id": 172,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19873,7 +19873,7 @@
 					}
 				},
 				{
-					"id": 203,
+					"id": 206,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19889,7 +19889,7 @@
 					],
 					"signatures": [
 						{
-							"id": 204,
+							"id": 207,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19899,7 +19899,7 @@
 							},
 							"parameters": [
 								{
-									"id": 205,
+									"id": 208,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19914,7 +19914,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 206,
+									"id": 209,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19948,7 +19948,7 @@
 					}
 				},
 				{
-					"id": 217,
+					"id": 220,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19964,7 +19964,7 @@
 					],
 					"signatures": [
 						{
-							"id": 218,
+							"id": 221,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20001,7 +20001,7 @@
 					}
 				},
 				{
-					"id": 74,
+					"id": 77,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20017,7 +20017,7 @@
 					],
 					"signatures": [
 						{
-							"id": 75,
+							"id": 78,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20030,7 +20030,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 52,
+										"id": 55,
 										"name": "SearchEmbed"
 									}
 								],
@@ -20048,7 +20048,7 @@
 					}
 				},
 				{
-					"id": 221,
+					"id": 224,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20064,7 +20064,7 @@
 					],
 					"signatures": [
 						{
-							"id": 222,
+							"id": 225,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20094,7 +20094,7 @@
 					}
 				},
 				{
-					"id": 223,
+					"id": 226,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20110,7 +20110,7 @@
 					],
 					"signatures": [
 						{
-							"id": 224,
+							"id": 227,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20140,7 +20140,7 @@
 					}
 				},
 				{
-					"id": 188,
+					"id": 191,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20156,7 +20156,7 @@
 					],
 					"signatures": [
 						{
-							"id": 189,
+							"id": 192,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20167,19 +20167,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 190,
+									"id": 193,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 191,
+									"id": 194,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -20188,7 +20188,7 @@
 							],
 							"parameters": [
 								{
-									"id": 192,
+									"id": 195,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20202,7 +20202,7 @@
 									}
 								},
 								{
-									"id": 193,
+									"id": 196,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20259,7 +20259,7 @@
 					}
 				},
 				{
-					"id": 194,
+					"id": 197,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20275,7 +20275,7 @@
 					],
 					"signatures": [
 						{
-							"id": 195,
+							"id": 198,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20286,21 +20286,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 196,
+									"id": 199,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 197,
+									"id": 200,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20314,7 +20314,7 @@
 									}
 								},
 								{
-									"id": 198,
+									"id": 201,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20367,30 +20367,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						53
+						56
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						213,
-						232,
-						72,
-						199,
-						227,
-						207,
-						215,
-						225,
-						170,
-						164,
-						203,
-						217,
-						74,
-						221,
-						223,
-						188,
-						194
+						216,
+						235,
+						75,
+						202,
+						230,
+						210,
+						218,
+						228,
+						173,
+						167,
+						206,
+						220,
+						77,
+						224,
+						226,
+						191,
+						197
 					]
 				}
 			],
@@ -20409,7 +20409,7 @@
 			]
 		},
 		{
-			"id": 1238,
+			"id": 1241,
 			"name": "SpotterAgentEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -20433,7 +20433,7 @@
 			},
 			"children": [
 				{
-					"id": 1239,
+					"id": 1242,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -20447,35 +20447,35 @@
 					],
 					"signatures": [
 						{
-							"id": 1240,
+							"id": 1243,
 							"name": "new SpotterAgentEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1241,
+									"id": 1244,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1270,
+										"id": 1273,
 										"name": "SpotterAgentEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1238,
+								"id": 1241,
 								"name": "SpotterAgentEmbed"
 							}
 						}
 					]
 				},
 				{
-					"id": 1243,
+					"id": 1246,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20491,14 +20491,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1244,
+							"id": 1247,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1245,
+									"id": 1248,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20518,14 +20518,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1246,
+													"id": 1249,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1248,
+															"id": 1251,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20536,7 +20536,7 @@
 															}
 														},
 														{
-															"id": 1247,
+															"id": 1250,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20547,7 +20547,7 @@
 															}
 														},
 														{
-															"id": 1249,
+															"id": 1252,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20564,9 +20564,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1248,
-																1247,
-																1249
+																1251,
+																1250,
+																1252
 															]
 														}
 													]
@@ -20575,14 +20575,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1250,
+													"id": 1253,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1251,
+															"id": 1254,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20593,7 +20593,7 @@
 															}
 														},
 														{
-															"id": 1253,
+															"id": 1256,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20604,7 +20604,7 @@
 															}
 														},
 														{
-															"id": 1252,
+															"id": 1255,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20621,9 +20621,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1251,
-																1253,
-																1252
+																1254,
+																1256,
+																1255
 															]
 														}
 													]
@@ -20638,7 +20638,7 @@
 					]
 				},
 				{
-					"id": 1254,
+					"id": 1257,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20654,7 +20654,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1255,
+							"id": 1258,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20665,7 +20665,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1256,
+									"id": 1259,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20688,14 +20688,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1257,
+													"id": 1260,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1259,
+															"id": 1262,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20707,7 +20707,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1258,
+															"id": 1261,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20723,8 +20723,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1259,
-																1258
+																1262,
+																1261
 															]
 														}
 													]
@@ -20733,14 +20733,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1260,
+													"id": 1263,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1261,
+															"id": 1264,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20748,14 +20748,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1262,
+																	"id": 1265,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1268,
+																			"id": 1271,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20767,7 +20767,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1267,
+																			"id": 1270,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20779,7 +20779,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1263,
+																			"id": 1266,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20791,7 +20791,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1266,
+																			"id": 1269,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20803,7 +20803,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1264,
+																			"id": 1267,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20815,7 +20815,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1265,
+																			"id": 1268,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -20832,12 +20832,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1268,
-																				1267,
-																				1263,
+																				1271,
+																				1270,
 																				1266,
-																				1264,
-																				1265
+																				1269,
+																				1267,
+																				1268
 																			]
 																		}
 																	]
@@ -20846,7 +20846,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1269,
+															"id": 1272,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -20862,8 +20862,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1261,
-																1269
+																1264,
+																1272
 															]
 														}
 													]
@@ -20883,15 +20883,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1239
+						1242
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1243,
-						1254
+						1246,
+						1257
 					]
 				}
 			],
@@ -20905,13 +20905,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1334,
+					"id": 1337,
 					"name": "BodylessConversation"
 				}
 			]
 		},
 		{
-			"id": 1365,
+			"id": 1368,
 			"name": "SpotterEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -20935,7 +20935,7 @@
 			},
 			"children": [
 				{
-					"id": 1366,
+					"id": 1369,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -20949,14 +20949,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1367,
+							"id": 1370,
 							"name": "new SpotterEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1368,
+									"id": 1371,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20967,21 +20967,21 @@
 									}
 								},
 								{
-									"id": 1369,
+									"id": 1372,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1538,
+										"id": 1541,
 										"name": "SpotterEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1365,
+								"id": 1368,
 								"name": "SpotterEmbed"
 							},
 							"overwrites": {
@@ -20996,7 +20996,7 @@
 					}
 				},
 				{
-					"id": 1516,
+					"id": 1519,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21012,7 +21012,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1517,
+							"id": 1520,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21042,7 +21042,7 @@
 					}
 				},
 				{
-					"id": 1535,
+					"id": 1538,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21058,7 +21058,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1536,
+							"id": 1539,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21074,7 +21074,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1537,
+									"id": 1540,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21095,7 +21095,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1869,
+										"id": 1872,
 										"name": "AnswerService"
 									}
 								],
@@ -21113,7 +21113,7 @@
 					}
 				},
 				{
-					"id": 1373,
+					"id": 1376,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21129,7 +21129,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1374,
+							"id": 1377,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21150,7 +21150,7 @@
 					}
 				},
 				{
-					"id": 1530,
+					"id": 1533,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21166,7 +21166,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1531,
+							"id": 1534,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21188,14 +21188,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1532,
+									"id": 1535,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1534,
+											"id": 1537,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21207,7 +21207,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1533,
+											"id": 1536,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21224,8 +21224,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1534,
-												1533
+												1537,
+												1536
 											]
 										}
 									]
@@ -21243,7 +21243,7 @@
 					}
 				},
 				{
-					"id": 1510,
+					"id": 1513,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21259,7 +21259,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1511,
+							"id": 1514,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21275,7 +21275,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1512,
+									"id": 1515,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21283,20 +21283,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1513,
+											"id": 1516,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1514,
+												"id": 1517,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1515,
+														"id": 1518,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -21341,7 +21341,7 @@
 					}
 				},
 				{
-					"id": 1518,
+					"id": 1521,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21357,7 +21357,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1519,
+							"id": 1522,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21378,7 +21378,7 @@
 					}
 				},
 				{
-					"id": 1528,
+					"id": 1531,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21394,7 +21394,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1529,
+							"id": 1532,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21418,7 +21418,7 @@
 					}
 				},
 				{
-					"id": 1475,
+					"id": 1478,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21434,7 +21434,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1476,
+							"id": 1479,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21450,7 +21450,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1477,
+									"id": 1480,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21460,12 +21460,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1478,
+									"id": 1481,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21475,7 +21475,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								}
@@ -21496,7 +21496,7 @@
 					}
 				},
 				{
-					"id": 1469,
+					"id": 1472,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21512,7 +21512,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1470,
+							"id": 1473,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21532,7 +21532,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1471,
+									"id": 1474,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21542,12 +21542,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1993,
+										"id": 1996,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1472,
+									"id": 1475,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21557,12 +21557,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2717,
+										"id": 2720,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1473,
+									"id": 1476,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21572,13 +21572,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2714,
+										"id": 2717,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1474,
+									"id": 1477,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21607,7 +21607,7 @@
 					}
 				},
 				{
-					"id": 1506,
+					"id": 1509,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21623,7 +21623,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1507,
+							"id": 1510,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21633,7 +21633,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1508,
+									"id": 1511,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21648,7 +21648,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1509,
+									"id": 1512,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21682,7 +21682,7 @@
 					}
 				},
 				{
-					"id": 1520,
+					"id": 1523,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21698,7 +21698,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1521,
+							"id": 1524,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21735,7 +21735,7 @@
 					}
 				},
 				{
-					"id": 1375,
+					"id": 1378,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21751,7 +21751,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1376,
+							"id": 1379,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21761,7 +21761,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1365,
+										"id": 1368,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -21779,7 +21779,7 @@
 					}
 				},
 				{
-					"id": 1524,
+					"id": 1527,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21795,7 +21795,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1525,
+							"id": 1528,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21825,7 +21825,7 @@
 					}
 				},
 				{
-					"id": 1526,
+					"id": 1529,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21841,7 +21841,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1527,
+							"id": 1530,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21871,7 +21871,7 @@
 					}
 				},
 				{
-					"id": 1493,
+					"id": 1496,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21887,7 +21887,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1494,
+							"id": 1497,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21898,19 +21898,19 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1495,
+									"id": 1498,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2089,
+										"id": 2092,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1496,
+									"id": 1499,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
@@ -21919,7 +21919,7 @@
 							],
 							"parameters": [
 								{
-									"id": 1497,
+									"id": 1500,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21933,7 +21933,7 @@
 									}
 								},
 								{
-									"id": 1498,
+									"id": 1501,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21990,7 +21990,7 @@
 					}
 				},
 				{
-					"id": 1499,
+					"id": 1502,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22006,7 +22006,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1500,
+							"id": 1503,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22017,21 +22017,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1501,
+									"id": 1504,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2975,
+										"id": 2978,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1502,
+									"id": 1505,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22045,7 +22045,7 @@
 									}
 								},
 								{
-									"id": 1503,
+									"id": 1506,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22098,29 +22098,29 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1366
+						1369
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1516,
-						1535,
-						1373,
-						1530,
-						1510,
-						1518,
-						1528,
-						1475,
-						1469,
-						1506,
-						1520,
-						1375,
-						1524,
-						1526,
-						1493,
-						1499
+						1519,
+						1538,
+						1376,
+						1533,
+						1513,
+						1521,
+						1531,
+						1478,
+						1472,
+						1509,
+						1523,
+						1378,
+						1527,
+						1529,
+						1496,
+						1502
 					]
 				}
 			],
@@ -22140,13 +22140,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1626,
+					"id": 1629,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2596,
+			"id": 2599,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -22162,7 +22162,7 @@
 			},
 			"children": [
 				{
-					"id": 2634,
+					"id": 2637,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22193,20 +22193,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2635,
+							"id": 2638,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2636,
+								"id": 2639,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2637,
+										"id": 2640,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -22242,7 +22242,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2664,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22284,7 +22284,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2619,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22321,7 +22321,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2661,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22351,7 +22351,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2309,
+						"id": 2312,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -22360,7 +22360,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2681,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22398,7 +22398,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2655,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22439,7 +22439,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2641,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22468,7 +22468,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -22477,7 +22477,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2620,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22511,12 +22511,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2989,
+						"id": 2992,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2665,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22558,7 +22558,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2602,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22596,7 +22596,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2649,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22634,7 +22634,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2633,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22672,7 +22672,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2632,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22704,7 +22704,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -22714,7 +22714,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2618,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22752,7 +22752,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2645,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22793,7 +22793,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2675,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22835,7 +22835,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2680,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22877,7 +22877,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2666,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22919,7 +22919,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2603,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22955,7 +22955,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2615,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -22993,7 +22993,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2646,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23031,7 +23031,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2662,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23069,7 +23069,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2663,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23107,7 +23107,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2648,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23144,7 +23144,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2629,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23174,7 +23174,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -23183,7 +23183,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2616,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23217,7 +23217,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2634,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23253,7 +23253,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -23263,7 +23263,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2670,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23295,7 +23295,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2695,
+							"id": 2698,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -23305,7 +23305,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2668,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23337,7 +23337,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2706,
+							"id": 2709,
 							"name": "HomepageModule"
 						}
 					},
@@ -23347,7 +23347,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2667,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23379,7 +23379,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2983,
+							"id": 2986,
 							"name": "ListPageColumns"
 						}
 					},
@@ -23389,7 +23389,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2607,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23427,7 +23427,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2604,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23465,7 +23465,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2601,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23503,7 +23503,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2678,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23545,7 +23545,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2671,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23587,7 +23587,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2606,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23625,7 +23625,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2605,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23663,7 +23663,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2613,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23700,7 +23700,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2608,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23738,7 +23738,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2612,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23772,7 +23772,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2621,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23798,12 +23798,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2940,
+						"id": 2943,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2642,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23841,7 +23841,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2658,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23878,7 +23878,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2657,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23918,7 +23918,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2683,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23956,7 +23956,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2685,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23994,7 +23994,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2684,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24032,7 +24032,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2676,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24074,7 +24074,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2674,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24112,7 +24112,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2623,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24146,7 +24146,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2656,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24180,7 +24180,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2624,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24214,7 +24214,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2622,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24252,7 +24252,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2625,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24289,7 +24289,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2626,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24323,7 +24323,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2651,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24361,7 +24361,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2682,
 					"name": "liveboardXLSXCSVDownload",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24399,7 +24399,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2636,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24437,7 +24437,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2617,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24475,7 +24475,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2650,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24513,7 +24513,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2610,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24543,12 +24543,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1952,
+						"id": 1955,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2609,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24582,7 +24582,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2644,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24620,7 +24620,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2652,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24658,7 +24658,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2669,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24690,7 +24690,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2706,
+							"id": 2709,
 							"name": "HomepageModule"
 						}
 					},
@@ -24700,7 +24700,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2659,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24732,7 +24732,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -24742,7 +24742,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2660,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24774,7 +24774,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -24784,7 +24784,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2654,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24821,7 +24821,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2673,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24863,7 +24863,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2679,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24905,7 +24905,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2672,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24947,7 +24947,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2677,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24989,7 +24989,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2686,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25002,7 +25002,7 @@
 						"tags": [
 							{
 								"tag": "version",
-								"text": "SDK: 1.43.0 | Thoughtspot: 26.2.0.cl"
+								"text": "SDK: 1.45.0 | Thoughtspot: 26.2.0.cl"
 							},
 							{
 								"tag": "default",
@@ -25031,7 +25031,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2600,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25069,7 +25069,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2611,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25103,7 +25103,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2627,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25141,7 +25141,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2635,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25177,7 +25177,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -25192,83 +25192,83 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2634,
-						2661,
-						2616,
-						2658,
-						2678,
-						2652,
-						2638,
-						2617,
-						2662,
-						2599,
-						2646,
-						2630,
-						2629,
-						2615,
-						2642,
-						2672,
-						2677,
-						2663,
-						2600,
-						2612,
-						2643,
-						2659,
-						2660,
-						2645,
-						2626,
-						2613,
-						2631,
-						2667,
-						2665,
+						2637,
 						2664,
+						2619,
+						2661,
+						2681,
+						2655,
+						2641,
+						2620,
+						2665,
+						2602,
+						2649,
+						2633,
+						2632,
+						2618,
+						2645,
+						2675,
+						2680,
+						2666,
+						2603,
+						2615,
+						2646,
+						2662,
+						2663,
+						2648,
+						2629,
+						2616,
+						2634,
+						2670,
+						2668,
+						2667,
+						2607,
 						2604,
 						2601,
-						2598,
-						2675,
-						2668,
-						2603,
-						2602,
-						2610,
-						2605,
-						2609,
-						2618,
-						2639,
-						2655,
-						2654,
-						2680,
-						2682,
-						2681,
-						2673,
+						2678,
 						2671,
-						2620,
-						2653,
-						2621,
-						2619,
-						2622,
-						2623,
-						2648,
-						2679,
-						2633,
-						2614,
-						2647,
-						2607,
 						2606,
-						2641,
-						2649,
-						2666,
-						2656,
-						2657,
-						2651,
-						2670,
-						2676,
-						2669,
-						2674,
-						2683,
-						2597,
+						2605,
+						2613,
 						2608,
+						2612,
+						2621,
+						2642,
+						2658,
+						2657,
+						2683,
+						2685,
+						2684,
+						2676,
+						2674,
+						2623,
+						2656,
 						2624,
-						2632
+						2622,
+						2625,
+						2626,
+						2651,
+						2682,
+						2636,
+						2617,
+						2650,
+						2610,
+						2609,
+						2644,
+						2652,
+						2669,
+						2659,
+						2660,
+						2654,
+						2673,
+						2679,
+						2672,
+						2677,
+						2686,
+						2600,
+						2611,
+						2627,
+						2635
 					]
 				}
 			],
@@ -25287,7 +25287,7 @@
 			]
 		},
 		{
-			"id": 1816,
+			"id": 1819,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -25303,14 +25303,14 @@
 			},
 			"children": [
 				{
-					"id": 1853,
+					"id": 1856,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1854,
+							"id": 1857,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25320,19 +25320,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1855,
+									"id": 1858,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1815,
+										"id": 1818,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1856,
+									"id": 1859,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25356,14 +25356,14 @@
 					]
 				},
 				{
-					"id": 1857,
+					"id": 1860,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1858,
+							"id": 1861,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25373,7 +25373,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1859,
+									"id": 1862,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25381,12 +25381,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1806,
+										"id": 1809,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1860,
+									"id": 1863,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25395,21 +25395,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1861,
+											"id": 1864,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1862,
+													"id": 1865,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1863,
+															"id": 1866,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25435,7 +25435,7 @@
 									}
 								},
 								{
-									"id": 1864,
+									"id": 1867,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25447,7 +25447,7 @@
 									}
 								},
 								{
-									"id": 1865,
+									"id": 1868,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25463,21 +25463,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1817,
+					"id": 1820,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1818,
+							"id": 1821,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25487,7 +25487,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1819,
+									"id": 1822,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25495,12 +25495,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1807,
+										"id": 1810,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1820,
+									"id": 1823,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25511,28 +25511,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1821,
+											"id": 1824,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1822,
+													"id": 1825,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1823,
+															"id": 1826,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1799,
+																"id": 1802,
 																"name": "AuthFailureType"
 															}
 														}
@@ -25549,12 +25549,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1824,
+							"id": 1827,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25564,7 +25564,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1825,
+									"id": 1828,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25575,29 +25575,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1808,
+												"id": 1811,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1814,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1812,
+												"id": 1815,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1813,
+												"id": 1816,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1826,
+									"id": 1829,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25608,14 +25608,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1827,
+											"id": 1830,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1828,
+													"id": 1831,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -25632,31 +25632,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1829,
+							"id": 1832,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1830,
+									"id": 1833,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1813,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1831,
+									"id": 1834,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25664,21 +25664,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1832,
+											"id": 1835,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1833,
+													"id": 1836,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1834,
+															"id": 1837,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25701,40 +25701,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1835,
+					"id": 1838,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1836,
+							"id": 1839,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1837,
+									"id": 1840,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1807,
+										"id": 1810,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1838,
+									"id": 1841,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25742,28 +25742,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1839,
+											"id": 1842,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1840,
+													"id": 1843,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1841,
+															"id": 1844,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1799,
+																"id": 1802,
 																"name": "AuthFailureType"
 															}
 														}
@@ -25780,19 +25780,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1842,
+							"id": 1845,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1843,
+									"id": 1846,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25802,29 +25802,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1808,
+												"id": 1811,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1814,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1812,
+												"id": 1815,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1813,
+												"id": 1816,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1844,
+									"id": 1847,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25832,14 +25832,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1845,
+											"id": 1848,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1846,
+													"id": 1849,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -25856,31 +25856,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1847,
+							"id": 1850,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1848,
+									"id": 1851,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1813,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1849,
+									"id": 1852,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25888,21 +25888,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1850,
+											"id": 1853,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1851,
+													"id": 1854,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1852,
+															"id": 1855,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -25925,21 +25925,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1866,
+					"id": 1869,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1867,
+							"id": 1870,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25949,7 +25949,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1868,
+									"id": 1871,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25959,14 +25959,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1806,
+										"id": 1809,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1816,
+								"id": 1819,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -25978,11 +25978,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1853,
-						1857,
-						1817,
-						1835,
-						1866
+						1856,
+						1860,
+						1820,
+						1838,
+						1869
 					]
 				}
 			],
@@ -25995,7 +25995,7 @@
 			]
 		},
 		{
-			"id": 1302,
+			"id": 1305,
 			"name": "BodylessConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26015,7 +26015,7 @@
 			},
 			"children": [
 				{
-					"id": 1313,
+					"id": 1316,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26046,20 +26046,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1314,
+							"id": 1317,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1315,
+								"id": 1318,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1316,
+										"id": 1319,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -26091,12 +26091,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1281,
+						"id": 1284,
 						"name": "SpotterAgentEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1330,
+					"id": 1333,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26133,12 +26133,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1298,
+						"id": 1301,
 						"name": "SpotterAgentEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1317,
+					"id": 1320,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26167,17 +26167,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1285,
+						"id": 1288,
 						"name": "SpotterAgentEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1325,
+					"id": 1328,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26211,12 +26211,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1293,
+						"id": 1296,
 						"name": "SpotterAgentEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1309,
+					"id": 1312,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26250,12 +26250,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1277,
+						"id": 1280,
 						"name": "SpotterAgentEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1308,
+					"id": 1311,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26287,18 +26287,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1276,
+						"id": 1279,
 						"name": "SpotterAgentEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1321,
+					"id": 1324,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26335,12 +26335,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1289,
+						"id": 1292,
 						"name": "SpotterAgentEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1322,
+					"id": 1325,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26374,12 +26374,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1290,
+						"id": 1293,
 						"name": "SpotterAgentEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1324,
+					"id": 1327,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26412,12 +26412,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1292,
+						"id": 1295,
 						"name": "SpotterAgentEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1305,
+					"id": 1308,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26447,17 +26447,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1273,
+						"id": 1276,
 						"name": "SpotterAgentEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1310,
+					"id": 1313,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26493,18 +26493,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1278,
+						"id": 1281,
 						"name": "SpotterAgentEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1318,
+					"id": 1321,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26538,12 +26538,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1286,
+						"id": 1289,
 						"name": "SpotterAgentEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1333,
+					"id": 1336,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26576,12 +26576,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1301,
+						"id": 1304,
 						"name": "SpotterAgentEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1332,
+					"id": 1335,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26617,12 +26617,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1300,
+						"id": 1303,
 						"name": "SpotterAgentEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1331,
+					"id": 1334,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26652,12 +26652,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1299,
+						"id": 1302,
 						"name": "SpotterAgentEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1327,
+					"id": 1330,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26691,12 +26691,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1295,
+						"id": 1298,
 						"name": "SpotterAgentEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1312,
+					"id": 1315,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26730,12 +26730,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1280,
+						"id": 1283,
 						"name": "SpotterAgentEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1326,
+					"id": 1329,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26769,12 +26769,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1294,
+						"id": 1297,
 						"name": "SpotterAgentEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1320,
+					"id": 1323,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26808,12 +26808,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1288,
+						"id": 1291,
 						"name": "SpotterAgentEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1329,
+					"id": 1332,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26846,12 +26846,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1297,
+						"id": 1300,
 						"name": "SpotterAgentEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1311,
+					"id": 1314,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26887,18 +26887,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1279,
+						"id": 1282,
 						"name": "SpotterAgentEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1303,
+					"id": 1306,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26919,7 +26919,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1271,
+						"id": 1274,
 						"name": "SpotterAgentEmbedViewConfig.worksheetId"
 					}
 				}
@@ -26929,28 +26929,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1313,
-						1330,
-						1317,
-						1325,
-						1309,
-						1308,
-						1321,
-						1322,
-						1324,
-						1305,
-						1310,
-						1318,
+						1316,
 						1333,
-						1332,
-						1331,
-						1327,
-						1312,
-						1326,
 						1320,
-						1329,
+						1328,
+						1312,
 						1311,
-						1303
+						1324,
+						1325,
+						1327,
+						1308,
+						1313,
+						1321,
+						1336,
+						1335,
+						1334,
+						1330,
+						1315,
+						1329,
+						1323,
+						1332,
+						1314,
+						1306
 					]
 				}
 			],
@@ -26964,13 +26964,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1270,
+					"id": 1273,
 					"name": "SpotterAgentEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1582,
+			"id": 1585,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26990,7 +26990,7 @@
 			},
 			"children": [
 				{
-					"id": 1605,
+					"id": 1608,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27021,20 +27021,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1606,
+							"id": 1609,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1607,
+								"id": 1610,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1608,
+										"id": 1611,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27066,12 +27066,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1564,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1625,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27108,12 +27108,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1578,
+						"id": 1581,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1612,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27142,17 +27142,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1565,
+						"id": 1568,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1590,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27190,12 +27190,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1546,
 						"name": "SpotterEmbedViewConfig.dataPanelV2"
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1620,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27229,12 +27229,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1573,
+						"id": 1576,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1588,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27268,12 +27268,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1544,
 						"name": "SpotterEmbedViewConfig.disableSourceSelection"
 					}
 				},
 				{
-					"id": 1601,
+					"id": 1604,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27307,12 +27307,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1557,
+						"id": 1560,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1603,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27344,18 +27344,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1559,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1616,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27392,12 +27392,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1569,
+						"id": 1572,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1597,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27435,12 +27435,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1550,
+						"id": 1553,
 						"name": "SpotterEmbedViewConfig.enablePastConversationsSidebar"
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1617,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27474,12 +27474,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1570,
+						"id": 1573,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1594,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27513,12 +27513,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1547,
+						"id": 1550,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeFiltersfromURL"
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1596,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27552,12 +27552,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1549,
+						"id": 1552,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeParametersfromURL"
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1619,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27590,12 +27590,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1572,
+						"id": 1575,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1600,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27625,17 +27625,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1553,
+						"id": 1556,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1602,
+					"id": 1605,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27671,18 +27671,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1561,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1592,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27716,12 +27716,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1545,
+						"id": 1548,
 						"name": "SpotterEmbedViewConfig.hideSampleQuestions"
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1589,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27755,12 +27755,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1542,
+						"id": 1545,
 						"name": "SpotterEmbedViewConfig.hideSourceSelection"
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1613,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27794,12 +27794,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1566,
+						"id": 1569,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1625,
+					"id": 1628,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27832,12 +27832,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1581,
+						"id": 1584,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1627,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27873,12 +27873,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1580,
+						"id": 1583,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1626,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27908,12 +27908,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1579,
+						"id": 1582,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1622,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27947,12 +27947,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1575,
+						"id": 1578,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1607,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27986,12 +27986,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1560,
+						"id": 1563,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1621,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28025,12 +28025,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1574,
+						"id": 1577,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1615,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28064,12 +28064,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1568,
+						"id": 1571,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1593,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28101,18 +28101,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1546,
+						"id": 1549,
 						"name": "SpotterEmbedViewConfig.runtimeFilters"
 					}
 				},
 				{
-					"id": 1592,
+					"id": 1595,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28144,18 +28144,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1548,
+						"id": 1551,
 						"name": "SpotterEmbedViewConfig.runtimeParameters"
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1587,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28178,12 +28178,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1543,
 						"name": "SpotterEmbedViewConfig.searchOptions"
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1624,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28216,12 +28216,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1577,
+						"id": 1580,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1591,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28255,12 +28255,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1544,
+						"id": 1547,
 						"name": "SpotterEmbedViewConfig.showSpotterLimitations"
 					}
 				},
 				{
-					"id": 1595,
+					"id": 1598,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28298,12 +28298,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1551,
+						"id": 1554,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1606,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28339,18 +28339,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1559,
+						"id": 1562,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1586,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28371,7 +28371,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1539,
+						"id": 1542,
 						"name": "SpotterEmbedViewConfig.worksheetId"
 					}
 				}
@@ -28381,40 +28381,40 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1605,
-						1622,
-						1609,
-						1587,
-						1617,
-						1585,
-						1601,
-						1600,
-						1613,
-						1594,
-						1614,
-						1591,
-						1593,
-						1616,
-						1597,
-						1602,
-						1589,
-						1586,
-						1610,
+						1608,
 						1625,
-						1624,
-						1623,
-						1619,
-						1604,
-						1618,
 						1612,
 						1590,
-						1592,
-						1584,
-						1621,
+						1620,
 						1588,
-						1595,
+						1604,
 						1603,
-						1583
+						1616,
+						1597,
+						1617,
+						1594,
+						1596,
+						1619,
+						1600,
+						1605,
+						1592,
+						1589,
+						1613,
+						1628,
+						1627,
+						1626,
+						1622,
+						1607,
+						1621,
+						1615,
+						1593,
+						1595,
+						1587,
+						1624,
+						1591,
+						1598,
+						1606,
+						1586
 					]
 				}
 			],
@@ -28428,13 +28428,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1538,
+					"id": 1541,
 					"name": "SpotterEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 2955,
+			"id": 2958,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28449,7 +28449,7 @@
 			},
 			"children": [
 				{
-					"id": 2956,
+					"id": 2959,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28466,14 +28466,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2957,
+							"id": 2960,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2958,
+									"id": 2961,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28487,12 +28487,12 @@
 									],
 									"type": {
 										"type": "reference",
-										"id": 2952,
+										"id": 2955,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 2959,
+									"id": 2962,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28508,7 +28508,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2952,
+											"id": 2955,
 											"name": "VizPoint"
 										}
 									}
@@ -28519,8 +28519,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2958,
-										2959
+										2961,
+										2962
 									]
 								}
 							]
@@ -28528,7 +28528,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2963,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28543,14 +28543,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2961,
+							"id": 2964,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2969,
+									"id": 2972,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28571,7 +28571,7 @@
 									}
 								},
 								{
-									"id": 2970,
+									"id": 2973,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28592,7 +28592,7 @@
 									}
 								},
 								{
-									"id": 2963,
+									"id": 2966,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28610,7 +28610,7 @@
 									}
 								},
 								{
-									"id": 2962,
+									"id": 2965,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28628,7 +28628,7 @@
 									}
 								},
 								{
-									"id": 2964,
+									"id": 2967,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -28643,14 +28643,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2965,
+											"id": 2968,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 2966,
+													"id": 2969,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -28665,14 +28665,14 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 2967,
+															"id": 2970,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 2968,
+																	"id": 2971,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -28695,7 +28695,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		2968
+																		2971
 																	]
 																}
 															]
@@ -28708,7 +28708,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														2966
+														2969
 													]
 												}
 											]
@@ -28721,23 +28721,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2969,
-										2970,
-										2963,
-										2962,
-										2964
+										2972,
+										2973,
+										2966,
+										2965,
+										2967
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2971,
+								"id": 2974,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2972,
+										"id": 2975,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -28756,7 +28756,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2976,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28770,12 +28770,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1942,
+						"id": 1945,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2977,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28800,10 +28800,10 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2956,
-						2960,
-						2973,
-						2974
+						2959,
+						2963,
+						2976,
+						2977
 					]
 				}
 			],
@@ -28816,7 +28816,7 @@
 			]
 		},
 		{
-			"id": 2752,
+			"id": 2755,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28826,7 +28826,7 @@
 			},
 			"children": [
 				{
-					"id": 2806,
+					"id": 2809,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28849,7 +28849,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2808,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28872,7 +28872,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2778,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28895,7 +28895,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2779,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28918,7 +28918,7 @@
 					}
 				},
 				{
-					"id": 2778,
+					"id": 2781,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28941,7 +28941,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2780,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28964,7 +28964,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2760,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28987,7 +28987,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2821,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29010,7 +29010,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2822,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29033,7 +29033,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2819,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29056,7 +29056,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2820,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29079,7 +29079,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2783,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29102,7 +29102,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2788,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29125,7 +29125,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2785,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29148,7 +29148,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2787,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29171,7 +29171,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2786,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29194,7 +29194,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2784,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29217,7 +29217,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2793,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29240,7 +29240,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2790,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29263,7 +29263,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2792,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29286,7 +29286,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2791,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29309,7 +29309,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2789,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29332,7 +29332,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2797,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29355,7 +29355,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2796,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29378,7 +29378,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2795,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29401,7 +29401,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2794,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29424,7 +29424,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2782,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29447,7 +29447,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2915,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29470,7 +29470,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2910,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29493,7 +29493,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2905,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29516,7 +29516,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2904,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29539,7 +29539,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2907,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29562,7 +29562,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2906,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29585,7 +29585,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2844,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29608,7 +29608,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2847,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29631,7 +29631,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2842,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29654,7 +29654,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2845,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29677,7 +29677,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2846,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29700,7 +29700,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2841,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29723,7 +29723,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2843,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29746,7 +29746,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2814,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29769,7 +29769,7 @@
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2813,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29792,7 +29792,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2816,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29815,7 +29815,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2815,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29838,7 +29838,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2812,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29861,7 +29861,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2810,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29884,7 +29884,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2811,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29907,7 +29907,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2817,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29930,7 +29930,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2818,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29953,7 +29953,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2829,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29976,7 +29976,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2830,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29999,7 +29999,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2833,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30022,7 +30022,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2831,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30045,7 +30045,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2832,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30068,7 +30068,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2840,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30091,7 +30091,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2839,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30114,7 +30114,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2838,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30137,7 +30137,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2837,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30160,7 +30160,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2903,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30183,7 +30183,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2902,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30206,7 +30206,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2901,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30229,7 +30229,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2909,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30252,7 +30252,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2908,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30275,7 +30275,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2835,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30298,7 +30298,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2834,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30321,7 +30321,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2862,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30344,7 +30344,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2875,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30368,7 +30368,7 @@
 					}
 				},
 				{
-					"id": 2871,
+					"id": 2874,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30392,7 +30392,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2872,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30416,7 +30416,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2873,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30440,7 +30440,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2880,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30463,7 +30463,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2878,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30486,7 +30486,7 @@
 					}
 				},
 				{
-					"id": 2874,
+					"id": 2877,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30509,7 +30509,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2863,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30533,7 +30533,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2864,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30557,7 +30557,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2868,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30581,7 +30581,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2856,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30605,7 +30605,7 @@
 					}
 				},
 				{
-					"id": 2868,
+					"id": 2871,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30629,7 +30629,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2870,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30653,7 +30653,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2861,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30677,7 +30677,7 @@
 					}
 				},
 				{
-					"id": 2866,
+					"id": 2869,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30701,7 +30701,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2859,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30725,7 +30725,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2860,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30749,7 +30749,7 @@
 					}
 				},
 				{
-					"id": 2864,
+					"id": 2867,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30773,7 +30773,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2857,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30797,7 +30797,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2858,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30821,7 +30821,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2894,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30844,7 +30844,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2891,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30867,7 +30867,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2892,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30890,7 +30890,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2893,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30913,7 +30913,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2849,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30936,7 +30936,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2900,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30959,7 +30959,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2895,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30982,7 +30982,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2896,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31005,7 +31005,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2899,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31028,7 +31028,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2897,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31051,7 +31051,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2898,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31074,7 +31074,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2850,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31097,7 +31097,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2848,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31120,7 +31120,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2866,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31143,7 +31143,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2865,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31166,7 +31166,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2879,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31189,7 +31189,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2881,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31212,7 +31212,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2882,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31235,7 +31235,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2852,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31258,7 +31258,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2851,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31281,7 +31281,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2853,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31304,7 +31304,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2854,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31327,7 +31327,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2855,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31350,7 +31350,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2883,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31373,7 +31373,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2884,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31396,7 +31396,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2827,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31419,7 +31419,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2824,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31442,7 +31442,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2823,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31465,7 +31465,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2825,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31488,7 +31488,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2828,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31511,7 +31511,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2826,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31534,7 +31534,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2761,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31557,7 +31557,7 @@
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2762,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31580,7 +31580,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2889,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31603,7 +31603,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2890,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31626,7 +31626,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2885,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31649,7 +31649,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2887,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31672,7 +31672,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2888,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31695,7 +31695,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2886,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31718,7 +31718,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2756,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31741,7 +31741,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2757,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31764,7 +31764,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2758,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31787,7 +31787,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2759,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31810,7 +31810,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2770,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31833,7 +31833,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2774,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31856,7 +31856,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2775,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31879,7 +31879,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2773,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31902,7 +31902,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2769,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31925,7 +31925,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2772,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31948,7 +31948,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2766,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31971,7 +31971,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2767,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31994,7 +31994,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2768,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32017,7 +32017,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2763,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32040,7 +32040,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2764,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32063,7 +32063,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2765,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32086,7 +32086,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2771,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32109,7 +32109,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2836,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32132,7 +32132,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2876,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32155,7 +32155,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2914,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32178,7 +32178,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2911,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32201,7 +32201,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2912,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32224,7 +32224,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2913,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32247,7 +32247,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2916,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32270,7 +32270,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2776,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32293,7 +32293,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2777,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32316,7 +32316,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2806,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32339,7 +32339,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2804,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32362,7 +32362,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2805,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32385,7 +32385,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2801,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32408,7 +32408,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2802,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32431,7 +32431,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2803,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32454,7 +32454,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2807,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32477,7 +32477,7 @@
 					}
 				},
 				{
-					"id": 2795,
+					"id": 2798,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32500,7 +32500,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2799,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32523,7 +32523,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2800,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32551,167 +32551,167 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2806,
-						2805,
-						2775,
-						2776,
+						2809,
+						2808,
 						2778,
-						2777,
-						2757,
-						2818,
-						2819,
-						2816,
-						2817,
-						2780,
-						2785,
-						2782,
-						2784,
-						2783,
+						2779,
 						2781,
-						2790,
-						2787,
-						2789,
+						2780,
+						2760,
+						2821,
+						2822,
+						2819,
+						2820,
+						2783,
 						2788,
+						2785,
+						2787,
 						2786,
-						2794,
+						2784,
 						2793,
+						2790,
 						2792,
 						2791,
-						2779,
-						2912,
+						2789,
+						2797,
+						2796,
+						2795,
+						2794,
+						2782,
+						2915,
+						2910,
+						2905,
+						2904,
 						2907,
+						2906,
+						2844,
+						2847,
+						2842,
+						2845,
+						2846,
+						2841,
+						2843,
+						2814,
+						2813,
+						2816,
+						2815,
+						2812,
+						2810,
+						2811,
+						2817,
+						2818,
+						2829,
+						2830,
+						2833,
+						2831,
+						2832,
+						2840,
+						2839,
+						2838,
+						2837,
+						2903,
 						2902,
 						2901,
-						2904,
-						2903,
-						2841,
-						2844,
-						2839,
-						2842,
-						2843,
-						2838,
-						2840,
-						2811,
-						2810,
-						2813,
-						2812,
-						2809,
-						2807,
-						2808,
-						2814,
-						2815,
-						2826,
-						2827,
-						2830,
-						2828,
-						2829,
-						2837,
-						2836,
+						2909,
+						2908,
 						2835,
 						2834,
-						2900,
-						2899,
-						2898,
-						2906,
-						2905,
-						2832,
-						2831,
-						2859,
-						2872,
-						2871,
-						2869,
-						2870,
-						2877,
+						2862,
 						2875,
 						2874,
-						2860,
-						2861,
-						2865,
-						2853,
-						2868,
-						2867,
-						2858,
-						2866,
-						2856,
-						2857,
+						2872,
+						2873,
+						2880,
+						2878,
+						2877,
+						2863,
 						2864,
-						2854,
-						2855,
+						2868,
+						2856,
+						2871,
+						2870,
+						2861,
+						2869,
+						2859,
+						2860,
+						2867,
+						2857,
+						2858,
+						2894,
 						2891,
-						2888,
-						2889,
-						2890,
-						2846,
-						2897,
 						2892,
 						2893,
-						2896,
-						2894,
-						2895,
-						2847,
-						2845,
-						2863,
-						2862,
-						2876,
-						2878,
-						2879,
 						2849,
-						2848,
+						2900,
+						2895,
+						2896,
+						2899,
+						2897,
+						2898,
 						2850,
-						2851,
-						2852,
-						2880,
+						2848,
+						2866,
+						2865,
+						2879,
 						2881,
+						2882,
+						2852,
+						2851,
+						2853,
+						2854,
+						2855,
+						2883,
+						2884,
+						2827,
 						2824,
-						2821,
-						2820,
-						2822,
-						2825,
 						2823,
+						2825,
+						2828,
+						2826,
+						2761,
+						2762,
+						2889,
+						2890,
+						2885,
+						2887,
+						2888,
+						2886,
+						2756,
+						2757,
 						2758,
 						2759,
-						2886,
-						2887,
-						2882,
-						2884,
-						2885,
-						2883,
-						2753,
-						2754,
-						2755,
-						2756,
-						2767,
-						2771,
-						2772,
 						2770,
-						2766,
+						2774,
+						2775,
+						2773,
 						2769,
+						2772,
+						2766,
+						2767,
+						2768,
 						2763,
 						2764,
 						2765,
-						2760,
-						2761,
-						2762,
-						2768,
-						2833,
-						2873,
+						2771,
+						2836,
+						2876,
+						2914,
 						2911,
-						2908,
-						2909,
-						2910,
+						2912,
 						2913,
-						2773,
-						2774,
-						2803,
+						2916,
+						2776,
+						2777,
+						2806,
+						2804,
+						2805,
 						2801,
 						2802,
+						2803,
+						2807,
 						2798,
 						2799,
-						2800,
-						2804,
-						2795,
-						2796,
-						2797
+						2800
 					]
 				}
 			],
@@ -32724,7 +32724,7 @@
 			]
 		},
 		{
-			"id": 2740,
+			"id": 2743,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32734,7 +32734,7 @@
 			},
 			"children": [
 				{
-					"id": 2742,
+					"id": 2745,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32750,12 +32750,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2743,
+						"id": 2746,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2744,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32780,8 +32780,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2742,
-						2741
+						2745,
+						2744
 					]
 				}
 			],
@@ -32794,7 +32794,7 @@
 			]
 		},
 		{
-			"id": 2730,
+			"id": 2733,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32810,7 +32810,7 @@
 			},
 			"children": [
 				{
-					"id": 2732,
+					"id": 2735,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32827,14 +32827,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2733,
+							"id": 2736,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2735,
+									"id": 2738,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32864,7 +32864,7 @@
 									}
 								},
 								{
-									"id": 2736,
+									"id": 2739,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32884,7 +32884,7 @@
 									}
 								},
 								{
-									"id": 2734,
+									"id": 2737,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -32927,21 +32927,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2735,
-										2736,
-										2734
+										2738,
+										2739,
+										2737
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2737,
+								"id": 2740,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2738,
+										"id": 2741,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -32960,7 +32960,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2742,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32980,7 +32980,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2734,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32996,7 +32996,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2740,
+						"id": 2743,
 						"name": "CustomStyles"
 					}
 				}
@@ -33006,9 +33006,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2732,
-						2739,
-						2731
+						2735,
+						2742,
+						2734
 					]
 				}
 			],
@@ -33021,7 +33021,7 @@
 			]
 		},
 		{
-			"id": 2313,
+			"id": 2316,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33037,7 +33037,7 @@
 			},
 			"children": [
 				{
-					"id": 2355,
+					"id": 2358,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33067,20 +33067,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2356,
+							"id": 2359,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2357,
+								"id": 2360,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2358,
+										"id": 2361,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33112,7 +33112,7 @@
 					}
 				},
 				{
-					"id": 2316,
+					"id": 2319,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33135,7 +33135,7 @@
 					}
 				},
 				{
-					"id": 2337,
+					"id": 2340,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33177,7 +33177,7 @@
 					}
 				},
 				{
-					"id": 2339,
+					"id": 2342,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33206,7 +33206,7 @@
 					}
 				},
 				{
-					"id": 2315,
+					"id": 2318,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33223,12 +33223,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1961,
+						"id": 1964,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2328,
+					"id": 2331,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33257,7 +33257,7 @@
 					}
 				},
 				{
-					"id": 2340,
+					"id": 2343,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33290,7 +33290,7 @@
 					}
 				},
 				{
-					"id": 2331,
+					"id": 2334,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33319,7 +33319,7 @@
 					}
 				},
 				{
-					"id": 2364,
+					"id": 2367,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33352,7 +33352,7 @@
 					}
 				},
 				{
-					"id": 2352,
+					"id": 2355,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33381,7 +33381,7 @@
 					}
 				},
 				{
-					"id": 2362,
+					"id": 2365,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33417,7 +33417,7 @@
 					}
 				},
 				{
-					"id": 2359,
+					"id": 2362,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33460,7 +33460,7 @@
 					}
 				},
 				{
-					"id": 2336,
+					"id": 2339,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33485,12 +33485,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2350,
+					"id": 2353,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33519,7 +33519,7 @@
 					}
 				},
 				{
-					"id": 2333,
+					"id": 2336,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33549,7 +33549,7 @@
 					}
 				},
 				{
-					"id": 2361,
+					"id": 2364,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33586,7 +33586,7 @@
 					}
 				},
 				{
-					"id": 2354,
+					"id": 2357,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33615,7 +33615,7 @@
 					}
 				},
 				{
-					"id": 2329,
+					"id": 2332,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33648,7 +33648,7 @@
 					}
 				},
 				{
-					"id": 2360,
+					"id": 2363,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33668,7 +33668,7 @@
 					}
 				},
 				{
-					"id": 2349,
+					"id": 2352,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33697,7 +33697,7 @@
 					}
 				},
 				{
-					"id": 2327,
+					"id": 2330,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33726,7 +33726,7 @@
 					}
 				},
 				{
-					"id": 2322,
+					"id": 2325,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33760,7 +33760,7 @@
 					}
 				},
 				{
-					"id": 2348,
+					"id": 2351,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33793,12 +33793,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2917,
+						"id": 2920,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2330,
+					"id": 2333,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33827,7 +33827,7 @@
 					}
 				},
 				{
-					"id": 2321,
+					"id": 2324,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33860,7 +33860,7 @@
 					}
 				},
 				{
-					"id": 2351,
+					"id": 2354,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33889,7 +33889,7 @@
 					}
 				},
 				{
-					"id": 2320,
+					"id": 2323,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33913,7 +33913,7 @@
 					}
 				},
 				{
-					"id": 2346,
+					"id": 2349,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33942,7 +33942,7 @@
 					}
 				},
 				{
-					"id": 2332,
+					"id": 2335,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33975,7 +33975,7 @@
 					}
 				},
 				{
-					"id": 2323,
+					"id": 2326,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34005,7 +34005,7 @@
 					}
 				},
 				{
-					"id": 2325,
+					"id": 2328,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34034,7 +34034,7 @@
 					}
 				},
 				{
-					"id": 2347,
+					"id": 2350,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34063,7 +34063,7 @@
 					}
 				},
 				{
-					"id": 2326,
+					"id": 2329,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34092,7 +34092,7 @@
 					}
 				},
 				{
-					"id": 2335,
+					"id": 2338,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34115,7 +34115,7 @@
 					}
 				},
 				{
-					"id": 2334,
+					"id": 2337,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34144,7 +34144,7 @@
 					}
 				},
 				{
-					"id": 2314,
+					"id": 2317,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34165,7 +34165,7 @@
 					}
 				},
 				{
-					"id": 2338,
+					"id": 2341,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34188,7 +34188,7 @@
 					}
 				},
 				{
-					"id": 2319,
+					"id": 2322,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34211,7 +34211,7 @@
 					}
 				},
 				{
-					"id": 2363,
+					"id": 2366,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34244,7 +34244,7 @@
 					}
 				},
 				{
-					"id": 2317,
+					"id": 2320,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -34260,7 +34260,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2318,
+							"id": 2321,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -34288,52 +34288,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2355,
-						2316,
-						2337,
-						2339,
-						2315,
-						2328,
-						2340,
-						2331,
-						2364,
-						2352,
-						2362,
-						2359,
-						2336,
-						2350,
-						2333,
-						2361,
-						2354,
-						2329,
-						2360,
-						2349,
-						2327,
-						2322,
-						2348,
-						2330,
-						2321,
-						2351,
-						2320,
-						2346,
-						2332,
-						2323,
-						2325,
-						2347,
-						2326,
-						2335,
-						2334,
-						2314,
-						2338,
+						2358,
 						2319,
-						2363
+						2340,
+						2342,
+						2318,
+						2331,
+						2343,
+						2334,
+						2367,
+						2355,
+						2365,
+						2362,
+						2339,
+						2353,
+						2336,
+						2364,
+						2357,
+						2332,
+						2363,
+						2352,
+						2330,
+						2325,
+						2351,
+						2333,
+						2324,
+						2354,
+						2323,
+						2349,
+						2335,
+						2326,
+						2328,
+						2350,
+						2329,
+						2338,
+						2337,
+						2317,
+						2341,
+						2322,
+						2366
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2317
+						2320
 					]
 				}
 			],
@@ -34346,7 +34346,7 @@
 			]
 		},
 		{
-			"id": 2689,
+			"id": 2692,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34362,7 +34362,7 @@
 			},
 			"children": [
 				{
-					"id": 2691,
+					"id": 2694,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34394,7 +34394,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2695,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34430,7 +34430,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2693,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34467,9 +34467,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2691,
-						2692,
-						2690
+						2694,
+						2695,
+						2693
 					]
 				}
 			],
@@ -34481,7 +34481,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2693,
+				"id": 2696,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -34491,7 +34491,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2694,
+						"id": 2697,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -34525,7 +34525,7 @@
 			}
 		},
 		{
-			"id": 2466,
+			"id": 2469,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34541,7 +34541,7 @@
 			},
 			"children": [
 				{
-					"id": 2477,
+					"id": 2480,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34575,7 +34575,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2503,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34606,20 +34606,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2501,
+							"id": 2504,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2502,
+								"id": 2505,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2503,
+										"id": 2506,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34655,7 +34655,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2530,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34697,7 +34697,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2527,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34727,7 +34727,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2309,
+						"id": 2312,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -34736,7 +34736,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2543,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34774,7 +34774,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2521,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34815,7 +34815,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2507,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34844,7 +34844,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -34853,7 +34853,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2531,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34895,7 +34895,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2471,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34933,7 +34933,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2515,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34971,7 +34971,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2499,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35009,7 +35009,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2498,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35041,7 +35041,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -35051,7 +35051,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2511,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35092,7 +35092,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2537,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35134,7 +35134,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2542,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35176,7 +35176,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2532,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35218,7 +35218,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2512,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35256,7 +35256,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2472,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35292,7 +35292,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2528,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35330,7 +35330,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2529,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35368,7 +35368,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2514,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35405,7 +35405,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2495,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35435,7 +35435,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -35444,7 +35444,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2470,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35478,7 +35478,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2500,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35514,7 +35514,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -35524,7 +35524,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2486,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35561,7 +35561,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2540,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35603,7 +35603,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2533,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35645,7 +35645,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2481,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35679,7 +35679,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2508,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35717,7 +35717,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2524,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35754,7 +35754,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2523,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35794,7 +35794,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2545,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35832,7 +35832,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2547,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35870,7 +35870,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2546,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35908,7 +35908,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2538,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35950,7 +35950,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2536,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35988,7 +35988,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2488,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36022,7 +36022,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2522,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36056,7 +36056,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2489,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36090,7 +36090,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2490,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36127,7 +36127,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2491,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36161,7 +36161,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2517,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36199,7 +36199,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2473,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36233,7 +36233,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2479,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36267,7 +36267,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2544,
 					"name": "liveboardXLSXCSVDownload",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36305,7 +36305,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2502,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36343,7 +36343,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2516,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36381,7 +36381,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2510,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36419,7 +36419,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2476,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36453,7 +36453,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2518,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36491,7 +36491,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2525,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36523,7 +36523,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -36533,7 +36533,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2526,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36565,7 +36565,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -36575,7 +36575,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2520,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36612,7 +36612,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2535,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36654,7 +36654,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2541,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36696,7 +36696,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2534,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36738,7 +36738,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2539,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36780,7 +36780,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2548,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36793,7 +36793,7 @@
 						"tags": [
 							{
 								"tag": "version",
-								"text": "SDK: 1.43.0 | Thoughtspot: 26.2.0.cl"
+								"text": "SDK: 1.45.0 | Thoughtspot: 26.2.0.cl"
 							},
 							{
 								"tag": "default",
@@ -36822,7 +36822,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2482,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36856,7 +36856,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2492,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36889,7 +36889,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2493,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36927,7 +36927,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2501,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36963,7 +36963,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -36973,7 +36973,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2487,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37010,7 +37010,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2477,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37047,7 +37047,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2475,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37086,71 +37086,71 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2477,
-						2500,
-						2527,
-						2524,
-						2540,
-						2518,
-						2504,
-						2528,
-						2468,
-						2512,
-						2496,
-						2495,
-						2508,
-						2534,
-						2539,
-						2529,
-						2509,
-						2469,
-						2525,
-						2526,
-						2511,
-						2492,
-						2467,
-						2497,
-						2483,
-						2537,
+						2480,
+						2503,
 						2530,
-						2478,
-						2505,
-						2521,
-						2520,
-						2542,
-						2544,
+						2527,
 						2543,
-						2535,
-						2533,
-						2485,
-						2519,
-						2486,
-						2487,
-						2488,
-						2514,
-						2470,
-						2476,
-						2541,
-						2499,
-						2513,
+						2521,
 						2507,
-						2473,
-						2515,
-						2522,
-						2523,
-						2517,
-						2532,
-						2538,
 						2531,
-						2536,
+						2471,
+						2515,
+						2499,
+						2498,
+						2511,
+						2537,
+						2542,
+						2532,
+						2512,
+						2472,
+						2528,
+						2529,
+						2514,
+						2495,
+						2470,
+						2500,
+						2486,
+						2540,
+						2533,
+						2481,
+						2508,
+						2524,
+						2523,
 						2545,
-						2479,
+						2547,
+						2546,
+						2538,
+						2536,
+						2488,
+						2522,
 						2489,
 						2490,
-						2498,
-						2484,
-						2474,
-						2472
+						2491,
+						2517,
+						2473,
+						2479,
+						2544,
+						2502,
+						2516,
+						2510,
+						2476,
+						2518,
+						2525,
+						2526,
+						2520,
+						2535,
+						2541,
+						2534,
+						2539,
+						2548,
+						2482,
+						2492,
+						2493,
+						2501,
+						2487,
+						2477,
+						2475
 					]
 				}
 			],
@@ -37177,7 +37177,7 @@
 			]
 		},
 		{
-			"id": 1973,
+			"id": 1976,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37187,7 +37187,7 @@
 			},
 			"children": [
 				{
-					"id": 1974,
+					"id": 1977,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37208,7 +37208,7 @@
 					}
 				},
 				{
-					"id": 1975,
+					"id": 1978,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37225,12 +37225,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1977,
+						"id": 1980,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 1976,
+					"id": 1979,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37276,9 +37276,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1974,
-						1975,
-						1976
+						1977,
+						1978,
+						1979
 					]
 				}
 			],
@@ -37291,7 +37291,7 @@
 			]
 		},
 		{
-			"id": 2914,
+			"id": 2917,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37301,7 +37301,7 @@
 			},
 			"children": [
 				{
-					"id": 2915,
+					"id": 2918,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37322,7 +37322,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2919,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37361,8 +37361,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2915,
-						2916
+						2918,
+						2919
 					]
 				}
 			],
@@ -37375,7 +37375,7 @@
 			]
 		},
 		{
-			"id": 2546,
+			"id": 2549,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37395,7 +37395,7 @@
 			},
 			"children": [
 				{
-					"id": 2575,
+					"id": 2578,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37426,20 +37426,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2576,
+							"id": 2579,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2577,
+								"id": 2580,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2578,
+										"id": 2581,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -37475,7 +37475,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2566,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37517,7 +37517,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2563,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37547,7 +37547,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2309,
+						"id": 2312,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -37556,7 +37556,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2595,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37597,7 +37597,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2582,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37626,7 +37626,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -37635,7 +37635,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2567,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37677,7 +37677,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2559,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37700,7 +37700,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2590,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37738,7 +37738,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2554,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37767,7 +37767,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2574,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37805,7 +37805,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2573,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37837,7 +37837,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -37847,7 +37847,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2586,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37888,7 +37888,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2568,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37930,7 +37930,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2587,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37968,7 +37968,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2564,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38006,7 +38006,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2565,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38044,7 +38044,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2589,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38081,7 +38081,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2570,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38111,7 +38111,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -38120,7 +38120,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2575,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38156,7 +38156,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -38166,7 +38166,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2556,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38195,7 +38195,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2553,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38224,7 +38224,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2558,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38258,7 +38258,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2552,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38291,7 +38291,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2555,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38320,7 +38320,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2583,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38358,7 +38358,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2598,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38395,7 +38395,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2597,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38435,7 +38435,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2596,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38469,7 +38469,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2592,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38507,7 +38507,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2577,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38545,7 +38545,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2591,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38583,7 +38583,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2585,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38621,7 +38621,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2561,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38653,7 +38653,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -38663,7 +38663,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2562,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38695,7 +38695,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -38705,7 +38705,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2560,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38739,7 +38739,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2594,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38776,7 +38776,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2550,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38805,7 +38805,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2557,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38834,7 +38834,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2576,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38870,7 +38870,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -38885,45 +38885,45 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2575,
+						2578,
+						2566,
 						2563,
-						2560,
-						2592,
-						2579,
-						2564,
-						2556,
+						2595,
+						2582,
+						2567,
+						2559,
+						2590,
+						2554,
+						2574,
+						2573,
+						2586,
+						2568,
 						2587,
-						2551,
-						2571,
-						2570,
-						2583,
+						2564,
 						2565,
-						2584,
+						2589,
+						2570,
+						2575,
+						2556,
+						2553,
+						2558,
+						2552,
+						2555,
+						2583,
+						2598,
+						2597,
+						2596,
+						2592,
+						2577,
+						2591,
+						2585,
 						2561,
 						2562,
-						2586,
-						2567,
-						2572,
-						2553,
-						2550,
-						2555,
-						2549,
-						2552,
-						2580,
-						2595,
+						2560,
 						2594,
-						2593,
-						2589,
-						2574,
-						2588,
-						2582,
-						2558,
-						2559,
+						2550,
 						2557,
-						2591,
-						2547,
-						2554,
-						2573
+						2576
 					]
 				}
 			],
@@ -38977,7 +38977,7 @@
 			]
 		},
 		{
-			"id": 2421,
+			"id": 2424,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -38992,7 +38992,7 @@
 			},
 			"children": [
 				{
-					"id": 2436,
+					"id": 2439,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39023,20 +39023,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2437,
+							"id": 2440,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2438,
+								"id": 2441,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2439,
+										"id": 2442,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -39072,7 +39072,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2466,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39114,7 +39114,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2463,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39144,7 +39144,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2309,
+						"id": 2312,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -39153,7 +39153,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2457,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39194,7 +39194,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2443,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39223,7 +39223,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -39232,7 +39232,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2467,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39274,7 +39274,7 @@
 					}
 				},
 				{
-					"id": 2423,
+					"id": 2426,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39308,7 +39308,7 @@
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2425,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39349,7 +39349,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2451,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39387,7 +39387,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2435,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39425,7 +39425,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2434,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39457,7 +39457,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -39467,7 +39467,7 @@
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2447,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39508,7 +39508,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2468,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39550,7 +39550,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2448,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39588,7 +39588,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2464,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39626,7 +39626,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2465,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39664,7 +39664,7 @@
 					}
 				},
 				{
-					"id": 2426,
+					"id": 2429,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39698,7 +39698,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2450,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39735,7 +39735,7 @@
 					}
 				},
 				{
-					"id": 2428,
+					"id": 2431,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39765,7 +39765,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -39774,7 +39774,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2436,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39810,7 +39810,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -39820,7 +39820,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2444,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39858,7 +39858,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2460,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39895,7 +39895,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2459,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39935,7 +39935,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2458,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39969,7 +39969,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2453,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40007,7 +40007,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2438,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40045,7 +40045,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2452,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40083,7 +40083,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2446,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40121,7 +40121,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2454,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40159,7 +40159,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2461,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40191,7 +40191,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -40201,7 +40201,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2462,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40233,7 +40233,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -40243,7 +40243,7 @@
 					}
 				},
 				{
-					"id": 2425,
+					"id": 2428,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40277,7 +40277,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2456,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40314,7 +40314,7 @@
 					}
 				},
 				{
-					"id": 2424,
+					"id": 2427,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40348,7 +40348,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2437,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40384,7 +40384,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -40399,41 +40399,41 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2436,
+						2439,
+						2466,
 						2463,
-						2460,
-						2454,
-						2440,
-						2464,
-						2423,
-						2422,
+						2457,
+						2443,
+						2467,
+						2426,
+						2425,
+						2451,
+						2435,
+						2434,
+						2447,
+						2468,
 						2448,
-						2432,
-						2431,
-						2444,
+						2464,
 						2465,
-						2445,
+						2429,
+						2450,
+						2431,
+						2436,
+						2444,
+						2460,
+						2459,
+						2458,
+						2453,
+						2438,
+						2452,
+						2446,
+						2454,
 						2461,
 						2462,
-						2426,
-						2447,
 						2428,
-						2433,
-						2441,
-						2457,
 						2456,
-						2455,
-						2450,
-						2435,
-						2449,
-						2443,
-						2451,
-						2458,
-						2459,
-						2425,
-						2453,
-						2424,
-						2434
+						2427,
+						2437
 					]
 				}
 			],
@@ -40456,7 +40456,7 @@
 			]
 		},
 		{
-			"id": 2365,
+			"id": 2368,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40472,7 +40472,7 @@
 			},
 			"children": [
 				{
-					"id": 2400,
+					"id": 2403,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40503,20 +40503,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2401,
+							"id": 2404,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2402,
+								"id": 2405,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2403,
+										"id": 2406,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -40552,7 +40552,7 @@
 					}
 				},
 				{
-					"id": 2377,
+					"id": 2380,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40586,7 +40586,7 @@
 					}
 				},
 				{
-					"id": 2367,
+					"id": 2370,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40620,7 +40620,7 @@
 					}
 				},
 				{
-					"id": 2366,
+					"id": 2369,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40654,7 +40654,7 @@
 					}
 				},
 				{
-					"id": 2388,
+					"id": 2391,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40696,7 +40696,7 @@
 					}
 				},
 				{
-					"id": 2380,
+					"id": 2383,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40733,7 +40733,7 @@
 					}
 				},
 				{
-					"id": 2385,
+					"id": 2388,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40763,7 +40763,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2309,
+						"id": 2312,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -40772,7 +40772,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2420,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40813,7 +40813,7 @@
 					}
 				},
 				{
-					"id": 2404,
+					"id": 2407,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40842,7 +40842,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -40851,7 +40851,7 @@
 					}
 				},
 				{
-					"id": 2381,
+					"id": 2384,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40889,7 +40889,7 @@
 					}
 				},
 				{
-					"id": 2389,
+					"id": 2392,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40931,7 +40931,7 @@
 					}
 				},
 				{
-					"id": 2373,
+					"id": 2376,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40965,7 +40965,7 @@
 					}
 				},
 				{
-					"id": 2372,
+					"id": 2375,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41001,7 +41001,7 @@
 					}
 				},
 				{
-					"id": 2412,
+					"id": 2415,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41039,7 +41039,7 @@
 					}
 				},
 				{
-					"id": 2396,
+					"id": 2399,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41077,7 +41077,7 @@
 					}
 				},
 				{
-					"id": 2395,
+					"id": 2398,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41109,7 +41109,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -41119,7 +41119,7 @@
 					}
 				},
 				{
-					"id": 2408,
+					"id": 2411,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41160,7 +41160,7 @@
 					}
 				},
 				{
-					"id": 2390,
+					"id": 2393,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41202,7 +41202,7 @@
 					}
 				},
 				{
-					"id": 2370,
+					"id": 2373,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41236,7 +41236,7 @@
 					}
 				},
 				{
-					"id": 2409,
+					"id": 2412,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41274,7 +41274,7 @@
 					}
 				},
 				{
-					"id": 2386,
+					"id": 2389,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41312,7 +41312,7 @@
 					}
 				},
 				{
-					"id": 2387,
+					"id": 2390,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41350,7 +41350,7 @@
 					}
 				},
 				{
-					"id": 2376,
+					"id": 2379,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41384,7 +41384,7 @@
 					}
 				},
 				{
-					"id": 2411,
+					"id": 2414,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41421,7 +41421,7 @@
 					}
 				},
 				{
-					"id": 2382,
+					"id": 2385,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41459,7 +41459,7 @@
 					}
 				},
 				{
-					"id": 2371,
+					"id": 2374,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41493,7 +41493,7 @@
 					}
 				},
 				{
-					"id": 2392,
+					"id": 2395,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41523,7 +41523,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -41532,7 +41532,7 @@
 					}
 				},
 				{
-					"id": 2397,
+					"id": 2400,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41568,7 +41568,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -41578,7 +41578,7 @@
 					}
 				},
 				{
-					"id": 2368,
+					"id": 2371,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41612,7 +41612,7 @@
 					}
 				},
 				{
-					"id": 2369,
+					"id": 2372,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41646,7 +41646,7 @@
 					}
 				},
 				{
-					"id": 2378,
+					"id": 2381,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41680,7 +41680,7 @@
 					}
 				},
 				{
-					"id": 2405,
+					"id": 2408,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41718,7 +41718,7 @@
 					}
 				},
 				{
-					"id": 2420,
+					"id": 2423,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41755,7 +41755,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2422,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41795,7 +41795,7 @@
 					}
 				},
 				{
-					"id": 2418,
+					"id": 2421,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41829,7 +41829,7 @@
 					}
 				},
 				{
-					"id": 2414,
+					"id": 2417,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41867,7 +41867,7 @@
 					}
 				},
 				{
-					"id": 2399,
+					"id": 2402,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41905,7 +41905,7 @@
 					}
 				},
 				{
-					"id": 2413,
+					"id": 2416,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41943,7 +41943,7 @@
 					}
 				},
 				{
-					"id": 2407,
+					"id": 2410,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41981,7 +41981,7 @@
 					}
 				},
 				{
-					"id": 2383,
+					"id": 2386,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42013,7 +42013,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -42023,7 +42023,7 @@
 					}
 				},
 				{
-					"id": 2384,
+					"id": 2387,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42055,7 +42055,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -42065,7 +42065,7 @@
 					}
 				},
 				{
-					"id": 2375,
+					"id": 2378,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42095,7 +42095,7 @@
 					}
 				},
 				{
-					"id": 2374,
+					"id": 2377,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42124,7 +42124,7 @@
 					}
 				},
 				{
-					"id": 2416,
+					"id": 2419,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42161,7 +42161,7 @@
 					}
 				},
 				{
-					"id": 2379,
+					"id": 2382,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42191,7 +42191,7 @@
 					}
 				},
 				{
-					"id": 2398,
+					"id": 2401,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42227,7 +42227,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -42242,52 +42242,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2400,
-						2377,
-						2367,
-						2366,
-						2388,
+						2403,
 						2380,
-						2385,
-						2417,
-						2404,
-						2381,
-						2389,
-						2373,
-						2372,
-						2412,
-						2396,
-						2395,
-						2408,
-						2390,
 						2370,
-						2409,
+						2369,
+						2391,
+						2383,
+						2388,
+						2420,
+						2407,
+						2384,
+						2392,
+						2376,
+						2375,
+						2415,
+						2399,
+						2398,
+						2411,
+						2393,
+						2373,
+						2412,
+						2389,
+						2390,
+						2379,
+						2414,
+						2385,
+						2374,
+						2395,
+						2400,
+						2371,
+						2372,
+						2381,
+						2408,
+						2423,
+						2422,
+						2421,
+						2417,
+						2402,
+						2416,
+						2410,
 						2386,
 						2387,
-						2376,
-						2411,
-						2382,
-						2371,
-						2392,
-						2397,
-						2368,
-						2369,
 						2378,
-						2405,
-						2420,
+						2377,
 						2419,
-						2418,
-						2414,
-						2399,
-						2413,
-						2407,
-						2383,
-						2384,
-						2375,
-						2374,
-						2416,
-						2379,
-						2398
+						2382,
+						2401
 					]
 				}
 			],
@@ -42320,14 +42320,14 @@
 			]
 		},
 		{
-			"id": 1942,
+			"id": 1945,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1945,
+					"id": 1948,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42342,14 +42342,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1946,
+							"id": 1949,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1948,
+									"id": 1951,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42367,7 +42367,7 @@
 									}
 								},
 								{
-									"id": 1947,
+									"id": 1950,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42390,8 +42390,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1948,
-										1947
+										1951,
+										1950
 									]
 								}
 							]
@@ -42399,7 +42399,7 @@
 					}
 				},
 				{
-					"id": 1944,
+					"id": 1947,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42417,7 +42417,7 @@
 					}
 				},
 				{
-					"id": 1943,
+					"id": 1946,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42440,9 +42440,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1945,
-						1944,
-						1943
+						1948,
+						1947,
+						1946
 					]
 				}
 			],
@@ -42455,7 +42455,7 @@
 			]
 		},
 		{
-			"id": 1270,
+			"id": 1273,
 			"name": "SpotterAgentEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42471,7 +42471,7 @@
 			},
 			"children": [
 				{
-					"id": 1281,
+					"id": 1284,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42502,20 +42502,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1282,
+							"id": 1285,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1283,
+								"id": 1286,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1284,
+										"id": 1287,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42551,7 +42551,7 @@
 					}
 				},
 				{
-					"id": 1298,
+					"id": 1301,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42592,7 +42592,7 @@
 					}
 				},
 				{
-					"id": 1285,
+					"id": 1288,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42621,7 +42621,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -42630,7 +42630,7 @@
 					}
 				},
 				{
-					"id": 1293,
+					"id": 1296,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42668,7 +42668,7 @@
 					}
 				},
 				{
-					"id": 1277,
+					"id": 1280,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42706,7 +42706,7 @@
 					}
 				},
 				{
-					"id": 1276,
+					"id": 1279,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42738,7 +42738,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -42748,7 +42748,7 @@
 					}
 				},
 				{
-					"id": 1289,
+					"id": 1292,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42789,7 +42789,7 @@
 					}
 				},
 				{
-					"id": 1290,
+					"id": 1293,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42827,7 +42827,7 @@
 					}
 				},
 				{
-					"id": 1292,
+					"id": 1295,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42864,7 +42864,7 @@
 					}
 				},
 				{
-					"id": 1273,
+					"id": 1276,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42894,7 +42894,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42903,7 +42903,7 @@
 					}
 				},
 				{
-					"id": 1278,
+					"id": 1281,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42939,7 +42939,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -42949,7 +42949,7 @@
 					}
 				},
 				{
-					"id": 1286,
+					"id": 1289,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42987,7 +42987,7 @@
 					}
 				},
 				{
-					"id": 1301,
+					"id": 1304,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43024,7 +43024,7 @@
 					}
 				},
 				{
-					"id": 1300,
+					"id": 1303,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43064,7 +43064,7 @@
 					}
 				},
 				{
-					"id": 1299,
+					"id": 1302,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43098,7 +43098,7 @@
 					}
 				},
 				{
-					"id": 1295,
+					"id": 1298,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43136,7 +43136,7 @@
 					}
 				},
 				{
-					"id": 1280,
+					"id": 1283,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43174,7 +43174,7 @@
 					}
 				},
 				{
-					"id": 1294,
+					"id": 1297,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43212,7 +43212,7 @@
 					}
 				},
 				{
-					"id": 1288,
+					"id": 1291,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43250,7 +43250,7 @@
 					}
 				},
 				{
-					"id": 1297,
+					"id": 1300,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43287,7 +43287,7 @@
 					}
 				},
 				{
-					"id": 1279,
+					"id": 1282,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43323,7 +43323,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -43333,7 +43333,7 @@
 					}
 				},
 				{
-					"id": 1271,
+					"id": 1274,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43359,28 +43359,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1281,
-						1298,
-						1285,
-						1293,
-						1277,
-						1276,
-						1289,
-						1290,
-						1292,
-						1273,
-						1278,
-						1286,
+						1284,
 						1301,
-						1300,
-						1299,
-						1295,
-						1280,
-						1294,
 						1288,
-						1297,
+						1296,
+						1280,
 						1279,
-						1271
+						1292,
+						1293,
+						1295,
+						1276,
+						1281,
+						1289,
+						1304,
+						1303,
+						1302,
+						1298,
+						1283,
+						1297,
+						1291,
+						1300,
+						1282,
+						1274
 					]
 				}
 			],
@@ -43410,13 +43410,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1302,
+					"id": 1305,
 					"name": "BodylessConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1538,
+			"id": 1541,
 			"name": "SpotterEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43432,7 +43432,7 @@
 			},
 			"children": [
 				{
-					"id": 1561,
+					"id": 1564,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43463,20 +43463,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1562,
+							"id": 1565,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1563,
+								"id": 1566,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1564,
+										"id": 1567,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43512,7 +43512,7 @@
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1581,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43553,7 +43553,7 @@
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1568,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43582,7 +43582,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2730,
+						"id": 2733,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -43591,7 +43591,7 @@
 					}
 				},
 				{
-					"id": 1543,
+					"id": 1546,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43629,7 +43629,7 @@
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1576,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43667,7 +43667,7 @@
 					}
 				},
 				{
-					"id": 1541,
+					"id": 1544,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43701,7 +43701,7 @@
 					}
 				},
 				{
-					"id": 1557,
+					"id": 1560,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43739,7 +43739,7 @@
 					}
 				},
 				{
-					"id": 1556,
+					"id": 1559,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43771,7 +43771,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -43781,7 +43781,7 @@
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1572,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43822,7 +43822,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1553,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43860,7 +43860,7 @@
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1573,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43898,7 +43898,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1550,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43932,7 +43932,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1552,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43966,7 +43966,7 @@
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1575,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44003,7 +44003,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1556,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44033,7 +44033,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2689,
+						"id": 2692,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44042,7 +44042,7 @@
 					}
 				},
 				{
-					"id": 1558,
+					"id": 1561,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44078,7 +44078,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -44088,7 +44088,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1548,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44122,7 +44122,7 @@
 					}
 				},
 				{
-					"id": 1542,
+					"id": 1545,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44156,7 +44156,7 @@
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1569,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44194,7 +44194,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1584,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44231,7 +44231,7 @@
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1583,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44271,7 +44271,7 @@
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1582,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44305,7 +44305,7 @@
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1578,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44343,7 +44343,7 @@
 					}
 				},
 				{
-					"id": 1560,
+					"id": 1563,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44381,7 +44381,7 @@
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1577,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44419,7 +44419,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1571,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44457,7 +44457,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1549,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44489,13 +44489,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1973,
+							"id": 1976,
 							"name": "RuntimeFilter"
 						}
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1551,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44527,13 +44527,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2914,
+							"id": 2917,
 							"name": "RuntimeParameter"
 						}
 					}
 				},
 				{
-					"id": 1540,
+					"id": 1543,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44556,7 +44556,7 @@
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1580,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44593,7 +44593,7 @@
 					}
 				},
 				{
-					"id": 1544,
+					"id": 1547,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44627,7 +44627,7 @@
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1554,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44665,7 +44665,7 @@
 					}
 				},
 				{
-					"id": 1559,
+					"id": 1562,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44701,7 +44701,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2167,
+							"id": 2170,
 							"name": "Action"
 						}
 					},
@@ -44711,7 +44711,7 @@
 					}
 				},
 				{
-					"id": 1539,
+					"id": 1542,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44737,40 +44737,40 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1561,
-						1578,
-						1565,
-						1543,
-						1573,
-						1541,
-						1557,
-						1556,
-						1569,
-						1550,
-						1570,
-						1547,
-						1549,
-						1572,
-						1553,
-						1558,
-						1545,
-						1542,
-						1566,
+						1564,
 						1581,
-						1580,
-						1579,
-						1575,
-						1560,
-						1574,
 						1568,
 						1546,
-						1548,
-						1540,
-						1577,
+						1576,
 						1544,
-						1551,
+						1560,
 						1559,
-						1539
+						1572,
+						1553,
+						1573,
+						1550,
+						1552,
+						1575,
+						1556,
+						1561,
+						1548,
+						1545,
+						1569,
+						1584,
+						1583,
+						1582,
+						1578,
+						1563,
+						1577,
+						1571,
+						1549,
+						1551,
+						1543,
+						1580,
+						1547,
+						1554,
+						1562,
+						1542
 					]
 				}
 			],
@@ -44800,20 +44800,20 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1582,
+					"id": 1585,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1949,
+			"id": 1952,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1950,
+					"id": 1953,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44831,7 +44831,7 @@
 					}
 				},
 				{
-					"id": 1951,
+					"id": 1954,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44854,8 +44854,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1950,
-						1951
+						1953,
+						1954
 					]
 				}
 			],
@@ -44868,14 +44868,14 @@
 			]
 		},
 		{
-			"id": 2952,
+			"id": 2955,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2953,
+					"id": 2956,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44896,7 +44896,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2957,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44922,8 +44922,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2953,
-						2954
+						2956,
+						2957
 					]
 				}
 			],
@@ -44936,7 +44936,7 @@
 			]
 		},
 		{
-			"id": 2743,
+			"id": 2746,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44946,7 +44946,7 @@
 			},
 			"children": [
 				{
-					"id": 2745,
+					"id": 2748,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44976,20 +44976,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2746,
+							"id": 2749,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2747,
+								"id": 2750,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2748,
+										"id": 2751,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -45002,7 +45002,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2749,
+										"id": 2752,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -45015,14 +45015,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2750,
+											"id": 2753,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2751,
+													"id": 2754,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -45044,7 +45044,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2747,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45063,7 +45063,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2752,
+						"id": 2755,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -45073,8 +45073,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2745,
-						2744
+						2748,
+						2747
 					]
 				}
 			],
@@ -45379,7 +45379,7 @@
 			]
 		},
 		{
-			"id": 2713,
+			"id": 2716,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45406,7 +45406,7 @@
 			}
 		},
 		{
-			"id": 2717,
+			"id": 2720,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45421,7 +45421,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2718,
+					"id": 2721,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -45444,7 +45444,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2719,
+							"id": 2722,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -45454,19 +45454,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2720,
+									"id": 2723,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2725,
+										"id": 2728,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2721,
+									"id": 2724,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -45476,7 +45476,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2722,
+											"id": 2725,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -45490,7 +45490,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2723,
+													"id": 2726,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -45500,7 +45500,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2724,
+															"id": 2727,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -45531,7 +45531,7 @@
 			}
 		},
 		{
-			"id": 2714,
+			"id": 2717,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45555,14 +45555,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2715,
+					"id": 2718,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2716,
+							"id": 2719,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45590,7 +45590,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2716
+								2719
 							]
 						}
 					],
@@ -45605,7 +45605,7 @@
 			}
 		},
 		{
-			"id": 2725,
+			"id": 2728,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -45629,14 +45629,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2726,
+					"id": 2729,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2728,
+							"id": 2731,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45654,7 +45654,7 @@
 							}
 						},
 						{
-							"id": 2729,
+							"id": 2732,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45674,7 +45674,7 @@
 							}
 						},
 						{
-							"id": 2727,
+							"id": 2730,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -45697,9 +45697,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2728,
-								2729,
-								2727
+								2731,
+								2732,
+								2730
 							]
 						}
 					],
@@ -45714,7 +45714,7 @@
 			}
 		},
 		{
-			"id": 48,
+			"id": 51,
 			"name": "createLiveboardWithAnswers",
 			"kind": 64,
 			"kindString": "Function",
@@ -45730,7 +45730,7 @@
 			],
 			"signatures": [
 				{
-					"id": 49,
+					"id": 52,
 					"name": "createLiveboardWithAnswers",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -45752,7 +45752,7 @@
 					},
 					"parameters": [
 						{
-							"id": 50,
+							"id": 53,
 							"name": "answers",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45764,13 +45764,13 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1869,
+									"id": 1872,
 									"name": "AnswerService"
 								}
 							}
 						},
 						{
-							"id": 51,
+							"id": 54,
 							"name": "name",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45934,7 +45934,7 @@
 			]
 		},
 		{
-			"id": 41,
+			"id": 44,
 			"name": "getAnswerFromQuery",
 			"kind": 64,
 			"kindString": "Function",
@@ -45950,7 +45950,7 @@
 			],
 			"signatures": [
 				{
-					"id": 42,
+					"id": 45,
 					"name": "getAnswerFromQuery",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -45971,7 +45971,7 @@
 					},
 					"parameters": [
 						{
-							"id": 43,
+							"id": 46,
 							"name": "query",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -45985,7 +45985,7 @@
 							}
 						},
 						{
-							"id": 44,
+							"id": 47,
 							"name": "worksheetId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -46005,14 +46005,14 @@
 							{
 								"type": "reflection",
 								"declaration": {
-									"id": 45,
+									"id": 48,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 46,
+											"id": 49,
 											"name": "answer",
 											"kind": 1024,
 											"kindString": "Property",
@@ -46026,12 +46026,12 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1869,
+												"id": 1872,
 												"name": "AnswerService"
 											}
 										},
 										{
-											"id": 47,
+											"id": 50,
 											"name": "suggestion",
 											"kind": 1024,
 											"kindString": "Property",
@@ -46054,8 +46054,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												46,
-												47
+												49,
+												50
 											]
 										}
 									]
@@ -46113,7 +46113,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2313,
+						"id": 2316,
 						"name": "EmbedConfig"
 					}
 				}
@@ -46213,14 +46213,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2313,
+								"id": 2316,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1816,
+						"id": 1819,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -46360,7 +46360,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2684,
+									"id": 2687,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -46432,7 +46432,7 @@
 			]
 		},
 		{
-			"id": 3006,
+			"id": 3009,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -46448,7 +46448,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3007,
+					"id": 3010,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -46563,11 +46563,86 @@
 						],
 						"name": "Promise"
 					}
+				},
+				{
+					"id": 41,
+					"name": "tokenizedFetch",
+					"kind": 4096,
+					"kindString": "Call signature",
+					"flags": {},
+					"comment": {
+						"shortText": "Fetch wrapper that adds the authentication token to the request.\nUse this to call the ThoughtSpot APIs when using the visual embed sdk.\nThe interface for this method is the same as Web `Fetch`.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ntokenizedFetch(\"<TS_ORIGIN>/api/rest/2.0/auth/session/user\", {\n  // .. fetch options ..\n});\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.28.0"
+							},
+							{
+								"tag": "group",
+								"text": "Global methods\n"
+							}
+						]
+					},
+					"parameters": [
+						{
+							"id": 42,
+							"name": "input",
+							"kind": 32768,
+							"kindString": "Parameter",
+							"flags": {},
+							"comment": {},
+							"type": {
+								"type": "union",
+								"types": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									},
+									{
+										"type": "reference",
+										"name": "URL"
+									},
+									{
+										"type": "reference",
+										"name": "globalThis.Request"
+									}
+								]
+							}
+						},
+						{
+							"id": 43,
+							"name": "init",
+							"kind": 32768,
+							"kindString": "Parameter",
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {},
+							"type": {
+								"type": "reference",
+								"name": "RequestInit"
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"typeArguments": [
+							{
+								"type": "reference",
+								"name": "Response"
+							}
+						],
+						"name": "Promise"
+					}
 				}
 			]
 		},
 		{
-			"id": 2924,
+			"id": 2927,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -46581,7 +46656,7 @@
 			],
 			"signatures": [
 				{
-					"id": 2925,
+					"id": 2928,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -46591,7 +46666,7 @@
 					},
 					"parameters": [
 						{
-							"id": 2926,
+							"id": 2929,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -46603,7 +46678,7 @@
 							}
 						},
 						{
-							"id": 2927,
+							"id": 2930,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -46614,7 +46689,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 2928,
+									"id": 2931,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -46637,75 +46712,75 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2167,
-				1814,
-				1799,
-				1806,
-				1961,
-				2309,
-				2997,
-				2993,
-				2989,
-				2163,
-				1993,
-				2695,
-				2946,
-				2940,
-				2706,
-				2089,
-				3002,
+				2170,
+				1817,
+				1802,
+				1809,
+				1964,
+				2312,
+				3000,
+				2996,
+				2992,
+				2166,
+				1996,
+				2698,
 				2949,
-				2983,
-				2917,
-				1952,
-				2684,
-				2944,
-				1977,
-				2975
+				2943,
+				2709,
+				2092,
+				3005,
+				2952,
+				2986,
+				2920,
+				1955,
+				2687,
+				2947,
+				1980,
+				2978
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1869,
-				1021,
-				1334,
-				1626,
-				608,
-				838,
-				235,
-				52,
-				1238,
-				1365
+				1872,
+				1024,
+				1337,
+				1629,
+				611,
+				841,
+				238,
+				55,
+				1241,
+				1368
 			]
 		},
 		{
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2596,
-				1816,
-				1302,
-				1582,
-				2955,
-				2752,
-				2740,
-				2730,
-				2313,
-				2689,
-				2466,
-				1973,
-				2914,
-				2546,
-				2421,
-				2365,
-				1942,
-				1270,
-				1538,
-				1949,
-				2952,
+				2599,
+				1819,
+				1305,
+				1585,
+				2958,
+				2755,
 				2743,
+				2733,
+				2316,
+				2692,
+				2469,
+				1976,
+				2917,
+				2549,
+				2424,
+				2368,
+				1945,
+				1273,
+				1541,
+				1952,
+				2955,
+				2746,
 				21,
 				25
 			]
@@ -46714,28 +46789,28 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2713,
+				2716,
+				2720,
 				2717,
-				2714,
-				2725
+				2728
 			]
 		},
 		{
 			"title": "Functions",
 			"kind": 64,
 			"children": [
-				48,
+				51,
 				15,
 				18,
-				41,
+				44,
 				33,
 				35,
 				1,
 				4,
 				7,
-				3006,
+				3009,
 				37,
-				2924
+				2927
 			]
 		}
 	],


### PR DESCRIPTION
## Summary

  Added a new embed configuration option `showMaskedFilterChip` to control the visibility of masked filter chips in Liveboard and App embeds.

  ## Changes

  - **New Configuration Option**: Added `showMaskedFilterChip` boolean parameter to `LiveboardAppEmbedViewConfig` interface
    - Defaults to `false`
    - Available for `AppEmbed` and `LiveboardEmbed` components

  - **Implementation**:
    - Added `Param.ShowMaskedFilterChip` enum value to URL parameters
    - Integrated parameter handling in `AppEmbed` (src/embed/app.ts:675, 710)
    - Integrated parameter handling in `LiveboardEmbed` (src/embed/liveboard.ts:483, 593)

  - **Test Coverage**: Added comprehensive test cases for both embed types:
    - `app.spec.ts`: 3 new tests validating true/false/default behavior
    - `liveboard.spec.ts`: 2 new tests validating true/false behavior