### PR TITLE
Update release version in SDK documentation for centralised liveboard filter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1599,7 +1599,7 @@ export interface LiveboardAppEmbedViewConfig {
      * To enable this feature on your instance, contact ThoughtSpot Support.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
-     * @version SDK: 1.42.0 | ThoughtSpot: 10.15.0.cl
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.4.0.cl
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -25654,7 +25654,7 @@
 						"tags": [
 							{
 								"tag": "version",
-								"text": "SDK: 1.42.0 | ThoughtSpot: 10.15.0.cl"
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.4.0.cl"
 							},
 							{
 								"tag": "example",
@@ -38529,7 +38529,7 @@
 						"tags": [
 							{
 								"tag": "version",
-								"text": "SDK: 1.42.0 | ThoughtSpot: 10.15.0.cl"
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.4.0.cl"
 							},
 							{
 								"tag": "example",
@@ -39267,7 +39267,7 @@
 							},
 							{
 								"tag": "version",
-								"text": "SDK: 1.45.0 | ThoughtSpot: 26.4.0.cl\n"
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.4.0.cl\n"
 							}
 						]
 					},


### PR DESCRIPTION
Updates were done in https://github.com/thoughtspot/visual-embed-sdk/pull/326. 
But the release of feature was pushed to 26.4.0.cl. 
Hence need to update the documentation as well.