### PR TITLE
[SCAL-289371] - feat(spotter): add sidebar embed actions, events, params, and CSS variables

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -852,4 +852,64 @@ export interface CustomCssVariables {
      * Width of the Spotter chat window.
      */
     '--ts-var-spotter-chat-width'?: string;
+
+    /**
+     * Border color for the saved chats sidebar container.
+     */
+    '--ts-var-saved-chats-border-color'?: string;
+
+    /**
+     * Background color for the saved chats sidebar container.
+     */
+    '--ts-var-saved-chats-bg'?: string;
+
+    /**
+     * Text color for the saved chats sidebar container.
+     */
+    '--ts-var-saved-chats-text-color'?: string;
+
+    /**
+     * Border color for the saved chats sidebar header.
+     */
+    '--ts-var-saved-chats-header-border'?: string;
+
+    /**
+     * Color for the saved chats sidebar title text.
+     */
+    '--ts-var-saved-chats-title-color'?: string;
+
+    /**
+     * Background color for buttons (new chat, toggle, footer) in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-btn-bg'?: string;
+
+    /**
+     * Hover background color for buttons in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-btn-hover-bg'?: string;
+
+    /**
+     * Text color for conversation items in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-conv-text-color'?: string;
+
+    /**
+     * Background color for conversation items on hover in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-conv-hover-bg'?: string;
+
+    /**
+     * Background color for the active/selected conversation in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-conv-active-bg'?: string;
+
+    /**
+     * Border color for the saved chats sidebar footer.
+     */
+    '--ts-var-saved-chats-footer-border'?: string;
+
+    /**
+     * Color for section title text (e.g., "Recent", "Older") in the saved chats sidebar.
+     */
+    '--ts-var-saved-chats-section-title-color'?: string;
   }

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -295,7 +295,9 @@ describe('ConversationEmbed', () => {
             searchOptions: {
                 searchQuery: 'searchQuery',
             },
-            enablePastConversationsSidebar: true,
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+            },
         };
 
         const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
@@ -312,7 +314,9 @@ describe('ConversationEmbed', () => {
             searchOptions: {
                 searchQuery: 'searchQuery',
             },
-            enablePastConversationsSidebar: false,
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: false,
+            },
         };
 
         const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
@@ -334,7 +338,9 @@ describe('ConversationEmbed', () => {
             dataPanelV2: true,
             showSpotterLimitations: true,
             hideSampleQuestions: true,
-            enablePastConversationsSidebar: true,
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+            },
         };
 
         const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
@@ -405,6 +411,7 @@ describe('ConversationEmbed', () => {
 
     describe('spotter sidebar config params', () => {
         it.each([
+            ['enablePastConversationsSidebar', true, 'enablePastConversationsSidebar=true'],
             ['spotterSidebarTitle', 'My Conversations', 'spotterSidebarTitle=My%20Conversations'],
             ['spotterSidebarDefaultExpanded', true, 'spotterSidebarDefaultExpanded=true'],
             ['spotterChatRenameLabel', 'Edit Name', 'spotterChatRenameLabel=Edit%20Name'],
@@ -415,10 +422,12 @@ describe('ConversationEmbed', () => {
             ['spotterConversationsBatchSize', 50, 'spotterConversationsBatchSize=50'],
             ['spotterNewChatButtonTitle', 'Start New Conversation', 'spotterNewChatButtonTitle=Start%20New%20Conversation'],
             ['spotterDocumentationUrl', 'https://docs.example.com/spotter', 'spotterDocumentationUrl=https%3A%2F%2Fdocs.example.com%2Fspotter'],
-        ])('should render with %s', async (configKey, configValue, expectedParam) => {
+        ])('should render with spotterSidebarConfig.%s', async (configKey, configValue, expectedParam) => {
             const viewConfig: SpotterEmbedViewConfig = {
                 worksheetId: 'worksheetId',
-                [configKey]: configValue,
+                spotterSidebarConfig: {
+                    [configKey]: configValue,
+                },
             };
             const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
             await conversationEmbed.render();
@@ -431,10 +440,12 @@ describe('ConversationEmbed', () => {
         it.each([
             ['invalid URL format', 'invalid-url'],
             ['invalid protocol (ftp)', 'ftp://docs.example.com/spotter'],
-        ])('should handle error for spotterDocumentationUrl with %s', async (_, invalidUrl) => {
+        ])('should handle error for spotterSidebarConfig.spotterDocumentationUrl with %s', async (_, invalidUrl) => {
             const viewConfig: SpotterEmbedViewConfig = {
                 worksheetId: 'worksheetId',
-                spotterDocumentationUrl: invalidUrl,
+                spotterSidebarConfig: {
+                    spotterDocumentationUrl: invalidUrl,
+                },
             };
             const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
             (conversationEmbed as any).handleError = jest.fn();
@@ -448,19 +459,22 @@ describe('ConversationEmbed', () => {
             );
         });
 
-        it('should render with multiple sidebar config options', async () => {
+        it('should render with multiple spotterSidebarConfig options', async () => {
             const viewConfig: SpotterEmbedViewConfig = {
                 worksheetId: 'worksheetId',
-                spotterSidebarTitle: 'Chats',
-                spotterSidebarDefaultExpanded: true,
-                spotterNewChatButtonTitle: 'New',
-                spotterConversationsBatchSize: 25,
+                spotterSidebarConfig: {
+                    enablePastConversationsSidebar: true,
+                    spotterSidebarTitle: 'Chats',
+                    spotterSidebarDefaultExpanded: true,
+                    spotterNewChatButtonTitle: 'New',
+                    spotterConversationsBatchSize: 25,
+                },
             };
             const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
             await conversationEmbed.render();
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true&spotterSidebarTitle=Chats&spotterConversationsBatchSize=25&spotterNewChatButtonTitle=New#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+                `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&enablePastConversationsSidebar=true&spotterSidebarDefaultExpanded=true&spotterSidebarTitle=Chats&spotterConversationsBatchSize=25&spotterNewChatButtonTitle=New#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
             );
         });
     });

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -402,4 +402,184 @@ describe('ConversationEmbed', () => {
             `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&updatedSpotterChatPrompt=false#/embed/insights/conv-assist?worksheet=worksheetId&query=searchQuery`,
         );
     });
+
+    it('should render with spotterSidebarTitle', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterSidebarTitle: 'My Conversations',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarTitle=My%20Conversations#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterSidebarDefaultExpanded set to true', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterSidebarDefaultExpanded: true,
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterChatRenameLabel', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterChatRenameLabel: 'Edit Name',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterChatRenameLabel=Edit%20Name#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterChatDeleteLabel', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterChatDeleteLabel: 'Remove',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterChatDeleteLabel=Remove#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterDeleteConversationModalTitle', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterDeleteConversationModalTitle: 'Remove Conversation',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterDeleteConversationModalTitle=Remove%20Conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterPastConversationAlertMessage', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterPastConversationAlertMessage: 'Viewing past conversation',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterPastConversationAlertMessage=Viewing%20past%20conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterBestPracticesLabel', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterBestPracticesLabel: 'Help Tips',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterBestPracticesLabel=Help%20Tips#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterConversationsBatchSize', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterConversationsBatchSize: 50,
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterConversationsBatchSize=50#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with spotterNewChatButtonTitle', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterNewChatButtonTitle: 'Start New Conversation',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterNewChatButtonTitle=Start%20New%20Conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should render with valid spotterDocumentationUrl', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterDocumentationUrl: 'https://docs.example.com/spotter',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterDocumentationUrl=https%3A%2F%2Fdocs.example.com%2Fspotter#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
+
+    it('should handle error for invalid spotterDocumentationUrl', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterDocumentationUrl: 'invalid-url',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        (conversationEmbed as any).handleError = jest.fn();
+        await conversationEmbed.render();
+        expect((conversationEmbed as any).handleError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                errorType: ErrorDetailsTypes.VALIDATION_ERROR,
+                message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
+                code: EmbedErrorCodes.INVALID_URL,
+            }),
+        );
+    });
+
+    it('should handle error for spotterDocumentationUrl with invalid protocol', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterDocumentationUrl: 'ftp://docs.example.com/spotter',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        (conversationEmbed as any).handleError = jest.fn();
+        await conversationEmbed.render();
+        expect((conversationEmbed as any).handleError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                errorType: ErrorDetailsTypes.VALIDATION_ERROR,
+                message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
+                code: EmbedErrorCodes.INVALID_URL,
+            }),
+        );
+    });
+
+    it('should render with multiple sidebar config options', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            spotterSidebarTitle: 'Chats',
+            spotterSidebarDefaultExpanded: true,
+            spotterNewChatButtonTitle: 'New',
+            spotterConversationsBatchSize: 25,
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true&spotterSidebarTitle=Chats&spotterConversationsBatchSize=25&spotterNewChatButtonTitle=New#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+        );
+    });
 });

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -403,183 +403,65 @@ describe('ConversationEmbed', () => {
         );
     });
 
-    it('should render with spotterSidebarTitle', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterSidebarTitle: 'My Conversations',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarTitle=My%20Conversations#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
+    describe('spotter sidebar config params', () => {
+        it.each([
+            ['spotterSidebarTitle', 'My Conversations', 'spotterSidebarTitle=My%20Conversations'],
+            ['spotterSidebarDefaultExpanded', true, 'spotterSidebarDefaultExpanded=true'],
+            ['spotterChatRenameLabel', 'Edit Name', 'spotterChatRenameLabel=Edit%20Name'],
+            ['spotterChatDeleteLabel', 'Remove', 'spotterChatDeleteLabel=Remove'],
+            ['spotterDeleteConversationModalTitle', 'Remove Conversation', 'spotterDeleteConversationModalTitle=Remove%20Conversation'],
+            ['spotterPastConversationAlertMessage', 'Viewing past conversation', 'spotterPastConversationAlertMessage=Viewing%20past%20conversation'],
+            ['spotterBestPracticesLabel', 'Help Tips', 'spotterBestPracticesLabel=Help%20Tips'],
+            ['spotterConversationsBatchSize', 50, 'spotterConversationsBatchSize=50'],
+            ['spotterNewChatButtonTitle', 'Start New Conversation', 'spotterNewChatButtonTitle=Start%20New%20Conversation'],
+            ['spotterDocumentationUrl', 'https://docs.example.com/spotter', 'spotterDocumentationUrl=https%3A%2F%2Fdocs.example.com%2Fspotter'],
+        ])('should render with %s', async (configKey, configValue, expectedParam) => {
+            const viewConfig: SpotterEmbedViewConfig = {
+                worksheetId: 'worksheetId',
+                [configKey]: configValue,
+            };
+            const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+            await conversationEmbed.render();
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&${expectedParam}#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+            );
+        });
 
-    it('should render with spotterSidebarDefaultExpanded set to true', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterSidebarDefaultExpanded: true,
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
+        it.each([
+            ['invalid URL format', 'invalid-url'],
+            ['invalid protocol (ftp)', 'ftp://docs.example.com/spotter'],
+        ])('should handle error for spotterDocumentationUrl with %s', async (_, invalidUrl) => {
+            const viewConfig: SpotterEmbedViewConfig = {
+                worksheetId: 'worksheetId',
+                spotterDocumentationUrl: invalidUrl,
+            };
+            const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+            (conversationEmbed as any).handleError = jest.fn();
+            await conversationEmbed.render();
+            expect((conversationEmbed as any).handleError).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    errorType: ErrorDetailsTypes.VALIDATION_ERROR,
+                    message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
+                    code: EmbedErrorCodes.INVALID_URL,
+                }),
+            );
+        });
 
-    it('should render with spotterChatRenameLabel', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterChatRenameLabel: 'Edit Name',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterChatRenameLabel=Edit%20Name#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterChatDeleteLabel', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterChatDeleteLabel: 'Remove',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterChatDeleteLabel=Remove#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterDeleteConversationModalTitle', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterDeleteConversationModalTitle: 'Remove Conversation',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterDeleteConversationModalTitle=Remove%20Conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterPastConversationAlertMessage', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterPastConversationAlertMessage: 'Viewing past conversation',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterPastConversationAlertMessage=Viewing%20past%20conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterBestPracticesLabel', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterBestPracticesLabel: 'Help Tips',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterBestPracticesLabel=Help%20Tips#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterConversationsBatchSize', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterConversationsBatchSize: 50,
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterConversationsBatchSize=50#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with spotterNewChatButtonTitle', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterNewChatButtonTitle: 'Start New Conversation',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterNewChatButtonTitle=Start%20New%20Conversation#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should render with valid spotterDocumentationUrl', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterDocumentationUrl: 'https://docs.example.com/spotter',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterDocumentationUrl=https%3A%2F%2Fdocs.example.com%2Fspotter#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
-    });
-
-    it('should handle error for invalid spotterDocumentationUrl', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterDocumentationUrl: 'invalid-url',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        (conversationEmbed as any).handleError = jest.fn();
-        await conversationEmbed.render();
-        expect((conversationEmbed as any).handleError).toHaveBeenCalledWith(
-            expect.objectContaining({
-                errorType: ErrorDetailsTypes.VALIDATION_ERROR,
-                message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
-                code: EmbedErrorCodes.INVALID_URL,
-            }),
-        );
-    });
-
-    it('should handle error for spotterDocumentationUrl with invalid protocol', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterDocumentationUrl: 'ftp://docs.example.com/spotter',
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        (conversationEmbed as any).handleError = jest.fn();
-        await conversationEmbed.render();
-        expect((conversationEmbed as any).handleError).toHaveBeenCalledWith(
-            expect.objectContaining({
-                errorType: ErrorDetailsTypes.VALIDATION_ERROR,
-                message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
-                code: EmbedErrorCodes.INVALID_URL,
-            }),
-        );
-    });
-
-    it('should render with multiple sidebar config options', async () => {
-        const viewConfig: SpotterEmbedViewConfig = {
-            worksheetId: 'worksheetId',
-            spotterSidebarTitle: 'Chats',
-            spotterSidebarDefaultExpanded: true,
-            spotterNewChatButtonTitle: 'New',
-            spotterConversationsBatchSize: 25,
-        };
-        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
-        await conversationEmbed.render();
-        expectUrlMatchesWithParams(
-            getIFrameSrc(),
-            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true&spotterSidebarTitle=Chats&spotterConversationsBatchSize=25&spotterNewChatButtonTitle=New#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
-        );
+        it('should render with multiple sidebar config options', async () => {
+            const viewConfig: SpotterEmbedViewConfig = {
+                worksheetId: 'worksheetId',
+                spotterSidebarTitle: 'Chats',
+                spotterSidebarDefaultExpanded: true,
+                spotterNewChatButtonTitle: 'New',
+                spotterConversationsBatchSize: 25,
+            };
+            const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+            await conversationEmbed.render();
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&spotterSidebarDefaultExpanded=true&spotterSidebarTitle=Chats&spotterConversationsBatchSize=25&spotterNewChatButtonTitle=New#/embed/insights/conv-assist?worksheet=worksheetId&query=`,
+            );
+        });
     });
 });

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -15,6 +15,82 @@ export interface SearchOptions {
 }
 
 /**
+ * Configuration for the Spotter sidebar.
+ * Can be used in SpotterEmbed and AppEmbed.
+ * @group Embed components
+ * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+ */
+export interface SpotterSidebarViewConfig {
+    /**
+     * Controls the visibility of the past conversations sidebar.
+     * @default false
+     * @version SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl
+     */
+    enablePastConversationsSidebar?: boolean;
+    /**
+     * Custom title text for the sidebar header.
+     * Defaults to translated "Spotter" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterSidebarTitle?: string;
+    /**
+     * Boolean to set the default expanded state of the sidebar.
+     * @default false
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterSidebarDefaultExpanded?: boolean;
+    /**
+     * Custom label text for the rename action in the conversation edit menu.
+     * Defaults to translated "Rename" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterChatRenameLabel?: string;
+    /**
+     * Custom label text for the delete action in the conversation edit menu.
+     * Defaults to translated "DELETE" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterChatDeleteLabel?: string;
+    /**
+     * Custom title text for the delete conversation confirmation modal.
+     * Defaults to translated "Delete chat" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterDeleteConversationModalTitle?: string;
+    /**
+     * Custom message text for the past conversation banner alert.
+     * Defaults to translated alert message.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterPastConversationAlertMessage?: string;
+    /**
+     * Custom URL for the documentation/best practices link.
+     * Defaults to ThoughtSpot docs URL based on release version.
+     * Note: URL must include the protocol (e.g., `https://www.example.com`).
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterDocumentationUrl?: string;
+    /**
+     * Custom label text for the best practices button in the footer.
+     * Defaults to translated "Best Practices" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterBestPracticesLabel?: string;
+    /**
+     * Number of conversations to fetch per batch when loading conversation history.
+     * @default 30
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterConversationsBatchSize?: number;
+    /**
+     * Custom title text for the "New Chat" button in the sidebar.
+     * Defaults to translated "New Chat" text.
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterNewChatButtonTitle?: string;
+}
+
+/**
  * The configuration for the embedded spotterEmbed options.
  * @group Embed components
  */
@@ -169,23 +245,6 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      */
     excludeRuntimeParametersfromURL?: boolean;
     /**
-     * enablePastConversationsSidebar : Controls the visibility of the past conversations
-     * sidebar.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @default false
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    enablePastConversationsSidebar : true,
-     * })
-     * ```
-     * @version SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl
-     */
-    enablePastConversationsSidebar?: boolean;
-
-    /**
      * updatedSpotterChatPrompt : Controls the updated spotter chat prompt.
      *
      * Supported embed types: `SpotterEmbed`
@@ -201,156 +260,23 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      */
     updatedSpotterChatPrompt?: boolean;
     /**
-     * Custom title text for the sidebar header.
-     * Defaults to translated "Spotter" text.
+     * Configuration for the Spotter sidebar UI customization.
      *
-     * Supported embed types: `SpotterEmbed`
+     * Supported embed types: `SpotterEmbed`, `AppEmbed`
      * @example
      * ```js
      * const embed = new SpotterEmbed('#tsEmbed', {
      *    ... //other embed view config
-     *    spotterSidebarTitle: 'My Conversations',
+     *    spotterSidebarConfig: {
+     *        enablePastConversationsSidebar: true,
+     *        spotterSidebarTitle: 'My Conversations',
+     *        spotterSidebarDefaultExpanded: true,
+     *    },
      * })
      * ```
      * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
      */
-    spotterSidebarTitle?: string;
-    /**
-     * Boolean to set the default expanded state of the sidebar.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @default false
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterSidebarDefaultExpanded: true,
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterSidebarDefaultExpanded?: boolean;
-    /**
-     * Custom label text for the rename action in the conversation edit menu.
-     * Defaults to translated "Rename" text.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterChatRenameLabel: 'Edit Name',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterChatRenameLabel?: string;
-    /**
-     * Custom label text for the delete action in the conversation edit menu.
-     * Defaults to translated "DELETE" text.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterChatDeleteLabel: 'Remove',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterChatDeleteLabel?: string;
-    /**
-     * Custom title text for the delete conversation confirmation modal.
-     * Defaults to translated "Delete chat" text.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterDeleteConversationModalTitle: 'Remove Conversation',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterDeleteConversationModalTitle?: string;
-    /**
-     * Custom message text for the past conversation banner alert.
-     * Defaults to translated alert message.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterPastConversationAlertMessage: 'You are viewing a past conversation',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterPastConversationAlertMessage?: string;
-    /**
-     * Custom URL for the documentation/best practices link.
-     * Defaults to ThoughtSpot docs URL based on release version.
-     * Note: URL must include the protocol (e.g., `https://www.example.com`).
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterDocumentationUrl: 'https://docs.example.com/spotter',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterDocumentationUrl?: string;
-    /**
-     * Custom label text for the best practices button in the footer.
-     * Defaults to translated "Best Practices" text.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterBestPracticesLabel: 'Help & Tips',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterBestPracticesLabel?: string;
-    /**
-     * Number of conversations to fetch per batch when loading conversation history.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @default 30
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterConversationsBatchSize: 50,
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterConversationsBatchSize?: number;
-    /**
-     * Custom title text for the "New Chat" button in the sidebar.
-     * Defaults to translated "New Chat" text.
-     *
-     * Supported embed types: `SpotterEmbed`
-     * @example
-     * ```js
-     * const embed = new SpotterEmbed('#tsEmbed', {
-     *    ... //other embed view config
-     *    spotterNewChatButtonTitle: 'Start New Conversation',
-     * })
-     * ```
-     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
-     */
-    spotterNewChatButtonTitle?: string;
+    spotterSidebarConfig?: SpotterSidebarViewConfig;
 }
 
 /**
@@ -397,12 +323,17 @@ export class SpotterEmbed extends TsEmbed {
             dataPanelV2,
             showSpotterLimitations,
             hideSampleQuestions,
-            enablePastConversationsSidebar,
             runtimeFilters,
             excludeRuntimeFiltersfromURL,
             runtimeParameters,
             excludeRuntimeParametersfromURL,
             updatedSpotterChatPrompt,
+            spotterSidebarConfig,
+        } = this.viewConfig;
+
+        // Extract sidebar config properties
+        const {
+            enablePastConversationsSidebar,
             spotterSidebarTitle,
             spotterSidebarDefaultExpanded,
             spotterChatRenameLabel,
@@ -413,7 +344,7 @@ export class SpotterEmbed extends TsEmbed {
             spotterBestPracticesLabel,
             spotterConversationsBatchSize,
             spotterNewChatButtonTitle,
-        } = this.viewConfig;
+        } = spotterSidebarConfig || {};
 
         if (!worksheetId) {
             this.handleError({
@@ -471,11 +402,12 @@ export class SpotterEmbed extends TsEmbed {
             excludeRuntimeFiltersfromURL,
             runtimeParameters,
             excludeRuntimeParametersfromURL,
-            enablePastConversationsSidebar,
+            spotterSidebarConfig,
         } = this.viewConfig;
         const path = 'insights/conv-assist';
         const queryParams = this.getEmbedParamsObject();
 
+        const enablePastConversationsSidebar = spotterSidebarConfig?.enablePastConversationsSidebar;
         if (!isUndefined(enablePastConversationsSidebar)) {
             queryParams[Param.EnablePastConversationsSidebar] = !!enablePastConversationsSidebar;
         }

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import { ERROR_MESSAGE } from '../errors';
 import { Param, BaseViewConfig, RuntimeFilter, RuntimeParameter, ErrorDetailsTypes, EmbedErrorCodes } from '../types';
 import { TsEmbed } from './ts-embed';
-import { getQueryParamString, getFilterQuery, getRuntimeParameters } from '../utils';
+import { getQueryParamString, getFilterQuery, getRuntimeParameters, validateHttpUrl, setParamIfDefined } from '../utils';
 
 /**
  * Configuration for search options
@@ -200,6 +200,157 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      * @version SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl
      */
     updatedSpotterChatPrompt?: boolean;
+    /**
+     * Custom title text for the sidebar header.
+     * Defaults to translated "Spotter" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterSidebarTitle: 'My Conversations',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterSidebarTitle?: string;
+    /**
+     * Boolean to set the default expanded state of the sidebar.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @default false
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterSidebarDefaultExpanded: true,
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterSidebarDefaultExpanded?: boolean;
+    /**
+     * Custom label text for the rename action in the conversation edit menu.
+     * Defaults to translated "Rename" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterChatRenameLabel: 'Edit Name',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterChatRenameLabel?: string;
+    /**
+     * Custom label text for the delete action in the conversation edit menu.
+     * Defaults to translated "DELETE" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterChatDeleteLabel: 'Remove',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterChatDeleteLabel?: string;
+    /**
+     * Custom title text for the delete conversation confirmation modal.
+     * Defaults to translated "Delete chat" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterDeleteConversationModalTitle: 'Remove Conversation',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterDeleteConversationModalTitle?: string;
+    /**
+     * Custom message text for the past conversation banner alert.
+     * Defaults to translated alert message.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterPastConversationAlertMessage: 'You are viewing a past conversation',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterPastConversationAlertMessage?: string;
+    /**
+     * Custom URL for the documentation/best practices link.
+     * Defaults to ThoughtSpot docs URL based on release version.
+     * Note: URL must include the protocol (e.g., `https://www.example.com`).
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterDocumentationUrl: 'https://docs.example.com/spotter',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterDocumentationUrl?: string;
+    /**
+     * Custom label text for the best practices button in the footer.
+     * Defaults to translated "Best Practices" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterBestPracticesLabel: 'Help & Tips',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterBestPracticesLabel?: string;
+    /**
+     * Number of conversations to fetch per batch when loading conversation history.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @default 30
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterConversationsBatchSize: 50,
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterConversationsBatchSize?: number;
+    /**
+     * Custom title text for the "New Chat" button in the sidebar.
+     * Defaults to translated "New Chat" text.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterNewChatButtonTitle: 'Start New Conversation',
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    spotterNewChatButtonTitle?: string;
 }
 
 /**
@@ -252,6 +403,16 @@ export class SpotterEmbed extends TsEmbed {
             runtimeParameters,
             excludeRuntimeParametersfromURL,
             updatedSpotterChatPrompt,
+            spotterSidebarTitle,
+            spotterSidebarDefaultExpanded,
+            spotterChatRenameLabel,
+            spotterChatDeleteLabel,
+            spotterDeleteConversationModalTitle,
+            spotterPastConversationAlertMessage,
+            spotterDocumentationUrl,
+            spotterBestPracticesLabel,
+            spotterConversationsBatchSize,
+            spotterNewChatButtonTitle,
         } = this.viewConfig;
 
         if (!worksheetId) {
@@ -264,27 +425,39 @@ export class SpotterEmbed extends TsEmbed {
         }
         const queryParams = this.getBaseQueryParams();
         queryParams[Param.SpotterEnabled] = true;
-        if (!isUndefined(disableSourceSelection)) {
-            queryParams[Param.DisableSourceSelection] = !!disableSourceSelection;
-        }
-        if (!isUndefined(hideSourceSelection)) {
-            queryParams[Param.HideSourceSelection] = !!hideSourceSelection;
-        }
 
-        if (!isUndefined(dataPanelV2)) {
-            queryParams[Param.DataPanelV2Enabled] = !!dataPanelV2;
-        }
+        // Boolean params
+        setParamIfDefined(queryParams, Param.DisableSourceSelection, disableSourceSelection, true);
+        setParamIfDefined(queryParams, Param.HideSourceSelection, hideSourceSelection, true);
+        setParamIfDefined(queryParams, Param.DataPanelV2Enabled, dataPanelV2, true);
+        setParamIfDefined(queryParams, Param.ShowSpotterLimitations, showSpotterLimitations, true);
+        setParamIfDefined(queryParams, Param.HideSampleQuestions, hideSampleQuestions, true);
+        setParamIfDefined(queryParams, Param.UpdatedSpotterChatPrompt, updatedSpotterChatPrompt, true);
+        setParamIfDefined(queryParams, Param.SpotterSidebarDefaultExpanded, spotterSidebarDefaultExpanded, true);
 
-        if (!isUndefined(showSpotterLimitations)) {
-            queryParams[Param.ShowSpotterLimitations] = !!showSpotterLimitations;
-        }
+        // String params
+        setParamIfDefined(queryParams, Param.SpotterSidebarTitle, spotterSidebarTitle);
+        setParamIfDefined(queryParams, Param.SpotterChatRenameLabel, spotterChatRenameLabel);
+        setParamIfDefined(queryParams, Param.SpotterChatDeleteLabel, spotterChatDeleteLabel);
+        setParamIfDefined(queryParams, Param.SpotterDeleteConversationModalTitle, spotterDeleteConversationModalTitle);
+        setParamIfDefined(queryParams, Param.SpotterPastConversationAlertMessage, spotterPastConversationAlertMessage);
+        setParamIfDefined(queryParams, Param.SpotterBestPracticesLabel, spotterBestPracticesLabel);
+        setParamIfDefined(queryParams, Param.SpotterConversationsBatchSize, spotterConversationsBatchSize);
+        setParamIfDefined(queryParams, Param.SpotterNewChatButtonTitle, spotterNewChatButtonTitle);
 
-        if (!isUndefined(hideSampleQuestions)) {
-            queryParams[Param.HideSampleQuestions] = !!hideSampleQuestions;
-        }
-
-        if (!isUndefined(updatedSpotterChatPrompt)) {
-            queryParams[Param.UpdatedSpotterChatPrompt] = !!updatedSpotterChatPrompt;
+        // URL param with validation
+        if (spotterDocumentationUrl !== undefined) {
+            const [isValid, validationError] = validateHttpUrl(spotterDocumentationUrl);
+            if (isValid) {
+                queryParams[Param.SpotterDocumentationUrl] = spotterDocumentationUrl;
+            } else {
+                this.handleError({
+                    errorType: ErrorDetailsTypes.VALIDATION_ERROR,
+                    message: ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
+                    code: EmbedErrorCodes.INVALID_URL,
+                    error: validationError?.message || ERROR_MESSAGE.INVALID_SPOTTER_DOCUMENTATION_URL,
+                });
+            }
         }
 
         return queryParams;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,6 +29,7 @@ export const ERROR_MESSAGE = {
     ERROR_PARSING_API_INTERCEPT_BODY: 'Error parsing api intercept body',
     SSR_ENVIRONMENT_ERROR: 'SSR environment detected. This function cannot be called in SSR environment.',
     UPDATE_PARAMS_FAILED: 'Failed to update embed parameters',
+    INVALID_SPOTTER_DOCUMENTATION_URL: 'Invalid spotterDocumentationUrl. Please provide a valid http or https URL.',
 };
 
 export const CUSTOM_ACTIONS_ERROR_MESSAGE = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { PinboardEmbed, LiveboardViewConfig, LiveboardEmbed } from './embed/live
 import { SearchEmbed, SearchViewConfig } from './embed/search';
 import { SearchBarEmbed, SearchBarViewConfig } from './embed/search-bar';
 import { SpotterAgentEmbed, SpotterAgentEmbedViewConfig, BodylessConversation, BodylessConversationViewConfig} from './embed/bodyless-conversation';
-import { SpotterEmbed, SpotterEmbedViewConfig, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
+import { SpotterEmbed, SpotterEmbedViewConfig, SpotterSidebarViewConfig, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
 import {
     AuthFailureType, AuthStatus, AuthEvent, AuthEventEmitter,
 } from './auth';
@@ -106,6 +106,7 @@ export {
     BodylessConversation,
     SpotterEmbed,
     SpotterEmbedViewConfig,
+    SpotterSidebarViewConfig,
     ConversationViewConfig,
     ConversationEmbed,
     AuthFailureType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3203,6 +3203,42 @@ export enum EmbedEvent {
      * @version SDK: 1.43.0 | ThoughtSpot: 10.15.0.cl
      */
     ApiIntercept = 'ApiIntercept',
+    /**
+     * Emitted when a Spotter conversation is renamed.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationRenamed, (payload) => {
+     *     console.log('Conversation renamed', payload);
+     *     // payload: { convId: string, oldTitle: string, newTitle: string }
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    SpotterConversationRenamed = 'spotterConversationRenamed',
+    /**
+     * Emitted when a Spotter conversation is deleted.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationDeleted, (payload) => {
+     *     console.log('Conversation deleted', payload);
+     *     // payload: { convId: string, title: string }
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    SpotterConversationDeleted = 'spotterConversationDeleted',
+    /**
+     * Emitted when a Spotter conversation is selected/clicked.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationSelected, (payload) => {
+     *     console.log('Conversation selected', payload);
+     *     // payload: { convId: string, title: string, worksheetId: string }
+     * })
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
+     */
+    SpotterConversationSelected = 'spotterConversationSelected',
     
     /**
      * @hidden
@@ -4771,6 +4807,16 @@ export enum Param {
     isLinkParametersEnabled = 'isLinkParametersEnabled',
     EnablePastConversationsSidebar = 'enablePastConversationsSidebar',
     UpdatedSpotterChatPrompt = 'updatedSpotterChatPrompt',
+    SpotterSidebarTitle = 'spotterSidebarTitle',
+    SpotterSidebarDefaultExpanded = 'spotterSidebarDefaultExpanded',
+    SpotterChatRenameLabel = 'spotterChatRenameLabel',
+    SpotterChatDeleteLabel = 'spotterChatDeleteLabel',
+    SpotterDeleteConversationModalTitle = 'spotterDeleteConversationModalTitle',
+    SpotterPastConversationAlertMessage = 'spotterPastConversationAlertMessage',
+    SpotterDocumentationUrl = 'spotterDocumentationUrl',
+    SpotterBestPracticesLabel = 'spotterBestPracticesLabel',
+    SpotterConversationsBatchSize = 'spotterConversationsBatchSize',
+    SpotterNewChatButtonTitle = 'spotterNewChatButtonTitle',
     IsThisPeriodInDateFiltersEnabled = 'isThisPeriodInDateFiltersEnabled',
 }
 
@@ -6217,6 +6263,96 @@ export enum Action {
      */
     UngroupLiveboardGroup = 'ungroupLiveboardGroup',
     /**
+     * Controls visibility of the sidebar header (title and toggle button)
+     * in the Spotter past conversations sidebar.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterSidebarHeader]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterSidebarHeader = 'spotterSidebarHeader',
+    /**
+     * Controls visibility of the sidebar footer (documentation link)
+     * in the Spotter past conversations sidebar.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterSidebarFooter]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterSidebarFooter = 'spotterSidebarFooter',
+    /**
+     * Controls visibility and disable state of the sidebar toggle/expand button
+     * in the Spotter past conversations sidebar.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterSidebarToggle]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterSidebarToggle = 'spotterSidebarToggle',
+    /**
+     * Controls visibility and disable state of the "New Chat" button
+     * in the Spotter past conversations sidebar.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterNewChat]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterNewChat = 'spotterNewChat',
+    /**
+     * Controls visibility of the past conversation banner alert
+     * in the Spotter interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterPastChatBanner]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterPastChatBanner = 'spotterPastChatBanner',
+    /**
+     * Controls visibility and disable state of the conversation edit menu
+     * (three-dot menu) in the Spotter past conversations sidebar.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterChatMenu]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterChatMenu = 'spotterChatMenu',
+    /**
+     * Controls visibility and disable state of the rename action
+     * in the Spotter conversation edit menu.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterChatRename]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterChatRename = 'spotterChatRename',
+    /**
+     * Controls visibility and disable state of the delete action
+     * in the Spotter conversation edit menu.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterChatDelete]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterChatDelete = 'spotterChatDelete',
+    /**
+     * Controls visibility and disable state of the documentation/best practices
+     * link in the Spotter sidebar footer.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterDocs]
+     * ```
+     * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
+     */
+    SpotterDocs = 'spotterDocs',
+    /**
      * The **Include current period** checkbox for date filters.
      * Controls the visibility and availability of the option to include
      * the current time period in filter results.
@@ -6500,6 +6636,9 @@ export enum EmbedErrorCodes {
 
     /** Failed to update embed parameters during pre-render */
     UPDATE_PARAMS_FAILED = 'UPDATE_PARAMS_FAILED',
+
+    /** Invalid URL provided in configuration */
+    INVALID_URL = 'INVALID_URL',
 }
 
 /**

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -828,100 +828,56 @@ describe('getValueFromWindow and storeValueInWindow', () => {
     });
 
     describe('validateHttpUrl', () => {
-        test('should return [true, null] for valid http URL', () => {
-            const [isValid, error] = validateHttpUrl('http://example.com');
+        test.each([
+            ['http URL', 'http://example.com'],
+            ['https URL', 'https://example.com'],
+            ['https URL with path', 'https://docs.example.com/spotter'],
+            ['https URL with query params', 'https://example.com/path?foo=bar'],
+        ])('should return [true, null] for valid %s', (_, url) => {
+            const [isValid, error] = validateHttpUrl(url);
             expect(isValid).toBe(true);
             expect(error).toBeNull();
         });
 
-        test('should return [true, null] for valid https URL', () => {
-            const [isValid, error] = validateHttpUrl('https://example.com');
-            expect(isValid).toBe(true);
-            expect(error).toBeNull();
-        });
-
-        test('should return [true, null] for https URL with path', () => {
-            const [isValid, error] = validateHttpUrl('https://docs.example.com/spotter');
-            expect(isValid).toBe(true);
-            expect(error).toBeNull();
-        });
-
-        test('should return [true, null] for https URL with query params', () => {
-            const [isValid, error] = validateHttpUrl('https://example.com/path?foo=bar');
-            expect(isValid).toBe(true);
-            expect(error).toBeNull();
-        });
-
-        test('should return [false, Error] for ftp protocol', () => {
-            const [isValid, error] = validateHttpUrl('ftp://example.com');
+        test.each([
+            ['ftp protocol', 'ftp://example.com', 'ftp:'],
+            ['file protocol', 'file:///path/to/file', 'file:'],
+            ['javascript protocol', 'javascript:alert(1)', 'javascript:'],
+        ])('should return [false, Error] for %s', (_, url, protocol) => {
+            const [isValid, error] = validateHttpUrl(url);
             expect(isValid).toBe(false);
             expect(error).toBeInstanceOf(Error);
             expect(error?.message).toContain('Invalid protocol');
-            expect(error?.message).toContain('ftp:');
+            expect(error?.message).toContain(protocol);
         });
 
-        test('should return [false, Error] for file protocol', () => {
-            const [isValid, error] = validateHttpUrl('file:///path/to/file');
-            expect(isValid).toBe(false);
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.message).toContain('Invalid protocol');
-        });
-
-        test('should return [false, Error] for javascript protocol', () => {
-            const [isValid, error] = validateHttpUrl('javascript:alert(1)');
-            expect(isValid).toBe(false);
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.message).toContain('Invalid protocol');
-        });
-
-        test('should return [false, Error] for invalid URL format', () => {
-            const [isValid, error] = validateHttpUrl('not-a-valid-url');
-            expect(isValid).toBe(false);
-            expect(error).toBeInstanceOf(Error);
-        });
-
-        test('should return [false, Error] for empty string', () => {
-            const [isValid, error] = validateHttpUrl('');
-            expect(isValid).toBe(false);
-            expect(error).toBeInstanceOf(Error);
-        });
-
-        test('should return [false, Error] for URL without protocol', () => {
-            const [isValid, error] = validateHttpUrl('example.com');
+        test.each([
+            ['invalid URL format', 'not-a-valid-url'],
+            ['empty string', ''],
+            ['URL without protocol', 'example.com'],
+        ])('should return [false, Error] for %s', (_, url) => {
+            const [isValid, error] = validateHttpUrl(url);
             expect(isValid).toBe(false);
             expect(error).toBeInstanceOf(Error);
         });
     });
 
     describe('setParamIfDefined', () => {
-        test('should set param when value is defined', () => {
+        test.each([
+            ['string value', 'testParam', 'testValue', false, 'testValue'],
+            ['number value', 'numParam', 42, false, 42],
+            ['truthy value as boolean', 'boolParam', 'truthy', true, true],
+            ['falsy value as boolean', 'boolParam', 0, true, false],
+        ])('should set %s correctly', (_, param, value, asBoolean, expected) => {
             const queryParams: Record<string, unknown> = {};
-            setParamIfDefined(queryParams, 'testParam', 'testValue');
-            expect(queryParams.testParam).toBe('testValue');
+            setParamIfDefined(queryParams, param, value, asBoolean);
+            expect(queryParams[param]).toBe(expected);
         });
 
         test('should not set param when value is undefined', () => {
             const queryParams: Record<string, unknown> = {};
             setParamIfDefined(queryParams, 'testParam', undefined);
             expect(queryParams.testParam).toBeUndefined();
-        });
-
-        test('should coerce value to boolean when asBoolean is true', () => {
-            const queryParams: Record<string, unknown> = {};
-            setParamIfDefined(queryParams, 'boolParam', 'truthy', true);
-            expect(queryParams.boolParam).toBe(true);
-        });
-
-        test('should coerce falsy value to false when asBoolean is true', () => {
-            const queryParams: Record<string, unknown> = {};
-            setParamIfDefined(queryParams, 'boolParam', 0, true);
-            expect(queryParams.boolParam).toBe(false);
-        });
-
-        test('should preserve original value when asBoolean is false', () => {
-            const queryParams: Record<string, unknown> = {};
-            setParamIfDefined(queryParams, 'numParam', 42);
-            expect(queryParams.numParam).toBe(42);
         });
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -581,3 +581,39 @@ export const isWindowUndefined = (): boolean => {
     }
     return false;
 }
+
+/**
+ * Validates that a URL uses only http: or https: protocols.
+ * Returns a tuple of [isValid, error] so the caller can handle validation errors.
+ * @param url - The URL string to validate
+ * @returns [true, null] if valid, [false, Error] if invalid
+ */
+export const validateHttpUrl = (url: string): [boolean, Error | null] => {
+    try {
+        const parsedUrl = new URL(url);
+        if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+            return [false, new Error(`Invalid protocol: ${parsedUrl.protocol}. Only http: and https: are allowed.`)];
+        }
+        return [true, null];
+    } catch (error) {
+        return [false, error instanceof Error ? error : new Error(String(error))];
+    }
+};
+
+/**
+ * Sets a query parameter if the value is defined.
+ * @param queryParams - The query params object to modify
+ * @param param - The parameter key
+ * @param value - The value to set
+ * @param asBoolean - If true, coerces value to boolean
+ */
+export const setParamIfDefined = <T>(
+    queryParams: Record<string, unknown>,
+    param: string,
+    value: T | undefined,
+    asBoolean = false,
+): void => {
+    if (value !== undefined) {
+        queryParams[param] = asBoolean ? !!value : value;
+    }
+};

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2251,
+			"id": 2243,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2365,
+					"id": 2357,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -55,7 +55,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2271,
+					"id": 2263,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -83,7 +83,7 @@
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2264,
+					"id": 2256,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -111,7 +111,7 @@
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2263,
+					"id": 2255,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -135,7 +135,7 @@
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2269,
+					"id": 2261,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -159,7 +159,7 @@
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2270,
+					"id": 2262,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -183,7 +183,7 @@
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2272,
+					"id": 2264,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -211,7 +211,7 @@
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2347,
+					"id": 2339,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -239,7 +239,7 @@
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2320,
+					"id": 2312,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -267,7 +267,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2362,
+					"id": 2354,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -295,7 +295,7 @@
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2319,
+					"id": 2311,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -323,7 +323,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2318,
+					"id": 2310,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -351,7 +351,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2361,
+					"id": 2353,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -380,7 +380,7 @@
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2331,
+					"id": 2323,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -408,7 +408,7 @@
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2334,
+					"id": 2326,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -436,7 +436,7 @@
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2339,
+					"id": 2331,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -464,7 +464,7 @@
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2333,
+					"id": 2325,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -492,7 +492,7 @@
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2336,
+					"id": 2328,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -520,7 +520,7 @@
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2340,
+					"id": 2332,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -548,7 +548,7 @@
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2337,
+					"id": 2329,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -576,7 +576,7 @@
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2342,
+					"id": 2334,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -604,7 +604,7 @@
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2338,
+					"id": 2330,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -632,7 +632,7 @@
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2335,
+					"id": 2327,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -660,7 +660,7 @@
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2341,
+					"id": 2333,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -688,7 +688,7 @@
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2332,
+					"id": 2324,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -716,7 +716,7 @@
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2374,
+					"id": 2366,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -744,7 +744,7 @@
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2268,
+					"id": 2260,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -768,7 +768,7 @@
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2267,
+					"id": 2259,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -796,7 +796,7 @@
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2266,
+					"id": 2258,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -824,7 +824,7 @@
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2382,
+					"id": 2374,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -852,7 +852,7 @@
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2265,
+					"id": 2257,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -876,7 +876,7 @@
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2311,
+					"id": 2303,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -891,7 +891,7 @@
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2258,
+					"id": 2250,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -915,7 +915,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2310,
+					"id": 2302,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -939,7 +939,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2383,
+					"id": 2375,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -967,7 +967,7 @@
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2397,
+					"id": 2389,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -995,7 +995,7 @@
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2359,
+					"id": 2351,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1023,7 +1023,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2322,
+					"id": 2314,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1051,7 +1051,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2327,
+					"id": 2319,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1079,7 +1079,7 @@
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2375,
+					"id": 2367,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1107,7 +1107,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2380,
+					"id": 2372,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1135,7 +1135,7 @@
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2371,
+					"id": 2363,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1163,7 +1163,7 @@
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2373,
+					"id": 2365,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1191,7 +1191,7 @@
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2280,
+					"id": 2272,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1215,7 +1215,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2283,
+					"id": 2275,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1239,7 +1239,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2282,
+					"id": 2274,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1264,7 +1264,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2281,
+					"id": 2273,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1288,7 +1288,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2284,
+					"id": 2276,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1312,7 +1312,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2285,
+					"id": 2277,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1340,7 +1340,7 @@
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2315,
+					"id": 2307,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1364,7 +1364,7 @@
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2309,
+					"id": 2301,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1388,7 +1388,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2308,
+					"id": 2300,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1412,7 +1412,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2293,
+					"id": 2285,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1436,7 +1436,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2257,
+					"id": 2249,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1460,7 +1460,7 @@
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2321,
+					"id": 2313,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1488,7 +1488,7 @@
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2313,
+					"id": 2305,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1503,7 +1503,7 @@
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2379,
+					"id": 2371,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1531,7 +1531,7 @@
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2351,
+					"id": 2343,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1559,7 +1559,7 @@
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2366,
+					"id": 2358,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1587,7 +1587,7 @@
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2290,
+					"id": 2282,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1611,7 +1611,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2294,
+					"id": 2286,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1635,7 +1635,7 @@
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2381,
+					"id": 2373,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1663,7 +1663,7 @@
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2348,
+					"id": 2340,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1691,7 +1691,7 @@
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2349,
+					"id": 2341,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1719,7 +1719,7 @@
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2307,
+					"id": 2299,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1743,7 +1743,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2287,
+					"id": 2279,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1768,7 +1768,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2288,
+					"id": 2280,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1792,7 +1792,7 @@
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2384,
+					"id": 2376,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1820,7 +1820,7 @@
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2408,
+					"id": 2400,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1848,7 +1848,7 @@
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2372,
+					"id": 2364,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1876,7 +1876,7 @@
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2301,
+					"id": 2293,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1900,7 +1900,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2390,
+					"id": 2382,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1928,7 +1928,7 @@
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2357,
+					"id": 2349,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1956,7 +1956,7 @@
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2256,
+					"id": 2248,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1980,7 +1980,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2355,
+					"id": 2347,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2004,7 +2004,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2326,
+					"id": 2318,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2032,7 +2032,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2392,
+					"id": 2384,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2060,7 +2060,7 @@
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2370,
+					"id": 2362,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2088,7 +2088,7 @@
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2346,
+					"id": 2338,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2116,7 +2116,7 @@
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2353,
+					"id": 2345,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2143,7 +2143,7 @@
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2396,
+					"id": 2388,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2171,7 +2171,7 @@
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2395,
+					"id": 2387,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2199,7 +2199,7 @@
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2354,
+					"id": 2346,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,7 +2223,7 @@
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2364,
+					"id": 2356,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,7 +2251,7 @@
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2394,
+					"id": 2386,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,7 +2279,7 @@
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2367,
+					"id": 2359,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,7 +2307,7 @@
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2356,
+					"id": 2348,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2335,7 +2335,7 @@
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2304,
+					"id": 2296,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2359,7 +2359,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2388,
+					"id": 2380,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2383,7 +2383,7 @@
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2291,
+					"id": 2283,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2407,7 +2407,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2376,
+					"id": 2368,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2435,7 +2435,7 @@
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2391,
+					"id": 2383,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2463,7 +2463,7 @@
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2317,
+					"id": 2309,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2488,7 +2488,7 @@
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2295,
+					"id": 2287,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2512,7 +2512,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2389,
+					"id": 2381,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2540,7 +2540,7 @@
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2330,
+					"id": 2322,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2568,7 +2568,7 @@
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2363,
+					"id": 2355,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2596,7 +2596,7 @@
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2344,
+					"id": 2336,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2624,7 +2624,7 @@
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2323,
+					"id": 2315,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2655,7 +2655,7 @@
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2316,
+					"id": 2308,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2679,7 +2679,7 @@
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2345,
+					"id": 2337,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2707,7 +2707,7 @@
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2377,
+					"id": 2369,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2735,7 +2735,7 @@
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2352,
+					"id": 2344,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2763,7 +2763,7 @@
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2252,
+					"id": 2244,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2787,7 +2787,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2255,
+					"id": 2247,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2811,7 +2811,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2260,
+					"id": 2252,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2835,7 +2835,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2261,
+					"id": 2253,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2859,7 +2859,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2314,
+					"id": 2306,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2874,7 +2874,7 @@
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2262,
+					"id": 2254,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2898,7 +2898,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2277,
+					"id": 2269,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2916,7 +2916,7 @@
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2350,
+					"id": 2342,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2944,7 +2944,7 @@
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2279,
+					"id": 2271,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2968,7 +2968,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2274,
+					"id": 2266,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2992,7 +2992,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2406,
+					"id": 2398,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3020,7 +3020,7 @@
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2404,
+					"id": 2396,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3048,7 +3048,7 @@
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2405,
+					"id": 2397,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3076,7 +3076,7 @@
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2407,
+					"id": 2399,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3104,7 +3104,7 @@
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2378,
+					"id": 2370,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3132,7 +3132,7 @@
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2402,
+					"id": 2394,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3160,7 +3160,7 @@
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2403,
+					"id": 2395,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3188,7 +3188,7 @@
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2400,
+					"id": 2392,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3216,7 +3216,7 @@
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2399,
+					"id": 2391,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3244,7 +3244,7 @@
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2401,
+					"id": 2393,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3272,7 +3272,7 @@
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2387,
+					"id": 2379,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3300,7 +3300,7 @@
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2385,
+					"id": 2377,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3328,7 +3328,7 @@
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2386,
+					"id": 2378,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3356,7 +3356,7 @@
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2306,
+					"id": 2298,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3380,7 +3380,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2325,
+					"id": 2317,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3408,7 +3408,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2324,
+					"id": 2316,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3436,7 +3436,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2328,
+					"id": 2320,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3464,7 +3464,7 @@
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2329,
+					"id": 2321,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3492,7 +3492,7 @@
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2358,
+					"id": 2350,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3524,7 +3524,7 @@
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2292,
+					"id": 2284,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3548,7 +3548,7 @@
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2398,
+					"id": 2390,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3576,7 +3576,7 @@
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2393,
+					"id": 2385,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3604,7 +3604,7 @@
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2369,
+					"id": 2361,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3632,7 +3632,7 @@
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2289,
+					"id": 2281,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3656,7 +3656,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2360,
+					"id": 2352,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3684,7 +3684,7 @@
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2368,
+					"id": 2360,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3717,145 +3717,145 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2365,
-						2271,
-						2264,
-						2263,
-						2269,
-						2270,
-						2272,
-						2347,
-						2320,
-						2362,
-						2319,
-						2318,
-						2361,
-						2331,
-						2334,
-						2339,
-						2333,
-						2336,
-						2340,
-						2337,
-						2342,
-						2338,
-						2335,
-						2341,
-						2332,
-						2374,
-						2268,
-						2267,
-						2266,
-						2382,
-						2265,
-						2311,
-						2258,
-						2310,
-						2383,
-						2397,
-						2359,
-						2322,
-						2327,
-						2375,
-						2380,
-						2371,
-						2373,
-						2280,
-						2283,
-						2282,
-						2281,
-						2284,
-						2285,
-						2315,
-						2309,
-						2308,
-						2293,
-						2257,
-						2321,
-						2313,
-						2379,
-						2351,
-						2366,
-						2290,
-						2294,
-						2381,
-						2348,
-						2349,
-						2307,
-						2287,
-						2288,
-						2384,
-						2408,
-						2372,
-						2301,
-						2390,
 						2357,
+						2263,
 						2256,
-						2355,
-						2326,
-						2392,
-						2370,
-						2346,
-						2353,
-						2396,
-						2395,
-						2354,
-						2364,
-						2394,
-						2367,
-						2356,
-						2304,
-						2388,
-						2291,
-						2376,
-						2391,
-						2317,
-						2295,
-						2389,
-						2330,
-						2363,
-						2344,
-						2323,
-						2316,
-						2345,
-						2377,
-						2352,
-						2252,
 						2255,
-						2260,
 						2261,
-						2314,
 						2262,
-						2277,
-						2350,
-						2279,
-						2274,
-						2406,
-						2404,
-						2405,
-						2407,
-						2378,
-						2402,
-						2403,
-						2400,
-						2399,
-						2401,
-						2387,
-						2385,
-						2386,
-						2306,
+						2264,
+						2339,
+						2312,
+						2354,
+						2311,
+						2310,
+						2353,
+						2323,
+						2326,
+						2331,
 						2325,
-						2324,
 						2328,
+						2332,
 						2329,
+						2334,
+						2330,
+						2327,
+						2333,
+						2324,
+						2366,
+						2260,
+						2259,
+						2258,
+						2374,
+						2257,
+						2303,
+						2250,
+						2302,
+						2375,
+						2389,
+						2351,
+						2314,
+						2319,
+						2367,
+						2372,
+						2363,
+						2365,
+						2272,
+						2275,
+						2274,
+						2273,
+						2276,
+						2277,
+						2307,
+						2301,
+						2300,
+						2285,
+						2249,
+						2313,
+						2305,
+						2371,
+						2343,
 						2358,
-						2292,
-						2398,
-						2393,
+						2282,
+						2286,
+						2373,
+						2340,
+						2341,
+						2299,
+						2279,
+						2280,
+						2376,
+						2400,
+						2364,
+						2293,
+						2382,
+						2349,
+						2248,
+						2347,
+						2318,
+						2384,
+						2362,
+						2338,
+						2345,
+						2388,
+						2387,
+						2346,
+						2356,
+						2386,
+						2359,
+						2348,
+						2296,
+						2380,
+						2283,
+						2368,
+						2383,
+						2309,
+						2287,
+						2381,
+						2322,
+						2355,
+						2336,
+						2315,
+						2308,
+						2337,
 						2369,
-						2289,
-						2360,
-						2368
+						2344,
+						2244,
+						2247,
+						2252,
+						2253,
+						2306,
+						2254,
+						2269,
+						2342,
+						2271,
+						2266,
+						2398,
+						2396,
+						2397,
+						2399,
+						2370,
+						2394,
+						2395,
+						2392,
+						2391,
+						2393,
+						2379,
+						2377,
+						2378,
+						2298,
+						2317,
+						2316,
+						2320,
+						2321,
+						2350,
+						2284,
+						2390,
+						2385,
+						2361,
+						2281,
+						2352,
+						2360
 					]
 				}
 			],
@@ -3868,7 +3868,7 @@
 			]
 		},
 		{
-			"id": 1884,
+			"id": 1876,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3884,7 +3884,7 @@
 			},
 			"children": [
 				{
-					"id": 1885,
+					"id": 1877,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3907,7 +3907,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1885
+						1877
 					]
 				}
 			],
@@ -3920,7 +3920,7 @@
 			]
 		},
 		{
-			"id": 1869,
+			"id": 1861,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3936,7 +3936,7 @@
 			},
 			"children": [
 				{
-					"id": 1872,
+					"id": 1864,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3951,7 +3951,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1874,
+					"id": 1866,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3966,7 +3966,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1871,
+					"id": 1863,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3981,7 +3981,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1873,
+					"id": 1865,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3996,7 +3996,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1870,
+					"id": 1862,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4011,7 +4011,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1875,
+					"id": 1867,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,12 +4031,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1872,
-						1874,
-						1871,
-						1873,
-						1870,
-						1875
+						1864,
+						1866,
+						1863,
+						1865,
+						1862,
+						1867
 					]
 				}
 			],
@@ -4049,7 +4049,7 @@
 			]
 		},
 		{
-			"id": 1876,
+			"id": 1868,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4065,7 +4065,7 @@
 			},
 			"children": [
 				{
-					"id": 1877,
+					"id": 1869,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4083,7 +4083,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1881,
+					"id": 1873,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4101,7 +4101,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1883,
+					"id": 1875,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4119,7 +4119,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1878,
+					"id": 1870,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4137,7 +4137,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1880,
+					"id": 1872,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4155,7 +4155,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1882,
+					"id": 1874,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4184,12 +4184,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1877,
-						1881,
-						1883,
-						1878,
-						1880,
-						1882
+						1869,
+						1873,
+						1875,
+						1870,
+						1872,
+						1874
 					]
 				}
 			],
@@ -4202,7 +4202,7 @@
 			]
 		},
 		{
-			"id": 2031,
+			"id": 2023,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4218,7 +4218,7 @@
 			},
 			"children": [
 				{
-					"id": 2042,
+					"id": 2034,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4237,7 +4237,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 2033,
+					"id": 2025,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4266,7 +4266,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 2032,
+					"id": 2024,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4290,7 +4290,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 2038,
+					"id": 2030,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4308,7 +4308,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 2036,
+					"id": 2028,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4341,7 +4341,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 2040,
+					"id": 2032,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4365,7 +4365,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 2041,
+					"id": 2033,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4398,13 +4398,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2042,
-						2033,
+						2034,
+						2025,
+						2024,
+						2030,
+						2028,
 						2032,
-						2038,
-						2036,
-						2040,
-						2041
+						2033
 					]
 				}
 			],
@@ -4417,7 +4417,7 @@
 			]
 		},
 		{
-			"id": 2409,
+			"id": 2401,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4427,7 +4427,7 @@
 			},
 			"children": [
 				{
-					"id": 2412,
+					"id": 2404,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4442,7 +4442,7 @@
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2410,
+					"id": 2402,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4457,7 +4457,7 @@
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2411,
+					"id": 2403,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4477,9 +4477,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2412,
-						2410,
-						2411
+						2404,
+						2402,
+						2403
 					]
 				}
 			],
@@ -4492,14 +4492,14 @@
 			]
 		},
 		{
-			"id": 2242,
+			"id": 2234,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2245,
+					"id": 2237,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4517,7 +4517,7 @@
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2244,
+					"id": 2236,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4535,7 +4535,7 @@
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2243,
+					"id": 2235,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4553,7 +4553,7 @@
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2246,
+					"id": 2238,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4576,10 +4576,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2245,
-						2244,
-						2243,
-						2246
+						2237,
+						2236,
+						2235,
+						2238
 					]
 				}
 			],
@@ -4592,7 +4592,7 @@
 			]
 		},
 		{
-			"id": 3137,
+			"id": 3130,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4602,7 +4602,7 @@
 			},
 			"children": [
 				{
-					"id": 3140,
+					"id": 3133,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4617,7 +4617,7 @@
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3138,
+					"id": 3131,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4632,7 +4632,7 @@
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3141,
+					"id": 3134,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4647,7 +4647,7 @@
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3139,
+					"id": 3132,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4667,10 +4667,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3140,
-						3138,
-						3141,
-						3139
+						3133,
+						3131,
+						3134,
+						3132
 					]
 				}
 			],
@@ -4683,7 +4683,7 @@
 			]
 		},
 		{
-			"id": 3133,
+			"id": 3126,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4693,7 +4693,7 @@
 			},
 			"children": [
 				{
-					"id": 3136,
+					"id": 3129,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4708,7 +4708,7 @@
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3135,
+					"id": 3128,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4723,7 +4723,7 @@
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3134,
+					"id": 3127,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4743,9 +4743,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3136,
-						3135,
-						3134
+						3129,
+						3128,
+						3127
 					]
 				}
 			],
@@ -4758,7 +4758,7 @@
 			]
 		},
 		{
-			"id": 3129,
+			"id": 3122,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4768,7 +4768,7 @@
 			},
 			"children": [
 				{
-					"id": 3131,
+					"id": 3124,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4779,14 +4779,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 74,
+							"line": 78,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3130,
+					"id": 3123,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4797,14 +4797,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 70,
+							"line": 74,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3132,
+					"id": 3125,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4815,7 +4815,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 78,
+							"line": 82,
 							"character": 4
 						}
 					],
@@ -4827,22 +4827,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3131,
-						3130,
-						3132
+						3124,
+						3123,
+						3125
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 66,
+					"line": 70,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2247,
+			"id": 2239,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4852,7 +4852,7 @@
 			},
 			"children": [
 				{
-					"id": 2249,
+					"id": 2241,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4870,7 +4870,7 @@
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2250,
+					"id": 2242,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4888,7 +4888,7 @@
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2248,
+					"id": 2240,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4911,9 +4911,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2249,
-						2250,
-						2248
+						2241,
+						2242,
+						2240
 					]
 				}
 			],
@@ -4926,7 +4926,7 @@
 			]
 		},
 		{
-			"id": 3146,
+			"id": 3139,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4959,7 +4959,7 @@
 			},
 			"children": [
 				{
-					"id": 3149,
+					"id": 3142,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4977,7 +4977,7 @@
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3150,
+					"id": 3143,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4995,7 +4995,7 @@
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3153,
+					"id": 3146,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5013,7 +5013,7 @@
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3156,
+					"id": 3149,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5031,7 +5031,7 @@
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3151,
+					"id": 3144,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5049,7 +5049,7 @@
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3159,
+					"id": 3152,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5067,7 +5067,7 @@
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3148,
+					"id": 3141,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5085,7 +5085,7 @@
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3154,
+					"id": 3147,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5103,7 +5103,7 @@
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3152,
+					"id": 3145,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5121,7 +5121,7 @@
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3157,
+					"id": 3150,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5139,7 +5139,7 @@
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3155,
+					"id": 3148,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5157,7 +5157,7 @@
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3158,
+					"id": 3151,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5175,7 +5175,7 @@
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3147,
+					"id": 3140,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5198,19 +5198,19 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						3142,
+						3143,
+						3146,
 						3149,
-						3150,
-						3153,
-						3156,
-						3151,
-						3159,
-						3148,
-						3154,
+						3144,
 						3152,
-						3157,
-						3155,
-						3158,
-						3147
+						3141,
+						3147,
+						3145,
+						3150,
+						3148,
+						3151,
+						3140
 					]
 				}
 			],
@@ -5223,7 +5223,7 @@
 			]
 		},
 		{
-			"id": 2063,
+			"id": 2055,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5248,7 +5248,7 @@
 			},
 			"children": [
 				{
-					"id": 2099,
+					"id": 2091,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5276,7 +5276,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2091,
+					"id": 2083,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5304,7 +5304,7 @@
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2071,
+					"id": 2063,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5336,7 +5336,7 @@
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2150,
+					"id": 2142,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5364,7 +5364,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2116,
+					"id": 2108,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5392,7 +5392,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2076,
+					"id": 2068,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5424,7 +5424,7 @@
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2112,
+					"id": 2104,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5452,7 +5452,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2098,
+					"id": 2090,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5480,7 +5480,7 @@
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2160,
+					"id": 2152,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5509,7 +5509,7 @@
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2139,
+					"id": 2131,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5549,7 +5549,7 @@
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2077,
+					"id": 2069,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5577,7 +5577,7 @@
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2065,
+					"id": 2057,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5609,7 +5609,7 @@
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2123,
+					"id": 2115,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5637,7 +5637,7 @@
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2110,
+					"id": 2102,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5665,7 +5665,7 @@
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2125,
+					"id": 2117,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5693,7 +5693,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2105,
+					"id": 2097,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5721,7 +5721,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2133,
+					"id": 2125,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5745,7 +5745,7 @@
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2144,
+					"id": 2136,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5770,7 +5770,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2145,
+					"id": 2137,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5794,7 +5794,7 @@
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2138,
+					"id": 2130,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5818,7 +5818,7 @@
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2126,
+					"id": 2118,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5846,7 +5846,7 @@
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2072,
+					"id": 2064,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5882,7 +5882,7 @@
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2067,
+					"id": 2059,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5918,7 +5918,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2151,
+					"id": 2143,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5946,7 +5946,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2070,
+					"id": 2062,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5978,7 +5978,7 @@
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2121,
+					"id": 2113,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6006,7 +6006,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2137,
+					"id": 2129,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6038,7 +6038,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2089,
+					"id": 2081,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6066,7 +6066,7 @@
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2088,
+					"id": 2080,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6094,7 +6094,7 @@
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2093,
+					"id": 2085,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6123,7 +6123,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2096,
+					"id": 2088,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6151,7 +6151,7 @@
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2095,
+					"id": 2087,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6179,7 +6179,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2094,
+					"id": 2086,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6207,7 +6207,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2097,
+					"id": 2089,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6235,7 +6235,7 @@
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2104,
+					"id": 2096,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6263,7 +6263,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2103,
+					"id": 2095,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6291,7 +6291,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2069,
+					"id": 2061,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6335,7 +6335,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2118,
+					"id": 2110,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6363,7 +6363,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2107,
+					"id": 2099,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6391,7 +6391,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2075,
+					"id": 2067,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6428,7 +6428,7 @@
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2124,
+					"id": 2116,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6456,7 +6456,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2108,
+					"id": 2100,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6484,7 +6484,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2129,
+					"id": 2121,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6508,7 +6508,7 @@
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2083,
+					"id": 2075,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6536,7 +6536,7 @@
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2064,
+					"id": 2056,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6564,7 +6564,7 @@
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2154,
+					"id": 2146,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6592,7 +6592,7 @@
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2153,
+					"id": 2145,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6620,7 +6620,7 @@
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2115,
+					"id": 2107,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6648,7 +6648,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2090,
+					"id": 2082,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6680,7 +6680,7 @@
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2066,
+					"id": 2058,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6712,7 +6712,7 @@
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2119,
+					"id": 2111,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6740,7 +6740,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2086,
+					"id": 2078,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6768,7 +6768,7 @@
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2141,
+					"id": 2133,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6802,7 +6802,7 @@
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2159,
+					"id": 2151,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6830,7 +6830,7 @@
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2142,
+					"id": 2134,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6854,7 +6854,7 @@
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2100,
+					"id": 2092,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6882,7 +6882,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2120,
+					"id": 2112,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6914,7 +6914,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2149,
+					"id": 2141,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6942,7 +6942,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2068,
+					"id": 2060,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6970,7 +6970,7 @@
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2140,
+					"id": 2132,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6994,7 +6994,7 @@
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2136,
+					"id": 2128,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7034,7 +7034,7 @@
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2155,
+					"id": 2147,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7062,7 +7062,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2084,
+					"id": 2076,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7090,7 +7090,7 @@
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2130,
+					"id": 2122,
 					"name": "SageEmbedQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7114,7 +7114,7 @@
 					"defaultValue": "\"sageEmbedQuery\""
 				},
 				{
-					"id": 2131,
+					"id": 2123,
 					"name": "SageWorksheetUpdated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7138,7 +7138,7 @@
 					"defaultValue": "\"sageWorksheetUpdated\""
 				},
 				{
-					"id": 2092,
+					"id": 2084,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7166,7 +7166,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2109,
+					"id": 2101,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7194,7 +7194,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2135,
+					"id": 2127,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7234,7 +7234,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2117,
+					"id": 2109,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7262,7 +7262,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2122,
+					"id": 2114,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7290,7 +7290,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2102,
+					"id": 2094,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7318,7 +7318,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2111,
+					"id": 2103,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7346,7 +7346,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2101,
+					"id": 2093,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7374,7 +7374,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2162,
+					"id": 2154,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7402,7 +7402,7 @@
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2161,
+					"id": 2153,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7430,7 +7430,7 @@
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2163,
+					"id": 2155,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7458,7 +7458,7 @@
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2148,
+					"id": 2140,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7486,7 +7486,7 @@
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2156,
+					"id": 2148,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7514,7 +7514,7 @@
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2157,
+					"id": 2149,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7542,7 +7542,7 @@
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2152,
+					"id": 2144,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7570,7 +7570,7 @@
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2143,
+					"id": 2135,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7599,7 +7599,7 @@
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2132,
+					"id": 2124,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7623,7 +7623,7 @@
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2134,
+					"id": 2126,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7663,7 +7663,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2106,
+					"id": 2098,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7691,7 +7691,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2074,
+					"id": 2066,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7727,7 +7727,7 @@
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2073,
+					"id": 2065,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7759,7 +7759,7 @@
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2127,
+					"id": 2119,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7792,93 +7792,93 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2099,
 						2091,
-						2071,
-						2150,
-						2116,
-						2076,
-						2112,
-						2098,
-						2160,
-						2139,
-						2077,
-						2065,
-						2123,
-						2110,
+						2083,
+						2063,
+						2142,
+						2108,
+						2068,
+						2104,
+						2090,
+						2152,
+						2131,
+						2069,
+						2057,
+						2115,
+						2102,
+						2117,
+						2097,
 						2125,
-						2105,
-						2133,
-						2144,
-						2145,
-						2138,
-						2126,
-						2072,
-						2067,
-						2151,
-						2070,
-						2121,
+						2136,
 						2137,
-						2089,
+						2130,
+						2118,
+						2064,
+						2059,
+						2143,
+						2062,
+						2113,
+						2129,
+						2081,
+						2080,
+						2085,
 						2088,
-						2093,
+						2087,
+						2086,
+						2089,
 						2096,
 						2095,
-						2094,
-						2097,
-						2104,
-						2103,
-						2069,
-						2118,
-						2107,
+						2061,
+						2110,
+						2099,
+						2067,
+						2116,
+						2100,
+						2121,
 						2075,
-						2124,
-						2108,
-						2129,
-						2083,
-						2064,
+						2056,
+						2146,
+						2145,
+						2107,
+						2082,
+						2058,
+						2111,
+						2078,
+						2133,
+						2151,
+						2134,
+						2092,
+						2112,
+						2141,
+						2060,
+						2132,
+						2128,
+						2147,
+						2076,
+						2122,
+						2123,
+						2084,
+						2101,
+						2127,
+						2109,
+						2114,
+						2094,
+						2103,
+						2093,
 						2154,
 						2153,
-						2115,
-						2090,
-						2066,
-						2119,
-						2086,
-						2141,
-						2159,
-						2142,
-						2100,
-						2120,
-						2149,
-						2068,
-						2140,
-						2136,
 						2155,
-						2084,
-						2130,
-						2131,
-						2092,
-						2109,
-						2135,
-						2117,
-						2122,
-						2102,
-						2111,
-						2101,
-						2162,
-						2161,
-						2163,
+						2140,
 						2148,
-						2156,
-						2157,
-						2152,
-						2143,
-						2132,
-						2134,
-						2106,
-						2074,
-						2073,
-						2127
+						2149,
+						2144,
+						2135,
+						2124,
+						2126,
+						2098,
+						2066,
+						2065,
+						2119
 					]
 				}
 			],
@@ -7891,7 +7891,7 @@
 			]
 		},
 		{
-			"id": 3160,
+			"id": 3153,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7920,7 +7920,7 @@
 			},
 			"children": [
 				{
-					"id": 3161,
+					"id": 3154,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7938,7 +7938,7 @@
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3163,
+					"id": 3156,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7956,7 +7956,7 @@
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3162,
+					"id": 3155,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7979,9 +7979,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3161,
-						3163,
-						3162
+						3154,
+						3156,
+						3155
 					]
 				}
 			],
@@ -7994,7 +7994,7 @@
 			]
 		},
 		{
-			"id": 2821,
+			"id": 2814,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8004,7 +8004,7 @@
 			},
 			"children": [
 				{
-					"id": 2825,
+					"id": 2818,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8028,7 +8028,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2829,
+					"id": 2822,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8052,7 +8052,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2831,
+					"id": 2824,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8076,7 +8076,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2823,
+					"id": 2816,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8100,7 +8100,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2828,
+					"id": 2821,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8124,7 +8124,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2824,
+					"id": 2817,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8148,7 +8148,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2826,
+					"id": 2819,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8172,7 +8172,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2822,
+					"id": 2815,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8196,7 +8196,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2827,
+					"id": 2820,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8220,7 +8220,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2830,
+					"id": 2823,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8249,16 +8249,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2825,
-						2829,
-						2831,
-						2823,
-						2828,
-						2824,
-						2826,
+						2818,
 						2822,
-						2827,
-						2830
+						2824,
+						2816,
+						2821,
+						2817,
+						2819,
+						2815,
+						2820,
+						2823
 					]
 				}
 			],
@@ -8271,7 +8271,7 @@
 			]
 		},
 		{
-			"id": 3084,
+			"id": 3077,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8287,7 +8287,7 @@
 			},
 			"children": [
 				{
-					"id": 3085,
+					"id": 3078,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8298,14 +8298,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 109,
+							"line": 113,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3086,
+					"id": 3079,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8316,7 +8316,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 114,
+							"line": 118,
 							"character": 4
 						}
 					],
@@ -8328,28 +8328,28 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3085,
-						3086
+						3078,
+						3079
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 104,
+					"line": 108,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3078,
+			"id": 3071,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3080,
+					"id": 3073,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8357,14 +8357,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 83,
+							"line": 87,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3081,
+					"id": 3074,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8372,14 +8372,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 84,
+							"line": 88,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3079,
+					"id": 3072,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8387,7 +8387,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 82,
+							"line": 86,
 							"character": 4
 						}
 					],
@@ -8399,22 +8399,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3080,
-						3081,
-						3079
+						3073,
+						3074,
+						3072
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 81,
+					"line": 85,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2832,
+			"id": 2825,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8431,7 +8431,7 @@
 			},
 			"children": [
 				{
-					"id": 2835,
+					"id": 2828,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8449,7 +8449,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2838,
+					"id": 2831,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8467,7 +8467,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2836,
+					"id": 2829,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8485,7 +8485,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2833,
+					"id": 2826,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8503,7 +8503,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2837,
+					"id": 2830,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8521,7 +8521,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2834,
+					"id": 2827,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8544,12 +8544,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2835,
-						2838,
-						2836,
-						2833,
-						2837,
-						2834
+						2828,
+						2831,
+						2829,
+						2826,
+						2830,
+						2827
 					]
 				}
 			],
@@ -8562,7 +8562,7 @@
 			]
 		},
 		{
-			"id": 2165,
+			"id": 2157,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8591,7 +8591,7 @@
 			},
 			"children": [
 				{
-					"id": 2187,
+					"id": 2179,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8619,7 +8619,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2176,
+					"id": 2168,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8652,7 +8652,7 @@
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2230,
+					"id": 2222,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8685,7 +8685,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2234,
+					"id": 2226,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8718,7 +8718,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2217,
+					"id": 2209,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8746,7 +8746,7 @@
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2237,
+					"id": 2229,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8779,7 +8779,7 @@
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2194,
+					"id": 2186,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8812,7 +8812,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2191,
+					"id": 2183,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8849,7 +8849,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2231,
+					"id": 2223,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8877,7 +8877,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2198,
+					"id": 2190,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8910,7 +8910,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2233,
+					"id": 2225,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8938,7 +8938,7 @@
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2239,
+					"id": 2231,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8966,7 +8966,7 @@
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2200,
+					"id": 2192,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9003,7 +9003,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2202,
+					"id": 2194,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9036,7 +9036,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2186,
+					"id": 2178,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9073,7 +9073,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2201,
+					"id": 2193,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9101,7 +9101,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2203,
+					"id": 2195,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9134,7 +9134,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2167,
+					"id": 2159,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9171,7 +9171,7 @@
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2193,
+					"id": 2185,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9209,7 +9209,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2228,
+					"id": 2220,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9242,7 +9242,7 @@
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2184,
+					"id": 2176,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9270,7 +9270,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2190,
+					"id": 2182,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9303,7 +9303,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2183,
+					"id": 2175,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9331,7 +9331,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2216,
+					"id": 2208,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9364,7 +9364,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2210,
+					"id": 2202,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9392,7 +9392,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2170,
+					"id": 2162,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9420,7 +9420,7 @@
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2221,
+					"id": 2213,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9449,7 +9449,7 @@
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2196,
+					"id": 2188,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9481,7 +9481,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2212,
+					"id": 2204,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9509,7 +9509,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2180,
+					"id": 2172,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9537,7 +9537,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2188,
+					"id": 2180,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9581,7 +9581,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2192,
+					"id": 2184,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9622,7 +9622,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2208,
+					"id": 2200,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9655,7 +9655,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2174,
+					"id": 2166,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9688,7 +9688,7 @@
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2175,
+					"id": 2167,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9725,7 +9725,7 @@
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2179,
+					"id": 2171,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9774,7 +9774,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2195,
+					"id": 2187,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9807,7 +9807,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2229,
+					"id": 2221,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9835,7 +9835,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2189,
+					"id": 2181,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9867,7 +9867,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2177,
+					"id": 2169,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9900,7 +9900,7 @@
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2219,
+					"id": 2211,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9928,7 +9928,7 @@
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2209,
+					"id": 2201,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9956,7 +9956,7 @@
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2232,
+					"id": 2224,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9984,7 +9984,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2205,
+					"id": 2197,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10017,7 +10017,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2224,
+					"id": 2216,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10054,7 +10054,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2181,
+					"id": 2173,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10082,7 +10082,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2182,
+					"id": 2174,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10110,7 +10110,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2166,
+					"id": 2158,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10139,7 +10139,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2172,
+					"id": 2164,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10172,7 +10172,7 @@
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2214,
+					"id": 2206,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10205,7 +10205,7 @@
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2213,
+					"id": 2205,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10238,7 +10238,7 @@
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2171,
+					"id": 2163,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10271,7 +10271,7 @@
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2204,
+					"id": 2196,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10299,7 +10299,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2197,
+					"id": 2189,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10332,7 +10332,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2199,
+					"id": 2191,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10365,7 +10365,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2227,
+					"id": 2219,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10398,7 +10398,7 @@
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2240,
+					"id": 2232,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10427,7 +10427,7 @@
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2207,
+					"id": 2199,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10460,7 +10460,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2206,
+					"id": 2198,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10493,7 +10493,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2226,
+					"id": 2218,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10526,7 +10526,7 @@
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2218,
+					"id": 2210,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10554,7 +10554,7 @@
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2211,
+					"id": 2203,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10599,7 +10599,7 @@
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2220,
+					"id": 2212,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10632,7 +10632,7 @@
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2222,
+					"id": 2214,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10656,7 +10656,7 @@
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2173,
+					"id": 2165,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10694,7 +10694,7 @@
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2215,
+					"id": 2207,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10727,7 +10727,7 @@
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2185,
+					"id": 2177,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10755,7 +10755,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2178,
+					"id": 2170,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10788,74 +10788,74 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2187,
-						2176,
-						2230,
-						2234,
-						2217,
-						2237,
-						2194,
-						2191,
-						2231,
-						2198,
-						2233,
-						2239,
-						2200,
-						2202,
-						2186,
-						2201,
-						2203,
-						2167,
-						2193,
-						2228,
-						2184,
-						2190,
-						2183,
-						2216,
-						2210,
-						2170,
-						2221,
-						2196,
-						2212,
-						2180,
-						2188,
-						2192,
-						2208,
-						2174,
-						2175,
 						2179,
-						2195,
-						2229,
-						2189,
-						2177,
-						2219,
-						2209,
-						2232,
-						2205,
-						2224,
-						2181,
-						2182,
-						2166,
-						2172,
-						2214,
-						2213,
-						2171,
-						2204,
-						2197,
-						2199,
-						2227,
-						2240,
-						2207,
-						2206,
-						2226,
-						2218,
-						2211,
-						2220,
+						2168,
 						2222,
-						2173,
-						2215,
+						2226,
+						2209,
+						2229,
+						2186,
+						2183,
+						2223,
+						2190,
+						2225,
+						2231,
+						2192,
+						2194,
+						2178,
+						2193,
+						2195,
+						2159,
 						2185,
-						2178
+						2220,
+						2176,
+						2182,
+						2175,
+						2208,
+						2202,
+						2162,
+						2213,
+						2188,
+						2204,
+						2172,
+						2180,
+						2184,
+						2200,
+						2166,
+						2167,
+						2171,
+						2187,
+						2221,
+						2181,
+						2169,
+						2211,
+						2201,
+						2224,
+						2197,
+						2216,
+						2173,
+						2174,
+						2158,
+						2164,
+						2206,
+						2205,
+						2163,
+						2196,
+						2189,
+						2191,
+						2219,
+						2232,
+						2199,
+						2198,
+						2218,
+						2210,
+						2203,
+						2212,
+						2214,
+						2165,
+						2207,
+						2177,
+						2170
 					]
 				}
 			],
@@ -10868,7 +10868,7 @@
 			]
 		},
 		{
-			"id": 3142,
+			"id": 3135,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10878,7 +10878,7 @@
 			},
 			"children": [
 				{
-					"id": 3144,
+					"id": 3137,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10896,7 +10896,7 @@
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3143,
+					"id": 3136,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10914,7 +10914,7 @@
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3145,
+					"id": 3138,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10937,9 +10937,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3144,
-						3143,
-						3145
+						3137,
+						3136,
+						3138
 					]
 				}
 			],
@@ -10952,7 +10952,7 @@
 			]
 		},
 		{
-			"id": 3087,
+			"id": 3080,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10968,7 +10968,7 @@
 			},
 			"children": [
 				{
-					"id": 3088,
+					"id": 3081,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10979,14 +10979,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 126,
+							"line": 130,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3089,
+					"id": 3082,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10997,7 +10997,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 130,
+							"line": 134,
 							"character": 4
 						}
 					],
@@ -11009,21 +11009,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3088,
-						3089
+						3081,
+						3082
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 121,
+					"line": 125,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3121,
+			"id": 3114,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11039,7 +11039,7 @@
 			},
 			"children": [
 				{
-					"id": 3125,
+					"id": 3118,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11057,7 +11057,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3126,
+					"id": 3119,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11075,7 +11075,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3122,
+					"id": 3115,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11093,7 +11093,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3123,
+					"id": 3116,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11116,7 +11116,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3127,
+					"id": 3120,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11134,7 +11134,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3124,
+					"id": 3117,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11152,7 +11152,7 @@
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3128,
+					"id": 3121,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11175,13 +11175,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3125,
-						3126,
-						3122,
-						3123,
-						3127,
-						3124,
-						3128
+						3118,
+						3119,
+						3115,
+						3116,
+						3120,
+						3117,
+						3121
 					]
 				}
 			],
@@ -11194,7 +11194,7 @@
 			]
 		},
 		{
-			"id": 3055,
+			"id": 3048,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11204,7 +11204,7 @@
 			},
 			"children": [
 				{
-					"id": 3060,
+					"id": 3053,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11232,7 +11232,7 @@
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3057,
+					"id": 3050,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11260,7 +11260,7 @@
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3059,
+					"id": 3052,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11288,7 +11288,7 @@
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3056,
+					"id": 3049,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11316,7 +11316,7 @@
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3061,
+					"id": 3054,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11344,7 +11344,7 @@
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3058,
+					"id": 3051,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11377,12 +11377,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3060,
-						3057,
-						3059,
-						3056,
-						3061,
-						3058
+						3053,
+						3050,
+						3052,
+						3049,
+						3054,
+						3051
 					]
 				}
 			],
@@ -11395,7 +11395,7 @@
 			]
 		},
 		{
-			"id": 2022,
+			"id": 2014,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11405,7 +11405,7 @@
 			},
 			"children": [
 				{
-					"id": 2025,
+					"id": 2017,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11416,14 +11416,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 39,
+							"line": 43,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2028,
+					"id": 2020,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11434,14 +11434,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 51,
+							"line": 55,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2023,
+					"id": 2015,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11452,14 +11452,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 31,
+							"line": 35,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 2026,
+					"id": 2018,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11470,14 +11470,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 43,
+							"line": 47,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2030,
+					"id": 2022,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11488,14 +11488,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 59,
+							"line": 63,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 2024,
+					"id": 2016,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11506,14 +11506,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 35,
+							"line": 39,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2029,
+					"id": 2021,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11524,7 +11524,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 55,
+							"line": 59,
 							"character": 4
 						}
 					],
@@ -11536,33 +11536,33 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2025,
-						2028,
-						2023,
-						2026,
-						2030,
-						2024,
-						2029
+						2017,
+						2020,
+						2015,
+						2018,
+						2022,
+						2016,
+						2021
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 27,
+					"line": 31,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2810,
+			"id": 2803,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2811,
+					"id": 2804,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11577,7 +11577,7 @@
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2813,
+					"id": 2806,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11592,7 +11592,7 @@
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2812,
+					"id": 2805,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11607,7 +11607,7 @@
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2814,
+					"id": 2807,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11627,10 +11627,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2811,
-						2813,
-						2812,
-						2814
+						2804,
+						2806,
+						2805,
+						2807
 					]
 				}
 			],
@@ -11643,7 +11643,7 @@
 			]
 		},
 		{
-			"id": 3082,
+			"id": 3075,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11659,7 +11659,7 @@
 			},
 			"children": [
 				{
-					"id": 3083,
+					"id": 3076,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11670,7 +11670,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 97,
+							"line": 101,
 							"character": 4
 						}
 					],
@@ -11682,20 +11682,20 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3083
+						3076
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 91,
+					"line": 95,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2047,
+			"id": 2039,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11705,7 +11705,7 @@
 			},
 			"children": [
 				{
-					"id": 2055,
+					"id": 2047,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11723,7 +11723,7 @@
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2060,
+					"id": 2052,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11741,7 +11741,7 @@
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2059,
+					"id": 2051,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11759,7 +11759,7 @@
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2057,
+					"id": 2049,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11777,7 +11777,7 @@
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2058,
+					"id": 2050,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11795,7 +11795,7 @@
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2054,
+					"id": 2046,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11813,7 +11813,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2056,
+					"id": 2048,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11831,7 +11831,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2048,
+					"id": 2040,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11849,7 +11849,7 @@
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2053,
+					"id": 2045,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11867,7 +11867,7 @@
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2052,
+					"id": 2044,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11885,7 +11885,7 @@
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2061,
+					"id": 2053,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11903,7 +11903,7 @@
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2051,
+					"id": 2043,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11921,7 +11921,7 @@
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2050,
+					"id": 2042,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11939,7 +11939,7 @@
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2049,
+					"id": 2041,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11957,7 +11957,7 @@
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2062,
+					"id": 2054,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11980,21 +11980,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2055,
-						2060,
-						2059,
-						2057,
-						2058,
-						2054,
-						2056,
-						2048,
-						2053,
+						2047,
 						2052,
-						2061,
 						2051,
-						2050,
 						2049,
-						2062
+						2050,
+						2046,
+						2048,
+						2040,
+						2045,
+						2044,
+						2053,
+						2043,
+						2042,
+						2041,
+						2054
 					]
 				}
 			],
@@ -12007,14 +12007,14 @@
 			]
 		},
 		{
-			"id": 3113,
+			"id": 3106,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3118,
+					"id": 3111,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12029,7 +12029,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3117,
+					"id": 3110,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12044,7 +12044,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3116,
+					"id": 3109,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12059,7 +12059,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3119,
+					"id": 3112,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12074,7 +12074,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3120,
+					"id": 3113,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12089,7 +12089,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3114,
+					"id": 3107,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12104,7 +12104,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3115,
+					"id": 3108,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12124,13 +12124,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3118,
-						3117,
-						3116,
-						3119,
-						3120,
-						3114,
-						3115
+						3111,
+						3110,
+						3109,
+						3112,
+						3113,
+						3107,
+						3108
 					]
 				}
 			],
@@ -12143,7 +12143,7 @@
 			]
 		},
 		{
-			"id": 1939,
+			"id": 1931,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -12172,7 +12172,7 @@
 			},
 			"children": [
 				{
-					"id": 1940,
+					"id": 1932,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -12189,7 +12189,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1941,
+							"id": 1933,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -12199,7 +12199,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1942,
+									"id": 1934,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12207,12 +12207,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2012,
+										"id": 2004,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1943,
+									"id": 1935,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12224,7 +12224,7 @@
 									}
 								},
 								{
-									"id": 1944,
+									"id": 1936,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12236,7 +12236,7 @@
 									}
 								},
 								{
-									"id": 1945,
+									"id": 1937,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12250,7 +12250,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3090,
+											"id": 3083,
 											"name": "VizPoint"
 										}
 									}
@@ -12258,14 +12258,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1939,
+								"id": 1931,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1954,
+					"id": 1946,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12281,7 +12281,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1955,
+							"id": 1947,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12292,7 +12292,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1956,
+									"id": 1948,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12321,7 +12321,7 @@
 					]
 				},
 				{
-					"id": 1957,
+					"id": 1949,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12337,7 +12337,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1958,
+							"id": 1950,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12353,7 +12353,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1959,
+									"id": 1951,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12382,7 +12382,7 @@
 					]
 				},
 				{
-					"id": 2006,
+					"id": 1998,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12398,14 +12398,14 @@
 					],
 					"signatures": [
 						{
-							"id": 2007,
+							"id": 1999,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2008,
+									"id": 2000,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12430,7 +12430,7 @@
 					]
 				},
 				{
-					"id": 1960,
+					"id": 1952,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12446,7 +12446,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1961,
+							"id": 1953,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12457,7 +12457,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1962,
+									"id": 1954,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12469,7 +12469,7 @@
 									}
 								},
 								{
-									"id": 1963,
+									"id": 1955,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12477,12 +12477,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2047,
+										"id": 2039,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1964,
+									"id": 1956,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12528,7 +12528,7 @@
 					]
 				},
 				{
-					"id": 1996,
+					"id": 1988,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12544,7 +12544,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1997,
+							"id": 1989,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12555,7 +12555,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1998,
+									"id": 1990,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12569,7 +12569,7 @@
 									}
 								},
 								{
-									"id": 1999,
+									"id": 1991,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12597,7 +12597,7 @@
 					]
 				},
 				{
-					"id": 1974,
+					"id": 1966,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12613,7 +12613,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1975,
+							"id": 1967,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12624,7 +12624,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1976,
+									"id": 1968,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12637,7 +12637,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1977,
+									"id": 1969,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12666,7 +12666,7 @@
 					]
 				},
 				{
-					"id": 1967,
+					"id": 1959,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12682,7 +12682,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1968,
+							"id": 1960,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12693,7 +12693,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1969,
+									"id": 1961,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12706,7 +12706,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1970,
+									"id": 1962,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12725,14 +12725,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1971,
+											"id": 1963,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1972,
+													"id": 1964,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12743,7 +12743,7 @@
 													}
 												},
 												{
-													"id": 1973,
+													"id": 1965,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12759,8 +12759,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1972,
-														1973
+														1964,
+														1965
 													]
 												}
 											]
@@ -12773,7 +12773,7 @@
 					]
 				},
 				{
-					"id": 1978,
+					"id": 1970,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12789,7 +12789,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1979,
+							"id": 1971,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12800,7 +12800,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1980,
+									"id": 1972,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12813,7 +12813,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1981,
+									"id": 1973,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12828,7 +12828,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1982,
+									"id": 1974,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12857,7 +12857,7 @@
 					]
 				},
 				{
-					"id": 2002,
+					"id": 1994,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12873,7 +12873,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2003,
+							"id": 1995,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12892,7 +12892,7 @@
 					]
 				},
 				{
-					"id": 1983,
+					"id": 1975,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12908,7 +12908,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1984,
+							"id": 1976,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12919,7 +12919,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1985,
+									"id": 1977,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12932,7 +12932,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1986,
+									"id": 1978,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12953,7 +12953,7 @@
 					]
 				},
 				{
-					"id": 1987,
+					"id": 1979,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12969,7 +12969,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1988,
+							"id": 1980,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12979,7 +12979,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1989,
+									"id": 1981,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12992,7 +12992,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1990,
+									"id": 1982,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13005,7 +13005,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1991,
+									"id": 1983,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13028,7 +13028,7 @@
 					]
 				},
 				{
-					"id": 1965,
+					"id": 1957,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13044,7 +13044,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1966,
+							"id": 1958,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13063,7 +13063,7 @@
 					]
 				},
 				{
-					"id": 2000,
+					"id": 1992,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13079,7 +13079,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2001,
+							"id": 1993,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13090,14 +13090,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2012,
+								"id": 2004,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1949,
+					"id": 1941,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13113,7 +13113,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1950,
+							"id": 1942,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13135,7 +13135,7 @@
 					]
 				},
 				{
-					"id": 2004,
+					"id": 1996,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13151,7 +13151,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2005,
+							"id": 1997,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13170,7 +13170,7 @@
 					]
 				},
 				{
-					"id": 1992,
+					"id": 1984,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13186,7 +13186,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1993,
+							"id": 1985,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13206,7 +13206,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1994,
+									"id": 1986,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13221,7 +13221,7 @@
 									}
 								},
 								{
-									"id": 1995,
+									"id": 1987,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13233,7 +13233,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2019,
+											"id": 2011,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -13244,7 +13244,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -13254,7 +13254,7 @@
 					]
 				},
 				{
-					"id": 1951,
+					"id": 1943,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13270,7 +13270,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1952,
+							"id": 1944,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13281,7 +13281,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1953,
+									"id": 1945,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13310,7 +13310,7 @@
 					]
 				},
 				{
-					"id": 2009,
+					"id": 2001,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13326,14 +13326,14 @@
 					],
 					"signatures": [
 						{
-							"id": 2010,
+							"id": 2002,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2011,
+									"id": 2003,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13357,31 +13357,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1940
+						1932
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1954,
-						1957,
-						2006,
-						1960,
-						1996,
-						1974,
-						1967,
-						1978,
-						2002,
-						1983,
-						1987,
-						1965,
-						2000,
+						1946,
 						1949,
-						2004,
+						1998,
+						1952,
+						1988,
+						1966,
+						1959,
+						1970,
+						1994,
+						1975,
+						1979,
+						1957,
 						1992,
-						1951,
-						2009
+						1941,
+						1996,
+						1984,
+						1943,
+						2001
 					]
 				}
 			],
@@ -13418,7 +13418,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 704,
+							"line": 726,
 							"character": 4
 						}
 					],
@@ -13438,7 +13438,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2839,
+										"id": 2832,
 										"name": "DOMSelector"
 									}
 								},
@@ -13450,7 +13450,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2715,
+										"id": 2707,
 										"name": "AppViewConfig"
 									}
 								}
@@ -13482,7 +13482,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1099,
+							"line": 1165,
 							"character": 11
 						}
 					],
@@ -13571,7 +13571,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -13652,7 +13652,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 968,
+							"line": 1034,
 							"character": 11
 						}
 					],
@@ -13989,7 +13989,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1073,
+							"line": 1139,
 							"character": 11
 						}
 					],
@@ -14099,7 +14099,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -14114,7 +14114,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -14181,7 +14181,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -14193,7 +14193,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -14205,7 +14205,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -14365,7 +14365,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1128,
+							"line": 1194,
 							"character": 17
 						}
 					],
@@ -14528,7 +14528,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -14547,7 +14547,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -14676,7 +14676,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -14782,7 +14782,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 698,
+					"line": 720,
 					"character": 13
 				}
 			],
@@ -15326,7 +15326,7 @@
 			]
 		},
 		{
-			"id": 1692,
+			"id": 1684,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -15354,7 +15354,7 @@
 			},
 			"children": [
 				{
-					"id": 1693,
+					"id": 1685,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -15362,20 +15362,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 533,
+							"line": 465,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1694,
+							"id": 1686,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1695,
+									"id": 1687,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15386,21 +15386,21 @@
 									}
 								},
 								{
-									"id": 1696,
+									"id": 1688,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1635,
+										"id": 1637,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1692,
+								"id": 1684,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
@@ -15417,7 +15417,7 @@
 					}
 				},
 				{
-					"id": 1847,
+					"id": 1839,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15433,7 +15433,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1848,
+							"id": 1840,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15465,7 +15465,7 @@
 					}
 				},
 				{
-					"id": 1866,
+					"id": 1858,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15481,7 +15481,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1867,
+							"id": 1859,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15497,7 +15497,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1868,
+									"id": 1860,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15518,7 +15518,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -15538,7 +15538,7 @@
 					}
 				},
 				{
-					"id": 1835,
+					"id": 1827,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15554,7 +15554,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1836,
+							"id": 1828,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15593,7 +15593,7 @@
 					}
 				},
 				{
-					"id": 1700,
+					"id": 1692,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15603,13 +15603,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 466,
+							"line": 397,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1701,
+							"id": 1693,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15632,7 +15632,7 @@
 					}
 				},
 				{
-					"id": 1861,
+					"id": 1853,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15648,7 +15648,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1862,
+							"id": 1854,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15670,14 +15670,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1863,
+									"id": 1855,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1865,
+											"id": 1857,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15689,7 +15689,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1864,
+											"id": 1856,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15706,8 +15706,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1865,
-												1864
+												1857,
+												1856
 											]
 										}
 									]
@@ -15727,7 +15727,7 @@
 					}
 				},
 				{
-					"id": 1841,
+					"id": 1833,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15743,7 +15743,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1842,
+							"id": 1834,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15759,7 +15759,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1843,
+									"id": 1835,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15767,20 +15767,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1844,
+											"id": 1836,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1845,
+												"id": 1837,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1846,
+														"id": 1838,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -15827,7 +15827,7 @@
 					}
 				},
 				{
-					"id": 1849,
+					"id": 1841,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15843,7 +15843,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1850,
+							"id": 1842,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15866,7 +15866,7 @@
 					}
 				},
 				{
-					"id": 1859,
+					"id": 1851,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15882,7 +15882,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1860,
+							"id": 1852,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15908,7 +15908,7 @@
 					}
 				},
 				{
-					"id": 1802,
+					"id": 1794,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15924,7 +15924,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1803,
+							"id": 1795,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15940,7 +15940,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1804,
+									"id": 1796,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15950,12 +15950,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1805,
+									"id": 1797,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15965,7 +15965,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -15988,7 +15988,7 @@
 					}
 				},
 				{
-					"id": 1796,
+					"id": 1788,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16004,7 +16004,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1797,
+							"id": 1789,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16024,7 +16024,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1798,
+									"id": 1790,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16034,12 +16034,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1799,
+									"id": 1791,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16049,12 +16049,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1800,
+									"id": 1792,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16064,13 +16064,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1801,
+									"id": 1793,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16101,7 +16101,7 @@
 					}
 				},
 				{
-					"id": 1837,
+					"id": 1829,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16117,7 +16117,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1838,
+							"id": 1830,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16127,7 +16127,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1839,
+									"id": 1831,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16142,7 +16142,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1840,
+									"id": 1832,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16178,7 +16178,7 @@
 					}
 				},
 				{
-					"id": 1851,
+					"id": 1843,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16194,7 +16194,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1852,
+							"id": 1844,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16233,7 +16233,7 @@
 					}
 				},
 				{
-					"id": 1702,
+					"id": 1694,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16243,13 +16243,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 506,
+							"line": 438,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1703,
+							"id": 1695,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16279,7 +16279,7 @@
 					}
 				},
 				{
-					"id": 1855,
+					"id": 1847,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16295,7 +16295,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1856,
+							"id": 1848,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16327,7 +16327,7 @@
 					}
 				},
 				{
-					"id": 1857,
+					"id": 1849,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16343,7 +16343,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1858,
+							"id": 1850,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16375,7 +16375,7 @@
 					}
 				},
 				{
-					"id": 1820,
+					"id": 1812,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16391,7 +16391,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1821,
+							"id": 1813,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16402,40 +16402,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1822,
+									"id": 1814,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1823,
+									"id": 1815,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1824,
+									"id": 1816,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1825,
+									"id": 1817,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16449,7 +16449,7 @@
 									}
 								},
 								{
-									"id": 1826,
+									"id": 1818,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16474,7 +16474,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1827,
+									"id": 1819,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16525,7 +16525,7 @@
 					}
 				},
 				{
-					"id": 1828,
+					"id": 1820,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16541,7 +16541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1829,
+							"id": 1821,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16552,21 +16552,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1830,
+									"id": 1822,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1831,
+									"id": 1823,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16580,7 +16580,7 @@
 									}
 								},
 								{
-									"id": 1832,
+									"id": 1824,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16635,37 +16635,37 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1693
+						1685
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1847,
-						1866,
-						1835,
-						1700,
-						1861,
+						1839,
+						1858,
+						1827,
+						1692,
+						1853,
+						1833,
 						1841,
-						1849,
-						1859,
-						1802,
-						1796,
-						1837,
 						1851,
-						1702,
-						1855,
-						1857,
-						1820,
-						1828
+						1794,
+						1788,
+						1829,
+						1843,
+						1694,
+						1847,
+						1849,
+						1812,
+						1820
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 532,
+					"line": 464,
 					"character": 13
 				}
 			],
@@ -16726,7 +16726,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2839,
+										"id": 2832,
 										"name": "DOMSelector"
 									}
 								},
@@ -16738,7 +16738,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2574,
+										"id": 2566,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -16859,7 +16859,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -17378,7 +17378,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17393,7 +17393,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -17460,7 +17460,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17472,7 +17472,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -17484,7 +17484,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17807,7 +17807,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -17826,7 +17826,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -17955,7 +17955,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -18121,7 +18121,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2839,
+										"id": 2832,
 										"name": "DOMSelector"
 									}
 								},
@@ -18133,7 +18133,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2661,
+										"id": 2653,
 										"name": "SageViewConfig"
 									}
 								}
@@ -18254,7 +18254,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -18705,7 +18705,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18720,7 +18720,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -18787,7 +18787,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18799,7 +18799,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -18811,7 +18811,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -19135,7 +19135,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -19154,7 +19154,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -19283,7 +19283,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19459,7 +19459,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2525,
+										"id": 2517,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -19580,7 +19580,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -19998,7 +19998,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20013,7 +20013,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -20080,7 +20080,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20095,7 +20095,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -20110,7 +20110,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -20446,7 +20446,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -20465,7 +20465,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -20594,7 +20594,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -20754,7 +20754,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2839,
+										"id": 2832,
 										"name": "DOMSelector"
 									}
 								},
@@ -20766,7 +20766,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2465,
+										"id": 2457,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -20887,7 +20887,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -21337,7 +21337,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21352,7 +21352,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -21419,7 +21419,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21434,7 +21434,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -21449,7 +21449,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21785,7 +21785,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -21804,7 +21804,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -21933,7 +21933,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22584,7 +22584,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 381,
+							"line": 307,
 							"character": 4
 						}
 					],
@@ -22736,7 +22736,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1939,
+										"id": 1931,
 										"name": "AnswerService"
 									}
 								],
@@ -22817,7 +22817,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 466,
+							"line": 397,
 							"character": 11
 						}
 					],
@@ -23154,7 +23154,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23169,7 +23169,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								}
@@ -23236,7 +23236,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2063,
+										"id": 2055,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23251,7 +23251,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2843,
+										"id": 2836,
 										"name": "MessageCallback"
 									}
 								},
@@ -23266,7 +23266,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2840,
+										"id": 2833,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23439,7 +23439,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 506,
+							"line": 438,
 							"character": 17
 						}
 					],
@@ -23599,7 +23599,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2165,
+										"id": 2157,
 										"name": "HostEvent"
 									}
 								},
@@ -23618,7 +23618,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2242,
+										"id": 2234,
 										"name": "ContextType"
 									}
 								}
@@ -23747,7 +23747,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3113,
+										"id": 3106,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -23851,7 +23851,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 380,
+					"line": 306,
 					"character": 13
 				}
 			],
@@ -23864,13 +23864,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1692,
+					"id": 1684,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2715,
+			"id": 2707,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -23886,7 +23886,7 @@
 			},
 			"children": [
 				{
-					"id": 2756,
+					"id": 2749,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23917,20 +23917,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2757,
+							"id": 2750,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2758,
+								"id": 2751,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2759,
+										"id": 2752,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -23966,7 +23966,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2779,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24008,7 +24008,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2727,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24035,7 +24035,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 505,
+							"line": 509,
 							"character": 4
 						}
 					],
@@ -24045,7 +24045,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2776,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24075,7 +24075,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2409,
+						"id": 2401,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -24084,7 +24084,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2797,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24122,7 +24122,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2767,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24163,7 +24163,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2753,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24192,7 +24192,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -24201,7 +24201,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2728,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24229,18 +24229,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 526,
+							"line": 530,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3129,
+						"id": 3122,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2780,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24282,7 +24282,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2710,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24310,7 +24310,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 213,
+							"line": 217,
 							"character": 4
 						}
 					],
@@ -24320,7 +24320,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2761,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24358,7 +24358,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2745,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24396,7 +24396,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2744,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24428,7 +24428,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -24438,7 +24438,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2726,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24465,7 +24465,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 498,
+							"line": 502,
 							"character": 4
 						}
 					],
@@ -24475,7 +24475,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2757,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24516,7 +24516,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2791,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24558,7 +24558,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2796,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24600,7 +24600,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2781,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24642,7 +24642,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2711,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24668,7 +24668,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 229,
+							"line": 233,
 							"character": 4
 						}
 					],
@@ -24678,7 +24678,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2723,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24706,7 +24706,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 439,
+							"line": 443,
 							"character": 4
 						}
 					],
@@ -24716,7 +24716,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2758,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24754,7 +24754,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2777,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24792,7 +24792,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2778,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24830,7 +24830,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2760,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24867,7 +24867,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2741,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24897,7 +24897,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -24906,7 +24906,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2724,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24930,7 +24930,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 462,
+							"line": 466,
 							"character": 4
 						}
 					],
@@ -24940,7 +24940,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2746,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24976,7 +24976,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -24986,7 +24986,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2786,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25018,7 +25018,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2821,
+							"id": 2814,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -25028,7 +25028,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2784,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25060,7 +25060,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2832,
+							"id": 2825,
 							"name": "HomepageModule"
 						}
 					},
@@ -25070,7 +25070,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2783,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25102,7 +25102,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3121,
+							"id": 3114,
 							"name": "ListPageColumns"
 						}
 					},
@@ -25112,7 +25112,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2715,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25140,7 +25140,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 306,
+							"line": 310,
 							"character": 4
 						}
 					],
@@ -25150,7 +25150,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2712,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25178,7 +25178,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 245,
+							"line": 249,
 							"character": 4
 						}
 					],
@@ -25188,7 +25188,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2709,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25216,7 +25216,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 195,
+							"line": 199,
 							"character": 4
 						}
 					],
@@ -25226,7 +25226,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2794,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25268,7 +25268,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2787,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25310,7 +25310,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2714,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25338,7 +25338,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 284,
+							"line": 288,
 							"character": 4
 						}
 					],
@@ -25348,7 +25348,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2713,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25376,7 +25376,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 265,
+							"line": 269,
 							"character": 4
 						}
 					],
@@ -25386,7 +25386,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2721,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25410,7 +25410,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 415,
+							"line": 419,
 							"character": 4
 						}
 					],
@@ -25423,7 +25423,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2716,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25451,7 +25451,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 324,
+							"line": 328,
 							"character": 4
 						}
 					],
@@ -25461,7 +25461,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2720,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25485,7 +25485,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 398,
+							"line": 402,
 							"character": 4
 						}
 					],
@@ -25495,7 +25495,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2729,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25515,18 +25515,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 533,
+							"line": 537,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3078,
+						"id": 3071,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2754,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25564,7 +25564,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2773,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25601,7 +25601,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2772,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25641,7 +25641,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2798,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25679,7 +25679,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2800,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25717,7 +25717,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2734,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25741,7 +25741,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 616,
+							"line": 620,
 							"character": 4
 						}
 					],
@@ -25751,7 +25751,7 @@
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2799,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25789,7 +25789,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2792,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25831,7 +25831,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2790,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25869,7 +25869,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2802,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25911,7 +25911,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2731,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25935,7 +25935,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 565,
+							"line": 569,
 							"character": 4
 						}
 					],
@@ -25945,7 +25945,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2733,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25969,7 +25969,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 599,
+							"line": 603,
 							"character": 4
 						}
 					],
@@ -25979,7 +25979,7 @@
 					}
 				},
 				{
-					"id": 2778,
+					"id": 2771,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26013,7 +26013,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2732,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26037,7 +26037,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 582,
+							"line": 586,
 							"character": 4
 						}
 					],
@@ -26047,7 +26047,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2782,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26085,7 +26085,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2730,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26113,7 +26113,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 548,
+							"line": 552,
 							"character": 4
 						}
 					],
@@ -26123,7 +26123,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2735,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26150,7 +26150,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 634,
+							"line": 638,
 							"character": 4
 						}
 					],
@@ -26160,7 +26160,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2736,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26184,7 +26184,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 658,
+							"line": 662,
 							"character": 4
 						}
 					],
@@ -26194,7 +26194,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2763,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26232,7 +26232,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2748,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26270,7 +26270,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2739,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26297,7 +26297,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 691,
+							"line": 713,
 							"character": 4
 						}
 					],
@@ -26307,7 +26307,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2725,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26334,7 +26334,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 478,
+							"line": 482,
 							"character": 4
 						}
 					],
@@ -26344,7 +26344,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2762,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26382,7 +26382,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2718,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26406,18 +26406,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 362,
+							"line": 366,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2022,
+						"id": 2014,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2717,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26441,7 +26441,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 344,
+							"line": 348,
 							"character": 4
 						}
 					],
@@ -26451,7 +26451,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2756,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26489,7 +26489,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2764,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26527,7 +26527,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2768,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26564,7 +26564,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2785,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26596,7 +26596,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2832,
+							"id": 2825,
 							"name": "HomepageModule"
 						}
 					},
@@ -26606,7 +26606,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2774,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26638,7 +26638,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -26648,7 +26648,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2775,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26680,7 +26680,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -26690,7 +26690,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2769,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26731,7 +26731,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2766,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26768,7 +26768,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2789,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26810,7 +26810,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2795,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26852,7 +26852,7 @@
 					}
 				},
 				{
-					"id": 2795,
+					"id": 2788,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26894,7 +26894,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2793,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26936,7 +26936,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2801,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26978,7 +26978,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2708,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27006,7 +27006,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 173,
+							"line": 177,
 							"character": 4
 						}
 					],
@@ -27016,7 +27016,42 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2738,
+					"name": "spotterSidebarConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the Spotter sidebar UI customization.\nOnly applicable when navigating to Spotter within the app.",
+						"text": "Supported embed types: `AppEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new AppEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarConfig: {\n       enablePastConversationsSidebar: true,\n       spotterSidebarTitle: 'My Conversations',\n   },\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/app.ts",
+							"line": 696,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1625,
+						"name": "SpotterSidebarViewConfig"
+					}
+				},
+				{
+					"id": 2719,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27040,7 +27075,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 378,
+							"line": 382,
 							"character": 4
 						}
 					],
@@ -27050,7 +27085,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2737,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27078,7 +27113,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 674,
+							"line": 678,
 							"character": 4
 						}
 					],
@@ -27088,7 +27123,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2770,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27129,7 +27164,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2747,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27165,7 +27200,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -27180,97 +27215,98 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2756,
-						2786,
-						2735,
-						2783,
-						2804,
-						2774,
-						2760,
-						2736,
-						2787,
-						2718,
-						2768,
-						2752,
-						2751,
-						2734,
-						2764,
-						2798,
-						2803,
-						2788,
-						2719,
-						2731,
-						2765,
-						2784,
-						2785,
-						2767,
-						2748,
-						2732,
-						2753,
-						2793,
-						2791,
-						2790,
-						2723,
-						2720,
-						2717,
-						2801,
-						2794,
-						2722,
-						2721,
-						2729,
-						2724,
-						2728,
-						2737,
-						2761,
-						2780,
+						2749,
 						2779,
-						2805,
-						2807,
-						2742,
-						2806,
-						2799,
-						2797,
-						2809,
-						2739,
-						2741,
-						2778,
-						2740,
-						2789,
-						2738,
-						2743,
-						2744,
-						2770,
-						2755,
-						2746,
-						2733,
-						2769,
-						2726,
-						2725,
-						2763,
-						2771,
-						2775,
-						2792,
-						2781,
-						2782,
-						2776,
-						2773,
-						2796,
-						2802,
-						2795,
-						2800,
-						2808,
-						2716,
 						2727,
+						2776,
+						2797,
+						2767,
+						2753,
+						2728,
+						2780,
+						2710,
+						2761,
 						2745,
+						2744,
+						2726,
+						2757,
+						2791,
+						2796,
+						2781,
+						2711,
+						2723,
+						2758,
 						2777,
-						2754
+						2778,
+						2760,
+						2741,
+						2724,
+						2746,
+						2786,
+						2784,
+						2783,
+						2715,
+						2712,
+						2709,
+						2794,
+						2787,
+						2714,
+						2713,
+						2721,
+						2716,
+						2720,
+						2729,
+						2754,
+						2773,
+						2772,
+						2798,
+						2800,
+						2734,
+						2799,
+						2792,
+						2790,
+						2802,
+						2731,
+						2733,
+						2771,
+						2732,
+						2782,
+						2730,
+						2735,
+						2736,
+						2763,
+						2748,
+						2739,
+						2725,
+						2762,
+						2718,
+						2717,
+						2756,
+						2764,
+						2768,
+						2785,
+						2774,
+						2775,
+						2769,
+						2766,
+						2789,
+						2795,
+						2788,
+						2793,
+						2801,
+						2708,
+						2738,
+						2719,
+						2737,
+						2770,
+						2747
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 156,
+					"line": 160,
 					"character": 17
 				}
 			],
@@ -27282,7 +27318,7 @@
 			]
 		},
 		{
-			"id": 1886,
+			"id": 1878,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27298,14 +27334,14 @@
 			},
 			"children": [
 				{
-					"id": 1923,
+					"id": 1915,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1924,
+							"id": 1916,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27315,19 +27351,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1925,
+									"id": 1917,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1885,
+										"id": 1877,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1926,
+									"id": 1918,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27351,14 +27387,14 @@
 					]
 				},
 				{
-					"id": 1927,
+					"id": 1919,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1928,
+							"id": 1920,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27368,7 +27404,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1929,
+									"id": 1921,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27376,12 +27412,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1876,
+										"id": 1868,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1930,
+									"id": 1922,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27390,21 +27426,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1931,
+											"id": 1923,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1932,
+													"id": 1924,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1933,
+															"id": 1925,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27430,7 +27466,7 @@
 									}
 								},
 								{
-									"id": 1934,
+									"id": 1926,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27442,7 +27478,7 @@
 									}
 								},
 								{
-									"id": 1935,
+									"id": 1927,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27458,21 +27494,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1887,
+					"id": 1879,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1888,
+							"id": 1880,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27482,7 +27518,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1889,
+									"id": 1881,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27490,12 +27526,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1877,
+										"id": 1869,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1890,
+									"id": 1882,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27506,28 +27542,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1891,
+											"id": 1883,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1892,
+													"id": 1884,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1893,
+															"id": 1885,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1869,
+																"id": 1861,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27544,12 +27580,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1894,
+							"id": 1886,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27559,7 +27595,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1895,
+									"id": 1887,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27570,29 +27606,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1878,
+												"id": 1870,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1881,
+												"id": 1873,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1882,
+												"id": 1874,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1883,
+												"id": 1875,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1896,
+									"id": 1888,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27603,14 +27639,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1897,
+											"id": 1889,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1898,
+													"id": 1890,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -27627,31 +27663,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1899,
+							"id": 1891,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1900,
+									"id": 1892,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1880,
+										"id": 1872,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1901,
+									"id": 1893,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27659,21 +27695,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1902,
+											"id": 1894,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1903,
+													"id": 1895,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1904,
+															"id": 1896,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27696,40 +27732,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1905,
+					"id": 1897,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1906,
+							"id": 1898,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1907,
+									"id": 1899,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1877,
+										"id": 1869,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1908,
+									"id": 1900,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27737,28 +27773,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1909,
+											"id": 1901,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1910,
+													"id": 1902,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1911,
+															"id": 1903,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1869,
+																"id": 1861,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27775,19 +27811,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1912,
+							"id": 1904,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1913,
+									"id": 1905,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27797,29 +27833,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1878,
+												"id": 1870,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1881,
+												"id": 1873,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1882,
+												"id": 1874,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1883,
+												"id": 1875,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1914,
+									"id": 1906,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27827,14 +27863,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1915,
+											"id": 1907,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1916,
+													"id": 1908,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -27851,31 +27887,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1917,
+							"id": 1909,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1918,
+									"id": 1910,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1880,
+										"id": 1872,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1919,
+									"id": 1911,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27883,21 +27919,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1920,
+											"id": 1912,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1921,
+													"id": 1913,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1922,
+															"id": 1914,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27920,21 +27956,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1936,
+					"id": 1928,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1937,
+							"id": 1929,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27944,7 +27980,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1938,
+									"id": 1930,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27954,14 +27990,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1876,
+										"id": 1868,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1886,
+								"id": 1878,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -27973,11 +28009,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1923,
-						1927,
-						1887,
-						1905,
-						1936
+						1915,
+						1919,
+						1879,
+						1897,
+						1928
 					]
 				}
 			],
@@ -28162,7 +28198,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -28282,7 +28318,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -28442,7 +28478,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28488,7 +28524,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -29004,7 +29040,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -29090,7 +29126,7 @@
 			]
 		},
 		{
-			"id": 1635,
+			"id": 1637,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -29110,7 +29146,7 @@
 			},
 			"children": [
 				{
-					"id": 1668,
+					"id": 1660,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29141,20 +29177,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1669,
+							"id": 1661,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1670,
+								"id": 1662,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1671,
+										"id": 1663,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -29186,12 +29222,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1611,
+						"id": 1601,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1685,
+					"id": 1677,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29228,12 +29264,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1628,
+						"id": 1618,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1672,
+					"id": 1664,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29262,17 +29298,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1615,
+						"id": 1605,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1640,
+					"id": 1642,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29300,7 +29336,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 75,
+							"line": 151,
 							"character": 4
 						}
 					],
@@ -29315,7 +29351,7 @@
 					}
 				},
 				{
-					"id": 1680,
+					"id": 1672,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29349,12 +29385,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1623,
+						"id": 1613,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1638,
+					"id": 1640,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29378,7 +29414,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 45,
+							"line": 121,
 							"character": 4
 						}
 					],
@@ -29393,7 +29429,7 @@
 					}
 				},
 				{
-					"id": 1664,
+					"id": 1656,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29427,12 +29463,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1607,
+						"id": 1597,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1663,
+					"id": 1655,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29464,18 +29500,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1606,
+						"id": 1596,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1676,
+					"id": 1668,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29512,55 +29548,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1619,
+						"id": 1609,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1647,
-					"name": "enablePastConversationsSidebar",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "enablePastConversationsSidebar : Controls the visibility of the past conversations\nsidebar.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "default",
-								"text": "false"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   enablePastConversationsSidebar : true,\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 186,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "boolean"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1590,
-						"name": "SpotterEmbedViewConfig.enablePastConversationsSidebar"
-					}
-				},
-				{
-					"id": 1677,
+					"id": 1669,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29594,12 +29587,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1620,
+						"id": 1610,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1644,
+					"id": 1646,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29623,7 +29616,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 139,
+							"line": 215,
 							"character": 4
 						}
 					],
@@ -29638,7 +29631,7 @@
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1648,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29662,7 +29655,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 170,
+							"line": 246,
 							"character": 4
 						}
 					],
@@ -29677,7 +29670,7 @@
 					}
 				},
 				{
-					"id": 1679,
+					"id": 1671,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29710,12 +29703,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1622,
+						"id": 1612,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1660,
+					"id": 1652,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29745,17 +29738,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1603,
+						"id": 1593,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1665,
+					"id": 1657,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29791,18 +29784,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1608,
+						"id": 1598,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1642,
+					"id": 1644,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29826,7 +29819,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 106,
+							"line": 182,
 							"character": 4
 						}
 					],
@@ -29841,7 +29834,7 @@
 					}
 				},
 				{
-					"id": 1639,
+					"id": 1641,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29865,7 +29858,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 59,
+							"line": 135,
 							"character": 4
 						}
 					],
@@ -29880,7 +29873,7 @@
 					}
 				},
 				{
-					"id": 1673,
+					"id": 1665,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29914,12 +29907,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1616,
+						"id": 1606,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1691,
+					"id": 1683,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29952,12 +29945,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1634,
+						"id": 1624,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1690,
+					"id": 1682,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29993,12 +29986,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1633,
+						"id": 1623,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1689,
+					"id": 1681,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30028,12 +30021,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1632,
+						"id": 1622,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1682,
+					"id": 1674,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30067,12 +30060,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1625,
+						"id": 1615,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1667,
+					"id": 1659,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30106,12 +30099,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1610,
+						"id": 1600,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1681,
+					"id": 1673,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30145,12 +30138,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1624,
+						"id": 1614,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1675,
+					"id": 1667,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30184,12 +30177,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1618,
+						"id": 1608,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1686,
+					"id": 1678,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30222,12 +30215,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1629,
+						"id": 1619,
 						"name": "SpotterEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1643,
+					"id": 1645,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30251,7 +30244,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 127,
+							"line": 203,
 							"character": 4
 						}
 					],
@@ -30259,7 +30252,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30270,7 +30263,7 @@
 					}
 				},
 				{
-					"id": 1645,
+					"id": 1647,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30294,7 +30287,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 158,
+							"line": 234,
 							"character": 4
 						}
 					],
@@ -30302,7 +30295,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30313,7 +30306,7 @@
 					}
 				},
 				{
-					"id": 1637,
+					"id": 1639,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30326,7 +30319,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 30,
+							"line": 106,
 							"character": 4
 						}
 					],
@@ -30341,7 +30334,7 @@
 					}
 				},
 				{
-					"id": 1687,
+					"id": 1679,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30378,12 +30371,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1630,
+						"id": 1620,
 						"name": "SpotterEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1684,
+					"id": 1676,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30416,12 +30409,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1627,
+						"id": 1617,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1641,
+					"id": 1643,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30445,7 +30438,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 91,
+							"line": 167,
 							"character": 4
 						}
 					],
@@ -30460,340 +30453,20 @@
 					}
 				},
 				{
-					"id": 1656,
-					"name": "spotterBestPracticesLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the best practices button in the footer.\nDefaults to translated \"Best Practices\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterBestPracticesLabel: 'Help & Tips',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 323,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1599,
-						"name": "SpotterEmbedViewConfig.spotterBestPracticesLabel"
-					}
-				},
-				{
-					"id": 1652,
-					"name": "spotterChatDeleteLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the delete action in the conversation edit menu.\nDefaults to translated \"DELETE\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatDeleteLabel: 'Remove',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 262,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1595,
-						"name": "SpotterEmbedViewConfig.spotterChatDeleteLabel"
-					}
-				},
-				{
-					"id": 1651,
-					"name": "spotterChatRenameLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the rename action in the conversation edit menu.\nDefaults to translated \"Rename\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatRenameLabel: 'Edit Name',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 247,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1594,
-						"name": "SpotterEmbedViewConfig.spotterChatRenameLabel"
-					}
-				},
-				{
-					"id": 1657,
-					"name": "spotterConversationsBatchSize",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Number of conversations to fetch per batch when loading conversation history.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "default",
-								"text": "30"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterConversationsBatchSize: 50,\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 338,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "number"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1600,
-						"name": "SpotterEmbedViewConfig.spotterConversationsBatchSize"
-					}
-				},
-				{
-					"id": 1653,
-					"name": "spotterDeleteConversationModalTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the delete conversation confirmation modal.\nDefaults to translated \"Delete chat\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDeleteConversationModalTitle: 'Remove Conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 277,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1596,
-						"name": "SpotterEmbedViewConfig.spotterDeleteConversationModalTitle"
-					}
-				},
-				{
-					"id": 1655,
-					"name": "spotterDocumentationUrl",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom URL for the documentation/best practices link.\nDefaults to ThoughtSpot docs URL based on release version.\nNote: URL must include the protocol (e.g., `https://www.example.com`).",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDocumentationUrl: 'https://docs.example.com/spotter',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 308,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1598,
-						"name": "SpotterEmbedViewConfig.spotterDocumentationUrl"
-					}
-				},
-				{
-					"id": 1658,
-					"name": "spotterNewChatButtonTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the \"New Chat\" button in the sidebar.\nDefaults to translated \"New Chat\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterNewChatButtonTitle: 'Start New Conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 353,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1601,
-						"name": "SpotterEmbedViewConfig.spotterNewChatButtonTitle"
-					}
-				},
-				{
-					"id": 1654,
-					"name": "spotterPastConversationAlertMessage",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom message text for the past conversation banner alert.\nDefaults to translated alert message.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterPastConversationAlertMessage: 'You are viewing a past conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 292,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1597,
-						"name": "SpotterEmbedViewConfig.spotterPastConversationAlertMessage"
-					}
-				},
-				{
 					"id": 1650,
-					"name": "spotterSidebarDefaultExpanded",
+					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Boolean to set the default expanded state of the sidebar.",
-						"text": "Supported embed types: `SpotterEmbed`",
+						"shortText": "Configuration for the Spotter sidebar UI customization.",
+						"text": "Supported embed types: `SpotterEmbed`, `AppEmbed`",
 						"tags": [
 							{
-								"tag": "default",
-								"text": "false"
-							},
-							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarDefaultExpanded: true,\n})\n```"
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarConfig: {\n       enablePastConversationsSidebar: true,\n       spotterSidebarTitle: 'My Conversations',\n       spotterSidebarDefaultExpanded: true,\n   },\n})\n```"
 							},
 							{
 								"tag": "version",
@@ -30804,61 +30477,23 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 232,
+							"line": 279,
 							"character": 4
 						}
 					],
 					"type": {
-						"type": "intrinsic",
-						"name": "boolean"
+						"type": "reference",
+						"id": 1625,
+						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1593,
-						"name": "SpotterEmbedViewConfig.spotterSidebarDefaultExpanded"
+						"id": 1591,
+						"name": "SpotterEmbedViewConfig.spotterSidebarConfig"
 					}
 				},
 				{
 					"id": 1649,
-					"name": "spotterSidebarTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the sidebar header.\nDefaults to translated \"Spotter\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarTitle: 'My Conversations',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 217,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1592,
-						"name": "SpotterEmbedViewConfig.spotterSidebarTitle"
-					}
-				},
-				{
-					"id": 1648,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30886,7 +30521,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 202,
+							"line": 261,
 							"character": 4
 						}
 					],
@@ -30896,12 +30531,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1591,
+						"id": 1590,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1688,
+					"id": 1680,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30938,12 +30573,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1631,
+						"id": 1621,
 						"name": "SpotterEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1666,
+					"id": 1658,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30979,18 +30614,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1609,
+						"id": 1599,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1636,
+					"id": 1638,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31001,7 +30636,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 26,
+							"line": 102,
 							"character": 4
 						}
 					],
@@ -31021,60 +30656,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1668,
-						1685,
+						1660,
+						1677,
+						1664,
+						1642,
 						1672,
 						1640,
-						1680,
-						1638,
-						1664,
-						1663,
-						1676,
-						1647,
-						1677,
-						1644,
-						1646,
-						1679,
-						1660,
-						1665,
-						1642,
-						1639,
-						1673,
-						1691,
-						1690,
-						1689,
-						1682,
-						1667,
-						1681,
-						1675,
-						1686,
-						1643,
-						1645,
-						1637,
-						1687,
-						1684,
-						1641,
 						1656,
-						1652,
-						1651,
-						1657,
-						1653,
 						1655,
-						1658,
-						1654,
+						1668,
+						1669,
+						1646,
+						1648,
+						1671,
+						1652,
+						1657,
+						1644,
+						1641,
+						1665,
+						1683,
+						1682,
+						1681,
+						1674,
+						1659,
+						1673,
+						1667,
+						1678,
+						1645,
+						1647,
+						1639,
+						1679,
+						1676,
+						1643,
 						1650,
 						1649,
-						1648,
-						1688,
-						1666,
-						1636
+						1680,
+						1658,
+						1638
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 363,
+					"line": 289,
 					"character": 17
 				}
 			],
@@ -31087,7 +30712,7 @@
 			]
 		},
 		{
-			"id": 3093,
+			"id": 3086,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31102,7 +30727,7 @@
 			},
 			"children": [
 				{
-					"id": 3094,
+					"id": 3087,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31119,14 +30744,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3095,
+							"id": 3088,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3096,
+									"id": 3089,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31140,12 +30765,12 @@
 									],
 									"type": {
 										"type": "reference",
-										"id": 3090,
+										"id": 3083,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3097,
+									"id": 3090,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31161,7 +30786,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3090,
+											"id": 3083,
 											"name": "VizPoint"
 										}
 									}
@@ -31172,8 +30797,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3096,
-										3097
+										3089,
+										3090
 									]
 								}
 							]
@@ -31181,7 +30806,7 @@
 					}
 				},
 				{
-					"id": 3098,
+					"id": 3091,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31196,14 +30821,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3099,
+							"id": 3092,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3107,
+									"id": 3100,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31224,7 +30849,7 @@
 									}
 								},
 								{
-									"id": 3108,
+									"id": 3101,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31245,7 +30870,7 @@
 									}
 								},
 								{
-									"id": 3101,
+									"id": 3094,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31263,7 +30888,7 @@
 									}
 								},
 								{
-									"id": 3100,
+									"id": 3093,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31281,7 +30906,7 @@
 									}
 								},
 								{
-									"id": 3102,
+									"id": 3095,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31296,14 +30921,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3103,
+											"id": 3096,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3104,
+													"id": 3097,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -31318,14 +30943,14 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3105,
+															"id": 3098,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3106,
+																	"id": 3099,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -31348,7 +30973,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3106
+																		3099
 																	]
 																}
 															]
@@ -31361,7 +30986,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3104
+														3097
 													]
 												}
 											]
@@ -31374,23 +30999,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3107,
-										3108,
-										3101,
 										3100,
-										3102
+										3101,
+										3094,
+										3093,
+										3095
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3109,
+								"id": 3102,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3110,
+										"id": 3103,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -31409,7 +31034,7 @@
 					}
 				},
 				{
-					"id": 3111,
+					"id": 3104,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31423,12 +31048,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2012,
+						"id": 2004,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3112,
+					"id": 3105,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31453,10 +31078,10 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3094,
-						3098,
-						3111,
-						3112
+						3087,
+						3091,
+						3104,
+						3105
 					]
 				}
 			],
@@ -31469,7 +31094,7 @@
 			]
 		},
 		{
-			"id": 2878,
+			"id": 2871,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31479,7 +31104,7 @@
 			},
 			"children": [
 				{
-					"id": 2932,
+					"id": 2925,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31502,7 +31127,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2924,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31525,7 +31150,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2894,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31548,7 +31173,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2895,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31571,7 +31196,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2897,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31594,7 +31219,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2896,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31617,7 +31242,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2876,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31640,7 +31265,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2937,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31663,7 +31288,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2938,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31686,7 +31311,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2935,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31709,7 +31334,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2936,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31732,7 +31357,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2899,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31755,7 +31380,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2904,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31778,7 +31403,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2901,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31801,7 +31426,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2903,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31824,7 +31449,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2902,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31847,7 +31472,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2900,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31870,7 +31495,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2909,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31893,7 +31518,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2906,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31916,7 +31541,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2908,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31939,7 +31564,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2907,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31962,7 +31587,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2905,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31985,7 +31610,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2913,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32008,7 +31633,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2912,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32031,7 +31656,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2911,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32054,7 +31679,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2910,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32077,7 +31702,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2898,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32100,7 +31725,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3031,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32123,7 +31748,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3026,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32146,7 +31771,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3021,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32169,7 +31794,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3020,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32192,7 +31817,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3023,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32215,7 +31840,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3022,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32238,7 +31863,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2960,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32261,7 +31886,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2963,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32284,7 +31909,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2958,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32307,7 +31932,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2961,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32330,7 +31955,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2962,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32353,7 +31978,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2957,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32376,7 +32001,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2959,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32399,7 +32024,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2930,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32422,7 +32047,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2929,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32445,7 +32070,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2932,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32468,7 +32093,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2931,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32491,7 +32116,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2928,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32514,7 +32139,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2926,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32537,7 +32162,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2927,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32560,7 +32185,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2933,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32583,7 +32208,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2934,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32606,7 +32231,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2945,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32629,7 +32254,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2946,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32652,7 +32277,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2949,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32675,7 +32300,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2947,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32698,7 +32323,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2948,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32721,7 +32346,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2956,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32744,7 +32369,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2955,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32767,7 +32392,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2954,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32790,7 +32415,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2953,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32813,7 +32438,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3019,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32836,7 +32461,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3018,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32859,7 +32484,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3017,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32882,7 +32507,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3025,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32905,7 +32530,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3024,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32928,7 +32553,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2951,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32951,7 +32576,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2950,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32974,7 +32599,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 2978,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32997,7 +32622,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 2991,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33021,7 +32646,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 2990,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33045,7 +32670,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 2988,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33069,7 +32694,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 2989,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33093,7 +32718,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 2996,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33116,7 +32741,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 2994,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33139,7 +32764,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 2993,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33162,7 +32787,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 2979,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33186,7 +32811,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 2980,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33210,7 +32835,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 2984,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33234,7 +32859,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2972,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33258,7 +32883,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 2987,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33282,7 +32907,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 2986,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33306,7 +32931,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 2977,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33330,7 +32955,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 2985,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33354,7 +32979,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2975,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33378,7 +33003,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2976,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33402,7 +33027,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 2983,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33426,7 +33051,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2973,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33450,7 +33075,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2974,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33474,7 +33099,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3010,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33497,7 +33122,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3007,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33520,7 +33145,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3008,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33543,7 +33168,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3009,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33566,7 +33191,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2965,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33589,7 +33214,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3016,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33612,7 +33237,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3011,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33635,7 +33260,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3012,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33658,7 +33283,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3015,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33681,7 +33306,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3013,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33704,7 +33329,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3014,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33727,7 +33352,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2966,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33750,7 +33375,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2964,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33773,7 +33398,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 2982,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33796,7 +33421,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 2981,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33819,7 +33444,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 2995,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33842,7 +33467,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 2997,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33865,7 +33490,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 2998,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33888,7 +33513,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2968,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33911,7 +33536,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2967,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33934,7 +33559,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2969,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33957,7 +33582,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2970,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33980,7 +33605,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2971,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34003,7 +33628,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 2999,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34026,7 +33651,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3000,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34049,7 +33674,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2943,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34072,7 +33697,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2940,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34095,7 +33720,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2939,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34118,7 +33743,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2941,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34141,7 +33766,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2944,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34164,7 +33789,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2942,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34187,7 +33812,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2877,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34210,7 +33835,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2878,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34233,7 +33858,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3005,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34256,7 +33881,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3006,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34279,7 +33904,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3001,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34302,7 +33927,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3003,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34325,7 +33950,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3004,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34348,7 +33973,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3002,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34371,7 +33996,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2872,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34394,7 +34019,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2873,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34417,7 +34042,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2874,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34440,7 +34065,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2875,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34463,7 +34088,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3034,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34486,7 +34111,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3033,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34509,7 +34134,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3038,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34532,7 +34157,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3039,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34555,7 +34180,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3042,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34578,7 +34203,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3041,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34601,7 +34226,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3040,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34624,7 +34249,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3043,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34647,7 +34272,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3036,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34670,7 +34295,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3044,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34693,7 +34318,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3035,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34716,7 +34341,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3037,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34739,7 +34364,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2886,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34762,7 +34387,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2890,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34785,7 +34410,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2891,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34808,7 +34433,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2889,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34831,7 +34456,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2885,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34854,7 +34479,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2888,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34877,7 +34502,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2882,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34900,7 +34525,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2883,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34923,7 +34548,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2884,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34946,7 +34571,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2879,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34969,7 +34594,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2880,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34992,7 +34617,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2881,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35015,7 +34640,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2887,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35038,7 +34663,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2952,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35061,7 +34686,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 2992,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35084,7 +34709,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3030,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35107,7 +34732,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3027,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35130,7 +34755,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3028,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35153,7 +34778,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3029,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35176,7 +34801,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3032,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35199,7 +34824,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2892,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35222,7 +34847,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2893,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35245,7 +34870,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2922,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35268,7 +34893,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2920,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35291,7 +34916,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2921,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35314,7 +34939,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2917,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35337,7 +34962,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2918,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35360,7 +34985,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2919,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35383,7 +35008,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2923,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35406,7 +35031,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2914,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35429,7 +35054,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2915,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35452,7 +35077,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2916,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35480,179 +35105,179 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2932,
-						2931,
-						2901,
-						2902,
-						2904,
-						2903,
-						2883,
-						2944,
-						2945,
-						2942,
-						2943,
-						2906,
-						2911,
-						2908,
-						2910,
-						2909,
-						2907,
-						2916,
-						2913,
-						2915,
-						2914,
-						2912,
-						2920,
-						2919,
-						2918,
-						2917,
-						2905,
-						3038,
-						3033,
-						3028,
-						3027,
-						3030,
-						3029,
-						2967,
-						2970,
-						2965,
-						2968,
-						2969,
-						2964,
-						2966,
+						2925,
+						2924,
+						2894,
+						2895,
+						2897,
+						2896,
+						2876,
 						2937,
-						2936,
-						2939,
 						2938,
 						2935,
+						2936,
+						2899,
+						2904,
+						2901,
+						2903,
+						2902,
+						2900,
+						2909,
+						2906,
+						2908,
+						2907,
+						2905,
+						2913,
+						2912,
+						2911,
+						2910,
+						2898,
+						3031,
+						3026,
+						3021,
+						3020,
+						3023,
+						3022,
+						2960,
+						2963,
+						2958,
+						2961,
+						2962,
+						2957,
+						2959,
+						2930,
+						2929,
+						2932,
+						2931,
+						2928,
+						2926,
+						2927,
 						2933,
 						2934,
-						2940,
-						2941,
-						2952,
-						2953,
+						2945,
+						2946,
+						2949,
+						2947,
+						2948,
 						2956,
-						2954,
 						2955,
-						2963,
-						2962,
-						2961,
-						2960,
-						3026,
+						2954,
+						2953,
+						3019,
+						3018,
+						3017,
 						3025,
 						3024,
-						3032,
-						3031,
-						2958,
-						2957,
-						2985,
-						2998,
-						2997,
-						2995,
-						2996,
-						3003,
-						3001,
-						3000,
-						2986,
-						2987,
+						2951,
+						2950,
+						2978,
 						2991,
-						2979,
+						2990,
+						2988,
+						2989,
+						2996,
 						2994,
 						2993,
-						2984,
-						2992,
-						2982,
-						2983,
-						2990,
+						2979,
 						2980,
-						2981,
-						3017,
-						3014,
-						3015,
-						3016,
+						2984,
 						2972,
-						3023,
-						3018,
-						3019,
-						3022,
-						3020,
-						3021,
-						2973,
-						2971,
-						2989,
-						2988,
-						3002,
-						3004,
-						3005,
-						2975,
-						2974,
-						2976,
+						2987,
+						2986,
 						2977,
-						2978,
-						3006,
-						3007,
-						2950,
-						2947,
-						2946,
-						2948,
-						2951,
-						2949,
-						2884,
-						2885,
-						3012,
-						3013,
-						3008,
+						2985,
+						2975,
+						2976,
+						2983,
+						2973,
+						2974,
 						3010,
-						3011,
+						3007,
+						3008,
 						3009,
+						2965,
+						3016,
+						3011,
+						3012,
+						3015,
+						3013,
+						3014,
+						2966,
+						2964,
+						2982,
+						2981,
+						2995,
+						2997,
+						2998,
+						2968,
+						2967,
+						2969,
+						2970,
+						2971,
+						2999,
+						3000,
+						2943,
+						2940,
+						2939,
+						2941,
+						2944,
+						2942,
+						2877,
+						2878,
+						3005,
+						3006,
+						3001,
+						3003,
+						3004,
+						3002,
+						2872,
+						2873,
+						2874,
+						2875,
+						3034,
+						3033,
+						3038,
+						3039,
+						3042,
+						3041,
+						3040,
+						3043,
+						3036,
+						3044,
+						3035,
+						3037,
+						2886,
+						2890,
+						2891,
+						2889,
+						2885,
+						2888,
+						2882,
+						2883,
+						2884,
 						2879,
 						2880,
 						2881,
-						2882,
-						3041,
-						3040,
-						3045,
-						3046,
-						3049,
-						3048,
-						3047,
-						3050,
-						3043,
-						3051,
-						3042,
-						3044,
-						2893,
-						2897,
-						2898,
-						2896,
-						2892,
-						2895,
-						2889,
-						2890,
-						2891,
-						2886,
 						2887,
-						2888,
-						2894,
-						2959,
-						2999,
-						3037,
-						3034,
-						3035,
-						3036,
-						3039,
-						2899,
-						2900,
-						2929,
-						2927,
-						2928,
-						2924,
-						2925,
-						2926,
-						2930,
-						2921,
+						2952,
+						2992,
+						3030,
+						3027,
+						3028,
+						3029,
+						3032,
+						2892,
+						2893,
 						2922,
-						2923
+						2920,
+						2921,
+						2917,
+						2918,
+						2919,
+						2923,
+						2914,
+						2915,
+						2916
 					]
 				}
 			],
@@ -35665,7 +35290,7 @@
 			]
 		},
 		{
-			"id": 2866,
+			"id": 2859,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35675,7 +35300,7 @@
 			},
 			"children": [
 				{
-					"id": 2868,
+					"id": 2861,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35691,12 +35316,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2862,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2860,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35721,8 +35346,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2868,
-						2867
+						2861,
+						2860
 					]
 				}
 			],
@@ -35735,7 +35360,7 @@
 			]
 		},
 		{
-			"id": 2856,
+			"id": 2849,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35751,7 +35376,7 @@
 			},
 			"children": [
 				{
-					"id": 2858,
+					"id": 2851,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35768,14 +35393,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2859,
+							"id": 2852,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2861,
+									"id": 2854,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35805,7 +35430,7 @@
 									}
 								},
 								{
-									"id": 2862,
+									"id": 2855,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35825,7 +35450,7 @@
 									}
 								},
 								{
-									"id": 2860,
+									"id": 2853,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35868,21 +35493,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2861,
-										2862,
-										2860
+										2854,
+										2855,
+										2853
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2863,
+								"id": 2856,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2864,
+										"id": 2857,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -35901,7 +35526,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2858,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35921,7 +35546,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2850,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35937,7 +35562,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2859,
 						"name": "CustomStyles"
 					}
 				}
@@ -35947,9 +35572,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
+						2851,
 						2858,
-						2865,
-						2857
+						2850
 					]
 				}
 			],
@@ -35962,7 +35587,7 @@
 			]
 		},
 		{
-			"id": 2413,
+			"id": 2405,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35978,7 +35603,7 @@
 			},
 			"children": [
 				{
-					"id": 2455,
+					"id": 2447,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36008,20 +35633,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2456,
+							"id": 2448,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2457,
+								"id": 2449,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2458,
+										"id": 2450,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36053,7 +35678,7 @@
 					}
 				},
 				{
-					"id": 2416,
+					"id": 2408,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36076,7 +35701,7 @@
 					}
 				},
 				{
-					"id": 2437,
+					"id": 2429,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36118,7 +35743,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2431,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36147,7 +35772,7 @@
 					}
 				},
 				{
-					"id": 2415,
+					"id": 2407,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36164,12 +35789,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2031,
+						"id": 2023,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2428,
+					"id": 2420,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36198,7 +35823,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2432,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36231,7 +35856,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2423,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36260,7 +35885,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2456,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36293,7 +35918,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2444,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36322,7 +35947,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2454,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36358,7 +35983,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2451,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36401,7 +36026,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2428,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36426,12 +36051,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2442,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36460,7 +36085,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2425,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36490,7 +36115,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2453,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36527,7 +36152,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2446,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36556,7 +36181,7 @@
 					}
 				},
 				{
-					"id": 2429,
+					"id": 2421,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36589,7 +36214,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2452,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36609,7 +36234,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2441,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36638,7 +36263,7 @@
 					}
 				},
 				{
-					"id": 2427,
+					"id": 2419,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36667,7 +36292,7 @@
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2414,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36701,7 +36326,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2440,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36734,12 +36359,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3055,
+						"id": 3048,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2422,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36768,7 +36393,7 @@
 					}
 				},
 				{
-					"id": 2421,
+					"id": 2413,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36801,7 +36426,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2443,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36830,7 +36455,7 @@
 					}
 				},
 				{
-					"id": 2420,
+					"id": 2412,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36854,7 +36479,7 @@
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2438,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36883,7 +36508,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2424,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36916,7 +36541,7 @@
 					}
 				},
 				{
-					"id": 2423,
+					"id": 2415,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36946,7 +36571,7 @@
 					}
 				},
 				{
-					"id": 2425,
+					"id": 2417,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36975,7 +36600,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2439,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37004,7 +36629,7 @@
 					}
 				},
 				{
-					"id": 2426,
+					"id": 2418,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37033,7 +36658,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2427,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37056,7 +36681,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2426,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37085,7 +36710,7 @@
 					}
 				},
 				{
-					"id": 2414,
+					"id": 2406,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37106,7 +36731,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2430,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37129,7 +36754,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2411,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37152,7 +36777,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2455,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37185,7 +36810,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2409,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -37201,7 +36826,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2418,
+							"id": 2410,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -37229,52 +36854,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2455,
-						2416,
-						2437,
-						2439,
-						2415,
-						2428,
-						2440,
-						2431,
-						2464,
-						2452,
-						2462,
-						2459,
-						2436,
-						2450,
-						2433,
-						2461,
-						2454,
+						2447,
+						2408,
 						2429,
-						2460,
-						2449,
-						2427,
-						2422,
-						2448,
-						2430,
-						2421,
-						2451,
+						2431,
+						2407,
 						2420,
-						2446,
 						2432,
 						2423,
+						2456,
+						2444,
+						2454,
+						2451,
+						2428,
+						2442,
 						2425,
-						2447,
-						2426,
-						2435,
-						2434,
-						2414,
-						2438,
+						2453,
+						2446,
+						2421,
+						2452,
+						2441,
 						2419,
-						2463
+						2414,
+						2440,
+						2422,
+						2413,
+						2443,
+						2412,
+						2438,
+						2424,
+						2415,
+						2417,
+						2439,
+						2418,
+						2427,
+						2426,
+						2406,
+						2430,
+						2411,
+						2455
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2417
+						2409
 					]
 				}
 			],
@@ -37287,7 +36912,7 @@
 			]
 		},
 		{
-			"id": 2815,
+			"id": 2808,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37303,7 +36928,7 @@
 			},
 			"children": [
 				{
-					"id": 2817,
+					"id": 2810,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37335,7 +36960,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2811,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37371,7 +36996,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2809,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37408,9 +37033,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2817,
-						2818,
-						2816
+						2810,
+						2811,
+						2809
 					]
 				}
 			],
@@ -37422,7 +37047,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2819,
+				"id": 2812,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -37432,7 +37057,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2820,
+						"id": 2813,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -37466,7 +37091,7 @@
 			}
 		},
 		{
-			"id": 2574,
+			"id": 2566,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37482,7 +37107,7 @@
 			},
 			"children": [
 				{
-					"id": 2586,
+					"id": 2578,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37516,7 +37141,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2603,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37547,20 +37172,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2612,
+							"id": 2604,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2613,
+								"id": 2605,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2614,
+										"id": 2606,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -37596,7 +37221,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2633,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37638,7 +37263,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2630,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37668,7 +37293,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2409,
+						"id": 2401,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -37677,7 +37302,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2647,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37715,7 +37340,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2621,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37756,7 +37381,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2607,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37785,7 +37410,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -37794,7 +37419,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2634,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37836,7 +37461,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2568,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37878,7 +37503,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2615,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37916,7 +37541,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2599,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37954,7 +37579,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2598,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37986,7 +37611,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -37996,7 +37621,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2611,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38037,7 +37662,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2641,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38079,7 +37704,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2646,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38121,7 +37746,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2635,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38163,7 +37788,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2612,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38201,7 +37826,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2570,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38237,7 +37862,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2631,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38275,7 +37900,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2632,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38313,7 +37938,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2614,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38350,7 +37975,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2595,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38380,7 +38005,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -38389,7 +38014,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2567,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38423,7 +38048,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2600,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38459,7 +38084,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -38469,7 +38094,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2584,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38506,7 +38131,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2644,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38548,7 +38173,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2637,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38590,7 +38215,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2579,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38624,7 +38249,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2608,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38662,7 +38287,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2627,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38699,7 +38324,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2626,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38739,7 +38364,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2648,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38777,7 +38402,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2650,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38815,7 +38440,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2589,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38849,7 +38474,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2649,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38887,7 +38512,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2642,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38929,7 +38554,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2640,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38967,7 +38592,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2652,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39009,7 +38634,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2586,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39043,7 +38668,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2588,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39077,7 +38702,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2625,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39111,7 +38736,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2587,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39145,7 +38770,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2636,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39183,7 +38808,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2590,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39220,7 +38845,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2591,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39254,7 +38879,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2617,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39292,7 +38917,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2571,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39326,7 +38951,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2577,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39360,7 +38985,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2602,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39398,7 +39023,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2569,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39435,7 +39060,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2616,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39473,7 +39098,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2610,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39511,7 +39136,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2574,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39545,7 +39170,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2618,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39583,7 +39208,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2622,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39620,7 +39245,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2628,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39652,7 +39277,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -39662,7 +39287,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2629,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39694,7 +39319,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -39704,7 +39329,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2623,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39745,7 +39370,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2620,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39782,7 +39407,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2639,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39824,7 +39449,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2645,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39866,7 +39491,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2638,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39908,7 +39533,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2643,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39950,7 +39575,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2651,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39992,7 +39617,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2580,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40026,7 +39651,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2592,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40059,7 +39684,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2593,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40097,7 +39722,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2624,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40138,7 +39763,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2601,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40174,7 +39799,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -40184,7 +39809,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2585,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40221,7 +39846,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2575,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40258,7 +39883,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2573,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40297,78 +39922,78 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2586,
+						2578,
+						2603,
+						2633,
+						2630,
+						2647,
+						2621,
+						2607,
+						2634,
+						2568,
+						2615,
+						2599,
+						2598,
 						2611,
 						2641,
-						2638,
-						2655,
-						2629,
-						2615,
-						2642,
-						2576,
-						2623,
-						2607,
-						2606,
-						2619,
-						2649,
-						2654,
-						2643,
-						2620,
-						2578,
-						2639,
-						2640,
-						2622,
-						2603,
-						2575,
-						2608,
-						2592,
-						2652,
-						2645,
-						2587,
-						2616,
-						2635,
-						2634,
-						2656,
-						2658,
-						2597,
-						2657,
-						2650,
-						2648,
-						2660,
-						2594,
-						2596,
-						2633,
-						2595,
-						2644,
-						2598,
-						2599,
-						2625,
-						2579,
-						2585,
-						2610,
-						2577,
-						2624,
-						2618,
-						2582,
-						2626,
-						2630,
-						2636,
-						2637,
-						2631,
-						2628,
-						2647,
-						2653,
 						2646,
-						2651,
-						2659,
-						2588,
-						2600,
-						2601,
+						2635,
+						2612,
+						2570,
+						2631,
 						2632,
-						2609,
+						2614,
+						2595,
+						2567,
+						2600,
+						2584,
+						2644,
+						2637,
+						2579,
+						2608,
+						2627,
+						2626,
+						2648,
+						2650,
+						2589,
+						2649,
+						2642,
+						2640,
+						2652,
+						2586,
+						2588,
+						2625,
+						2587,
+						2636,
+						2590,
+						2591,
+						2617,
+						2571,
+						2577,
+						2602,
+						2569,
+						2616,
+						2610,
+						2574,
+						2618,
+						2622,
+						2628,
+						2629,
+						2623,
+						2620,
+						2639,
+						2645,
+						2638,
+						2643,
+						2651,
+						2580,
+						2592,
 						2593,
-						2583,
-						2581
+						2624,
+						2601,
+						2585,
+						2575,
+						2573
 					]
 				}
 			],
@@ -40395,7 +40020,7 @@
 			]
 		},
 		{
-			"id": 2043,
+			"id": 2035,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40405,7 +40030,7 @@
 			},
 			"children": [
 				{
-					"id": 2044,
+					"id": 2036,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40426,7 +40051,7 @@
 					}
 				},
 				{
-					"id": 2045,
+					"id": 2037,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40443,12 +40068,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2047,
+						"id": 2039,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2046,
+					"id": 2038,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40494,9 +40119,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2044,
-						2045,
-						2046
+						2036,
+						2037,
+						2038
 					]
 				}
 			],
@@ -40509,7 +40134,7 @@
 			]
 		},
 		{
-			"id": 3052,
+			"id": 3045,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40519,7 +40144,7 @@
 			},
 			"children": [
 				{
-					"id": 3053,
+					"id": 3046,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40540,7 +40165,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3047,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40579,8 +40204,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3053,
-						3054
+						3046,
+						3047
 					]
 				}
 			],
@@ -40593,7 +40218,7 @@
 			]
 		},
 		{
-			"id": 2661,
+			"id": 2653,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40613,7 +40238,7 @@
 			},
 			"children": [
 				{
-					"id": 2691,
+					"id": 2683,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40644,20 +40269,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2692,
+							"id": 2684,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2693,
+								"id": 2685,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2694,
+										"id": 2686,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -40693,7 +40318,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2670,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40735,7 +40360,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2667,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40765,7 +40390,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2409,
+						"id": 2401,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -40774,7 +40399,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2700,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40815,7 +40440,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2687,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40844,7 +40469,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -40853,7 +40478,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2671,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40895,7 +40520,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2663,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40918,7 +40543,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2695,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40956,7 +40581,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2658,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40985,7 +40610,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2679,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41023,7 +40648,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2678,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41055,7 +40680,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -41065,7 +40690,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2691,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41106,7 +40731,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2672,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41148,7 +40773,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2692,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41186,7 +40811,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2668,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41224,7 +40849,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2669,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41262,7 +40887,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2694,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41299,7 +40924,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2675,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41329,7 +40954,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -41338,7 +40963,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2680,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41374,7 +40999,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -41384,7 +41009,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2660,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41413,7 +41038,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2657,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41442,7 +41067,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2662,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41476,7 +41101,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2656,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41509,7 +41134,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2659,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41538,7 +41163,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2688,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41576,7 +41201,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2706,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41613,7 +41238,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2705,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41653,7 +41278,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2704,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41687,7 +41312,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2673,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41725,7 +41350,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2697,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41763,7 +41388,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2682,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41801,7 +41426,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2696,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41839,7 +41464,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2690,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41877,7 +41502,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2701,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41914,7 +41539,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2665,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41946,7 +41571,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -41956,7 +41581,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2666,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41988,7 +41613,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -41998,7 +41623,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2664,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42032,7 +41657,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2702,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42073,7 +41698,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2699,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42110,7 +41735,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2654,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42139,7 +41764,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2661,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42168,7 +41793,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2703,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42209,7 +41834,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2681,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42245,7 +41870,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -42260,49 +41885,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2691,
-						2678,
-						2675,
-						2708,
-						2695,
-						2679,
-						2671,
-						2703,
-						2666,
-						2687,
-						2686,
-						2699,
-						2680,
-						2700,
-						2676,
-						2677,
-						2702,
 						2683,
-						2688,
-						2668,
-						2665,
 						2670,
-						2664,
 						2667,
-						2696,
-						2714,
-						2713,
-						2712,
-						2681,
-						2705,
-						2690,
-						2704,
-						2698,
-						2709,
-						2673,
-						2674,
+						2700,
+						2687,
+						2671,
+						2663,
+						2695,
+						2658,
+						2679,
+						2678,
+						2691,
 						2672,
-						2710,
-						2707,
-						2662,
+						2692,
+						2668,
 						2669,
-						2711,
-						2689
+						2694,
+						2675,
+						2680,
+						2660,
+						2657,
+						2662,
+						2656,
+						2659,
+						2688,
+						2706,
+						2705,
+						2704,
+						2673,
+						2697,
+						2682,
+						2696,
+						2690,
+						2701,
+						2665,
+						2666,
+						2664,
+						2702,
+						2699,
+						2654,
+						2661,
+						2703,
+						2681
 					]
 				}
 			],
@@ -42356,7 +41981,7 @@
 			]
 		},
 		{
-			"id": 2525,
+			"id": 2517,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42371,7 +41996,7 @@
 			},
 			"children": [
 				{
-					"id": 2540,
+					"id": 2532,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42402,20 +42027,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2541,
+							"id": 2533,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2542,
+								"id": 2534,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2543,
+										"id": 2535,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42451,7 +42076,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2562,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42493,7 +42118,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2559,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42523,7 +42148,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2409,
+						"id": 2401,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -42532,7 +42157,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2550,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42573,7 +42198,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2536,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42602,7 +42227,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -42611,7 +42236,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2563,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42653,7 +42278,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2519,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42687,7 +42312,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2518,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42728,7 +42353,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2544,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42766,7 +42391,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2528,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42804,7 +42429,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2527,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42836,7 +42461,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -42846,7 +42471,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2540,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42887,7 +42512,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2564,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42929,7 +42554,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2541,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42967,7 +42592,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2560,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43005,7 +42630,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2561,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43043,7 +42668,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2522,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43077,7 +42702,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2543,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43114,7 +42739,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2524,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43144,7 +42769,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -43153,7 +42778,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2529,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43189,7 +42814,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -43199,7 +42824,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2537,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43237,7 +42862,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2556,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43274,7 +42899,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2555,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43314,7 +42939,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2554,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43348,7 +42973,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2565,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43386,7 +43011,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2546,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43424,7 +43049,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2531,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43462,7 +43087,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2545,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43500,7 +43125,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2539,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43538,7 +43163,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2547,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43576,7 +43201,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2551,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43613,7 +43238,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2557,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43645,7 +43270,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -43655,7 +43280,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2558,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43687,7 +43312,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -43697,7 +43322,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2521,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43731,7 +43356,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2552,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43772,7 +43397,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2549,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43809,7 +43434,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2553,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43850,7 +43475,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2520,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43884,7 +43509,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2530,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43920,7 +43545,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -43935,45 +43560,45 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2540,
-						2570,
-						2567,
-						2558,
-						2544,
-						2571,
-						2527,
-						2526,
-						2552,
-						2536,
-						2535,
-						2548,
-						2572,
-						2549,
-						2568,
-						2569,
-						2530,
-						2551,
 						2532,
-						2537,
-						2545,
-						2564,
-						2563,
 						2562,
-						2573,
-						2554,
-						2539,
-						2553,
-						2547,
-						2555,
 						2559,
-						2565,
-						2566,
-						2529,
-						2560,
-						2557,
-						2561,
+						2550,
+						2536,
+						2563,
+						2519,
+						2518,
+						2544,
 						2528,
-						2538
+						2527,
+						2540,
+						2564,
+						2541,
+						2560,
+						2561,
+						2522,
+						2543,
+						2524,
+						2529,
+						2537,
+						2556,
+						2555,
+						2554,
+						2565,
+						2546,
+						2531,
+						2545,
+						2539,
+						2547,
+						2551,
+						2557,
+						2558,
+						2521,
+						2552,
+						2549,
+						2553,
+						2520,
+						2530
 					]
 				}
 			],
@@ -43996,7 +43621,7 @@
 			]
 		},
 		{
-			"id": 2465,
+			"id": 2457,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44012,7 +43637,7 @@
 			},
 			"children": [
 				{
-					"id": 2501,
+					"id": 2493,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44043,20 +43668,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2502,
+							"id": 2494,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2503,
+								"id": 2495,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2504,
+										"id": 2496,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -44092,7 +43717,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2469,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44126,7 +43751,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2459,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44160,7 +43785,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2458,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44194,7 +43819,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2480,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44236,7 +43861,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2472,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44273,7 +43898,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2477,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44303,7 +43928,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2409,
+						"id": 2401,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -44312,7 +43937,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2510,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44353,7 +43978,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2497,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44382,7 +44007,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44391,7 +44016,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2473,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44429,7 +44054,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2481,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44471,7 +44096,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2465,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44505,7 +44130,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2464,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44541,7 +44166,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2505,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44579,7 +44204,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2489,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44617,7 +44242,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2488,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44649,7 +44274,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -44659,7 +44284,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2501,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44700,7 +44325,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2482,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44742,7 +44367,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2462,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44776,7 +44401,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2502,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44814,7 +44439,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2478,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44852,7 +44477,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2479,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44890,7 +44515,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2468,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44924,7 +44549,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2504,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44961,7 +44586,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2474,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44999,7 +44624,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2463,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45033,7 +44658,7 @@
 					}
 				},
 				{
-					"id": 2493,
+					"id": 2485,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45063,7 +44688,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45072,7 +44697,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2490,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45108,7 +44733,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -45118,7 +44743,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2460,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45152,7 +44777,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2461,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45186,7 +44811,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2470,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45220,7 +44845,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2498,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45258,7 +44883,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2516,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45295,7 +44920,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2515,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45335,7 +44960,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2514,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45369,7 +44994,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2483,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45407,7 +45032,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2507,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45445,7 +45070,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2492,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45483,7 +45108,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2506,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45521,7 +45146,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2500,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45559,7 +45184,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2511,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45596,7 +45221,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2475,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45628,7 +45253,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -45638,7 +45263,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2476,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45670,7 +45295,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -45680,7 +45305,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2467,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45710,7 +45335,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2466,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45739,7 +45364,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2512,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45780,7 +45405,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2509,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45817,7 +45442,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2513,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45858,7 +45483,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2471,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45888,7 +45513,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2491,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45924,7 +45549,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -45939,56 +45564,56 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2501,
+						2493,
+						2469,
+						2459,
+						2458,
+						2480,
+						2472,
 						2477,
+						2510,
+						2497,
+						2473,
+						2481,
+						2465,
+						2464,
+						2505,
+						2489,
+						2488,
+						2501,
+						2482,
+						2462,
+						2502,
+						2478,
+						2479,
+						2468,
+						2504,
+						2474,
+						2463,
+						2485,
+						2490,
+						2460,
+						2461,
+						2470,
+						2498,
+						2516,
+						2515,
+						2514,
+						2483,
+						2507,
+						2492,
+						2506,
+						2500,
+						2511,
+						2475,
+						2476,
 						2467,
 						2466,
-						2488,
-						2480,
-						2485,
-						2518,
-						2505,
-						2481,
-						2489,
-						2473,
-						2472,
-						2513,
-						2497,
-						2496,
-						2509,
-						2490,
-						2470,
-						2510,
-						2486,
-						2487,
-						2476,
 						2512,
-						2482,
+						2509,
+						2513,
 						2471,
-						2493,
-						2498,
-						2468,
-						2469,
-						2478,
-						2506,
-						2524,
-						2523,
-						2522,
-						2491,
-						2515,
-						2500,
-						2514,
-						2508,
-						2519,
-						2483,
-						2484,
-						2475,
-						2474,
-						2520,
-						2517,
-						2521,
-						2479,
-						2499
+						2491
 					]
 				}
 			],
@@ -46021,14 +45646,14 @@
 			]
 		},
 		{
-			"id": 2012,
+			"id": 2004,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2015,
+					"id": 2007,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46043,14 +45668,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2016,
+							"id": 2008,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2018,
+									"id": 2010,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -46068,7 +45693,7 @@
 									}
 								},
 								{
-									"id": 2017,
+									"id": 2009,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -46091,8 +45716,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2018,
-										2017
+										2010,
+										2009
 									]
 								}
 							]
@@ -46100,7 +45725,7 @@
 					}
 				},
 				{
-					"id": 2014,
+					"id": 2006,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46118,7 +45743,7 @@
 					}
 				},
 				{
-					"id": 2013,
+					"id": 2005,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46141,9 +45766,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2015,
-						2014,
-						2013
+						2007,
+						2006,
+						2005
 					]
 				}
 			],
@@ -46322,7 +45947,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -46439,7 +46064,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -46595,7 +46220,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -46640,7 +46265,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -47143,7 +46768,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -47255,7 +46880,7 @@
 			},
 			"children": [
 				{
-					"id": 1611,
+					"id": 1601,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47286,20 +46911,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1612,
+							"id": 1602,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1613,
+								"id": 1603,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1614,
+										"id": 1604,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47335,7 +46960,7 @@
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1618,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47376,7 +47001,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1605,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47405,7 +47030,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2856,
+						"id": 2849,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47442,7 +47067,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 75,
+							"line": 151,
 							"character": 4
 						}
 					],
@@ -47452,7 +47077,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1613,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47514,7 +47139,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 45,
+							"line": 121,
 							"character": 4
 						}
 					],
@@ -47524,7 +47149,7 @@
 					}
 				},
 				{
-					"id": 1607,
+					"id": 1597,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47562,7 +47187,7 @@
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1596,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47594,7 +47219,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -47604,7 +47229,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1609,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47645,45 +47270,7 @@
 					}
 				},
 				{
-					"id": 1590,
-					"name": "enablePastConversationsSidebar",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "enablePastConversationsSidebar : Controls the visibility of the past conversations\nsidebar.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "default",
-								"text": "false"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   enablePastConversationsSidebar : true,\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 186,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "boolean"
-					}
-				},
-				{
-					"id": 1620,
+					"id": 1610,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47745,7 +47332,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 139,
+							"line": 215,
 							"character": 4
 						}
 					],
@@ -47779,7 +47366,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 170,
+							"line": 246,
 							"character": 4
 						}
 					],
@@ -47789,7 +47376,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1612,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47826,7 +47413,7 @@
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1593,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47856,7 +47443,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2815,
+						"id": 2808,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -47865,7 +47452,7 @@
 					}
 				},
 				{
-					"id": 1608,
+					"id": 1598,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47901,7 +47488,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -47935,7 +47522,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 106,
+							"line": 182,
 							"character": 4
 						}
 					],
@@ -47969,7 +47556,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 59,
+							"line": 135,
 							"character": 4
 						}
 					],
@@ -47979,7 +47566,7 @@
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1606,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48017,7 +47604,7 @@
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1624,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48054,7 +47641,7 @@
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1623,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48094,7 +47681,7 @@
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1622,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48128,7 +47715,7 @@
 					}
 				},
 				{
-					"id": 1625,
+					"id": 1615,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48166,7 +47753,7 @@
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1600,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48204,7 +47791,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1614,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48242,7 +47829,7 @@
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1608,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48280,7 +47867,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1619,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48341,7 +47928,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 127,
+							"line": 203,
 							"character": 4
 						}
 					],
@@ -48349,7 +47936,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2043,
+							"id": 2035,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -48379,7 +47966,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 158,
+							"line": 234,
 							"character": 4
 						}
 					],
@@ -48387,7 +47974,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3052,
+							"id": 3045,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -48406,7 +47993,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 30,
+							"line": 106,
 							"character": 4
 						}
 					],
@@ -48416,7 +48003,7 @@
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1620,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48457,7 +48044,7 @@
 					}
 				},
 				{
-					"id": 1627,
+					"id": 1617,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48518,365 +48105,52 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 91,
+							"line": 167,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "intrinsic",
 						"name": "boolean"
-					}
-				},
-				{
-					"id": 1599,
-					"name": "spotterBestPracticesLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the best practices button in the footer.\nDefaults to translated \"Best Practices\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterBestPracticesLabel: 'Help & Tips',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 323,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1595,
-					"name": "spotterChatDeleteLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the delete action in the conversation edit menu.\nDefaults to translated \"DELETE\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatDeleteLabel: 'Remove',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 262,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1594,
-					"name": "spotterChatRenameLabel",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom label text for the rename action in the conversation edit menu.\nDefaults to translated \"Rename\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatRenameLabel: 'Edit Name',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 247,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1600,
-					"name": "spotterConversationsBatchSize",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Number of conversations to fetch per batch when loading conversation history.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "default",
-								"text": "30"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterConversationsBatchSize: 50,\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 338,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "number"
-					}
-				},
-				{
-					"id": 1596,
-					"name": "spotterDeleteConversationModalTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the delete conversation confirmation modal.\nDefaults to translated \"Delete chat\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDeleteConversationModalTitle: 'Remove Conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 277,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1598,
-					"name": "spotterDocumentationUrl",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom URL for the documentation/best practices link.\nDefaults to ThoughtSpot docs URL based on release version.\nNote: URL must include the protocol (e.g., `https://www.example.com`).",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDocumentationUrl: 'https://docs.example.com/spotter',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 308,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1601,
-					"name": "spotterNewChatButtonTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the \"New Chat\" button in the sidebar.\nDefaults to translated \"New Chat\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterNewChatButtonTitle: 'Start New Conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 353,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1597,
-					"name": "spotterPastConversationAlertMessage",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom message text for the past conversation banner alert.\nDefaults to translated alert message.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterPastConversationAlertMessage: 'You are viewing a past conversation',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 292,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 1593,
-					"name": "spotterSidebarDefaultExpanded",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Boolean to set the default expanded state of the sidebar.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "default",
-								"text": "false"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarDefaultExpanded: true,\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 232,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "boolean"
-					}
-				},
-				{
-					"id": 1592,
-					"name": "spotterSidebarTitle",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Custom title text for the sidebar header.\nDefaults to translated \"Spotter\" text.",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarTitle: 'My Conversations',\n})\n```"
-							},
-							{
-								"tag": "version",
-								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 217,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
 					}
 				},
 				{
 					"id": 1591,
+					"name": "spotterSidebarConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the Spotter sidebar UI customization.",
+						"text": "Supported embed types: `SpotterEmbed`, `AppEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarConfig: {\n       enablePastConversationsSidebar: true,\n       spotterSidebarTitle: 'My Conversations',\n       spotterSidebarDefaultExpanded: true,\n   },\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 279,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1625,
+						"name": "SpotterSidebarViewConfig"
+					}
+				},
+				{
+					"id": 1590,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48904,7 +48178,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 202,
+							"line": 261,
 							"character": 4
 						}
 					],
@@ -48914,7 +48188,7 @@
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1621,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48955,7 +48229,7 @@
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1599,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48991,7 +48265,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2251,
+							"id": 2243,
 							"name": "Action"
 						}
 					},
@@ -49012,7 +48286,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 26,
+							"line": 102,
 							"character": 4
 						}
 					],
@@ -49027,52 +48301,42 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1611,
-						1628,
-						1615,
+						1601,
+						1618,
+						1605,
 						1583,
-						1623,
+						1613,
 						1581,
-						1607,
-						1606,
-						1619,
-						1590,
-						1620,
+						1597,
+						1596,
+						1609,
+						1610,
 						1587,
 						1589,
-						1622,
-						1603,
-						1608,
+						1612,
+						1593,
+						1598,
 						1585,
 						1582,
-						1616,
-						1634,
-						1633,
-						1632,
-						1625,
-						1610,
+						1606,
 						1624,
-						1618,
-						1629,
+						1623,
+						1622,
+						1615,
+						1600,
+						1614,
+						1608,
+						1619,
 						1586,
 						1588,
 						1580,
-						1630,
-						1627,
+						1620,
+						1617,
 						1584,
-						1599,
-						1595,
-						1594,
-						1600,
-						1596,
-						1598,
-						1601,
-						1597,
-						1593,
-						1592,
 						1591,
-						1631,
-						1609,
+						1590,
+						1621,
+						1599,
 						1579
 					]
 				}
@@ -49080,7 +48344,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 21,
+					"line": 97,
 					"character": 17
 				}
 			],
@@ -49103,20 +48367,399 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1635,
+					"id": 1637,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 2019,
+			"id": 1625,
+			"name": "SpotterSidebarViewConfig",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for the Spotter sidebar.\nCan be used in SpotterEmbed and AppEmbed.",
+				"tags": [
+					{
+						"tag": "group",
+						"text": "Embed components"
+					},
+					{
+						"tag": "version",
+						"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1626,
+					"name": "enablePastConversationsSidebar",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Controls the visibility of the past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.45.0 | ThoughtSpot: 26.2.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 29,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1634,
+					"name": "spotterBestPracticesLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the best practices button in the footer.\nDefaults to translated \"Best Practices\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 78,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1630,
+					"name": "spotterChatDeleteLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the delete action in the conversation edit menu.\nDefaults to translated \"DELETE\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 53,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1629,
+					"name": "spotterChatRenameLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the rename action in the conversation edit menu.\nDefaults to translated \"Rename\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 47,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1635,
+					"name": "spotterConversationsBatchSize",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Number of conversations to fetch per batch when loading conversation history.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "30"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 84,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1631,
+					"name": "spotterDeleteConversationModalTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the delete conversation confirmation modal.\nDefaults to translated \"Delete chat\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 59,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1633,
+					"name": "spotterDocumentationUrl",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom URL for the documentation/best practices link.\nDefaults to ThoughtSpot docs URL based on release version.\nNote: URL must include the protocol (e.g., `https://www.example.com`).",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 72,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1636,
+					"name": "spotterNewChatButtonTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the \"New Chat\" button in the sidebar.\nDefaults to translated \"New Chat\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 90,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1632,
+					"name": "spotterPastConversationAlertMessage",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom message text for the past conversation banner alert.\nDefaults to translated alert message.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 65,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1628,
+					"name": "spotterSidebarDefaultExpanded",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Boolean to set the default expanded state of the sidebar.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 41,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1627,
+					"name": "spotterSidebarTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the sidebar header.\nDefaults to translated \"Spotter\" text.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 35,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1626,
+						1634,
+						1630,
+						1629,
+						1635,
+						1631,
+						1633,
+						1636,
+						1632,
+						1628,
+						1627
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 23,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 2011,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2020,
+					"id": 2012,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49134,7 +48777,7 @@
 					}
 				},
 				{
-					"id": 2021,
+					"id": 2013,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49157,8 +48800,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2020,
-						2021
+						2012,
+						2013
 					]
 				}
 			],
@@ -49171,14 +48814,14 @@
 			]
 		},
 		{
-			"id": 3090,
+			"id": 3083,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3091,
+					"id": 3084,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49199,7 +48842,7 @@
 					}
 				},
 				{
-					"id": 3092,
+					"id": 3085,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49225,8 +48868,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3091,
-						3092
+						3084,
+						3085
 					]
 				}
 			],
@@ -49239,7 +48882,7 @@
 			]
 		},
 		{
-			"id": 2869,
+			"id": 2862,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49249,7 +48892,7 @@
 			},
 			"children": [
 				{
-					"id": 2871,
+					"id": 2864,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49279,20 +48922,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2872,
+							"id": 2865,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2873,
+								"id": 2866,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2874,
+										"id": 2867,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -49305,7 +48948,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2875,
+										"id": 2868,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -49318,14 +48961,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2876,
+											"id": 2869,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2877,
+													"id": 2870,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -49347,7 +48990,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2863,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49366,7 +49009,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2878,
+						"id": 2871,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -49376,8 +49019,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2871,
-						2870
+						2864,
+						2863
 					]
 				}
 			],
@@ -49682,7 +49325,7 @@
 			]
 		},
 		{
-			"id": 2839,
+			"id": 2832,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49709,7 +49352,7 @@
 			}
 		},
 		{
-			"id": 2843,
+			"id": 2836,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49724,7 +49367,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2844,
+					"id": 2837,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -49747,7 +49390,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2845,
+							"id": 2838,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -49757,19 +49400,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2846,
+									"id": 2839,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2851,
+										"id": 2844,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2847,
+									"id": 2840,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -49779,7 +49422,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2848,
+											"id": 2841,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -49793,7 +49436,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2849,
+													"id": 2842,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -49803,7 +49446,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2850,
+															"id": 2843,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -49834,7 +49477,7 @@
 			}
 		},
 		{
-			"id": 2840,
+			"id": 2833,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49858,14 +49501,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2841,
+					"id": 2834,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2842,
+							"id": 2835,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49893,7 +49536,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2842
+								2835
 							]
 						}
 					],
@@ -49908,7 +49551,7 @@
 			}
 		},
 		{
-			"id": 2851,
+			"id": 2844,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49932,14 +49575,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2852,
+					"id": 2845,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2854,
+							"id": 2847,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49957,7 +49600,7 @@
 							}
 						},
 						{
-							"id": 2855,
+							"id": 2848,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49977,7 +49620,7 @@
 							}
 						},
 						{
-							"id": 2853,
+							"id": 2846,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -50000,9 +49643,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2854,
-								2855,
-								2853
+								2847,
+								2848,
+								2846
 							]
 						}
 					],
@@ -50067,7 +49710,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1939,
+									"id": 1931,
 									"name": "AnswerService"
 								}
 							}
@@ -50329,7 +49972,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1939,
+												"id": 1931,
 												"name": "AnswerService"
 											}
 										},
@@ -50416,7 +50059,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2413,
+						"id": 2405,
 						"name": "EmbedConfig"
 					}
 				}
@@ -50516,14 +50159,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2413,
+								"id": 2405,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1886,
+						"id": 1878,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -50663,7 +50306,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2810,
+									"id": 2803,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -50791,7 +50434,7 @@
 			]
 		},
 		{
-			"id": 3164,
+			"id": 3157,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -50807,7 +50450,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3165,
+					"id": 3158,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -51001,7 +50644,7 @@
 			]
 		},
 		{
-			"id": 3062,
+			"id": 3055,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -51015,7 +50658,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3063,
+					"id": 3056,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -51025,7 +50668,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3064,
+							"id": 3057,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -51037,7 +50680,7 @@
 							}
 						},
 						{
-							"id": 3065,
+							"id": 3058,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -51048,7 +50691,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3066,
+									"id": 3059,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -51071,44 +50714,44 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2251,
-				1884,
-				1869,
+				2243,
 				1876,
-				2031,
-				2409,
-				2242,
-				3137,
-				3133,
-				3129,
-				2247,
-				3146,
-				2063,
-				3160,
-				2821,
-				3084,
-				3078,
-				2832,
-				2165,
-				3142,
-				3087,
-				3121,
-				3055,
-				2022,
-				2810,
-				3082,
-				2047,
-				3113
+				1861,
+				1868,
+				2023,
+				2401,
+				2234,
+				3130,
+				3126,
+				3122,
+				2239,
+				3139,
+				2055,
+				3153,
+				2814,
+				3077,
+				3071,
+				2825,
+				2157,
+				3135,
+				3080,
+				3114,
+				3048,
+				2014,
+				2803,
+				3075,
+				2039,
+				3106
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1939,
+				1931,
 				1047,
 				1370,
-				1692,
+				1684,
 				626,
 				860,
 				245,
@@ -51121,28 +50764,29 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2715,
-				1886,
+				2707,
+				1878,
 				1335,
-				1635,
-				3093,
-				2878,
-				2866,
-				2856,
-				2413,
-				2815,
-				2574,
-				2043,
-				3052,
-				2661,
-				2525,
-				2465,
-				2012,
+				1637,
+				3086,
+				2871,
+				2859,
+				2849,
+				2405,
+				2808,
+				2566,
+				2035,
+				3045,
+				2653,
+				2517,
+				2457,
+				2004,
 				1300,
 				1578,
-				2019,
-				3090,
-				2869,
+				1625,
+				2011,
+				3083,
+				2862,
 				21,
 				28
 			]
@@ -51151,10 +50795,10 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2839,
-				2843,
-				2840,
-				2851
+				2832,
+				2836,
+				2833,
+				2844
 			]
 		},
 		{
@@ -51171,9 +50815,9 @@
 				4,
 				7,
 				25,
-				3164,
+				3157,
 				40,
-				3062
+				3055
 			]
 		}
 	],

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2228,
+			"id": 2251,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2342,
+					"id": 2365,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -48,14 +48,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5852,
+							"line": 5898,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2248,
+					"id": 2271,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -76,14 +76,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4986,
+							"line": 5032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2241,
+					"id": 2264,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -104,14 +104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4915,
+							"line": 4961,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2240,
+					"id": 2263,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -128,14 +128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4904,
+							"line": 4950,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2246,
+					"id": 2269,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -152,14 +152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4967,
+							"line": 5013,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2247,
+					"id": 2270,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -176,14 +176,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4976,
+							"line": 5022,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2249,
+					"id": 2272,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -204,14 +204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4996,
+							"line": 5042,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2324,
+					"id": 2347,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -232,14 +232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5646,
+							"line": 5692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2297,
+					"id": 2320,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -260,14 +260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5368,
+							"line": 5414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2339,
+					"id": 2362,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -288,14 +288,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5819,
+							"line": 5865,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2296,
+					"id": 2319,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -316,14 +316,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5356,
+							"line": 5402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2295,
+					"id": 2318,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -344,14 +344,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5344,
+							"line": 5390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2338,
+					"id": 2361,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5808,
+							"line": 5854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2308,
+					"id": 2331,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -401,14 +401,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5481,
+							"line": 5527,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2311,
+					"id": 2334,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -429,14 +429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5515,
+							"line": 5561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2316,
+					"id": 2339,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -457,14 +457,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5570,
+							"line": 5616,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2310,
+					"id": 2333,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -485,14 +485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5504,
+							"line": 5550,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2313,
+					"id": 2336,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -513,14 +513,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5538,
+							"line": 5584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2317,
+					"id": 2340,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -541,14 +541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5580,
+							"line": 5626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2314,
+					"id": 2337,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -569,14 +569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5549,
+							"line": 5595,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2319,
+					"id": 2342,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -597,14 +597,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5602,
+							"line": 5648,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2315,
+					"id": 2338,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -625,14 +625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5559,
+							"line": 5605,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2312,
+					"id": 2335,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -653,14 +653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5526,
+							"line": 5572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2318,
+					"id": 2341,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -681,14 +681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5590,
+							"line": 5636,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2309,
+					"id": 2332,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -709,14 +709,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5492,
+							"line": 5538,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2351,
+					"id": 2374,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -737,14 +737,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5950,
+							"line": 5996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2245,
+					"id": 2268,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -761,14 +761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4958,
+							"line": 5004,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2244,
+					"id": 2267,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -789,14 +789,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4949,
+							"line": 4995,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2243,
+					"id": 2266,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -817,14 +817,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4937,
+							"line": 4983,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2359,
+					"id": 2382,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -845,14 +845,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6038,
+							"line": 6084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2242,
+					"id": 2265,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -869,14 +869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4926,
+							"line": 4972,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2288,
+					"id": 2311,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -884,14 +884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5293,
+							"line": 5339,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2235,
+					"id": 2258,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -908,14 +908,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4863,
+							"line": 4909,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2287,
+					"id": 2310,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -932,14 +932,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5292,
+							"line": 5338,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2360,
+					"id": 2383,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -960,14 +960,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6048,
+							"line": 6094,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2374,
+					"id": 2397,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -988,14 +988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6208,
+							"line": 6254,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2336,
+					"id": 2359,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1016,14 +1016,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5783,
+							"line": 5829,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2299,
+					"id": 2322,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1044,14 +1044,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5388,
+							"line": 5434,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2304,
+					"id": 2327,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1072,14 +1072,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5439,
+							"line": 5485,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2352,
+					"id": 2375,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1100,14 +1100,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5962,
+							"line": 6008,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2357,
+					"id": 2380,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1128,14 +1128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6019,
+							"line": 6065,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2348,
+					"id": 2371,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1156,14 +1156,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5919,
+							"line": 5965,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2350,
+					"id": 2373,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1184,14 +1184,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5938,
+							"line": 5984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2257,
+					"id": 2280,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1208,14 +1208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5046,
+							"line": 5092,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2260,
+					"id": 2283,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1232,14 +1232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5079,
+							"line": 5125,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2259,
+					"id": 2282,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1257,14 +1257,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5069,
+							"line": 5115,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2258,
+					"id": 2281,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1281,14 +1281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5056,
+							"line": 5102,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2261,
+					"id": 2284,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1305,14 +1305,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5089,
+							"line": 5135,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2262,
+					"id": 2285,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1333,14 +1333,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5099,
+							"line": 5145,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2292,
+					"id": 2315,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1357,14 +1357,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5309,
+							"line": 5355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2286,
+					"id": 2309,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1381,14 +1381,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5282,
+							"line": 5328,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2285,
+					"id": 2308,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1405,14 +1405,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5273,
+							"line": 5319,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2270,
+					"id": 2293,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1429,14 +1429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5175,
+							"line": 5221,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2234,
+					"id": 2257,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1453,14 +1453,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4854,
+							"line": 4900,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2298,
+					"id": 2321,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1481,14 +1481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5377,
+							"line": 5423,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2290,
+					"id": 2313,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1496,14 +1496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5298,
+							"line": 5344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2356,
+					"id": 2379,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1524,14 +1524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6008,
+							"line": 6054,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2328,
+					"id": 2351,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1552,14 +1552,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5690,
+							"line": 5736,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2343,
+					"id": 2366,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1580,14 +1580,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5865,
+							"line": 5911,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2267,
+					"id": 2290,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1604,14 +1604,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5143,
+							"line": 5189,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2271,
+					"id": 2294,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1628,14 +1628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5183,
+							"line": 5229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2358,
+					"id": 2381,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1656,14 +1656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6029,
+							"line": 6075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2325,
+					"id": 2348,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1684,14 +1684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5656,
+							"line": 5702,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2326,
+					"id": 2349,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1712,14 +1712,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5667,
+							"line": 5713,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2284,
+					"id": 2307,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1736,14 +1736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5262,
+							"line": 5308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2264,
+					"id": 2287,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1761,14 +1761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5115,
+							"line": 5161,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2265,
+					"id": 2288,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1785,14 +1785,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5125,
+							"line": 5171,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2361,
+					"id": 2384,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1813,14 +1813,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6063,
+							"line": 6109,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2376,
+					"id": 2408,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1841,14 +1841,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6230,
+							"line": 6366,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2349,
+					"id": 2372,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1869,14 +1869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5929,
+							"line": 5975,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2278,
+					"id": 2301,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1893,14 +1893,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5224,
+							"line": 5270,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2367,
+					"id": 2390,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1921,14 +1921,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6129,
+							"line": 6175,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2334,
+					"id": 2357,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1949,14 +1949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5751,
+							"line": 5797,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2233,
+					"id": 2256,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1973,14 +1973,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4845,
+							"line": 4891,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2332,
+					"id": 2355,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1997,14 +1997,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5731,
+							"line": 5777,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2303,
+					"id": 2326,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2025,14 +2025,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5429,
+							"line": 5475,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2369,
+					"id": 2392,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2053,14 +2053,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6155,
+							"line": 6201,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2347,
+					"id": 2370,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2081,14 +2081,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5908,
+							"line": 5954,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2323,
+					"id": 2346,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2109,14 +2109,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5636,
+							"line": 5682,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2330,
+					"id": 2353,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2136,14 +2136,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5711,
+							"line": 5757,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2373,
+					"id": 2396,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2164,14 +2164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6198,
+							"line": 6244,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2372,
+					"id": 2395,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2192,14 +2192,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6188,
+							"line": 6234,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2331,
+					"id": 2354,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2216,14 +2216,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5720,
+							"line": 5766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2341,
+					"id": 2364,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2244,14 +2244,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5841,
+							"line": 5887,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2371,
+					"id": 2394,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2272,14 +2272,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6178,
+							"line": 6224,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2344,
+					"id": 2367,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2300,14 +2300,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5876,
+							"line": 5922,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2333,
+					"id": 2356,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2328,14 +2328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5741,
+							"line": 5787,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2281,
+					"id": 2304,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2352,14 +2352,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5241,
+							"line": 5287,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2365,
+					"id": 2388,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2376,14 +2376,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6107,
+							"line": 6153,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2268,
+					"id": 2291,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2400,14 +2400,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5153,
+							"line": 5199,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2353,
+					"id": 2376,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2428,14 +2428,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5974,
+							"line": 6020,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2368,
+					"id": 2391,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2456,14 +2456,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6142,
+							"line": 6188,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2294,
+					"id": 2317,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2481,14 +2481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5334,
+							"line": 5380,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2272,
+					"id": 2295,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2505,14 +2505,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5193,
+							"line": 5239,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2366,
+					"id": 2389,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2533,14 +2533,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6119,
+							"line": 6165,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2307,
+					"id": 2330,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2561,14 +2561,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5470,
+							"line": 5516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2340,
+					"id": 2363,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2589,14 +2589,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5830,
+							"line": 5876,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2321,
+					"id": 2344,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2617,14 +2617,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5616,
+							"line": 5662,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2300,
+					"id": 2323,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2648,14 +2648,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5398,
+							"line": 5444,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2293,
+					"id": 2316,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2672,14 +2672,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5318,
+							"line": 5364,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2322,
+					"id": 2345,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2700,14 +2700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5626,
+							"line": 5672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2354,
+					"id": 2377,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2728,14 +2728,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5986,
+							"line": 6032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2329,
+					"id": 2352,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2756,14 +2756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5702,
+							"line": 5748,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2229,
+					"id": 2252,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2780,14 +2780,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4814,
+							"line": 4860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2232,
+					"id": 2255,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2804,14 +2804,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4832,
+							"line": 4878,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2237,
+					"id": 2260,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2828,14 +2828,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4877,
+							"line": 4923,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2238,
+					"id": 2261,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2852,14 +2852,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4886,
+							"line": 4932,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2291,
+					"id": 2314,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2867,14 +2867,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5299,
+							"line": 5345,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2239,
+					"id": 2262,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2891,14 +2891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4895,
+							"line": 4941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2254,
+					"id": 2277,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2909,14 +2909,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5021,
+							"line": 5067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2327,
+					"id": 2350,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2937,14 +2937,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5677,
+							"line": 5723,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2256,
+					"id": 2279,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2961,14 +2961,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5036,
+							"line": 5082,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2251,
+					"id": 2274,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2985,14 +2985,126 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5009,
+							"line": 5055,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2355,
+					"id": 2406,
+					"name": "SpotterChatDelete",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the delete action\nin the Spotter conversation edit menu.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterChatDelete]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6344,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterChatDelete\""
+				},
+				{
+					"id": 2404,
+					"name": "SpotterChatMenu",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the conversation edit menu\n(three-dot menu) in the Spotter past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterChatMenu]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6324,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterChatMenu\""
+				},
+				{
+					"id": 2405,
+					"name": "SpotterChatRename",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the rename action\nin the Spotter conversation edit menu.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterChatRename]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6334,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterChatRename\""
+				},
+				{
+					"id": 2407,
+					"name": "SpotterDocs",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the documentation/best practices\nlink in the Spotter sidebar footer.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterDocs]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6354,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterDocs\""
+				},
+				{
+					"id": 2378,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3013,14 +3125,154 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5997,
+							"line": 6043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2364,
+					"id": 2402,
+					"name": "SpotterNewChat",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the \"New Chat\" button\nin the Spotter past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterNewChat]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6304,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterNewChat\""
+				},
+				{
+					"id": 2403,
+					"name": "SpotterPastChatBanner",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility of the past conversation banner alert\nin the Spotter interface.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterPastChatBanner]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6314,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterPastChatBanner\""
+				},
+				{
+					"id": 2400,
+					"name": "SpotterSidebarFooter",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility of the sidebar footer (documentation link)\nin the Spotter past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterSidebarFooter]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6284,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterSidebarFooter\""
+				},
+				{
+					"id": 2399,
+					"name": "SpotterSidebarHeader",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility of the sidebar header (title and toggle button)\nin the Spotter past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterSidebarHeader]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6274,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterSidebarHeader\""
+				},
+				{
+					"id": 2401,
+					"name": "SpotterSidebarToggle",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the sidebar toggle/expand button\nin the Spotter past conversations sidebar.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\ndisabledActions: [Action.SpotterSidebarToggle]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6294,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterSidebarToggle\""
+				},
+				{
+					"id": 2387,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3041,14 +3293,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6096,
+							"line": 6142,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2362,
+					"id": 2385,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3069,14 +3321,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6074,
+							"line": 6120,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2363,
+					"id": 2386,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3097,14 +3349,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6085,
+							"line": 6131,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2283,
+					"id": 2306,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3121,14 +3373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5254,
+							"line": 5300,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2302,
+					"id": 2325,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3149,14 +3401,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5419,
+							"line": 5465,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2301,
+					"id": 2324,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3177,14 +3429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5408,
+							"line": 5454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2305,
+					"id": 2328,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3205,14 +3457,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5449,
+							"line": 5495,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2306,
+					"id": 2329,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3233,14 +3485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5459,
+							"line": 5505,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2335,
+					"id": 2358,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3265,14 +3517,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5770,
+							"line": 5816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2269,
+					"id": 2292,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3289,14 +3541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5165,
+							"line": 5211,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2375,
+					"id": 2398,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3317,14 +3569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6218,
+							"line": 6264,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2370,
+					"id": 2393,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3345,14 +3597,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6167,
+							"line": 6213,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2346,
+					"id": 2369,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3373,14 +3625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5898,
+							"line": 5944,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2266,
+					"id": 2289,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3397,14 +3649,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5134,
+							"line": 5180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2337,
+					"id": 2360,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3425,14 +3677,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5794,
+							"line": 5840,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2345,
+					"id": 2368,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3453,7 +3705,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5887,
+							"line": 5933,
 							"character": 4
 						}
 					],
@@ -3465,149 +3717,158 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2342,
-						2248,
-						2241,
-						2240,
-						2246,
-						2247,
-						2249,
-						2324,
-						2297,
-						2339,
-						2296,
-						2295,
-						2338,
-						2308,
-						2311,
-						2316,
-						2310,
-						2313,
-						2317,
-						2314,
-						2319,
-						2315,
-						2312,
-						2318,
-						2309,
-						2351,
-						2245,
-						2244,
-						2243,
-						2359,
-						2242,
-						2288,
-						2235,
-						2287,
-						2360,
-						2374,
-						2336,
-						2299,
-						2304,
-						2352,
-						2357,
-						2348,
-						2350,
-						2257,
-						2260,
-						2259,
-						2258,
-						2261,
-						2262,
-						2292,
-						2286,
-						2285,
-						2270,
-						2234,
-						2298,
-						2290,
-						2356,
-						2328,
-						2343,
-						2267,
-						2271,
-						2358,
-						2325,
-						2326,
-						2284,
-						2264,
-						2265,
-						2361,
-						2376,
-						2349,
-						2278,
-						2367,
-						2334,
-						2233,
-						2332,
-						2303,
-						2369,
-						2347,
-						2323,
-						2330,
-						2373,
-						2372,
-						2331,
-						2341,
-						2371,
-						2344,
-						2333,
-						2281,
 						2365,
-						2268,
-						2353,
-						2368,
-						2294,
-						2272,
-						2366,
-						2307,
-						2340,
-						2321,
-						2300,
-						2293,
-						2322,
-						2354,
-						2329,
-						2229,
-						2232,
-						2237,
-						2238,
-						2291,
-						2239,
-						2254,
-						2327,
-						2256,
-						2251,
-						2355,
-						2364,
-						2362,
-						2363,
-						2283,
-						2302,
-						2301,
-						2305,
-						2306,
-						2335,
+						2271,
+						2264,
+						2263,
 						2269,
+						2270,
+						2272,
+						2347,
+						2320,
+						2362,
+						2319,
+						2318,
+						2361,
+						2331,
+						2334,
+						2339,
+						2333,
+						2336,
+						2340,
+						2337,
+						2342,
+						2338,
+						2335,
+						2341,
+						2332,
+						2374,
+						2268,
+						2267,
+						2266,
+						2382,
+						2265,
+						2311,
+						2258,
+						2310,
+						2383,
+						2397,
+						2359,
+						2322,
+						2327,
 						2375,
+						2380,
+						2371,
+						2373,
+						2280,
+						2283,
+						2282,
+						2281,
+						2284,
+						2285,
+						2315,
+						2309,
+						2308,
+						2293,
+						2257,
+						2321,
+						2313,
+						2379,
+						2351,
+						2366,
+						2290,
+						2294,
+						2381,
+						2348,
+						2349,
+						2307,
+						2287,
+						2288,
+						2384,
+						2408,
+						2372,
+						2301,
+						2390,
+						2357,
+						2256,
+						2355,
+						2326,
+						2392,
 						2370,
 						2346,
-						2266,
-						2337,
-						2345
+						2353,
+						2396,
+						2395,
+						2354,
+						2364,
+						2394,
+						2367,
+						2356,
+						2304,
+						2388,
+						2291,
+						2376,
+						2391,
+						2317,
+						2295,
+						2389,
+						2330,
+						2363,
+						2344,
+						2323,
+						2316,
+						2345,
+						2377,
+						2352,
+						2252,
+						2255,
+						2260,
+						2261,
+						2314,
+						2262,
+						2277,
+						2350,
+						2279,
+						2274,
+						2406,
+						2404,
+						2405,
+						2407,
+						2378,
+						2402,
+						2403,
+						2400,
+						2399,
+						2401,
+						2387,
+						2385,
+						2386,
+						2306,
+						2325,
+						2324,
+						2328,
+						2329,
+						2358,
+						2292,
+						2398,
+						2393,
+						2369,
+						2289,
+						2360,
+						2368
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4805,
+					"line": 4851,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1864,
+			"id": 1884,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3623,7 +3884,7 @@
 			},
 			"children": [
 				{
-					"id": 1865,
+					"id": 1885,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3646,7 +3907,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1865
+						1885
 					]
 				}
 			],
@@ -3659,7 +3920,7 @@
 			]
 		},
 		{
-			"id": 1849,
+			"id": 1869,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3675,7 +3936,7 @@
 			},
 			"children": [
 				{
-					"id": 1852,
+					"id": 1872,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3690,7 +3951,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1854,
+					"id": 1874,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3705,7 +3966,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1851,
+					"id": 1871,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3720,7 +3981,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1853,
+					"id": 1873,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3735,7 +3996,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1850,
+					"id": 1870,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3750,7 +4011,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1855,
+					"id": 1875,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3770,12 +4031,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1852,
-						1854,
-						1851,
-						1853,
-						1850,
-						1855
+						1872,
+						1874,
+						1871,
+						1873,
+						1870,
+						1875
 					]
 				}
 			],
@@ -3788,7 +4049,7 @@
 			]
 		},
 		{
-			"id": 1856,
+			"id": 1876,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3804,7 +4065,7 @@
 			},
 			"children": [
 				{
-					"id": 1857,
+					"id": 1877,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3822,7 +4083,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1861,
+					"id": 1881,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3840,7 +4101,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1863,
+					"id": 1883,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3858,7 +4119,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1858,
+					"id": 1878,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3876,7 +4137,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1860,
+					"id": 1880,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3894,7 +4155,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1862,
+					"id": 1882,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3923,12 +4184,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1857,
-						1861,
-						1863,
-						1858,
-						1860,
-						1862
+						1877,
+						1881,
+						1883,
+						1878,
+						1880,
+						1882
 					]
 				}
 			],
@@ -3941,7 +4202,7 @@
 			]
 		},
 		{
-			"id": 2011,
+			"id": 2031,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3957,7 +4218,7 @@
 			},
 			"children": [
 				{
-					"id": 2022,
+					"id": 2042,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3976,7 +4237,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 2013,
+					"id": 2033,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4005,7 +4266,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 2012,
+					"id": 2032,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4029,7 +4290,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 2018,
+					"id": 2038,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4047,7 +4308,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 2016,
+					"id": 2036,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4080,7 +4341,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 2020,
+					"id": 2040,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4104,7 +4365,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 2021,
+					"id": 2041,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4137,13 +4398,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2022,
-						2013,
-						2012,
-						2018,
-						2016,
-						2020,
-						2021
+						2042,
+						2033,
+						2032,
+						2038,
+						2036,
+						2040,
+						2041
 					]
 				}
 			],
@@ -4156,7 +4417,7 @@
 			]
 		},
 		{
-			"id": 2377,
+			"id": 2409,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4166,7 +4427,7 @@
 			},
 			"children": [
 				{
-					"id": 2380,
+					"id": 2412,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4174,14 +4435,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6250,
+							"line": 6386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2378,
+					"id": 2410,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4189,14 +4450,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6248,
+							"line": 6384,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2379,
+					"id": 2411,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4204,7 +4465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6249,
+							"line": 6385,
 							"character": 4
 						}
 					],
@@ -4216,29 +4477,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2380,
-						2378,
-						2379
+						2412,
+						2410,
+						2411
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6247,
+					"line": 6383,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2219,
+			"id": 2242,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2222,
+					"id": 2245,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4249,14 +4510,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6589,
+							"line": 6728,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2221,
+					"id": 2244,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4267,14 +4528,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6585,
+							"line": 6724,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2220,
+					"id": 2243,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4285,14 +4546,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6581,
+							"line": 6720,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2223,
+					"id": 2246,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4303,7 +4564,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6593,
+							"line": 6732,
 							"character": 4
 						}
 					],
@@ -4315,23 +4576,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2222,
-						2221,
-						2220,
-						2223
+						2245,
+						2244,
+						2243,
+						2246
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6577,
+					"line": 6716,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3093,
+			"id": 3137,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4341,7 +4602,7 @@
 			},
 			"children": [
 				{
-					"id": 3096,
+					"id": 3140,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4349,14 +4610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6335,
+							"line": 6471,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3094,
+					"id": 3138,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4364,14 +4625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6333,
+							"line": 6469,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3097,
+					"id": 3141,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4379,14 +4640,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6336,
+							"line": 6472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3095,
+					"id": 3139,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4394,7 +4655,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6334,
+							"line": 6470,
 							"character": 4
 						}
 					],
@@ -4406,23 +4667,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3096,
-						3094,
-						3097,
-						3095
+						3140,
+						3138,
+						3141,
+						3139
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6332,
+					"line": 6468,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3089,
+			"id": 3133,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4432,7 +4693,7 @@
 			},
 			"children": [
 				{
-					"id": 3092,
+					"id": 3136,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4440,14 +4701,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6326,
+							"line": 6462,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3091,
+					"id": 3135,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4455,14 +4716,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6325,
+							"line": 6461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3090,
+					"id": 3134,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4470,7 +4731,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6324,
+							"line": 6460,
 							"character": 4
 						}
 					],
@@ -4482,22 +4743,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3092,
-						3091,
-						3090
+						3136,
+						3135,
+						3134
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6323,
+					"line": 6459,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3085,
+			"id": 3129,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4507,7 +4768,7 @@
 			},
 			"children": [
 				{
-					"id": 3087,
+					"id": 3131,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4525,7 +4786,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3086,
+					"id": 3130,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4543,7 +4804,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3088,
+					"id": 3132,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4566,9 +4827,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3087,
-						3086,
-						3088
+						3131,
+						3130,
+						3132
 					]
 				}
 			],
@@ -4581,7 +4842,7 @@
 			]
 		},
 		{
-			"id": 2224,
+			"id": 2247,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4591,7 +4852,7 @@
 			},
 			"children": [
 				{
-					"id": 2226,
+					"id": 2249,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4602,14 +4863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4631,
+							"line": 4667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2227,
+					"id": 2250,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4620,14 +4881,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4635,
+							"line": 4671,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2225,
+					"id": 2248,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4638,7 +4899,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4627,
+							"line": 4663,
 							"character": 4
 						}
 					],
@@ -4650,22 +4911,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2226,
-						2227,
-						2225
+						2249,
+						2250,
+						2248
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4623,
+					"line": 4659,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3102,
+			"id": 3146,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4698,7 +4959,7 @@
 			},
 			"children": [
 				{
-					"id": 3105,
+					"id": 3149,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4709,14 +4970,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6475,
+							"line": 6611,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3106,
+					"id": 3150,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4727,14 +4988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6478,
+							"line": 6614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3109,
+					"id": 3153,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4745,14 +5006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6487,
+							"line": 6623,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3112,
+					"id": 3156,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4763,14 +5024,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6496,
+							"line": 6632,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3107,
+					"id": 3151,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4781,14 +5042,32 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6481,
+							"line": 6617,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3104,
+					"id": 3159,
+					"name": "INVALID_URL",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Invalid URL provided in configuration"
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 6641,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"INVALID_URL\""
+				},
+				{
+					"id": 3148,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4799,14 +5078,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6472,
+							"line": 6608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3110,
+					"id": 3154,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4817,14 +5096,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6490,
+							"line": 6626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3108,
+					"id": 3152,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4835,14 +5114,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6484,
+							"line": 6620,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3113,
+					"id": 3157,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4853,14 +5132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6499,
+							"line": 6635,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3111,
+					"id": 3155,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4871,14 +5150,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6493,
+							"line": 6629,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3114,
+					"id": 3158,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4889,14 +5168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6502,
+							"line": 6638,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3103,
+					"id": 3147,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4907,7 +5186,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6469,
+							"line": 6605,
 							"character": 4
 						}
 					],
@@ -4919,31 +5198,32 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3105,
-						3106,
-						3109,
-						3112,
-						3107,
-						3104,
-						3110,
-						3108,
-						3113,
-						3111,
-						3114,
-						3103
+						3149,
+						3150,
+						3153,
+						3156,
+						3151,
+						3159,
+						3148,
+						3154,
+						3152,
+						3157,
+						3155,
+						3158,
+						3147
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6467,
+					"line": 6603,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2043,
+			"id": 2063,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4968,7 +5248,7 @@
 			},
 			"children": [
 				{
-					"id": 2079,
+					"id": 2099,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4996,7 +5276,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2071,
+					"id": 2091,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5024,7 +5304,7 @@
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2051,
+					"id": 2071,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5056,7 +5336,7 @@
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2130,
+					"id": 2150,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5084,7 +5364,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2096,
+					"id": 2116,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5112,7 +5392,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2056,
+					"id": 2076,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5144,7 +5424,7 @@
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2092,
+					"id": 2112,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5172,7 +5452,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2078,
+					"id": 2098,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5200,7 +5480,7 @@
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2140,
+					"id": 2160,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5229,7 +5509,7 @@
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2119,
+					"id": 2139,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5269,7 +5549,7 @@
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2057,
+					"id": 2077,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5297,7 +5577,7 @@
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2045,
+					"id": 2065,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5329,7 +5609,7 @@
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2103,
+					"id": 2123,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5357,7 +5637,7 @@
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2090,
+					"id": 2110,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5385,7 +5665,7 @@
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2105,
+					"id": 2125,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5413,7 +5693,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2085,
+					"id": 2105,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5441,7 +5721,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2113,
+					"id": 2133,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5465,7 +5745,7 @@
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2124,
+					"id": 2144,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5490,7 +5770,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2125,
+					"id": 2145,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5514,7 +5794,7 @@
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2118,
+					"id": 2138,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5538,7 +5818,7 @@
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2106,
+					"id": 2126,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5566,7 +5846,7 @@
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2052,
+					"id": 2072,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5602,7 +5882,7 @@
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2047,
+					"id": 2067,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5638,7 +5918,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2131,
+					"id": 2151,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5666,7 +5946,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2050,
+					"id": 2070,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5698,7 +5978,7 @@
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2101,
+					"id": 2121,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5726,7 +6006,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2117,
+					"id": 2137,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5758,7 +6038,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2069,
+					"id": 2089,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5786,7 +6066,7 @@
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2068,
+					"id": 2088,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5814,7 +6094,7 @@
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2073,
+					"id": 2093,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5843,7 +6123,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2076,
+					"id": 2096,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5871,7 +6151,7 @@
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2075,
+					"id": 2095,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5899,7 +6179,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2074,
+					"id": 2094,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5927,7 +6207,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2077,
+					"id": 2097,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5955,7 +6235,7 @@
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2084,
+					"id": 2104,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5983,7 +6263,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2083,
+					"id": 2103,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6011,7 +6291,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2049,
+					"id": 2069,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6055,7 +6335,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2098,
+					"id": 2118,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6083,7 +6363,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2087,
+					"id": 2107,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6111,7 +6391,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2055,
+					"id": 2075,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6148,7 +6428,7 @@
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2104,
+					"id": 2124,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6176,7 +6456,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2088,
+					"id": 2108,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6204,7 +6484,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2109,
+					"id": 2129,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6228,7 +6508,7 @@
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2063,
+					"id": 2083,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6256,7 +6536,7 @@
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2044,
+					"id": 2064,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6284,7 +6564,7 @@
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2134,
+					"id": 2154,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6312,7 +6592,7 @@
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2133,
+					"id": 2153,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6340,7 +6620,7 @@
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2095,
+					"id": 2115,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6368,7 +6648,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2070,
+					"id": 2090,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6400,7 +6680,7 @@
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2046,
+					"id": 2066,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6432,7 +6712,7 @@
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2099,
+					"id": 2119,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6460,7 +6740,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2066,
+					"id": 2086,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6488,7 +6768,7 @@
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2121,
+					"id": 2141,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6522,7 +6802,7 @@
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2139,
+					"id": 2159,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6550,7 +6830,7 @@
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2122,
+					"id": 2142,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6574,7 +6854,7 @@
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2080,
+					"id": 2100,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6602,7 +6882,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2100,
+					"id": 2120,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6634,7 +6914,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2129,
+					"id": 2149,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6662,7 +6942,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2048,
+					"id": 2068,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6690,7 +6970,7 @@
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2120,
+					"id": 2140,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6714,7 +6994,7 @@
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2116,
+					"id": 2136,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6754,7 +7034,7 @@
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2135,
+					"id": 2155,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6782,7 +7062,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2064,
+					"id": 2084,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6810,7 +7090,7 @@
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2110,
+					"id": 2130,
 					"name": "SageEmbedQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6834,7 +7114,7 @@
 					"defaultValue": "\"sageEmbedQuery\""
 				},
 				{
-					"id": 2111,
+					"id": 2131,
 					"name": "SageWorksheetUpdated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6858,7 +7138,7 @@
 					"defaultValue": "\"sageWorksheetUpdated\""
 				},
 				{
-					"id": 2072,
+					"id": 2092,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6886,7 +7166,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2089,
+					"id": 2109,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6914,7 +7194,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2115,
+					"id": 2135,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6954,7 +7234,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2097,
+					"id": 2117,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6982,7 +7262,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2102,
+					"id": 2122,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7010,7 +7290,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2082,
+					"id": 2102,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7038,7 +7318,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2091,
+					"id": 2111,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7066,7 +7346,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2081,
+					"id": 2101,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7094,7 +7374,91 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2128,
+					"id": 2162,
+					"name": "SpotterConversationDeleted",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Emitted when a Spotter conversation is deleted.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nspotterEmbed.on(EmbedEvent.SpotterConversationDeleted, (payload) => {\n    console.log('Conversation deleted', payload);\n    // payload: { convId: string, title: string }\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 3229,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterConversationDeleted\""
+				},
+				{
+					"id": 2161,
+					"name": "SpotterConversationRenamed",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Emitted when a Spotter conversation is renamed.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nspotterEmbed.on(EmbedEvent.SpotterConversationRenamed, (payload) => {\n    console.log('Conversation renamed', payload);\n    // payload: { convId: string, oldTitle: string, newTitle: string }\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 3217,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterConversationRenamed\""
+				},
+				{
+					"id": 2163,
+					"name": "SpotterConversationSelected",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Emitted when a Spotter conversation is selected/clicked.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nspotterEmbed.on(EmbedEvent.SpotterConversationSelected, (payload) => {\n    console.log('Conversation selected', payload);\n    // payload: { convId: string, title: string, worksheetId: string }\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 3241,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterConversationSelected\""
+				},
+				{
+					"id": 2148,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7122,7 +7486,7 @@
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2136,
+					"id": 2156,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7150,7 +7514,7 @@
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2137,
+					"id": 2157,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7178,7 +7542,7 @@
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2132,
+					"id": 2152,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7206,7 +7570,7 @@
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2123,
+					"id": 2143,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7235,7 +7599,7 @@
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2112,
+					"id": 2132,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7259,7 +7623,7 @@
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2114,
+					"id": 2134,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7299,7 +7663,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2086,
+					"id": 2106,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7327,7 +7691,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2054,
+					"id": 2074,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7363,7 +7727,7 @@
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2053,
+					"id": 2073,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7395,7 +7759,7 @@
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2107,
+					"id": 2127,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7428,90 +7792,93 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2079,
-						2071,
-						2051,
-						2130,
-						2096,
-						2056,
-						2092,
-						2078,
-						2140,
-						2119,
-						2057,
-						2045,
-						2103,
-						2090,
-						2105,
-						2085,
-						2113,
-						2124,
-						2125,
-						2118,
-						2106,
-						2052,
-						2047,
-						2131,
-						2050,
-						2101,
-						2117,
-						2069,
-						2068,
-						2073,
-						2076,
-						2075,
-						2074,
-						2077,
-						2084,
-						2083,
-						2049,
-						2098,
-						2087,
-						2055,
-						2104,
-						2088,
-						2109,
-						2063,
-						2044,
-						2134,
-						2133,
-						2095,
-						2070,
-						2046,
 						2099,
-						2066,
-						2121,
-						2139,
-						2122,
-						2080,
-						2100,
-						2129,
-						2048,
-						2120,
-						2116,
-						2135,
-						2064,
-						2110,
-						2111,
-						2072,
-						2089,
-						2115,
-						2097,
-						2102,
-						2082,
 						2091,
-						2081,
-						2128,
-						2136,
-						2137,
-						2132,
-						2123,
+						2071,
+						2150,
+						2116,
+						2076,
 						2112,
-						2114,
+						2098,
+						2160,
+						2139,
+						2077,
+						2065,
+						2123,
+						2110,
+						2125,
+						2105,
+						2133,
+						2144,
+						2145,
+						2138,
+						2126,
+						2072,
+						2067,
+						2151,
+						2070,
+						2121,
+						2137,
+						2089,
+						2088,
+						2093,
+						2096,
+						2095,
+						2094,
+						2097,
+						2104,
+						2103,
+						2069,
+						2118,
+						2107,
+						2075,
+						2124,
+						2108,
+						2129,
+						2083,
+						2064,
+						2154,
+						2153,
+						2115,
+						2090,
+						2066,
+						2119,
 						2086,
-						2054,
-						2053,
-						2107
+						2141,
+						2159,
+						2142,
+						2100,
+						2120,
+						2149,
+						2068,
+						2140,
+						2136,
+						2155,
+						2084,
+						2130,
+						2131,
+						2092,
+						2109,
+						2135,
+						2117,
+						2122,
+						2102,
+						2111,
+						2101,
+						2162,
+						2161,
+						2163,
+						2148,
+						2156,
+						2157,
+						2152,
+						2143,
+						2132,
+						2134,
+						2106,
+						2074,
+						2073,
+						2127
 					]
 				}
 			],
@@ -7524,7 +7891,7 @@
 			]
 		},
 		{
-			"id": 3115,
+			"id": 3160,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7553,7 +7920,7 @@
 			},
 			"children": [
 				{
-					"id": 3116,
+					"id": 3161,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7564,14 +7931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6439,
+							"line": 6575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3118,
+					"id": 3163,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7582,14 +7949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6443,
+							"line": 6579,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3117,
+					"id": 3162,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7600,7 +7967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6441,
+							"line": 6577,
 							"character": 4
 						}
 					],
@@ -7612,22 +7979,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3116,
-						3118,
-						3117
+						3161,
+						3163,
+						3162
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6437,
+					"line": 6573,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2789,
+			"id": 2821,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7637,7 +8004,7 @@
 			},
 			"children": [
 				{
-					"id": 2793,
+					"id": 2825,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7661,7 +8028,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2797,
+					"id": 2829,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7685,7 +8052,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2799,
+					"id": 2831,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7709,7 +8076,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2791,
+					"id": 2823,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7733,7 +8100,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2796,
+					"id": 2828,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7757,7 +8124,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2792,
+					"id": 2824,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7781,7 +8148,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2794,
+					"id": 2826,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7805,7 +8172,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2790,
+					"id": 2822,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7829,7 +8196,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2795,
+					"id": 2827,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7853,7 +8220,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2798,
+					"id": 2830,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7882,16 +8249,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2793,
-						2797,
-						2799,
-						2791,
-						2796,
-						2792,
-						2794,
-						2790,
-						2795,
-						2798
+						2825,
+						2829,
+						2831,
+						2823,
+						2828,
+						2824,
+						2826,
+						2822,
+						2827,
+						2830
 					]
 				}
 			],
@@ -7904,7 +8271,7 @@
 			]
 		},
 		{
-			"id": 3040,
+			"id": 3084,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7920,7 +8287,7 @@
 			},
 			"children": [
 				{
-					"id": 3041,
+					"id": 3085,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7938,7 +8305,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3042,
+					"id": 3086,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7961,8 +8328,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3041,
-						3042
+						3085,
+						3086
 					]
 				}
 			],
@@ -7975,14 +8342,14 @@
 			]
 		},
 		{
-			"id": 3034,
+			"id": 3078,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3036,
+					"id": 3080,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7997,7 +8364,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3037,
+					"id": 3081,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8012,7 +8379,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3035,
+					"id": 3079,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8032,9 +8399,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3036,
-						3037,
-						3035
+						3080,
+						3081,
+						3079
 					]
 				}
 			],
@@ -8047,7 +8414,7 @@
 			]
 		},
 		{
-			"id": 2800,
+			"id": 2832,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8064,7 +8431,7 @@
 			},
 			"children": [
 				{
-					"id": 2803,
+					"id": 2835,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8082,7 +8449,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2806,
+					"id": 2838,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8100,7 +8467,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2804,
+					"id": 2836,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8118,7 +8485,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2801,
+					"id": 2833,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8136,7 +8503,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2805,
+					"id": 2837,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8154,7 +8521,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2802,
+					"id": 2834,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8177,12 +8544,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2803,
-						2806,
-						2804,
-						2801,
-						2805,
-						2802
+						2835,
+						2838,
+						2836,
+						2833,
+						2837,
+						2834
 					]
 				}
 			],
@@ -8195,7 +8562,7 @@
 			]
 		},
 		{
-			"id": 2142,
+			"id": 2165,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8224,7 +8591,7 @@
 			},
 			"children": [
 				{
-					"id": 2164,
+					"id": 2187,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8245,14 +8612,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3656,
+							"line": 3692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2153,
+					"id": 2176,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8278,14 +8645,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3466,
+							"line": 3502,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2207,
+					"id": 2230,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8311,14 +8678,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4490,
+							"line": 4526,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2211,
+					"id": 2234,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8344,14 +8711,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4532,
+							"line": 4568,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2194,
+					"id": 2217,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8372,14 +8739,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4306,
+							"line": 4342,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2214,
+					"id": 2237,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8405,14 +8772,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4570,
+							"line": 4606,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2171,
+					"id": 2194,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8438,14 +8805,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3792,
+							"line": 3828,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2168,
+					"id": 2191,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8475,14 +8842,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3730,
+							"line": 3766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2208,
+					"id": 2231,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8503,14 +8870,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4499,
+							"line": 4535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2175,
+					"id": 2198,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8536,14 +8903,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3876,
+							"line": 3912,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2210,
+					"id": 2233,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8564,14 +8931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4517,
+							"line": 4553,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2216,
+					"id": 2239,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8592,14 +8959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4590,
+							"line": 4626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2177,
+					"id": 2200,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8629,14 +8996,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3922,
+							"line": 3958,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2179,
+					"id": 2202,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8662,14 +9029,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3973,
+							"line": 4009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2163,
+					"id": 2186,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8699,14 +9066,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3646,
+							"line": 3682,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2178,
+					"id": 2201,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8727,14 +9094,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3946,
+							"line": 3982,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2180,
+					"id": 2203,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8760,14 +9127,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4000,
+							"line": 4036,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2144,
+					"id": 2167,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8797,14 +9164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3345,
+							"line": 3381,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2170,
+					"id": 2193,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8835,14 +9202,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3775,
+							"line": 3811,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2205,
+					"id": 2228,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8868,14 +9235,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4470,
+							"line": 4506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2161,
+					"id": 2184,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8896,14 +9263,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3610,
+							"line": 3646,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2167,
+					"id": 2190,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8929,14 +9296,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3713,
+							"line": 3749,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2160,
+					"id": 2183,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8957,14 +9324,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3600,
+							"line": 3636,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2193,
+					"id": 2216,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8990,14 +9357,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4296,
+							"line": 4332,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2187,
+					"id": 2210,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9018,14 +9385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4123,
+							"line": 4159,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2147,
+					"id": 2170,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9046,14 +9413,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3365,
+							"line": 3401,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2198,
+					"id": 2221,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9075,14 +9442,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4370,
+							"line": 4406,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2173,
+					"id": 2196,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9107,14 +9474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3840,
+							"line": 3876,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2189,
+					"id": 2212,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9135,14 +9502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4225,
+							"line": 4261,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2157,
+					"id": 2180,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9163,14 +9530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3572,
+							"line": 3608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2165,
+					"id": 2188,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9207,14 +9574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3689,
+							"line": 3725,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2169,
+					"id": 2192,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9248,14 +9615,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3751,
+							"line": 3787,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2185,
+					"id": 2208,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9281,14 +9648,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4100,
+							"line": 4136,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2151,
+					"id": 2174,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9314,14 +9681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3436,
+							"line": 3472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2152,
+					"id": 2175,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9351,14 +9718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3456,
+							"line": 3492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2156,
+					"id": 2179,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9400,14 +9767,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3562,
+							"line": 3598,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2172,
+					"id": 2195,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9433,14 +9800,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3809,
+							"line": 3845,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2206,
+					"id": 2229,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9461,14 +9828,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4479,
+							"line": 4515,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2166,
+					"id": 2189,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9493,14 +9860,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3703,
+							"line": 3739,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2154,
+					"id": 2177,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9526,14 +9893,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3476,
+							"line": 3512,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2196,
+					"id": 2219,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9554,14 +9921,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4331,
+							"line": 4367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2186,
+					"id": 2209,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9582,14 +9949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4112,
+							"line": 4148,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2209,
+					"id": 2232,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9610,14 +9977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4508,
+							"line": 4544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2182,
+					"id": 2205,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9643,14 +10010,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4053,
+							"line": 4089,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2201,
+					"id": 2224,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9680,14 +10047,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4419,
+							"line": 4455,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2158,
+					"id": 2181,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9708,14 +10075,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3581,
+							"line": 3617,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2159,
+					"id": 2182,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9736,14 +10103,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3590,
+							"line": 3626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2143,
+					"id": 2166,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9765,14 +10132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3295,
+							"line": 3331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2149,
+					"id": 2172,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9798,14 +10165,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3390,
+							"line": 3426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2191,
+					"id": 2214,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9831,14 +10198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4251,
+							"line": 4287,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2190,
+					"id": 2213,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9864,14 +10231,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4238,
+							"line": 4274,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2148,
+					"id": 2171,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9897,14 +10264,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3378,
+							"line": 3414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2181,
+					"id": 2204,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9925,14 +10292,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4013,
+							"line": 4049,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2174,
+					"id": 2197,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9958,14 +10325,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3859,
+							"line": 3895,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2176,
+					"id": 2199,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9991,14 +10358,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3896,
+							"line": 3932,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2204,
+					"id": 2227,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10024,14 +10391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4460,
+							"line": 4496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2217,
+					"id": 2240,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10053,14 +10420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4603,
+							"line": 4639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2184,
+					"id": 2207,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10086,14 +10453,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4084,
+							"line": 4120,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2183,
+					"id": 2206,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10119,14 +10486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4068,
+							"line": 4104,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2203,
+					"id": 2226,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10152,14 +10519,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4444,
+							"line": 4480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2195,
+					"id": 2218,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10180,14 +10547,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4322,
+							"line": 4358,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2188,
+					"id": 2211,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10225,14 +10592,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4212,
+							"line": 4248,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2197,
+					"id": 2220,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10258,14 +10625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4350,
+							"line": 4386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2199,
+					"id": 2222,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10282,14 +10649,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4378,
+							"line": 4414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2150,
+					"id": 2173,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10320,14 +10687,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3424,
+							"line": 3460,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2192,
+					"id": 2215,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10353,14 +10720,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4266,
+							"line": 4302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2162,
+					"id": 2185,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10381,14 +10748,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3619,
+							"line": 3655,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2155,
+					"id": 2178,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10409,7 +10776,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3492,
+							"line": 3528,
 							"character": 4
 						}
 					],
@@ -10421,87 +10788,87 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2164,
-						2153,
-						2207,
-						2211,
-						2194,
-						2214,
-						2171,
-						2168,
-						2208,
-						2175,
-						2210,
-						2216,
-						2177,
-						2179,
-						2163,
-						2178,
-						2180,
-						2144,
-						2170,
-						2205,
-						2161,
-						2167,
-						2160,
-						2193,
 						2187,
-						2147,
-						2198,
-						2173,
-						2189,
-						2157,
-						2165,
-						2169,
-						2185,
-						2151,
-						2152,
-						2156,
-						2172,
-						2206,
-						2166,
-						2154,
-						2196,
-						2186,
-						2209,
-						2182,
-						2201,
-						2158,
-						2159,
-						2143,
-						2149,
-						2191,
-						2190,
-						2148,
-						2181,
-						2174,
 						2176,
-						2204,
+						2230,
+						2234,
 						2217,
-						2184,
-						2183,
+						2237,
+						2194,
+						2191,
+						2231,
+						2198,
+						2233,
+						2239,
+						2200,
+						2202,
+						2186,
+						2201,
 						2203,
-						2195,
+						2167,
+						2193,
+						2228,
+						2184,
+						2190,
+						2183,
+						2216,
+						2210,
+						2170,
+						2221,
+						2196,
+						2212,
+						2180,
 						2188,
+						2192,
+						2208,
+						2174,
+						2175,
+						2179,
+						2195,
+						2229,
+						2189,
+						2177,
+						2219,
+						2209,
+						2232,
+						2205,
+						2224,
+						2181,
+						2182,
+						2166,
+						2172,
+						2214,
+						2213,
+						2171,
+						2204,
 						2197,
 						2199,
-						2150,
-						2192,
-						2162,
-						2155
+						2227,
+						2240,
+						2207,
+						2206,
+						2226,
+						2218,
+						2211,
+						2220,
+						2222,
+						2173,
+						2215,
+						2185,
+						2178
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 3275,
+					"line": 3311,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3098,
+			"id": 3142,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10511,7 +10878,7 @@
 			},
 			"children": [
 				{
-					"id": 3100,
+					"id": 3144,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10522,14 +10889,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6623,
+							"line": 6762,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3099,
+					"id": 3143,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10540,14 +10907,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6619,
+							"line": 6758,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3101,
+					"id": 3145,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10558,7 +10925,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6627,
+							"line": 6766,
 							"character": 4
 						}
 					],
@@ -10570,22 +10937,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3100,
-						3099,
-						3101
+						3144,
+						3143,
+						3145
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6615,
+					"line": 6754,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3043,
+			"id": 3087,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10601,7 +10968,7 @@
 			},
 			"children": [
 				{
-					"id": 3044,
+					"id": 3088,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10619,7 +10986,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3045,
+					"id": 3089,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10642,8 +11009,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3044,
-						3045
+						3088,
+						3089
 					]
 				}
 			],
@@ -10656,7 +11023,7 @@
 			]
 		},
 		{
-			"id": 3077,
+			"id": 3121,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10672,7 +11039,7 @@
 			},
 			"children": [
 				{
-					"id": 3081,
+					"id": 3125,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10690,7 +11057,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3082,
+					"id": 3126,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10708,7 +11075,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3078,
+					"id": 3122,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10726,7 +11093,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3079,
+					"id": 3123,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10749,7 +11116,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3083,
+					"id": 3127,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10767,7 +11134,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3080,
+					"id": 3124,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10785,7 +11152,7 @@
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3084,
+					"id": 3128,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10808,13 +11175,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3081,
-						3082,
-						3078,
-						3079,
-						3083,
-						3080,
-						3084
+						3125,
+						3126,
+						3122,
+						3123,
+						3127,
+						3124,
+						3128
 					]
 				}
 			],
@@ -10827,7 +11194,7 @@
 			]
 		},
 		{
-			"id": 3011,
+			"id": 3055,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10837,7 +11204,7 @@
 			},
 			"children": [
 				{
-					"id": 3016,
+					"id": 3060,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10858,14 +11225,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6410,
+							"line": 6546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3013,
+					"id": 3057,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10886,14 +11253,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6371,
+							"line": 6507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3015,
+					"id": 3059,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10914,14 +11281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6396,
+							"line": 6532,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3012,
+					"id": 3056,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10942,14 +11309,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6359,
+							"line": 6495,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3017,
+					"id": 3061,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10970,14 +11337,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6422,
+							"line": 6558,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3014,
+					"id": 3058,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10998,7 +11365,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6383,
+							"line": 6519,
 							"character": 4
 						}
 					],
@@ -11010,25 +11377,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3016,
-						3013,
-						3015,
-						3012,
-						3017,
-						3014
+						3060,
+						3057,
+						3059,
+						3056,
+						3061,
+						3058
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6346,
+					"line": 6482,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2002,
+			"id": 2022,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11038,7 +11405,7 @@
 			},
 			"children": [
 				{
-					"id": 2005,
+					"id": 2025,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11056,7 +11423,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2008,
+					"id": 2028,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11074,7 +11441,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2003,
+					"id": 2023,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11092,7 +11459,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 2006,
+					"id": 2026,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11110,7 +11477,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2010,
+					"id": 2030,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11128,7 +11495,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 2004,
+					"id": 2024,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11146,7 +11513,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2009,
+					"id": 2029,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11169,13 +11536,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2005,
-						2008,
-						2003,
-						2006,
-						2010,
-						2004,
-						2009
+						2025,
+						2028,
+						2023,
+						2026,
+						2030,
+						2024,
+						2029
 					]
 				}
 			],
@@ -11188,14 +11555,14 @@
 			]
 		},
 		{
-			"id": 2778,
+			"id": 2810,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2779,
+					"id": 2811,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11203,14 +11570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6237,
+							"line": 6373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2781,
+					"id": 2813,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11218,14 +11585,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6239,
+							"line": 6375,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2780,
+					"id": 2812,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11233,14 +11600,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6238,
+							"line": 6374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2782,
+					"id": 2814,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11248,7 +11615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6240,
+							"line": 6376,
 							"character": 4
 						}
 					],
@@ -11260,23 +11627,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2779,
-						2781,
-						2780,
-						2782
+						2811,
+						2813,
+						2812,
+						2814
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6236,
+					"line": 6372,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3038,
+			"id": 3082,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11292,7 +11659,7 @@
 			},
 			"children": [
 				{
-					"id": 3039,
+					"id": 3083,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11315,7 +11682,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3039
+						3083
 					]
 				}
 			],
@@ -11328,7 +11695,7 @@
 			]
 		},
 		{
-			"id": 2027,
+			"id": 2047,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11338,7 +11705,7 @@
 			},
 			"children": [
 				{
-					"id": 2035,
+					"id": 2055,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11356,7 +11723,7 @@
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2040,
+					"id": 2060,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11374,7 +11741,7 @@
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2039,
+					"id": 2059,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11392,7 +11759,7 @@
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2037,
+					"id": 2057,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11410,7 +11777,7 @@
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2038,
+					"id": 2058,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11428,7 +11795,7 @@
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2034,
+					"id": 2054,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11446,7 +11813,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2036,
+					"id": 2056,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11464,7 +11831,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2028,
+					"id": 2048,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11482,7 +11849,7 @@
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2033,
+					"id": 2053,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11500,7 +11867,7 @@
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2032,
+					"id": 2052,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11518,7 +11885,7 @@
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2041,
+					"id": 2061,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11536,7 +11903,7 @@
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2031,
+					"id": 2051,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11554,7 +11921,7 @@
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2030,
+					"id": 2050,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11572,7 +11939,7 @@
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2029,
+					"id": 2049,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11590,7 +11957,7 @@
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2042,
+					"id": 2062,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11613,21 +11980,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2035,
-						2040,
-						2039,
-						2037,
-						2038,
-						2034,
-						2036,
-						2028,
-						2033,
-						2032,
-						2041,
-						2031,
-						2030,
-						2029,
-						2042
+						2055,
+						2060,
+						2059,
+						2057,
+						2058,
+						2054,
+						2056,
+						2048,
+						2053,
+						2052,
+						2061,
+						2051,
+						2050,
+						2049,
+						2062
 					]
 				}
 			],
@@ -11640,14 +12007,14 @@
 			]
 		},
 		{
-			"id": 3069,
+			"id": 3113,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3074,
+					"id": 3118,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11662,7 +12029,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3073,
+					"id": 3117,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11677,7 +12044,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3072,
+					"id": 3116,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11692,7 +12059,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3075,
+					"id": 3119,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11707,7 +12074,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3076,
+					"id": 3120,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11722,7 +12089,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3070,
+					"id": 3114,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11737,7 +12104,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3071,
+					"id": 3115,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11757,13 +12124,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3074,
-						3073,
-						3072,
-						3075,
-						3076,
-						3070,
-						3071
+						3118,
+						3117,
+						3116,
+						3119,
+						3120,
+						3114,
+						3115
 					]
 				}
 			],
@@ -11776,7 +12143,7 @@
 			]
 		},
 		{
-			"id": 1919,
+			"id": 1939,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -11805,7 +12172,7 @@
 			},
 			"children": [
 				{
-					"id": 1920,
+					"id": 1940,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -11822,7 +12189,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1941,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -11832,7 +12199,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1942,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11840,12 +12207,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1992,
+										"id": 2012,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1923,
+									"id": 1943,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11857,7 +12224,7 @@
 									}
 								},
 								{
-									"id": 1924,
+									"id": 1944,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11869,7 +12236,7 @@
 									}
 								},
 								{
-									"id": 1925,
+									"id": 1945,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11883,7 +12250,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3046,
+											"id": 3090,
 											"name": "VizPoint"
 										}
 									}
@@ -11891,14 +12258,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1919,
+								"id": 1939,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1934,
+					"id": 1954,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11914,7 +12281,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1935,
+							"id": 1955,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11925,7 +12292,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1936,
+									"id": 1956,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -11954,7 +12321,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1957,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -11970,7 +12337,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1958,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -11986,7 +12353,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1939,
+									"id": 1959,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12015,7 +12382,7 @@
 					]
 				},
 				{
-					"id": 1986,
+					"id": 2006,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12031,14 +12398,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1987,
+							"id": 2007,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1988,
+									"id": 2008,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12063,7 +12430,7 @@
 					]
 				},
 				{
-					"id": 1940,
+					"id": 1960,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12079,7 +12446,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1941,
+							"id": 1961,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12090,7 +12457,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1942,
+									"id": 1962,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12102,7 +12469,7 @@
 									}
 								},
 								{
-									"id": 1943,
+									"id": 1963,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12110,12 +12477,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2027,
+										"id": 2047,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1944,
+									"id": 1964,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12161,7 +12528,7 @@
 					]
 				},
 				{
-					"id": 1976,
+					"id": 1996,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12177,7 +12544,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1977,
+							"id": 1997,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12188,7 +12555,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1978,
+									"id": 1998,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12202,7 +12569,7 @@
 									}
 								},
 								{
-									"id": 1979,
+									"id": 1999,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12230,7 +12597,7 @@
 					]
 				},
 				{
-					"id": 1954,
+					"id": 1974,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12246,7 +12613,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1955,
+							"id": 1975,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12257,7 +12624,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1956,
+									"id": 1976,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12270,7 +12637,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1957,
+									"id": 1977,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12299,7 +12666,7 @@
 					]
 				},
 				{
-					"id": 1947,
+					"id": 1967,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12315,7 +12682,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1948,
+							"id": 1968,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12326,7 +12693,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1949,
+									"id": 1969,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12339,7 +12706,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1950,
+									"id": 1970,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12358,14 +12725,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1951,
+											"id": 1971,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1952,
+													"id": 1972,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12376,7 +12743,7 @@
 													}
 												},
 												{
-													"id": 1953,
+													"id": 1973,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12392,8 +12759,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1952,
-														1953
+														1972,
+														1973
 													]
 												}
 											]
@@ -12406,7 +12773,7 @@
 					]
 				},
 				{
-					"id": 1958,
+					"id": 1978,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12422,7 +12789,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1959,
+							"id": 1979,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12433,7 +12800,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1960,
+									"id": 1980,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12446,7 +12813,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1961,
+									"id": 1981,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12461,7 +12828,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1962,
+									"id": 1982,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12490,7 +12857,7 @@
 					]
 				},
 				{
-					"id": 1982,
+					"id": 2002,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12506,7 +12873,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1983,
+							"id": 2003,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12525,7 +12892,7 @@
 					]
 				},
 				{
-					"id": 1963,
+					"id": 1983,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12541,7 +12908,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1964,
+							"id": 1984,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12552,7 +12919,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1965,
+									"id": 1985,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12565,7 +12932,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1966,
+									"id": 1986,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12586,7 +12953,7 @@
 					]
 				},
 				{
-					"id": 1967,
+					"id": 1987,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12602,7 +12969,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1968,
+							"id": 1988,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12612,7 +12979,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1969,
+									"id": 1989,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12625,7 +12992,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1970,
+									"id": 1990,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12638,7 +13005,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1971,
+									"id": 1991,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12661,7 +13028,7 @@
 					]
 				},
 				{
-					"id": 1945,
+					"id": 1965,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12677,7 +13044,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1946,
+							"id": 1966,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12696,7 +13063,7 @@
 					]
 				},
 				{
-					"id": 1980,
+					"id": 2000,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12712,7 +13079,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1981,
+							"id": 2001,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12723,14 +13090,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1992,
+								"id": 2012,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1929,
+					"id": 1949,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12746,7 +13113,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1930,
+							"id": 1950,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12768,7 +13135,7 @@
 					]
 				},
 				{
-					"id": 1984,
+					"id": 2004,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12784,7 +13151,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1985,
+							"id": 2005,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12803,7 +13170,7 @@
 					]
 				},
 				{
-					"id": 1972,
+					"id": 1992,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12819,7 +13186,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1973,
+							"id": 1993,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12839,7 +13206,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1974,
+									"id": 1994,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12854,7 +13221,7 @@
 									}
 								},
 								{
-									"id": 1975,
+									"id": 1995,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12866,7 +13233,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1999,
+											"id": 2019,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -12877,7 +13244,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -12887,7 +13254,7 @@
 					]
 				},
 				{
-					"id": 1931,
+					"id": 1951,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12903,7 +13270,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1932,
+							"id": 1952,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12914,7 +13281,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1933,
+									"id": 1953,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12943,7 +13310,7 @@
 					]
 				},
 				{
-					"id": 1989,
+					"id": 2009,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12959,14 +13326,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1990,
+							"id": 2010,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1991,
+									"id": 2011,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12990,31 +13357,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1920
+						1940
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1934,
-						1937,
-						1986,
-						1940,
-						1976,
 						1954,
-						1947,
-						1958,
-						1982,
-						1963,
+						1957,
+						2006,
+						1960,
+						1996,
+						1974,
 						1967,
-						1945,
-						1980,
-						1929,
-						1984,
-						1972,
-						1931,
-						1989
+						1978,
+						2002,
+						1983,
+						1987,
+						1965,
+						2000,
+						1949,
+						2004,
+						1992,
+						1951,
+						2009
 					]
 				}
 			],
@@ -13071,7 +13438,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2807,
+										"id": 2839,
 										"name": "DOMSelector"
 									}
 								},
@@ -13083,7 +13450,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2683,
+										"id": 2715,
 										"name": "AppViewConfig"
 									}
 								}
@@ -13204,7 +13571,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -13732,7 +14099,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -13747,7 +14114,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -13814,7 +14181,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -13826,7 +14193,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -13838,7 +14205,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -14161,7 +14528,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -14180,7 +14547,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -14309,7 +14676,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -14959,7 +15326,7 @@
 			]
 		},
 		{
-			"id": 1672,
+			"id": 1692,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -14987,7 +15354,7 @@
 			},
 			"children": [
 				{
-					"id": 1673,
+					"id": 1693,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -14995,20 +15362,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 360,
+							"line": 533,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1674,
+							"id": 1694,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1675,
+									"id": 1695,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15019,21 +15386,21 @@
 									}
 								},
 								{
-									"id": 1676,
+									"id": 1696,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1625,
+										"id": 1635,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1672,
+								"id": 1692,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
@@ -15050,7 +15417,7 @@
 					}
 				},
 				{
-					"id": 1827,
+					"id": 1847,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15066,7 +15433,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1828,
+							"id": 1848,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15098,7 +15465,7 @@
 					}
 				},
 				{
-					"id": 1846,
+					"id": 1866,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15114,7 +15481,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1847,
+							"id": 1867,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15130,7 +15497,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1848,
+									"id": 1868,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15151,7 +15518,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -15171,7 +15538,7 @@
 					}
 				},
 				{
-					"id": 1815,
+					"id": 1835,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15187,7 +15554,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1816,
+							"id": 1836,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15226,7 +15593,7 @@
 					}
 				},
 				{
-					"id": 1680,
+					"id": 1700,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15236,13 +15603,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 293,
+							"line": 466,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1681,
+							"id": 1701,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15265,7 +15632,7 @@
 					}
 				},
 				{
-					"id": 1841,
+					"id": 1861,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15281,7 +15648,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1842,
+							"id": 1862,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15303,14 +15670,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1843,
+									"id": 1863,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1845,
+											"id": 1865,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15322,7 +15689,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1844,
+											"id": 1864,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15339,8 +15706,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1845,
-												1844
+												1865,
+												1864
 											]
 										}
 									]
@@ -15360,7 +15727,7 @@
 					}
 				},
 				{
-					"id": 1821,
+					"id": 1841,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15376,7 +15743,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1822,
+							"id": 1842,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15392,7 +15759,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1823,
+									"id": 1843,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15400,20 +15767,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1824,
+											"id": 1844,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1825,
+												"id": 1845,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1826,
+														"id": 1846,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -15460,7 +15827,7 @@
 					}
 				},
 				{
-					"id": 1829,
+					"id": 1849,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15476,7 +15843,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1830,
+							"id": 1850,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15499,7 +15866,7 @@
 					}
 				},
 				{
-					"id": 1839,
+					"id": 1859,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15515,7 +15882,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1840,
+							"id": 1860,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15541,7 +15908,7 @@
 					}
 				},
 				{
-					"id": 1782,
+					"id": 1802,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15557,7 +15924,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1783,
+							"id": 1803,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15573,7 +15940,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1784,
+									"id": 1804,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15583,12 +15950,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1785,
+									"id": 1805,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15598,7 +15965,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -15621,7 +15988,7 @@
 					}
 				},
 				{
-					"id": 1776,
+					"id": 1796,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15637,7 +16004,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1777,
+							"id": 1797,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15657,7 +16024,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1778,
+									"id": 1798,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15667,12 +16034,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1779,
+									"id": 1799,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15682,12 +16049,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1780,
+									"id": 1800,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15697,13 +16064,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1781,
+									"id": 1801,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15734,7 +16101,7 @@
 					}
 				},
 				{
-					"id": 1817,
+					"id": 1837,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15750,7 +16117,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1818,
+							"id": 1838,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15760,7 +16127,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1819,
+									"id": 1839,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15775,7 +16142,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1820,
+									"id": 1840,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15811,7 +16178,7 @@
 					}
 				},
 				{
-					"id": 1831,
+					"id": 1851,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15827,7 +16194,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1832,
+							"id": 1852,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15866,7 +16233,7 @@
 					}
 				},
 				{
-					"id": 1682,
+					"id": 1702,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15876,13 +16243,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 333,
+							"line": 506,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1683,
+							"id": 1703,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15912,7 +16279,7 @@
 					}
 				},
 				{
-					"id": 1835,
+					"id": 1855,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15928,7 +16295,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1836,
+							"id": 1856,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15960,7 +16327,7 @@
 					}
 				},
 				{
-					"id": 1837,
+					"id": 1857,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15976,7 +16343,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1838,
+							"id": 1858,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16008,7 +16375,7 @@
 					}
 				},
 				{
-					"id": 1800,
+					"id": 1820,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16024,7 +16391,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1801,
+							"id": 1821,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16035,40 +16402,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1802,
+									"id": 1822,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1803,
+									"id": 1823,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1804,
+									"id": 1824,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1805,
+									"id": 1825,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16082,7 +16449,7 @@
 									}
 								},
 								{
-									"id": 1806,
+									"id": 1826,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16107,7 +16474,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1807,
+									"id": 1827,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16158,7 +16525,7 @@
 					}
 				},
 				{
-					"id": 1808,
+					"id": 1828,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16174,7 +16541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1809,
+							"id": 1829,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16185,21 +16552,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1810,
+									"id": 1830,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1811,
+									"id": 1831,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16213,7 +16580,7 @@
 									}
 								},
 								{
-									"id": 1812,
+									"id": 1832,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16268,37 +16635,37 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1673
+						1693
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1827,
-						1846,
-						1815,
-						1680,
-						1841,
-						1821,
-						1829,
-						1839,
-						1782,
-						1776,
-						1817,
-						1831,
-						1682,
+						1847,
+						1866,
 						1835,
+						1700,
+						1861,
+						1841,
+						1849,
+						1859,
+						1802,
+						1796,
 						1837,
-						1800,
-						1808
+						1851,
+						1702,
+						1855,
+						1857,
+						1820,
+						1828
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 359,
+					"line": 532,
 					"character": 13
 				}
 			],
@@ -16359,7 +16726,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2807,
+										"id": 2839,
 										"name": "DOMSelector"
 									}
 								},
@@ -16371,7 +16738,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2542,
+										"id": 2574,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -16492,7 +16859,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -17011,7 +17378,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17026,7 +17393,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -17093,7 +17460,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17105,7 +17472,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -17117,7 +17484,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17440,7 +17807,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -17459,7 +17826,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -17588,7 +17955,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -17754,7 +18121,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2807,
+										"id": 2839,
 										"name": "DOMSelector"
 									}
 								},
@@ -17766,7 +18133,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2629,
+										"id": 2661,
 										"name": "SageViewConfig"
 									}
 								}
@@ -17887,7 +18254,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -18338,7 +18705,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18353,7 +18720,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -18420,7 +18787,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18432,7 +18799,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -18444,7 +18811,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18768,7 +19135,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -18787,7 +19154,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -18916,7 +19283,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19092,7 +19459,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2493,
+										"id": 2525,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -19213,7 +19580,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -19631,7 +19998,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -19646,7 +20013,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -19713,7 +20080,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -19728,7 +20095,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -19743,7 +20110,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -20079,7 +20446,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -20098,7 +20465,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -20227,7 +20594,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -20387,7 +20754,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2807,
+										"id": 2839,
 										"name": "DOMSelector"
 									}
 								},
@@ -20399,7 +20766,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2433,
+										"id": 2465,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -20520,7 +20887,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -20970,7 +21337,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20985,7 +21352,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -21052,7 +21419,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21067,7 +21434,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -21082,7 +21449,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21418,7 +21785,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -21437,7 +21804,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -21566,7 +21933,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22217,7 +22584,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 230,
+							"line": 381,
 							"character": 4
 						}
 					],
@@ -22369,7 +22736,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1919,
+										"id": 1939,
 										"name": "AnswerService"
 									}
 								],
@@ -22450,7 +22817,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 293,
+							"line": 466,
 							"character": 11
 						}
 					],
@@ -22787,7 +23154,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -22802,7 +23169,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								}
@@ -22869,7 +23236,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2043,
+										"id": 2063,
 										"name": "EmbedEvent"
 									}
 								},
@@ -22884,7 +23251,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2811,
+										"id": 2843,
 										"name": "MessageCallback"
 									}
 								},
@@ -22899,7 +23266,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2808,
+										"id": 2840,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23072,7 +23439,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 333,
+							"line": 506,
 							"character": 17
 						}
 					],
@@ -23232,7 +23599,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2142,
+										"id": 2165,
 										"name": "HostEvent"
 									}
 								},
@@ -23251,7 +23618,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2219,
+										"id": 2242,
 										"name": "ContextType"
 									}
 								}
@@ -23380,7 +23747,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3069,
+										"id": 3113,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -23484,7 +23851,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 229,
+					"line": 380,
 					"character": 13
 				}
 			],
@@ -23497,13 +23864,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1672,
+					"id": 1692,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2683,
+			"id": 2715,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -23519,7 +23886,7 @@
 			},
 			"children": [
 				{
-					"id": 2724,
+					"id": 2756,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23550,20 +23917,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2725,
+							"id": 2757,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2726,
+								"id": 2758,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2727,
+										"id": 2759,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -23599,7 +23966,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2786,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23641,7 +24008,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2735,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23678,7 +24045,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2783,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23708,7 +24075,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2377,
+						"id": 2409,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -23717,7 +24084,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2804,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23755,7 +24122,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2774,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23796,7 +24163,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2760,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23825,7 +24192,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -23834,7 +24201,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2736,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23868,12 +24235,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3085,
+						"id": 3129,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2787,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23915,7 +24282,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2718,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23953,7 +24320,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2768,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23991,7 +24358,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2752,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24029,7 +24396,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2751,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24061,7 +24428,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -24071,7 +24438,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2734,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24108,7 +24475,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2764,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24149,7 +24516,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2798,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24191,7 +24558,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2803,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24233,7 +24600,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2788,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24275,7 +24642,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2719,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24311,7 +24678,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2731,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24349,7 +24716,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2765,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24387,7 +24754,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2784,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24425,7 +24792,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2785,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24463,7 +24830,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2767,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24500,7 +24867,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2748,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24530,7 +24897,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -24539,7 +24906,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2732,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24573,7 +24940,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2753,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24609,7 +24976,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -24619,7 +24986,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2793,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24651,7 +25018,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2789,
+							"id": 2821,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -24661,7 +25028,7 @@
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2791,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24693,7 +25060,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2800,
+							"id": 2832,
 							"name": "HomepageModule"
 						}
 					},
@@ -24703,7 +25070,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2790,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24735,7 +25102,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3077,
+							"id": 3121,
 							"name": "ListPageColumns"
 						}
 					},
@@ -24745,7 +25112,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2723,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24783,7 +25150,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2720,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24821,7 +25188,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2717,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24859,7 +25226,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2801,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24901,7 +25268,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2794,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24943,7 +25310,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2722,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24981,7 +25348,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2721,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25019,7 +25386,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2729,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25056,7 +25423,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2724,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25094,7 +25461,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2728,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25128,7 +25495,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2737,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25154,12 +25521,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3034,
+						"id": 3078,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2761,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25197,7 +25564,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2780,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25220,7 +25587,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -25234,7 +25601,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2779,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25257,7 +25624,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -25274,7 +25641,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2805,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25312,7 +25679,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2807,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25350,7 +25717,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2742,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25384,7 +25751,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2806,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25422,7 +25789,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2799,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25464,7 +25831,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2797,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25502,7 +25869,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2809,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25544,7 +25911,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2739,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25578,7 +25945,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2741,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25612,7 +25979,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2778,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25632,7 +25999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -25646,7 +26013,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2740,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25680,7 +26047,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2789,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25718,7 +26085,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2738,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25756,7 +26123,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2743,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25793,7 +26160,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2744,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25827,7 +26194,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2770,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25865,7 +26232,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2755,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25903,7 +26270,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2746,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25940,7 +26307,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2733,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25977,7 +26344,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2769,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26015,7 +26382,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2726,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26045,12 +26412,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2002,
+						"id": 2022,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2725,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26084,7 +26451,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2763,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26122,7 +26489,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2771,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26160,7 +26527,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2775,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26197,7 +26564,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2792,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26229,7 +26596,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2800,
+							"id": 2832,
 							"name": "HomepageModule"
 						}
 					},
@@ -26239,7 +26606,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2781,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26271,7 +26638,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -26281,7 +26648,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2782,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26313,7 +26680,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -26323,7 +26690,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2776,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26364,7 +26731,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2773,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26401,7 +26768,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2796,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26443,7 +26810,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2802,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26485,7 +26852,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2795,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26527,7 +26894,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2800,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26569,7 +26936,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2808,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26611,7 +26978,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2716,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26649,7 +27016,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2727,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26683,7 +27050,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2745,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26721,7 +27088,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2777,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26762,7 +27129,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2754,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26798,7 +27165,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -26813,90 +27180,90 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2724,
-						2754,
-						2703,
-						2751,
-						2772,
-						2742,
-						2728,
-						2704,
-						2755,
-						2686,
-						2736,
-						2720,
-						2719,
-						2702,
-						2732,
-						2766,
-						2771,
 						2756,
-						2687,
-						2699,
-						2733,
-						2752,
-						2753,
+						2786,
 						2735,
-						2716,
-						2700,
-						2721,
-						2761,
-						2759,
-						2758,
-						2691,
-						2688,
-						2685,
-						2769,
-						2762,
-						2690,
-						2689,
-						2697,
-						2692,
-						2696,
-						2705,
-						2729,
-						2748,
-						2747,
-						2773,
-						2775,
-						2710,
+						2783,
+						2804,
 						2774,
-						2767,
-						2765,
-						2777,
-						2707,
-						2709,
-						2746,
-						2708,
-						2757,
-						2706,
-						2711,
-						2712,
-						2738,
-						2723,
-						2714,
-						2701,
-						2737,
-						2694,
-						2693,
-						2731,
-						2739,
-						2743,
 						2760,
-						2749,
-						2750,
-						2744,
-						2741,
-						2764,
-						2770,
-						2763,
+						2736,
+						2787,
+						2718,
 						2768,
+						2752,
+						2751,
+						2734,
+						2764,
+						2798,
+						2803,
+						2788,
+						2719,
+						2731,
+						2765,
+						2784,
+						2785,
+						2767,
+						2748,
+						2732,
+						2753,
+						2793,
+						2791,
+						2790,
+						2723,
+						2720,
+						2717,
+						2801,
+						2794,
+						2722,
+						2721,
+						2729,
+						2724,
+						2728,
+						2737,
+						2761,
+						2780,
+						2779,
+						2805,
+						2807,
+						2742,
+						2806,
+						2799,
+						2797,
+						2809,
+						2739,
+						2741,
+						2778,
+						2740,
+						2789,
+						2738,
+						2743,
+						2744,
+						2770,
+						2755,
+						2746,
+						2733,
+						2769,
+						2726,
+						2725,
+						2763,
+						2771,
+						2775,
+						2792,
+						2781,
+						2782,
 						2776,
-						2684,
-						2695,
-						2713,
+						2773,
+						2796,
+						2802,
+						2795,
+						2800,
+						2808,
+						2716,
+						2727,
 						2745,
-						2722
+						2777,
+						2754
 					]
 				}
 			],
@@ -26915,7 +27282,7 @@
 			]
 		},
 		{
-			"id": 1866,
+			"id": 1886,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26931,14 +27298,14 @@
 			},
 			"children": [
 				{
-					"id": 1903,
+					"id": 1923,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1904,
+							"id": 1924,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26948,19 +27315,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1905,
+									"id": 1925,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1865,
+										"id": 1885,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1906,
+									"id": 1926,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26984,14 +27351,14 @@
 					]
 				},
 				{
-					"id": 1907,
+					"id": 1927,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1908,
+							"id": 1928,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27001,7 +27368,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1909,
+									"id": 1929,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27009,12 +27376,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1856,
+										"id": 1876,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1910,
+									"id": 1930,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27023,21 +27390,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1911,
+											"id": 1931,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1912,
+													"id": 1932,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1913,
+															"id": 1933,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27063,7 +27430,7 @@
 									}
 								},
 								{
-									"id": 1914,
+									"id": 1934,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27075,7 +27442,7 @@
 									}
 								},
 								{
-									"id": 1915,
+									"id": 1935,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27091,21 +27458,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1867,
+					"id": 1887,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1868,
+							"id": 1888,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27115,7 +27482,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1869,
+									"id": 1889,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27123,12 +27490,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1857,
+										"id": 1877,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1870,
+									"id": 1890,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27139,28 +27506,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1871,
+											"id": 1891,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1872,
+													"id": 1892,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1873,
+															"id": 1893,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1849,
+																"id": 1869,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27177,12 +27544,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1874,
+							"id": 1894,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27192,7 +27559,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1875,
+									"id": 1895,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27203,29 +27570,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1858,
+												"id": 1878,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1861,
+												"id": 1881,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1862,
+												"id": 1882,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1863,
+												"id": 1883,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1876,
+									"id": 1896,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27236,14 +27603,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1877,
+											"id": 1897,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1878,
+													"id": 1898,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -27260,31 +27627,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1879,
+							"id": 1899,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1880,
+									"id": 1900,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1860,
+										"id": 1880,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1881,
+									"id": 1901,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27292,21 +27659,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1882,
+											"id": 1902,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1883,
+													"id": 1903,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1884,
+															"id": 1904,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27329,40 +27696,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1885,
+					"id": 1905,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1886,
+							"id": 1906,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1887,
+									"id": 1907,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1857,
+										"id": 1877,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1888,
+									"id": 1908,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27370,28 +27737,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1889,
+											"id": 1909,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1890,
+													"id": 1910,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1891,
+															"id": 1911,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1849,
+																"id": 1869,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27408,19 +27775,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1892,
+							"id": 1912,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1893,
+									"id": 1913,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27430,29 +27797,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1858,
+												"id": 1878,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1861,
+												"id": 1881,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1862,
+												"id": 1882,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1863,
+												"id": 1883,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1894,
+									"id": 1914,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27460,14 +27827,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1895,
+											"id": 1915,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1896,
+													"id": 1916,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -27484,31 +27851,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1897,
+							"id": 1917,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1898,
+									"id": 1918,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1860,
+										"id": 1880,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1899,
+									"id": 1919,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27516,21 +27883,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1900,
+											"id": 1920,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1901,
+													"id": 1921,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1902,
+															"id": 1922,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27553,21 +27920,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1916,
+					"id": 1936,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1917,
+							"id": 1937,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27577,7 +27944,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1918,
+									"id": 1938,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27587,14 +27954,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1856,
+										"id": 1876,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1866,
+								"id": 1886,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -27606,11 +27973,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1903,
-						1907,
-						1867,
-						1885,
-						1916
+						1923,
+						1927,
+						1887,
+						1905,
+						1936
 					]
 				}
 			],
@@ -27795,7 +28162,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27915,7 +28282,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -28075,7 +28442,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28121,7 +28488,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -28194,7 +28561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -28232,7 +28599,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -28270,7 +28637,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -28637,7 +29004,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -28723,7 +29090,7 @@
 			]
 		},
 		{
-			"id": 1625,
+			"id": 1635,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28743,7 +29110,7 @@
 			},
 			"children": [
 				{
-					"id": 1648,
+					"id": 1668,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28774,20 +29141,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1649,
+							"id": 1669,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1650,
+								"id": 1670,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1651,
+										"id": 1671,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -28819,12 +29186,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1601,
+						"id": 1611,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1665,
+					"id": 1685,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28861,12 +29228,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1618,
+						"id": 1628,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1652,
+					"id": 1672,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28895,17 +29262,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1605,
+						"id": 1615,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1640,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28948,7 +29315,7 @@
 					}
 				},
 				{
-					"id": 1660,
+					"id": 1680,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28982,12 +29349,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1613,
+						"id": 1623,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1638,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29026,7 +29393,7 @@
 					}
 				},
 				{
-					"id": 1644,
+					"id": 1664,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29060,12 +29427,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1597,
+						"id": 1607,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1643,
+					"id": 1663,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29097,18 +29464,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1596,
+						"id": 1606,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1656,
+					"id": 1676,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29145,12 +29512,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1609,
+						"id": 1619,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1637,
+					"id": 1647,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29193,7 +29560,7 @@
 					}
 				},
 				{
-					"id": 1657,
+					"id": 1677,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29227,12 +29594,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1610,
+						"id": 1620,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1644,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29271,7 +29638,7 @@
 					}
 				},
 				{
-					"id": 1636,
+					"id": 1646,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29310,7 +29677,7 @@
 					}
 				},
 				{
-					"id": 1659,
+					"id": 1679,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29343,12 +29710,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1612,
+						"id": 1622,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1640,
+					"id": 1660,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29378,17 +29745,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1593,
+						"id": 1603,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1645,
+					"id": 1665,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29424,18 +29791,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1598,
+						"id": 1608,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1642,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29474,7 +29841,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1639,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29513,7 +29880,7 @@
 					}
 				},
 				{
-					"id": 1653,
+					"id": 1673,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29547,12 +29914,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1606,
+						"id": 1616,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1671,
+					"id": 1691,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29575,7 +29942,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -29585,12 +29952,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1624,
+						"id": 1634,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1670,
+					"id": 1690,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29613,7 +29980,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -29626,12 +29993,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1623,
+						"id": 1633,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1669,
+					"id": 1689,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29651,7 +30018,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -29661,12 +30028,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1622,
+						"id": 1632,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1662,
+					"id": 1682,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29700,12 +30067,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1615,
+						"id": 1625,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1647,
+					"id": 1667,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29739,12 +30106,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1600,
+						"id": 1610,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1661,
+					"id": 1681,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29778,12 +30145,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1614,
+						"id": 1624,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1655,
+					"id": 1675,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29817,12 +30184,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1608,
+						"id": 1618,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1666,
+					"id": 1686,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29855,12 +30222,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1619,
+						"id": 1629,
 						"name": "SpotterEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1643,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29892,7 +30259,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -29903,7 +30270,7 @@
 					}
 				},
 				{
-					"id": 1635,
+					"id": 1645,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29935,7 +30302,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -29946,7 +30313,7 @@
 					}
 				},
 				{
-					"id": 1627,
+					"id": 1637,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29974,7 +30341,7 @@
 					}
 				},
 				{
-					"id": 1667,
+					"id": 1687,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30011,12 +30378,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1620,
+						"id": 1630,
 						"name": "SpotterEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1664,
+					"id": 1684,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30049,12 +30416,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1617,
+						"id": 1627,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1641,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30093,7 +30460,405 @@
 					}
 				},
 				{
-					"id": 1638,
+					"id": 1656,
+					"name": "spotterBestPracticesLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the best practices button in the footer.\nDefaults to translated \"Best Practices\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterBestPracticesLabel: 'Help & Tips',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 323,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1599,
+						"name": "SpotterEmbedViewConfig.spotterBestPracticesLabel"
+					}
+				},
+				{
+					"id": 1652,
+					"name": "spotterChatDeleteLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the delete action in the conversation edit menu.\nDefaults to translated \"DELETE\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatDeleteLabel: 'Remove',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 262,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1595,
+						"name": "SpotterEmbedViewConfig.spotterChatDeleteLabel"
+					}
+				},
+				{
+					"id": 1651,
+					"name": "spotterChatRenameLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the rename action in the conversation edit menu.\nDefaults to translated \"Rename\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatRenameLabel: 'Edit Name',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 247,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1594,
+						"name": "SpotterEmbedViewConfig.spotterChatRenameLabel"
+					}
+				},
+				{
+					"id": 1657,
+					"name": "spotterConversationsBatchSize",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Number of conversations to fetch per batch when loading conversation history.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "30"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterConversationsBatchSize: 50,\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 338,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1600,
+						"name": "SpotterEmbedViewConfig.spotterConversationsBatchSize"
+					}
+				},
+				{
+					"id": 1653,
+					"name": "spotterDeleteConversationModalTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the delete conversation confirmation modal.\nDefaults to translated \"Delete chat\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDeleteConversationModalTitle: 'Remove Conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 277,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1596,
+						"name": "SpotterEmbedViewConfig.spotterDeleteConversationModalTitle"
+					}
+				},
+				{
+					"id": 1655,
+					"name": "spotterDocumentationUrl",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom URL for the documentation/best practices link.\nDefaults to ThoughtSpot docs URL based on release version.\nNote: URL must include the protocol (e.g., `https://www.example.com`).",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDocumentationUrl: 'https://docs.example.com/spotter',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 308,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1598,
+						"name": "SpotterEmbedViewConfig.spotterDocumentationUrl"
+					}
+				},
+				{
+					"id": 1658,
+					"name": "spotterNewChatButtonTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the \"New Chat\" button in the sidebar.\nDefaults to translated \"New Chat\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterNewChatButtonTitle: 'Start New Conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 353,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1601,
+						"name": "SpotterEmbedViewConfig.spotterNewChatButtonTitle"
+					}
+				},
+				{
+					"id": 1654,
+					"name": "spotterPastConversationAlertMessage",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom message text for the past conversation banner alert.\nDefaults to translated alert message.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterPastConversationAlertMessage: 'You are viewing a past conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 292,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1597,
+						"name": "SpotterEmbedViewConfig.spotterPastConversationAlertMessage"
+					}
+				},
+				{
+					"id": 1650,
+					"name": "spotterSidebarDefaultExpanded",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Boolean to set the default expanded state of the sidebar.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarDefaultExpanded: true,\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 232,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1593,
+						"name": "SpotterEmbedViewConfig.spotterSidebarDefaultExpanded"
+					}
+				},
+				{
+					"id": 1649,
+					"name": "spotterSidebarTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the sidebar header.\nDefaults to translated \"Spotter\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarTitle: 'My Conversations',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 217,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1592,
+						"name": "SpotterEmbedViewConfig.spotterSidebarTitle"
+					}
+				},
+				{
+					"id": 1648,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30136,7 +30901,7 @@
 					}
 				},
 				{
-					"id": 1668,
+					"id": 1688,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30173,12 +30938,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1621,
+						"id": 1631,
 						"name": "SpotterEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1666,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30214,18 +30979,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1599,
+						"id": 1609,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1636,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30256,50 +31021,60 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1648,
-						1665,
-						1652,
-						1630,
-						1660,
-						1628,
-						1644,
-						1643,
-						1656,
-						1637,
-						1657,
-						1634,
-						1636,
-						1659,
-						1640,
-						1645,
-						1632,
-						1629,
-						1653,
-						1671,
-						1670,
-						1669,
-						1662,
-						1647,
-						1661,
-						1655,
-						1666,
-						1633,
-						1635,
-						1627,
-						1667,
-						1664,
-						1631,
-						1638,
 						1668,
+						1685,
+						1672,
+						1640,
+						1680,
+						1638,
+						1664,
+						1663,
+						1676,
+						1647,
+						1677,
+						1644,
 						1646,
-						1626
+						1679,
+						1660,
+						1665,
+						1642,
+						1639,
+						1673,
+						1691,
+						1690,
+						1689,
+						1682,
+						1667,
+						1681,
+						1675,
+						1686,
+						1643,
+						1645,
+						1637,
+						1687,
+						1684,
+						1641,
+						1656,
+						1652,
+						1651,
+						1657,
+						1653,
+						1655,
+						1658,
+						1654,
+						1650,
+						1649,
+						1648,
+						1688,
+						1666,
+						1636
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 212,
+					"line": 363,
 					"character": 17
 				}
 			],
@@ -30312,7 +31087,7 @@
 			]
 		},
 		{
-			"id": 3049,
+			"id": 3093,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -30327,7 +31102,7 @@
 			},
 			"children": [
 				{
-					"id": 3050,
+					"id": 3094,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30337,21 +31112,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6281,
+							"line": 6417,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3051,
+							"id": 3095,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3052,
+									"id": 3096,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30359,18 +31134,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6282,
+											"line": 6418,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3046,
+										"id": 3090,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3053,
+									"id": 3097,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30378,7 +31153,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6283,
+											"line": 6419,
 											"character": 8
 										}
 									],
@@ -30386,7 +31161,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3046,
+											"id": 3090,
 											"name": "VizPoint"
 										}
 									}
@@ -30397,8 +31172,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3052,
-										3053
+										3096,
+										3097
 									]
 								}
 							]
@@ -30406,7 +31181,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3098,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30414,21 +31189,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6285,
+							"line": 6421,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3055,
+							"id": 3099,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3063,
+									"id": 3107,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30436,7 +31211,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6293,
+											"line": 6429,
 											"character": 8
 										}
 									],
@@ -30449,7 +31224,7 @@
 									}
 								},
 								{
-									"id": 3064,
+									"id": 3108,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30457,7 +31232,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6294,
+											"line": 6430,
 											"character": 8
 										}
 									],
@@ -30470,7 +31245,7 @@
 									}
 								},
 								{
-									"id": 3057,
+									"id": 3101,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30478,7 +31253,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6287,
+											"line": 6423,
 											"character": 8
 										}
 									],
@@ -30488,7 +31263,7 @@
 									}
 								},
 								{
-									"id": 3056,
+									"id": 3100,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30496,7 +31271,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6286,
+											"line": 6422,
 											"character": 8
 										}
 									],
@@ -30506,7 +31281,7 @@
 									}
 								},
 								{
-									"id": 3058,
+									"id": 3102,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30514,21 +31289,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6288,
+											"line": 6424,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3059,
+											"id": 3103,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3060,
+													"id": 3104,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -30536,21 +31311,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 6289,
+															"line": 6425,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3061,
+															"id": 3105,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3062,
+																	"id": 3106,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -30558,7 +31333,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 6290,
+																			"line": 6426,
 																			"character": 16
 																		}
 																	],
@@ -30573,7 +31348,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3062
+																		3106
 																	]
 																}
 															]
@@ -30586,7 +31361,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3060
+														3104
 													]
 												}
 											]
@@ -30599,23 +31374,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3063,
-										3064,
-										3057,
-										3056,
-										3058
+										3107,
+										3108,
+										3101,
+										3100,
+										3102
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3065,
+								"id": 3109,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3066,
+										"id": 3110,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -30634,7 +31409,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3111,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30642,18 +31417,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6297,
+							"line": 6433,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1992,
+						"id": 2012,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3112,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30663,7 +31438,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6298,
+							"line": 6434,
 							"character": 4
 						}
 					],
@@ -30678,23 +31453,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3050,
-						3054,
-						3067,
-						3068
+						3094,
+						3098,
+						3111,
+						3112
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6280,
+					"line": 6416,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2846,
+			"id": 2878,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -30704,7 +31479,7 @@
 			},
 			"children": [
 				{
-					"id": 2900,
+					"id": 2932,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30727,7 +31502,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2931,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30750,7 +31525,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2901,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30773,7 +31548,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2902,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30796,7 +31571,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2904,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30819,7 +31594,7 @@
 					}
 				},
 				{
-					"id": 2871,
+					"id": 2903,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30842,7 +31617,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2883,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30865,7 +31640,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2944,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30888,7 +31663,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2945,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30911,7 +31686,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2942,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30934,7 +31709,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2943,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30957,7 +31732,7 @@
 					}
 				},
 				{
-					"id": 2874,
+					"id": 2906,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30980,7 +31755,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2911,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31003,7 +31778,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2908,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31026,7 +31801,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2910,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31049,7 +31824,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2909,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31072,7 +31847,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2907,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31095,7 +31870,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2916,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31118,7 +31893,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2913,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31141,7 +31916,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2915,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31164,7 +31939,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2914,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31187,7 +31962,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2912,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31210,7 +31985,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2920,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31233,7 +32008,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2919,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31256,7 +32031,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2918,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31279,7 +32054,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2917,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31302,7 +32077,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2905,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31325,7 +32100,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3038,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31348,7 +32123,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3033,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31371,7 +32146,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 3028,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31394,7 +32169,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3027,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31417,7 +32192,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3030,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31440,7 +32215,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3029,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31463,7 +32238,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2967,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31486,7 +32261,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2970,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31509,7 +32284,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2965,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31532,7 +32307,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2968,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31555,7 +32330,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2969,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31578,7 +32353,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2964,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31601,7 +32376,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2966,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31624,7 +32399,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2937,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31647,7 +32422,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2936,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31670,7 +32445,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2939,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31693,7 +32468,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2938,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31716,7 +32491,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2935,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31739,7 +32514,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2933,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31762,7 +32537,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2934,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31785,7 +32560,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2940,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31808,7 +32583,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2941,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31831,7 +32606,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2952,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31854,7 +32629,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2953,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31877,7 +32652,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2956,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31900,7 +32675,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2954,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31923,7 +32698,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2955,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31946,7 +32721,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2963,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31969,7 +32744,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2962,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31992,7 +32767,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2961,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32015,7 +32790,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2960,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32038,7 +32813,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3026,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32061,7 +32836,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 3025,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32084,7 +32859,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 3024,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32107,7 +32882,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3032,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32130,7 +32905,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3031,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32153,7 +32928,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2958,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32176,7 +32951,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2957,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32199,7 +32974,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2985,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32222,7 +32997,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2998,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32246,7 +33021,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2997,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32270,7 +33045,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2995,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32294,7 +33069,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2996,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32318,7 +33093,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 3003,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32341,7 +33116,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 3001,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32364,7 +33139,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 3000,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32387,7 +33162,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2986,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32411,7 +33186,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2987,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32435,7 +33210,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2991,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32459,7 +33234,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2979,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32483,7 +33258,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2994,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32507,7 +33282,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2993,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32531,7 +33306,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2984,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32555,7 +33330,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2992,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32579,7 +33354,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2982,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32603,7 +33378,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2983,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32627,7 +33402,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2990,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32651,7 +33426,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2980,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32675,7 +33450,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2981,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32699,7 +33474,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 3017,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32722,7 +33497,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 3014,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32745,7 +33520,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 3015,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32768,7 +33543,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 3016,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32791,7 +33566,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2972,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32814,7 +33589,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 3023,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32837,7 +33612,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 3018,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32860,7 +33635,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 3019,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32883,7 +33658,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 3022,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32906,7 +33681,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 3020,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32929,7 +33704,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 3021,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32952,7 +33727,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2973,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32975,7 +33750,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2971,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32998,7 +33773,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2989,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33021,7 +33796,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2988,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33044,7 +33819,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 3002,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33067,7 +33842,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 3004,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33090,7 +33865,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 3005,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33113,7 +33888,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2975,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33136,7 +33911,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2974,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33159,7 +33934,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2976,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33182,7 +33957,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2977,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33205,7 +33980,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2978,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33228,7 +34003,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 3006,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33251,7 +34026,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 3007,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33274,7 +34049,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2950,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33297,7 +34072,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2947,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33320,7 +34095,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2946,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33343,7 +34118,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2948,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33366,7 +34141,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2951,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33389,7 +34164,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2949,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33412,7 +34187,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2884,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33435,7 +34210,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2885,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33458,7 +34233,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 3012,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33481,7 +34256,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 3013,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33504,7 +34279,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 3008,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33527,7 +34302,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 3010,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33550,7 +34325,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 3011,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33573,7 +34348,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 3009,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33596,7 +34371,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2879,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33619,7 +34394,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2880,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33642,7 +34417,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2881,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33665,7 +34440,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2882,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33688,7 +34463,283 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 3041,
+					"name": "--ts-var-saved-chats-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the saved chats sidebar container."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 864,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3040,
+					"name": "--ts-var-saved-chats-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar container."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 859,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3045,
+					"name": "--ts-var-saved-chats-btn-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for buttons (new chat, toggle, footer) in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 884,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3046,
+					"name": "--ts-var-saved-chats-btn-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color for buttons in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 889,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3049,
+					"name": "--ts-var-saved-chats-conv-active-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the active/selected conversation in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 904,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3048,
+					"name": "--ts-var-saved-chats-conv-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for conversation items on hover in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 899,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3047,
+					"name": "--ts-var-saved-chats-conv-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for conversation items in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 894,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3050,
+					"name": "--ts-var-saved-chats-footer-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar footer."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 909,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3043,
+					"name": "--ts-var-saved-chats-header-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 874,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3051,
+					"name": "--ts-var-saved-chats-section-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for section title text (e.g., \"Recent\", \"Older\") in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 914,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3042,
+					"name": "--ts-var-saved-chats-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for the saved chats sidebar container."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 869,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3044,
+					"name": "--ts-var-saved-chats-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for the saved chats sidebar title text."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 879,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2893,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33711,7 +34762,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2897,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33734,7 +34785,7 @@
 					}
 				},
 				{
-					"id": 2866,
+					"id": 2898,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33757,7 +34808,7 @@
 					}
 				},
 				{
-					"id": 2864,
+					"id": 2896,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33780,7 +34831,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2892,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33803,7 +34854,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2895,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33826,7 +34877,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2889,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33849,7 +34900,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2890,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33872,7 +34923,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2891,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33895,7 +34946,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2886,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33918,7 +34969,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2887,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33941,7 +34992,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2888,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33964,7 +35015,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2894,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33987,7 +35038,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2959,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34010,7 +35061,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2999,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34033,7 +35084,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3037,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34056,7 +35107,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3034,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34079,7 +35130,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3035,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34102,7 +35153,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3036,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34125,7 +35176,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3039,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34148,7 +35199,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2899,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34171,7 +35222,7 @@
 					}
 				},
 				{
-					"id": 2868,
+					"id": 2900,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34194,7 +35245,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2929,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34217,7 +35268,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2927,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34240,7 +35291,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2928,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34263,7 +35314,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2924,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34286,7 +35337,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2925,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34309,7 +35360,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2926,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34332,7 +35383,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2930,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34355,7 +35406,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2921,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34378,7 +35429,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2922,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34401,7 +35452,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2923,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34429,167 +35480,179 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2900,
-						2899,
-						2869,
-						2870,
-						2872,
-						2871,
-						2851,
-						2912,
-						2913,
-						2910,
-						2911,
-						2874,
-						2879,
-						2876,
-						2878,
-						2877,
-						2875,
-						2884,
-						2881,
-						2883,
-						2882,
-						2880,
-						2888,
-						2887,
-						2886,
-						2885,
-						2873,
-						3006,
-						3001,
-						2996,
-						2995,
-						2998,
-						2997,
-						2935,
-						2938,
-						2933,
-						2936,
-						2937,
 						2932,
-						2934,
-						2905,
-						2904,
-						2907,
-						2906,
-						2903,
+						2931,
 						2901,
 						2902,
-						2908,
-						2909,
-						2920,
-						2921,
-						2924,
-						2922,
-						2923,
-						2931,
-						2930,
-						2929,
-						2928,
-						2994,
-						2993,
-						2992,
-						3000,
-						2999,
-						2926,
-						2925,
-						2953,
-						2966,
-						2965,
-						2963,
-						2964,
-						2971,
-						2969,
-						2968,
-						2954,
-						2955,
-						2959,
-						2947,
-						2962,
-						2961,
-						2952,
-						2960,
-						2950,
-						2951,
-						2958,
-						2948,
-						2949,
-						2985,
-						2982,
-						2983,
-						2984,
-						2940,
-						2991,
-						2986,
-						2987,
-						2990,
-						2988,
-						2989,
-						2941,
-						2939,
-						2957,
-						2956,
-						2970,
-						2972,
-						2973,
-						2943,
-						2942,
+						2904,
+						2903,
+						2883,
 						2944,
 						2945,
-						2946,
-						2974,
-						2975,
-						2918,
+						2942,
+						2943,
+						2906,
+						2911,
+						2908,
+						2910,
+						2909,
+						2907,
+						2916,
+						2913,
 						2915,
 						2914,
-						2916,
+						2912,
+						2920,
 						2919,
+						2918,
 						2917,
-						2852,
-						2853,
+						2905,
+						3038,
+						3033,
+						3028,
+						3027,
+						3030,
+						3029,
+						2967,
+						2970,
+						2965,
+						2968,
+						2969,
+						2964,
+						2966,
+						2937,
+						2936,
+						2939,
+						2938,
+						2935,
+						2933,
+						2934,
+						2940,
+						2941,
+						2952,
+						2953,
+						2956,
+						2954,
+						2955,
+						2963,
+						2962,
+						2961,
+						2960,
+						3026,
+						3025,
+						3024,
+						3032,
+						3031,
+						2958,
+						2957,
+						2985,
+						2998,
+						2997,
+						2995,
+						2996,
+						3003,
+						3001,
+						3000,
+						2986,
+						2987,
+						2991,
+						2979,
+						2994,
+						2993,
+						2984,
+						2992,
+						2982,
+						2983,
+						2990,
 						2980,
 						2981,
-						2976,
-						2978,
-						2979,
-						2977,
-						2847,
-						2848,
-						2849,
-						2850,
-						2861,
-						2865,
-						2866,
-						2864,
-						2860,
-						2863,
-						2857,
-						2858,
-						2859,
-						2854,
-						2855,
-						2856,
-						2862,
-						2927,
-						2967,
-						3005,
+						3017,
+						3014,
+						3015,
+						3016,
+						2972,
+						3023,
+						3018,
+						3019,
+						3022,
+						3020,
+						3021,
+						2973,
+						2971,
+						2989,
+						2988,
 						3002,
-						3003,
 						3004,
+						3005,
+						2975,
+						2974,
+						2976,
+						2977,
+						2978,
+						3006,
 						3007,
-						2867,
-						2868,
+						2950,
+						2947,
+						2946,
+						2948,
+						2951,
+						2949,
+						2884,
+						2885,
+						3012,
+						3013,
+						3008,
+						3010,
+						3011,
+						3009,
+						2879,
+						2880,
+						2881,
+						2882,
+						3041,
+						3040,
+						3045,
+						3046,
+						3049,
+						3048,
+						3047,
+						3050,
+						3043,
+						3051,
+						3042,
+						3044,
+						2893,
 						2897,
-						2895,
+						2898,
 						2896,
 						2892,
-						2893,
-						2894,
-						2898,
+						2895,
 						2889,
 						2890,
-						2891
+						2891,
+						2886,
+						2887,
+						2888,
+						2894,
+						2959,
+						2999,
+						3037,
+						3034,
+						3035,
+						3036,
+						3039,
+						2899,
+						2900,
+						2929,
+						2927,
+						2928,
+						2924,
+						2925,
+						2926,
+						2930,
+						2921,
+						2922,
+						2923
 					]
 				}
 			],
@@ -34602,7 +35665,7 @@
 			]
 		},
 		{
-			"id": 2834,
+			"id": 2866,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34612,7 +35675,7 @@
 			},
 			"children": [
 				{
-					"id": 2836,
+					"id": 2868,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34628,12 +35691,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2837,
+						"id": 2869,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2867,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34658,8 +35721,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2836,
-						2835
+						2868,
+						2867
 					]
 				}
 			],
@@ -34672,7 +35735,7 @@
 			]
 		},
 		{
-			"id": 2824,
+			"id": 2856,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34688,7 +35751,7 @@
 			},
 			"children": [
 				{
-					"id": 2826,
+					"id": 2858,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34705,14 +35768,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2827,
+							"id": 2859,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2829,
+									"id": 2861,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34742,7 +35805,7 @@
 									}
 								},
 								{
-									"id": 2830,
+									"id": 2862,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34762,7 +35825,7 @@
 									}
 								},
 								{
-									"id": 2828,
+									"id": 2860,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34805,21 +35868,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2829,
-										2830,
-										2828
+										2861,
+										2862,
+										2860
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2831,
+								"id": 2863,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2832,
+										"id": 2864,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34838,7 +35901,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2865,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34858,7 +35921,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2857,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34874,7 +35937,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2834,
+						"id": 2866,
 						"name": "CustomStyles"
 					}
 				}
@@ -34884,9 +35947,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2826,
-						2833,
-						2825
+						2858,
+						2865,
+						2857
 					]
 				}
 			],
@@ -34899,7 +35962,7 @@
 			]
 		},
 		{
-			"id": 2381,
+			"id": 2413,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34915,7 +35978,7 @@
 			},
 			"children": [
 				{
-					"id": 2423,
+					"id": 2455,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34945,20 +36008,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2424,
+							"id": 2456,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2425,
+								"id": 2457,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2426,
+										"id": 2458,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34990,7 +36053,7 @@
 					}
 				},
 				{
-					"id": 2384,
+					"id": 2416,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35013,7 +36076,7 @@
 					}
 				},
 				{
-					"id": 2405,
+					"id": 2437,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35055,7 +36118,7 @@
 					}
 				},
 				{
-					"id": 2407,
+					"id": 2439,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35084,7 +36147,7 @@
 					}
 				},
 				{
-					"id": 2383,
+					"id": 2415,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35101,12 +36164,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2011,
+						"id": 2031,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2396,
+					"id": 2428,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35135,7 +36198,7 @@
 					}
 				},
 				{
-					"id": 2408,
+					"id": 2440,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35168,7 +36231,7 @@
 					}
 				},
 				{
-					"id": 2399,
+					"id": 2431,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35197,7 +36260,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2464,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35230,7 +36293,7 @@
 					}
 				},
 				{
-					"id": 2420,
+					"id": 2452,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35259,7 +36322,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2462,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35295,7 +36358,7 @@
 					}
 				},
 				{
-					"id": 2427,
+					"id": 2459,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35338,7 +36401,7 @@
 					}
 				},
 				{
-					"id": 2404,
+					"id": 2436,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35363,12 +36426,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2418,
+					"id": 2450,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35397,7 +36460,7 @@
 					}
 				},
 				{
-					"id": 2401,
+					"id": 2433,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35427,7 +36490,7 @@
 					}
 				},
 				{
-					"id": 2429,
+					"id": 2461,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35464,7 +36527,7 @@
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2454,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35493,7 +36556,7 @@
 					}
 				},
 				{
-					"id": 2397,
+					"id": 2429,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35526,7 +36589,7 @@
 					}
 				},
 				{
-					"id": 2428,
+					"id": 2460,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35546,7 +36609,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2449,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35575,7 +36638,7 @@
 					}
 				},
 				{
-					"id": 2395,
+					"id": 2427,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35604,7 +36667,7 @@
 					}
 				},
 				{
-					"id": 2390,
+					"id": 2422,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35638,7 +36701,7 @@
 					}
 				},
 				{
-					"id": 2416,
+					"id": 2448,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35671,12 +36734,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3011,
+						"id": 3055,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2398,
+					"id": 2430,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35705,7 +36768,7 @@
 					}
 				},
 				{
-					"id": 2389,
+					"id": 2421,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35738,7 +36801,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2451,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35767,7 +36830,7 @@
 					}
 				},
 				{
-					"id": 2388,
+					"id": 2420,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35791,7 +36854,7 @@
 					}
 				},
 				{
-					"id": 2414,
+					"id": 2446,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35820,7 +36883,7 @@
 					}
 				},
 				{
-					"id": 2400,
+					"id": 2432,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35853,7 +36916,7 @@
 					}
 				},
 				{
-					"id": 2391,
+					"id": 2423,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35883,7 +36946,7 @@
 					}
 				},
 				{
-					"id": 2393,
+					"id": 2425,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35912,7 +36975,7 @@
 					}
 				},
 				{
-					"id": 2415,
+					"id": 2447,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35941,7 +37004,7 @@
 					}
 				},
 				{
-					"id": 2394,
+					"id": 2426,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35970,7 +37033,7 @@
 					}
 				},
 				{
-					"id": 2403,
+					"id": 2435,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35993,7 +37056,7 @@
 					}
 				},
 				{
-					"id": 2402,
+					"id": 2434,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36022,7 +37085,7 @@
 					}
 				},
 				{
-					"id": 2382,
+					"id": 2414,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36043,7 +37106,7 @@
 					}
 				},
 				{
-					"id": 2406,
+					"id": 2438,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36066,7 +37129,7 @@
 					}
 				},
 				{
-					"id": 2387,
+					"id": 2419,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36089,7 +37152,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2463,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36122,7 +37185,7 @@
 					}
 				},
 				{
-					"id": 2385,
+					"id": 2417,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -36138,7 +37201,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2386,
+							"id": 2418,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -36166,52 +37229,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2423,
-						2384,
-						2405,
-						2407,
-						2383,
-						2396,
-						2408,
-						2399,
-						2432,
-						2420,
-						2430,
-						2427,
-						2404,
-						2418,
-						2401,
-						2429,
-						2422,
-						2397,
-						2428,
-						2417,
-						2395,
-						2390,
+						2455,
 						2416,
-						2398,
-						2389,
-						2419,
-						2388,
-						2414,
-						2400,
-						2391,
-						2393,
+						2437,
+						2439,
 						2415,
-						2394,
-						2403,
-						2402,
-						2382,
-						2406,
-						2387,
-						2431
+						2428,
+						2440,
+						2431,
+						2464,
+						2452,
+						2462,
+						2459,
+						2436,
+						2450,
+						2433,
+						2461,
+						2454,
+						2429,
+						2460,
+						2449,
+						2427,
+						2422,
+						2448,
+						2430,
+						2421,
+						2451,
+						2420,
+						2446,
+						2432,
+						2423,
+						2425,
+						2447,
+						2426,
+						2435,
+						2434,
+						2414,
+						2438,
+						2419,
+						2463
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2385
+						2417
 					]
 				}
 			],
@@ -36224,7 +37287,7 @@
 			]
 		},
 		{
-			"id": 2783,
+			"id": 2815,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36240,7 +37303,7 @@
 			},
 			"children": [
 				{
-					"id": 2785,
+					"id": 2817,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36272,7 +37335,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2818,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36308,7 +37371,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2816,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36345,9 +37408,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2785,
-						2786,
-						2784
+						2817,
+						2818,
+						2816
 					]
 				}
 			],
@@ -36359,7 +37422,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2787,
+				"id": 2819,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -36369,7 +37432,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2788,
+						"id": 2820,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -36403,7 +37466,7 @@
 			}
 		},
 		{
-			"id": 2542,
+			"id": 2574,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36419,7 +37482,7 @@
 			},
 			"children": [
 				{
-					"id": 2554,
+					"id": 2586,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36453,7 +37516,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2611,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36484,20 +37547,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2580,
+							"id": 2612,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2581,
+								"id": 2613,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2582,
+										"id": 2614,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36533,7 +37596,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2641,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36575,7 +37638,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2638,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36605,7 +37668,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2377,
+						"id": 2409,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -36614,7 +37677,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2655,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36652,7 +37715,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2629,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36693,7 +37756,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2615,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36722,7 +37785,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -36731,7 +37794,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2642,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36773,7 +37836,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2576,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36815,7 +37878,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2623,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36853,7 +37916,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2607,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36891,7 +37954,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2606,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36923,7 +37986,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -36933,7 +37996,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2619,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36974,7 +38037,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2649,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37016,7 +38079,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2654,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37058,7 +38121,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2643,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37100,7 +38163,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2620,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37138,7 +38201,7 @@
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2578,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37174,7 +38237,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2639,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37212,7 +38275,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2640,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37250,7 +38313,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2622,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37287,7 +38350,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2603,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37317,7 +38380,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -37326,7 +38389,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2575,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37360,7 +38423,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2608,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37396,7 +38459,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -37406,7 +38469,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2592,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37443,7 +38506,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2652,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37485,7 +38548,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2645,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37527,7 +38590,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2587,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37561,7 +38624,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2616,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37599,7 +38662,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2635,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37622,7 +38685,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -37636,7 +38699,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2634,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37659,7 +38722,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -37676,7 +38739,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2656,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37714,7 +38777,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2658,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37752,7 +38815,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2597,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37786,7 +38849,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2657,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37824,7 +38887,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2650,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37866,7 +38929,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2648,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37904,7 +38967,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2660,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37946,7 +39009,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2594,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37980,7 +39043,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2596,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38014,7 +39077,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2633,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38034,7 +39097,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -38048,7 +39111,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2595,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38082,7 +39145,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2644,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38120,7 +39183,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2598,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38157,7 +39220,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2599,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38191,7 +39254,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2625,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38229,7 +39292,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2579,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38263,7 +39326,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2585,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38297,7 +39360,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2610,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38335,7 +39398,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2577,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38372,7 +39435,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2624,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38410,7 +39473,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2618,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38448,7 +39511,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2582,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38482,7 +39545,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2626,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38520,7 +39583,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2630,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38557,7 +39620,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2636,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38589,7 +39652,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -38599,7 +39662,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2637,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38631,7 +39694,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -38641,7 +39704,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2631,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38682,7 +39745,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2628,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38719,7 +39782,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2647,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38761,7 +39824,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2653,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38803,7 +39866,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2646,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38845,7 +39908,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2651,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38887,7 +39950,7 @@
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2659,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38929,7 +39992,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2588,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38963,7 +40026,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2600,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38996,7 +40059,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2601,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39034,7 +40097,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2632,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39075,7 +40138,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2609,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39111,7 +40174,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -39121,7 +40184,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2593,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39158,7 +40221,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2583,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39195,7 +40258,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2581,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39234,78 +40297,78 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2554,
-						2579,
-						2609,
-						2606,
-						2623,
-						2597,
-						2583,
-						2610,
-						2544,
-						2591,
-						2575,
-						2574,
-						2587,
-						2617,
-						2622,
-						2611,
-						2588,
-						2546,
-						2607,
-						2608,
-						2590,
-						2571,
-						2543,
-						2576,
-						2560,
-						2620,
-						2613,
-						2555,
-						2584,
-						2603,
-						2602,
-						2624,
-						2626,
-						2565,
-						2625,
-						2618,
-						2616,
-						2628,
-						2562,
-						2564,
-						2601,
-						2563,
-						2612,
-						2566,
-						2567,
-						2593,
-						2547,
-						2553,
-						2578,
-						2545,
-						2592,
 						2586,
-						2550,
-						2594,
-						2598,
-						2604,
-						2605,
-						2599,
-						2596,
+						2611,
+						2641,
+						2638,
+						2655,
+						2629,
 						2615,
-						2621,
-						2614,
+						2642,
+						2576,
+						2623,
+						2607,
+						2606,
 						2619,
-						2627,
-						2556,
-						2568,
-						2569,
-						2600,
+						2649,
+						2654,
+						2643,
+						2620,
+						2578,
+						2639,
+						2640,
+						2622,
+						2603,
+						2575,
+						2608,
+						2592,
+						2652,
+						2645,
+						2587,
+						2616,
+						2635,
+						2634,
+						2656,
+						2658,
+						2597,
+						2657,
+						2650,
+						2648,
+						2660,
+						2594,
+						2596,
+						2633,
+						2595,
+						2644,
+						2598,
+						2599,
+						2625,
+						2579,
+						2585,
+						2610,
 						2577,
-						2561,
-						2551,
-						2549
+						2624,
+						2618,
+						2582,
+						2626,
+						2630,
+						2636,
+						2637,
+						2631,
+						2628,
+						2647,
+						2653,
+						2646,
+						2651,
+						2659,
+						2588,
+						2600,
+						2601,
+						2632,
+						2609,
+						2593,
+						2583,
+						2581
 					]
 				}
 			],
@@ -39332,7 +40395,7 @@
 			]
 		},
 		{
-			"id": 2023,
+			"id": 2043,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39342,7 +40405,7 @@
 			},
 			"children": [
 				{
-					"id": 2024,
+					"id": 2044,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39363,7 +40426,7 @@
 					}
 				},
 				{
-					"id": 2025,
+					"id": 2045,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39380,12 +40443,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2027,
+						"id": 2047,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2026,
+					"id": 2046,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39431,9 +40494,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2024,
-						2025,
-						2026
+						2044,
+						2045,
+						2046
 					]
 				}
 			],
@@ -39446,7 +40509,7 @@
 			]
 		},
 		{
-			"id": 3008,
+			"id": 3052,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39456,7 +40519,7 @@
 			},
 			"children": [
 				{
-					"id": 3009,
+					"id": 3053,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39477,7 +40540,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3054,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39516,8 +40579,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3009,
-						3010
+						3053,
+						3054
 					]
 				}
 			],
@@ -39530,7 +40593,7 @@
 			]
 		},
 		{
-			"id": 2629,
+			"id": 2661,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39550,7 +40613,7 @@
 			},
 			"children": [
 				{
-					"id": 2659,
+					"id": 2691,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39581,20 +40644,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2660,
+							"id": 2692,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2661,
+								"id": 2693,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2662,
+										"id": 2694,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -39630,7 +40693,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2678,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39672,7 +40735,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2675,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39702,7 +40765,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2377,
+						"id": 2409,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -39711,7 +40774,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2708,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39752,7 +40815,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2695,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39781,7 +40844,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -39790,7 +40853,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2679,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39832,7 +40895,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2671,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39855,7 +40918,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2703,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39893,7 +40956,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2666,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39922,7 +40985,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2687,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39960,7 +41023,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2686,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39992,7 +41055,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -40002,7 +41065,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2699,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40043,7 +41106,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2680,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40085,7 +41148,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2700,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40123,7 +41186,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2676,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40161,7 +41224,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2677,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40199,7 +41262,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2702,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40236,7 +41299,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2683,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40266,7 +41329,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -40275,7 +41338,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2688,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40311,7 +41374,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -40321,7 +41384,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2668,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40350,7 +41413,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2665,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40379,7 +41442,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2670,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40413,7 +41476,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2664,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40446,7 +41509,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2667,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40475,7 +41538,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2696,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40513,7 +41576,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2714,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40536,7 +41599,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -40550,7 +41613,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2713,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40573,7 +41636,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -40590,7 +41653,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2712,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40610,7 +41673,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -40624,7 +41687,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2681,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40662,7 +41725,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2705,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40700,7 +41763,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2690,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40738,7 +41801,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2704,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40776,7 +41839,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2698,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40814,7 +41877,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2709,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40851,7 +41914,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2673,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40883,7 +41946,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -40893,7 +41956,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2674,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40925,7 +41988,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -40935,7 +41998,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2672,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40969,7 +42032,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2710,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41010,7 +42073,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2707,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41047,7 +42110,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2662,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41076,7 +42139,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2669,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41105,7 +42168,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2711,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41146,7 +42209,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2689,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41182,7 +42245,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -41197,49 +42260,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2659,
-						2646,
-						2643,
-						2676,
-						2663,
-						2647,
-						2639,
-						2671,
-						2634,
-						2655,
-						2654,
-						2667,
-						2648,
-						2668,
-						2644,
-						2645,
-						2670,
-						2651,
-						2656,
-						2636,
-						2633,
-						2638,
-						2632,
-						2635,
-						2664,
-						2682,
-						2681,
-						2680,
-						2649,
-						2673,
-						2658,
-						2672,
-						2666,
-						2677,
-						2641,
-						2642,
-						2640,
+						2691,
 						2678,
 						2675,
-						2630,
-						2637,
+						2708,
+						2695,
 						2679,
-						2657
+						2671,
+						2703,
+						2666,
+						2687,
+						2686,
+						2699,
+						2680,
+						2700,
+						2676,
+						2677,
+						2702,
+						2683,
+						2688,
+						2668,
+						2665,
+						2670,
+						2664,
+						2667,
+						2696,
+						2714,
+						2713,
+						2712,
+						2681,
+						2705,
+						2690,
+						2704,
+						2698,
+						2709,
+						2673,
+						2674,
+						2672,
+						2710,
+						2707,
+						2662,
+						2669,
+						2711,
+						2689
 					]
 				}
 			],
@@ -41293,7 +42356,7 @@
 			]
 		},
 		{
-			"id": 2493,
+			"id": 2525,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41308,7 +42371,7 @@
 			},
 			"children": [
 				{
-					"id": 2508,
+					"id": 2540,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41339,20 +42402,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2509,
+							"id": 2541,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2510,
+								"id": 2542,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2511,
+										"id": 2543,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -41388,7 +42451,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2570,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41430,7 +42493,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2567,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41460,7 +42523,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2377,
+						"id": 2409,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -41469,7 +42532,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2558,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41510,7 +42573,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2544,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41539,7 +42602,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -41548,7 +42611,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2571,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41590,7 +42653,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2527,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41624,7 +42687,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2526,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41665,7 +42728,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2552,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41703,7 +42766,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2536,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41741,7 +42804,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2535,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41773,7 +42836,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -41783,7 +42846,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2548,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41824,7 +42887,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2572,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41866,7 +42929,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2549,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41904,7 +42967,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2568,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41942,7 +43005,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2569,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41980,7 +43043,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2530,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42014,7 +43077,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2551,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42051,7 +43114,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2532,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42081,7 +43144,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42090,7 +43153,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2537,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42126,7 +43189,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -42136,7 +43199,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2545,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42174,7 +43237,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2564,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42197,7 +43260,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -42211,7 +43274,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2563,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42234,7 +43297,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -42251,7 +43314,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2562,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42271,7 +43334,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -42285,7 +43348,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2573,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42323,7 +43386,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2554,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42361,7 +43424,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2539,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42399,7 +43462,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2553,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42437,7 +43500,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2547,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42475,7 +43538,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2555,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42513,7 +43576,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2559,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42550,7 +43613,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2565,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42582,7 +43645,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -42592,7 +43655,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2566,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42624,7 +43687,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -42634,7 +43697,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2529,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42668,7 +43731,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2560,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42709,7 +43772,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2557,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42746,7 +43809,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2561,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42787,7 +43850,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2528,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42821,7 +43884,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2538,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42857,7 +43920,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -42872,45 +43935,45 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2508,
-						2538,
-						2535,
-						2526,
-						2512,
-						2539,
-						2495,
-						2494,
-						2520,
-						2504,
-						2503,
-						2516,
 						2540,
-						2517,
-						2536,
-						2537,
-						2498,
-						2519,
-						2500,
-						2505,
-						2513,
-						2532,
-						2531,
-						2530,
-						2541,
-						2522,
-						2507,
-						2521,
-						2515,
-						2523,
+						2570,
+						2567,
+						2558,
+						2544,
+						2571,
 						2527,
-						2533,
-						2534,
-						2497,
-						2528,
-						2525,
+						2526,
+						2552,
+						2536,
+						2535,
+						2548,
+						2572,
+						2549,
+						2568,
+						2569,
+						2530,
+						2551,
+						2532,
+						2537,
+						2545,
+						2564,
+						2563,
+						2562,
+						2573,
+						2554,
+						2539,
+						2553,
+						2547,
+						2555,
+						2559,
+						2565,
+						2566,
 						2529,
-						2496,
-						2506
+						2560,
+						2557,
+						2561,
+						2528,
+						2538
 					]
 				}
 			],
@@ -42933,7 +43996,7 @@
 			]
 		},
 		{
-			"id": 2433,
+			"id": 2465,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42949,7 +44012,7 @@
 			},
 			"children": [
 				{
-					"id": 2469,
+					"id": 2501,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42980,20 +44043,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2470,
+							"id": 2502,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2471,
+								"id": 2503,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2472,
+										"id": 2504,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43029,7 +44092,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2477,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43063,7 +44126,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2467,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43097,7 +44160,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2466,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43131,7 +44194,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2488,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43173,7 +44236,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2480,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43210,7 +44273,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2485,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43240,7 +44303,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2377,
+						"id": 2409,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -43249,7 +44312,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2518,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43290,7 +44353,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2505,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43319,7 +44382,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -43328,7 +44391,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2481,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43366,7 +44429,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2489,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43408,7 +44471,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2473,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43442,7 +44505,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2472,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43478,7 +44541,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2513,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43516,7 +44579,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2497,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43554,7 +44617,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2496,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43586,7 +44649,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -43596,7 +44659,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2509,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43637,7 +44700,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2490,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43679,7 +44742,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2470,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43713,7 +44776,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2510,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43751,7 +44814,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2486,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43789,7 +44852,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2487,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43827,7 +44890,7 @@
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2476,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43861,7 +44924,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2512,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43898,7 +44961,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2482,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43936,7 +44999,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2471,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43970,7 +45033,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2493,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44000,7 +45063,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44009,7 +45072,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2498,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44045,7 +45108,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -44055,7 +45118,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2468,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44089,7 +45152,7 @@
 					}
 				},
 				{
-					"id": 2437,
+					"id": 2469,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44123,7 +45186,7 @@
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2478,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44157,7 +45220,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2506,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44195,7 +45258,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2524,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44218,7 +45281,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -44232,7 +45295,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2523,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44255,7 +45318,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -44272,7 +45335,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2522,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44292,7 +45355,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -44306,7 +45369,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2491,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44344,7 +45407,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2515,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44382,7 +45445,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2500,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44420,7 +45483,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2514,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44458,7 +45521,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2508,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44496,7 +45559,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2519,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44533,7 +45596,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2483,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44565,7 +45628,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -44575,7 +45638,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2484,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44607,7 +45670,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -44617,7 +45680,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2475,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44647,7 +45710,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2474,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44676,7 +45739,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2520,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44717,7 +45780,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2517,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44754,7 +45817,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2521,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44795,7 +45858,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2479,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44825,7 +45888,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2499,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44861,7 +45924,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -44876,56 +45939,56 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2469,
-						2445,
-						2435,
-						2434,
-						2456,
-						2448,
-						2453,
-						2486,
-						2473,
-						2449,
-						2457,
-						2441,
-						2440,
-						2481,
-						2465,
-						2464,
+						2501,
 						2477,
-						2458,
-						2438,
-						2478,
-						2454,
-						2455,
-						2444,
-						2480,
-						2450,
-						2439,
-						2461,
+						2467,
 						2466,
-						2436,
-						2437,
-						2446,
-						2474,
-						2492,
-						2491,
-						2490,
-						2459,
-						2483,
-						2468,
-						2482,
-						2476,
-						2487,
-						2451,
-						2452,
-						2443,
-						2442,
 						2488,
+						2480,
 						2485,
+						2518,
+						2505,
+						2481,
 						2489,
-						2447,
-						2467
+						2473,
+						2472,
+						2513,
+						2497,
+						2496,
+						2509,
+						2490,
+						2470,
+						2510,
+						2486,
+						2487,
+						2476,
+						2512,
+						2482,
+						2471,
+						2493,
+						2498,
+						2468,
+						2469,
+						2478,
+						2506,
+						2524,
+						2523,
+						2522,
+						2491,
+						2515,
+						2500,
+						2514,
+						2508,
+						2519,
+						2483,
+						2484,
+						2475,
+						2474,
+						2520,
+						2517,
+						2521,
+						2479,
+						2499
 					]
 				}
 			],
@@ -44958,14 +46021,14 @@
 			]
 		},
 		{
-			"id": 1992,
+			"id": 2012,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1995,
+					"id": 2015,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44980,14 +46043,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1996,
+							"id": 2016,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1998,
+									"id": 2018,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -45005,7 +46068,7 @@
 									}
 								},
 								{
-									"id": 1997,
+									"id": 2017,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -45028,8 +46091,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1998,
-										1997
+										2018,
+										2017
 									]
 								}
 							]
@@ -45037,7 +46100,7 @@
 					}
 				},
 				{
-					"id": 1994,
+					"id": 2014,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45055,7 +46118,7 @@
 					}
 				},
 				{
-					"id": 1993,
+					"id": 2013,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45078,9 +46141,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1995,
-						1994,
-						1993
+						2015,
+						2014,
+						2013
 					]
 				}
 			],
@@ -45259,7 +46322,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -45376,7 +46439,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -45532,7 +46595,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45577,7 +46640,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -45648,7 +46711,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -45685,7 +46748,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -45722,7 +46785,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -46080,7 +47143,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -46192,7 +47255,7 @@
 			},
 			"children": [
 				{
-					"id": 1601,
+					"id": 1611,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46223,20 +47286,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1602,
+							"id": 1612,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1603,
+								"id": 1613,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1604,
+										"id": 1614,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -46272,7 +47335,7 @@
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1628,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46313,7 +47376,7 @@
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1615,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46342,7 +47405,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2824,
+						"id": 2856,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -46389,7 +47452,7 @@
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1623,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46461,7 +47524,7 @@
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1607,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46499,7 +47562,7 @@
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1606,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46531,7 +47594,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -46541,7 +47604,7 @@
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1619,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46620,7 +47683,7 @@
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1620,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46726,7 +47789,7 @@
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1622,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46763,7 +47826,7 @@
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1603,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46793,7 +47856,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2783,
+						"id": 2815,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -46802,7 +47865,7 @@
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1608,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46838,7 +47901,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -46916,7 +47979,7 @@
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1616,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46954,7 +48017,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1634,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46977,7 +48040,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6671,
+							"line": 6810,
 							"character": 4
 						}
 					],
@@ -46991,7 +48054,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1633,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47014,7 +48077,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6793,
 							"character": 4
 						}
 					],
@@ -47031,7 +48094,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1632,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47051,7 +48114,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6638,
+							"line": 6777,
 							"character": 4
 						}
 					],
@@ -47065,7 +48128,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1625,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47103,7 +48166,7 @@
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1610,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47141,7 +48204,7 @@
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1624,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47179,7 +48242,7 @@
 					}
 				},
 				{
-					"id": 1608,
+					"id": 1618,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47217,7 +48280,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1629,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47286,7 +48349,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2023,
+							"id": 2043,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -47324,7 +48387,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3008,
+							"id": 3052,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -47353,7 +48416,7 @@
 					}
 				},
 				{
-					"id": 1620,
+					"id": 1630,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47394,7 +48457,7 @@
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1627,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47465,6 +48528,354 @@
 					}
 				},
 				{
+					"id": 1599,
+					"name": "spotterBestPracticesLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the best practices button in the footer.\nDefaults to translated \"Best Practices\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterBestPracticesLabel: 'Help & Tips',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 323,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1595,
+					"name": "spotterChatDeleteLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the delete action in the conversation edit menu.\nDefaults to translated \"DELETE\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatDeleteLabel: 'Remove',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 262,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1594,
+					"name": "spotterChatRenameLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom label text for the rename action in the conversation edit menu.\nDefaults to translated \"Rename\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterChatRenameLabel: 'Edit Name',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 247,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1600,
+					"name": "spotterConversationsBatchSize",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Number of conversations to fetch per batch when loading conversation history.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "30"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterConversationsBatchSize: 50,\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 338,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1596,
+					"name": "spotterDeleteConversationModalTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the delete conversation confirmation modal.\nDefaults to translated \"Delete chat\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDeleteConversationModalTitle: 'Remove Conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 277,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1598,
+					"name": "spotterDocumentationUrl",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom URL for the documentation/best practices link.\nDefaults to ThoughtSpot docs URL based on release version.\nNote: URL must include the protocol (e.g., `https://www.example.com`).",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterDocumentationUrl: 'https://docs.example.com/spotter',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 308,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1601,
+					"name": "spotterNewChatButtonTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the \"New Chat\" button in the sidebar.\nDefaults to translated \"New Chat\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterNewChatButtonTitle: 'Start New Conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 353,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1597,
+					"name": "spotterPastConversationAlertMessage",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom message text for the past conversation banner alert.\nDefaults to translated alert message.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterPastConversationAlertMessage: 'You are viewing a past conversation',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 292,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1593,
+					"name": "spotterSidebarDefaultExpanded",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Boolean to set the default expanded state of the sidebar.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarDefaultExpanded: true,\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 232,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1592,
+					"name": "spotterSidebarTitle",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom title text for the sidebar header.\nDefaults to translated \"Spotter\" text.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterSidebarTitle: 'My Conversations',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 217,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
 					"id": 1591,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
@@ -47503,7 +48914,7 @@
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1631,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47544,7 +48955,7 @@
 					}
 				},
 				{
-					"id": 1599,
+					"id": 1609,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47580,7 +48991,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2228,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -47616,42 +49027,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1601,
-						1618,
-						1605,
+						1611,
+						1628,
+						1615,
 						1583,
-						1613,
+						1623,
 						1581,
-						1597,
-						1596,
-						1609,
+						1607,
+						1606,
+						1619,
 						1590,
-						1610,
+						1620,
 						1587,
 						1589,
-						1612,
-						1593,
-						1598,
+						1622,
+						1603,
+						1608,
 						1585,
 						1582,
-						1606,
+						1616,
+						1634,
+						1633,
+						1632,
+						1625,
+						1610,
 						1624,
-						1623,
-						1622,
-						1615,
-						1600,
-						1614,
-						1608,
-						1619,
+						1618,
+						1629,
 						1586,
 						1588,
 						1580,
-						1620,
-						1617,
+						1630,
+						1627,
 						1584,
-						1591,
-						1621,
 						1599,
+						1595,
+						1594,
+						1600,
+						1596,
+						1598,
+						1601,
+						1597,
+						1593,
+						1592,
+						1591,
+						1631,
+						1609,
 						1579
 					]
 				}
@@ -47682,20 +49103,20 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1625,
+					"id": 1635,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1999,
+			"id": 2019,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2000,
+					"id": 2020,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47713,7 +49134,7 @@
 					}
 				},
 				{
-					"id": 2001,
+					"id": 2021,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47736,8 +49157,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2000,
-						2001
+						2020,
+						2021
 					]
 				}
 			],
@@ -47750,14 +49171,14 @@
 			]
 		},
 		{
-			"id": 3046,
+			"id": 3090,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3047,
+					"id": 3091,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47765,7 +49186,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6273,
+							"line": 6409,
 							"character": 4
 						}
 					],
@@ -47778,7 +49199,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3092,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47786,7 +49207,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6274,
+							"line": 6410,
 							"character": 4
 						}
 					],
@@ -47804,21 +49225,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3047,
-						3048
+						3091,
+						3092
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6272,
+					"line": 6408,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2837,
+			"id": 2869,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47828,7 +49249,7 @@
 			},
 			"children": [
 				{
-					"id": 2839,
+					"id": 2871,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47858,20 +49279,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2840,
+							"id": 2872,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2841,
+								"id": 2873,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2842,
+										"id": 2874,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -47884,7 +49305,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2843,
+										"id": 2875,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -47897,14 +49318,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2844,
+											"id": 2876,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2845,
+													"id": 2877,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -47926,7 +49347,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2870,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47945,7 +49366,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2846,
+						"id": 2878,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -47955,8 +49376,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2839,
-						2838
+						2871,
+						2870
 					]
 				}
 			],
@@ -48261,7 +49682,7 @@
 			]
 		},
 		{
-			"id": 2807,
+			"id": 2839,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -48288,7 +49709,7 @@
 			}
 		},
 		{
-			"id": 2811,
+			"id": 2843,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -48303,7 +49724,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2812,
+					"id": 2844,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -48326,7 +49747,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2813,
+							"id": 2845,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -48336,19 +49757,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2814,
+									"id": 2846,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2819,
+										"id": 2851,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2815,
+									"id": 2847,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -48358,7 +49779,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2816,
+											"id": 2848,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -48372,7 +49793,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2817,
+													"id": 2849,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -48382,7 +49803,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2818,
+															"id": 2850,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -48413,7 +49834,7 @@
 			}
 		},
 		{
-			"id": 2808,
+			"id": 2840,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -48437,14 +49858,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2809,
+					"id": 2841,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2810,
+							"id": 2842,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48472,7 +49893,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2810
+								2842
 							]
 						}
 					],
@@ -48487,7 +49908,7 @@
 			}
 		},
 		{
-			"id": 2819,
+			"id": 2851,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -48511,14 +49932,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2820,
+					"id": 2852,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2822,
+							"id": 2854,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48536,7 +49957,7 @@
 							}
 						},
 						{
-							"id": 2823,
+							"id": 2855,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48556,7 +49977,7 @@
 							}
 						},
 						{
-							"id": 2821,
+							"id": 2853,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -48579,9 +50000,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2822,
-								2823,
-								2821
+								2854,
+								2855,
+								2853
 							]
 						}
 					],
@@ -48646,7 +50067,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1919,
+									"id": 1939,
 									"name": "AnswerService"
 								}
 							}
@@ -48908,7 +50329,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1919,
+												"id": 1939,
 												"name": "AnswerService"
 											}
 										},
@@ -48995,7 +50416,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2381,
+						"id": 2413,
 						"name": "EmbedConfig"
 					}
 				}
@@ -49095,14 +50516,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2381,
+								"id": 2413,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1866,
+						"id": 1886,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -49242,7 +50663,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2778,
+									"id": 2810,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -49370,7 +50791,7 @@
 			]
 		},
 		{
-			"id": 3119,
+			"id": 3164,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -49386,7 +50807,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3120,
+					"id": 3165,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -49580,7 +51001,7 @@
 			]
 		},
 		{
-			"id": 3018,
+			"id": 3062,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -49594,7 +51015,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3019,
+					"id": 3063,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -49604,7 +51025,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3020,
+							"id": 3064,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -49616,7 +51037,7 @@
 							}
 						},
 						{
-							"id": 3021,
+							"id": 3065,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -49627,7 +51048,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3022,
+									"id": 3066,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -49650,44 +51071,44 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2228,
-				1864,
-				1849,
-				1856,
-				2011,
-				2377,
-				2219,
-				3093,
-				3089,
-				3085,
-				2224,
-				3102,
-				2043,
-				3115,
-				2789,
-				3040,
-				3034,
-				2800,
-				2142,
-				3098,
-				3043,
-				3077,
-				3011,
-				2002,
-				2778,
-				3038,
-				2027,
-				3069
+				2251,
+				1884,
+				1869,
+				1876,
+				2031,
+				2409,
+				2242,
+				3137,
+				3133,
+				3129,
+				2247,
+				3146,
+				2063,
+				3160,
+				2821,
+				3084,
+				3078,
+				2832,
+				2165,
+				3142,
+				3087,
+				3121,
+				3055,
+				2022,
+				2810,
+				3082,
+				2047,
+				3113
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1919,
+				1939,
 				1047,
 				1370,
-				1672,
+				1692,
 				626,
 				860,
 				245,
@@ -49700,28 +51121,28 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2683,
-				1866,
+				2715,
+				1886,
 				1335,
-				1625,
-				3049,
-				2846,
-				2834,
-				2824,
-				2381,
-				2783,
-				2542,
-				2023,
-				3008,
-				2629,
-				2493,
-				2433,
-				1992,
+				1635,
+				3093,
+				2878,
+				2866,
+				2856,
+				2413,
+				2815,
+				2574,
+				2043,
+				3052,
+				2661,
+				2525,
+				2465,
+				2012,
 				1300,
 				1578,
-				1999,
-				3046,
-				2837,
+				2019,
+				3090,
+				2869,
 				21,
 				28
 			]
@@ -49730,10 +51151,10 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2807,
-				2811,
-				2808,
-				2819
+				2839,
+				2843,
+				2840,
+				2851
 			]
 		},
 		{
@@ -49750,9 +51171,9 @@
 				4,
 				7,
 				25,
-				3119,
+				3164,
 				40,
-				3018
+				3062
 			]
 		}
 	],


### PR DESCRIPTION
- Add 9 new Action enum entries for Spotter sidebar controls
- Add 3 new EmbedEvent entries for conversation lifecycle events
- Add 9 new Param enum entries and SpotterEmbedViewConfig properties
- Add 12 new CSS variables for saved chats sidebar theming

Add SDK support for Spotter past conversations sidebar customization:

- **Actions:** 9 new actions for sidebar visibility/disable control (`SpotterSidebarHeader`, `SpotterNewChat`, `SpotterChatRename`, etc.)
- **Events:** 3 new events for conversation lifecycle (`SpotterConversationRenamed`, `SpotterConversationDeleted`, `SpotterConversationSelected`)
- **Parameters:** 9 new config options for labels, URLs, and sidebar behavior
- **CSS Variables:** 12 new variables for saved chats sidebar theming

Version: SDK 1.46.0 | ThoughtSpot 26.3.0.cl