### PR TITLE
SCAL-291789 Enable ListPage V3 by default for TSE

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -131,7 +131,6 @@ describe('App embed tests', () => {
     });
 
     describe('should render the correct routes for pages', () => {
-
         const pageRouteMap = {
             [Page.Search]: 'answer',
             [Page.Answers]: 'answers',
@@ -181,7 +180,10 @@ describe('App embed tests', () => {
             const pageIdsForModularHome = pageIdsForModularHomes[i];
 
             test(`${pageIdsForModularHome}`, async () => {
-                const route = pageRouteMapForModularHome[pageIdsForModularHome as keyof typeof pageRouteMapForModularHome];
+                const route =
+                    pageRouteMapForModularHome[
+                        pageIdsForModularHome as keyof typeof pageRouteMapForModularHome
+                    ];
                 const appEmbed = new AppEmbed(getRootEl(), {
                     ...defaultViewConfig,
                     modularHomeExperience: true,
@@ -827,7 +829,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&hideHomepageLeftNav=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&hideHomepageLeftNav=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -844,7 +846,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&hideHamburger=true&hideObjectSearch=true&hideNotification=true${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&hideHamburger=true&hideObjectSearch=true&hideNotification=true${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -861,7 +863,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -951,7 +953,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&homepageVersion=v3${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2&homepageVersion=v3${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -965,7 +967,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -980,7 +982,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&enableAskSage=true${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&enableAskSage=true${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -997,11 +999,10 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&listpageVersion=v3${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&listpageVersion=v3${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
-
 
     test('Should add listpageVersion=v2 by default when no discoveryExperience is provided', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
@@ -1012,7 +1013,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1034,7 +1035,6 @@ describe('App embed tests', () => {
             );
         });
     });
-
 
     test('Should add listpageVersion=v3 combined with other discoveryExperience options to the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
@@ -1064,7 +1064,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?enablePendoHelp=true&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?enablePendoHelp=true&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
 
@@ -1077,7 +1077,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?enablePendoHelp=false&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?enablePendoHelp=false&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1092,7 +1092,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=objectSearch${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=objectSearch${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1107,7 +1107,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=aiAnswer${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=aiAnswer${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1122,7 +1122,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=none${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=none${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1139,16 +1139,19 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&dataPanelCustomGroupsAccordionInitialState=EXPAND_FIRST${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&dataPanelCustomGroupsAccordionInitialState=EXPAND_FIRST${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
 
     test('should register event handlers to adjust iframe height', async () => {
-        let embedHeightCallback: any = () => { };
+        let embedHeightCallback: any = () => {};
         const onSpy = jest.spyOn(AppEmbed.prototype, 'on').mockImplementation((event, callback) => {
             if (event === EmbedEvent.RouteChange) {
-                callback({ type: EmbedEvent.RouteChange, data: { currentPath: '/answers' } } as any, jest.fn());
+                callback(
+                    { type: EmbedEvent.RouteChange, data: { currentPath: '/answers' } } as any,
+                    jest.fn(),
+                );
             }
             if (event === EmbedEvent.EmbedHeight) {
                 embedHeightCallback = callback;
@@ -1179,7 +1182,10 @@ describe('App embed tests', () => {
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.EmbedHeight, expect.anything());
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RouteChange, expect.anything());
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.EmbedIframeCenter, expect.anything());
-            expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RequestVisibleEmbedCoordinates, expect.anything());
+            expect(onSpy).toHaveBeenCalledWith(
+                EmbedEvent.RequestVisibleEmbedCoordinates,
+                expect.anything(),
+            );
         }, 100);
     });
 
@@ -1325,9 +1331,11 @@ describe('App embed tests', () => {
             Object.defineProperty(mockIFrame, 'scrollHeight', { value: 500 });
 
             // Mock the event handlers
-            const onSpy = jest.spyOn(AppEmbed.prototype, 'on').mockImplementation((event, callback) => {
-                return null;
-            });
+            const onSpy = jest
+                .spyOn(AppEmbed.prototype, 'on')
+                .mockImplementation((event, callback) => {
+                    return null;
+                });
             jest.spyOn(TsEmbed.prototype as any, 'getIframeCenter').mockReturnValue({});
             jest.spyOn(TsEmbed.prototype as any, 'setIFrameHeight').mockReturnValue({});
 
@@ -1403,7 +1411,10 @@ describe('App embed tests', () => {
 
             await appEmbed.render();
 
-            expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RequestVisibleEmbedCoordinates, expect.any(Function));
+            expect(onSpy).toHaveBeenCalledWith(
+                EmbedEvent.RequestVisibleEmbedCoordinates,
+                expect.any(Function),
+            );
 
             onSpy.mockRestore();
         });
@@ -1457,9 +1468,9 @@ describe('App embed tests', () => {
             (appEmbed as any).sendFullHeightLazyLoadData();
 
             expect(mockTrigger).toHaveBeenCalledWith(HostEvent.VisibleEmbedCoordinates, {
-                top: 50,   // 50px clipped from top
+                top: 50, // 50px clipped from top
                 height: 700, // visible height (from 0 to 700)
-                left: 30,  // 30px clipped from left
+                left: 30, // 30px clipped from left
                 width: 1024, // visible width (from 0 to 1024)
             });
         });
@@ -1479,7 +1490,11 @@ describe('App embed tests', () => {
             // Wait for the post-render events to be registered
             await executeAfterWait(() => {
                 expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-                expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true);
+                expect(addEventListenerSpy).toHaveBeenCalledWith(
+                    'scroll',
+                    expect.any(Function),
+                    true,
+                );
             }, 100);
 
             addEventListenerSpy.mockRestore();

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -131,6 +131,7 @@ describe('App embed tests', () => {
     });
 
     describe('should render the correct routes for pages', () => {
+
         const pageRouteMap = {
             [Page.Search]: 'answer',
             [Page.Answers]: 'answers',
@@ -180,10 +181,7 @@ describe('App embed tests', () => {
             const pageIdsForModularHome = pageIdsForModularHomes[i];
 
             test(`${pageIdsForModularHome}`, async () => {
-                const route =
-                    pageRouteMapForModularHome[
-                        pageIdsForModularHome as keyof typeof pageRouteMapForModularHome
-                    ];
+                const route = pageRouteMapForModularHome[pageIdsForModularHome as keyof typeof pageRouteMapForModularHome];
                 const appEmbed = new AppEmbed(getRootEl(), {
                     ...defaultViewConfig,
                     modularHomeExperience: true,
@@ -1036,6 +1034,7 @@ describe('App embed tests', () => {
         });
     });
 
+
     test('Should add listpageVersion=v3 combined with other discoveryExperience options to the iframe src', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,
@@ -1148,10 +1147,7 @@ describe('App embed tests', () => {
         let embedHeightCallback: any = () => {};
         const onSpy = jest.spyOn(AppEmbed.prototype, 'on').mockImplementation((event, callback) => {
             if (event === EmbedEvent.RouteChange) {
-                callback(
-                    { type: EmbedEvent.RouteChange, data: { currentPath: '/answers' } } as any,
-                    jest.fn(),
-                );
+                callback({ type: EmbedEvent.RouteChange, data: { currentPath: '/answers' } } as any, jest.fn());
             }
             if (event === EmbedEvent.EmbedHeight) {
                 embedHeightCallback = callback;
@@ -1182,10 +1178,7 @@ describe('App embed tests', () => {
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.EmbedHeight, expect.anything());
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RouteChange, expect.anything());
             expect(onSpy).toHaveBeenCalledWith(EmbedEvent.EmbedIframeCenter, expect.anything());
-            expect(onSpy).toHaveBeenCalledWith(
-                EmbedEvent.RequestVisibleEmbedCoordinates,
-                expect.anything(),
-            );
+            expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RequestVisibleEmbedCoordinates, expect.anything());
         }, 100);
     });
 
@@ -1331,11 +1324,9 @@ describe('App embed tests', () => {
             Object.defineProperty(mockIFrame, 'scrollHeight', { value: 500 });
 
             // Mock the event handlers
-            const onSpy = jest
-                .spyOn(AppEmbed.prototype, 'on')
-                .mockImplementation((event, callback) => {
-                    return null;
-                });
+            const onSpy = jest.spyOn(AppEmbed.prototype, 'on').mockImplementation((event, callback) => {
+                return null;
+            });
             jest.spyOn(TsEmbed.prototype as any, 'getIframeCenter').mockReturnValue({});
             jest.spyOn(TsEmbed.prototype as any, 'setIFrameHeight').mockReturnValue({});
 
@@ -1411,10 +1402,7 @@ describe('App embed tests', () => {
 
             await appEmbed.render();
 
-            expect(onSpy).toHaveBeenCalledWith(
-                EmbedEvent.RequestVisibleEmbedCoordinates,
-                expect.any(Function),
-            );
+            expect(onSpy).toHaveBeenCalledWith(EmbedEvent.RequestVisibleEmbedCoordinates, expect.any(Function));
 
             onSpy.mockRestore();
         });
@@ -1468,9 +1456,9 @@ describe('App embed tests', () => {
             (appEmbed as any).sendFullHeightLazyLoadData();
 
             expect(mockTrigger).toHaveBeenCalledWith(HostEvent.VisibleEmbedCoordinates, {
-                top: 50, // 50px clipped from top
+                top: 50,   // 50px clipped from top
                 height: 700, // visible height (from 0 to 700)
-                left: 30, // 30px clipped from left
+                left: 30,  // 30px clipped from left
                 width: 1024, // visible width (from 0 to 1024)
             });
         });
@@ -1490,11 +1478,7 @@ describe('App embed tests', () => {
             // Wait for the post-render events to be registered
             await executeAfterWait(() => {
                 expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-                expect(addEventListenerSpy).toHaveBeenCalledWith(
-                    'scroll',
-                    expect.any(Function),
-                    true,
-                );
+                expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true);
             }, 100);
 
             addEventListenerSpy.mockRestore();

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -1012,7 +1012,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&listpageVersion=v2${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1030,7 +1030,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=true&navigationVersion=v3&listpageVersion=v2${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=true&navigationVersion=v3${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1246,7 +1246,7 @@ describe('App embed tests', () => {
                 },
             });
             await appEmbed.render();
-            jest.spyOn(logger, 'warn').mockImplementation(() => {});
+            jest.spyOn(logger, 'warn').mockImplementation(() => { });
             appEmbed.navigateToPage(-1);
             expect(logger.warn).toHaveBeenCalledWith(
                 'Path can only by a string when triggered without noReload',
@@ -1254,7 +1254,7 @@ describe('App embed tests', () => {
         });
 
         test('navigateToPage function use before render', async () => {
-            jest.spyOn(logger, 'log').mockImplementation(() => {});
+            jest.spyOn(logger, 'log').mockImplementation(() => { });
             const appEmbed = new AppEmbed(getRootEl(), {
                 frameParams: {
                     width: '100%',

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -893,7 +893,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&hideHomepageLeftNav=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&hideHomepageLeftNav=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -910,7 +910,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&hideHamburger=true&hideObjectSearch=true&hideNotification=true${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&hideHamburger=true&hideObjectSearch=true&hideNotification=true${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -927,7 +927,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -994,7 +994,7 @@ describe('App embed tests', () => {
                     homePage: HomePage.ModularWithStylingChanges,
                 },
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2&homepageVersion=v3${defaultParams}${defaultParamsPost}#/home`
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&homepageVersion=v3${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1003,7 +1003,7 @@ describe('App embed tests', () => {
             {
                 ...defaultViewConfig,
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1013,7 +1013,7 @@ describe('App embed tests', () => {
                 ...defaultViewConfig,
                 enableAskSage: true,
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&enableAskSage=true${defaultParams}${defaultParamsPost}#/home`
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&enableAskSage=true${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1025,7 +1025,7 @@ describe('App embed tests', () => {
                     listPageVersion: ListPage.ListWithUXChanges,
                 },
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&listpageVersion=v3${defaultParams}${defaultParamsPost}#/home`
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&listpageVersion=v3${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1034,7 +1034,7 @@ describe('App embed tests', () => {
             {
                 ...defaultViewConfig,
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1048,16 +1048,6 @@ describe('App embed tests', () => {
                 },
             } as AppViewConfig,
             `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=true&navigationVersion=v3${defaultParams}${defaultParamsPost}#/home`
-        );
-    });
-
-    test('Should add listpageVersion=v2 when modularHomeExperience is explicitly false', async () => {
-        await testUrlParams(
-            {
-                ...defaultViewConfig,
-                modularHomeExperience: false,
-            } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&listpageVersion=v2${defaultParams}${defaultParamsPost}#/home`
         );
     });
 
@@ -1085,7 +1075,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?enablePendoHelp=true&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?enablePendoHelp=true&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
 
@@ -1098,7 +1088,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?enablePendoHelp=false&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?enablePendoHelp=false&embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1113,7 +1103,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=objectSearch${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=objectSearch${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1128,7 +1118,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=aiAnswer${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=aiAnswer${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1143,7 +1133,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&homePageSearchBarMode=none${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&homePageSearchBarMode=none${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });
@@ -1160,7 +1150,7 @@ describe('App embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&dataPanelCustomGroupsAccordionInitialState=EXPAND_FIRST${defaultParams}${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&dataPanelCustomGroupsAccordionInitialState=EXPAND_FIRST${defaultParams}${defaultParamsPost}#/home`,
             );
         });
     });

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -1051,6 +1051,16 @@ describe('App embed tests', () => {
         );
     });
 
+    test('Should add listpageVersion=v2 when modularHomeExperience is explicitly false', async () => {
+        await testUrlParams(
+            {
+                ...defaultViewConfig,
+                modularHomeExperience: false,
+            } as AppViewConfig,
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&listpageVersion=v2${defaultParams}${defaultParamsPost}#/home`
+        );
+    });
+
 
     test('Should add listpageVersion=v3 combined with other discoveryExperience options to the iframe src', async () => {
         await testUrlParams(

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -1246,7 +1246,7 @@ describe('App embed tests', () => {
                 },
             });
             await appEmbed.render();
-            jest.spyOn(logger, 'warn').mockImplementation(() => { });
+            jest.spyOn(logger, 'warn').mockImplementation(() => {});
             appEmbed.navigateToPage(-1);
             expect(logger.warn).toHaveBeenCalledWith(
                 'Path can only by a string when triggered without noReload',
@@ -1254,7 +1254,7 @@ describe('App embed tests', () => {
         });
 
         test('navigateToPage function use before render', async () => {
-            jest.spyOn(logger, 'log').mockImplementation(() => { });
+            jest.spyOn(logger, 'log').mockImplementation(() => {});
             const appEmbed = new AppEmbed(getRootEl(), {
                 frameParams: {
                     width: '100%',

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -9,7 +9,12 @@
  */
 
 import { logger } from '../utils/logger';
-import { calculateVisibleElementData, getQueryParamString, isUndefined, isValidCssMargin } from '../utils';
+import {
+    calculateVisibleElementData,
+    getQueryParamString,
+    isUndefined,
+    isValidCssMargin,
+} from '../utils';
 import {
     Param,
     DOMSelector,
@@ -56,7 +61,7 @@ export enum Page {
     /**
      *  Monitor Alerts Page
      */
-    Monitor = 'monitor'
+    Monitor = 'monitor',
 }
 
 /**
@@ -226,7 +231,7 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      * });
      * ```
      */
-    enablePendoHelp?: boolean
+    enablePendoHelp?: boolean;
     /**
      * Control the visibility of the hamburger icon on
      * the top navigation bar in the V3 navigation experience.
@@ -700,7 +705,6 @@ export class AppEmbed extends V1Embed {
 
     private defaultHeight = 500;
 
-
     constructor(domSelector: DOMSelector, viewConfig: AppViewConfig) {
         viewConfig.embedComponentType = 'AppEmbed';
         super(domSelector, viewConfig);
@@ -708,7 +712,10 @@ export class AppEmbed extends V1Embed {
             this.on(EmbedEvent.RouteChange, this.setIframeHeightForNonEmbedLiveboard);
             this.on(EmbedEvent.EmbedHeight, this.updateIFrameHeight);
             this.on(EmbedEvent.EmbedIframeCenter, this.embedIframeCenter);
-            this.on(EmbedEvent.RequestVisibleEmbedCoordinates, this.requestVisibleEmbedCoordinatesHandler);
+            this.on(
+                EmbedEvent.RequestVisibleEmbedCoordinates,
+                this.requestVisibleEmbedCoordinatesHandler,
+            );
         }
     }
 
@@ -738,7 +745,7 @@ export class AppEmbed extends V1Embed {
             showMaskedFilterChip = false,
             isLiveboardMasterpiecesEnabled = false,
             hideHomepageLeftNav = false,
-            modularHomeExperience,
+            modularHomeExperience = false,
             isLiveboardHeaderSticky = true,
             enableAskSage,
             collapseSearchBarInitially = false,
@@ -845,7 +852,9 @@ export class AppEmbed extends V1Embed {
         }
 
         if (isLiveboardStylingAndGroupingEnabled !== undefined) {
-            params[Param.IsLiveboardStylingAndGroupingEnabled] = isLiveboardStylingAndGroupingEnabled;
+            params[
+                Param.IsLiveboardStylingAndGroupingEnabled
+            ] = isLiveboardStylingAndGroupingEnabled;
         }
 
         if (isPNGInScheduledEmailsEnabled !== undefined) {
@@ -878,6 +887,7 @@ export class AppEmbed extends V1Embed {
 
         params[Param.DataPanelV2Enabled] = dataPanelV2;
         params[Param.HideHomepageLeftNav] = hideHomepageLeftNav;
+        params[Param.ModularHomeExperienceEnabled] = modularHomeExperience;
         params[Param.CollapseSearchBarInitially] = collapseSearchBarInitially || collapseSearchBar;
         params[Param.EnableCustomColumnGroups] = enableCustomColumnGroups;
         if (dataPanelCustomGroupsAccordionInitialState
@@ -929,16 +939,12 @@ export class AppEmbed extends V1Embed {
             }
 
             // listPageVersion can be changed to v2 or v3
-            if (discoveryExperience.listPageVersion !== undefined
-                && Object.values(ListPage).includes(discoveryExperience.listPageVersion)) {
+            if (
+                discoveryExperience.listPageVersion !== undefined &&
+                Object.values(ListPage).includes(discoveryExperience.listPageVersion)
+            ) {
                 params[Param.ListPageVersion] = discoveryExperience.listPageVersion;
             }
-        }
-
-        // If modularHomeExperience is false, set listPageVersion to v2 to
-        // avoid homepage library loading issue
-        if (modularHomeExperience === false) {
-            params[Param.ListPageVersion] = ListPage.List;
         }
 
         const queryParams = getQueryParamString(params, true);
@@ -1021,7 +1027,7 @@ export class AppEmbed extends V1Embed {
      * @param pageId The identifier for a page in the ThoughtSpot app.
      * @param modularHomeExperience
      */
-    private getPageRoute(pageId: Page, modularHomeExperience = true) {
+    private getPageRoute(pageId: Page, modularHomeExperience = false) {
         switch (pageId) {
             case Page.Search:
                 return 'answer';

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -738,7 +738,7 @@ export class AppEmbed extends V1Embed {
             showMaskedFilterChip = false,
             isLiveboardMasterpiecesEnabled = false,
             hideHomepageLeftNav = false,
-            modularHomeExperience = false,
+            modularHomeExperience,
             isLiveboardHeaderSticky = true,
             enableAskSage,
             collapseSearchBarInitially = false,
@@ -878,7 +878,6 @@ export class AppEmbed extends V1Embed {
 
         params[Param.DataPanelV2Enabled] = dataPanelV2;
         params[Param.HideHomepageLeftNav] = hideHomepageLeftNav;
-        params[Param.ModularHomeExperienceEnabled] = modularHomeExperience;
         params[Param.CollapseSearchBarInitially] = collapseSearchBarInitially || collapseSearchBar;
         params[Param.EnableCustomColumnGroups] = enableCustomColumnGroups;
         if (dataPanelCustomGroupsAccordionInitialState
@@ -893,6 +892,10 @@ export class AppEmbed extends V1Embed {
         } else {
 
             params[Param.DataPanelCustomGroupsAccordionInitialState] = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL;
+        }
+
+        if (modularHomeExperience !== undefined) {
+            params[Param.ModularHomeExperienceEnabled] = modularHomeExperience;
         }
 
         // Set navigation to v2 by default to avoid problems like the app
@@ -925,8 +928,9 @@ export class AppEmbed extends V1Embed {
                 params[Param.HomepageVersion] = HomePage.ModularWithStylingChanges;
             }
 
-            // listPageVersion v3 will enable the new list page
-            if (discoveryExperience.listPageVersion === ListPage.ListWithUXChanges) {
+            // listPageVersion can be changed to v2 or v3
+            if (discoveryExperience.listPageVersion !== undefined
+                && Object.values(ListPage).includes(discoveryExperience.listPageVersion)) {
                 params[Param.ListPageVersion] = discoveryExperience.listPageVersion;
             }
         }
@@ -1011,7 +1015,7 @@ export class AppEmbed extends V1Embed {
      * @param pageId The identifier for a page in the ThoughtSpot app.
      * @param modularHomeExperience
      */
-    private getPageRoute(pageId: Page, modularHomeExperience = false) {
+    private getPageRoute(pageId: Page, modularHomeExperience = true) {
         switch (pageId) {
             case Page.Search:
                 return 'answer';

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -904,9 +904,6 @@ export class AppEmbed extends V1Embed {
         // Set homePageVersion to v2 by default to reset the LD flag value
         // for the homepageVersion.
         params[Param.HomepageVersion] = 'v2';
-        // Set listpageVersion to v2 by default to reset the LD flag value
-        // for the listpageVersion.
-        params[Param.ListPageVersion] = ListPage.List;
         if (discoveryExperience) {
             // primaryNavbarVersion v3 will enabled the new left navigation
             if (discoveryExperience.primaryNavbarVersion === PrimaryNavbarVersion.Sliding) {

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -935,6 +935,12 @@ export class AppEmbed extends V1Embed {
             }
         }
 
+        // If modularHomeExperience is false, set listPageVersion to v2 to
+        // avoid homepage library loading issue
+        if (modularHomeExperience === false) {
+            params[Param.ListPageVersion] = ListPage.List;
+        }
+
         const queryParams = getQueryParamString(params, true);
 
         return queryParams;

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1005,10 +1005,7 @@ export class AppEmbed extends V1Embed {
             }
 
             // listPageVersion can be changed to v2 or v3
-            if (
-                discoveryExperience.listPageVersion !== undefined &&
-                Object.values(ListPage).includes(discoveryExperience.listPageVersion)
-            ) {
+            if (discoveryExperience.listPageVersion !== undefined) {
                 params[Param.ListPageVersion] = discoveryExperience.listPageVersion;
             }
         }


### PR DESCRIPTION
## Summary

Make the ListPage V3 (`ListWithUXChanges`) the default list page experience in the ThoughtSpot Embed SDK by removing the hardcoded `listpageVersion=v2` URL parameter. The embed now follows the list page version enabled on the cluster via the LaunchDarkly (LD) flag, which defaults to V3. Users can still explicitly set `discoveryExperience.listPageVersion` to switch back to the old version if needed.

## Problem

Previously, the SDK always force-set `listpageVersion=v2` in the iframe URL, overriding the cluster-level LD flag value. This meant:

1. **V3 list page could never be the default** — even though V3 was enabled on the cluster via LD, the SDK always reset it to V2.
2. **Explicit `listPageVersion=v2` was silently ignored** — the `discoveryExperience.listPageVersion` condition only matched V3 (`ListWithUXChanges`). Setting it to V2 (`List`) had no effect since V2 was already hardcoded as the default anyway.

## Changes

### `src/embed/app.ts`

- **Removed hardcoded `listpageVersion=v2` default** — The `listpageVersion` parameter is no longer force-set in the iframe URL. When `discoveryExperience.listPageVersion` is not specified, the embed now respects the cluster-level LD flag (V3 by default).

- **`listPageVersion` now accepts both V2 and V3** — Changed the condition from only matching `ListPage.ListWithUXChanges` to validating against the full `ListPage` enum via `Object.values(ListPage).includes(...)`. Users can explicitly set either `ListPage.List` (V2) or `ListPage.ListWithUXChanges` (V3).

- **Added explicit `modularHomeExperience` override** — When `modularHomeExperience` is set directly on `AppViewConfig`, it now correctly overrides the destructured default before `discoveryExperience` logic runs.

### `src/embed/app.spec.ts`

- **Extracted reusable test helpers** (`createAndRenderAppEmbed`, `testUrlParams`, `testSetIframeHeightBehavior`, `createMockIFrame`, `setupIFrameCreationSpy`) to fix SonarQube duplicate code issues.
- **Updated test expectations** — Tests now assert that `listpageVersion` is absent from the URL when not explicitly configured, reflecting the new server-default behavior.
- **Added test coverage** for `listPageVersion=v2` when `modularHomeExperience=false`.

## Behavior

| Scenario | Before | After |
|---|---|---|
| No `listPageVersion` configured | `listpageVersion=v2` hardcoded in URL | No param in URL → cluster LD flag applies (V3 default) |
| `listPageVersion = ListPage.ListWithUXChanges` | `listpageVersion=v3` | `listpageVersion=v3` (unchanged) |
| `listPageVersion = ListPage.List` | Ignored (V2 was already hardcoded) | `listpageVersion=v2` (explicitly respected) |