### PR TITLE
SCAL-290924 add personalizedViewId parameter in LiveboardEmbedConfig

### DIFF
--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -223,7 +223,7 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      *    activeTabId: 'tab-guid',
      * })
      * ```
-     * @version SDK: 1.45.0 | ThoughtSpot: 26.4.0.cl
+     * @version SDK: 1.46.0 | ThoughtSpot: 26.4.0.cl
      */
     personalizedViewId?: string;
     /**

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2243,
+			"id": 2248,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2357,
+					"id": 2362,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -55,7 +55,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2263,
+					"id": 2268,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -83,7 +83,7 @@
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2256,
+					"id": 2261,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -111,7 +111,7 @@
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2255,
+					"id": 2260,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -135,7 +135,7 @@
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2261,
+					"id": 2266,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -159,7 +159,7 @@
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2262,
+					"id": 2267,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -183,7 +183,7 @@
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2264,
+					"id": 2269,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -211,7 +211,7 @@
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2339,
+					"id": 2344,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -239,7 +239,7 @@
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2312,
+					"id": 2317,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -267,7 +267,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2354,
+					"id": 2359,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -295,7 +295,7 @@
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2311,
+					"id": 2316,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -323,7 +323,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2310,
+					"id": 2315,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -351,7 +351,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2353,
+					"id": 2358,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -380,7 +380,7 @@
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2323,
+					"id": 2328,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -408,7 +408,7 @@
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2326,
+					"id": 2331,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -436,7 +436,7 @@
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2331,
+					"id": 2336,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -464,7 +464,7 @@
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2325,
+					"id": 2330,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -492,7 +492,7 @@
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2328,
+					"id": 2333,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -520,7 +520,7 @@
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2332,
+					"id": 2337,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -548,7 +548,7 @@
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2329,
+					"id": 2334,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -576,7 +576,7 @@
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2334,
+					"id": 2339,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -604,7 +604,7 @@
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2330,
+					"id": 2335,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -632,7 +632,7 @@
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2327,
+					"id": 2332,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -660,7 +660,7 @@
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2333,
+					"id": 2338,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -688,7 +688,7 @@
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2324,
+					"id": 2329,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -716,7 +716,7 @@
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2366,
+					"id": 2371,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -744,7 +744,7 @@
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2260,
+					"id": 2265,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -768,7 +768,7 @@
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2259,
+					"id": 2264,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -796,7 +796,7 @@
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2258,
+					"id": 2263,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -824,7 +824,7 @@
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2374,
+					"id": 2379,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -852,7 +852,7 @@
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2257,
+					"id": 2262,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -876,7 +876,7 @@
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2303,
+					"id": 2308,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -891,7 +891,7 @@
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2250,
+					"id": 2255,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -915,7 +915,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2302,
+					"id": 2307,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -939,7 +939,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2375,
+					"id": 2380,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -967,7 +967,7 @@
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2389,
+					"id": 2394,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -995,7 +995,7 @@
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2351,
+					"id": 2356,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1023,7 +1023,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2314,
+					"id": 2319,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1051,7 +1051,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2319,
+					"id": 2324,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1079,7 +1079,7 @@
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2367,
+					"id": 2372,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1107,7 +1107,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2372,
+					"id": 2377,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1135,7 +1135,7 @@
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2363,
+					"id": 2368,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1163,7 +1163,7 @@
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2365,
+					"id": 2370,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1191,7 +1191,7 @@
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2272,
+					"id": 2277,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1215,7 +1215,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2275,
+					"id": 2280,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1239,7 +1239,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2274,
+					"id": 2279,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1264,7 +1264,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2273,
+					"id": 2278,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1288,7 +1288,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2276,
+					"id": 2281,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1312,7 +1312,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2277,
+					"id": 2282,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1340,7 +1340,7 @@
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2307,
+					"id": 2312,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1364,7 +1364,7 @@
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2301,
+					"id": 2306,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1388,7 +1388,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2300,
+					"id": 2305,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1412,7 +1412,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2285,
+					"id": 2290,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1436,7 +1436,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2249,
+					"id": 2254,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1460,7 +1460,7 @@
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2313,
+					"id": 2318,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1488,7 +1488,7 @@
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2305,
+					"id": 2310,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1503,7 +1503,7 @@
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2371,
+					"id": 2376,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1531,7 +1531,7 @@
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2343,
+					"id": 2348,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1559,7 +1559,7 @@
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2358,
+					"id": 2363,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1587,7 +1587,7 @@
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2282,
+					"id": 2287,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1611,7 +1611,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2286,
+					"id": 2291,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1635,7 +1635,7 @@
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2373,
+					"id": 2378,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1663,7 +1663,7 @@
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2340,
+					"id": 2345,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1691,7 +1691,7 @@
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2341,
+					"id": 2346,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1719,7 +1719,7 @@
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2299,
+					"id": 2304,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1743,7 +1743,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2279,
+					"id": 2284,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1768,7 +1768,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2280,
+					"id": 2285,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1792,7 +1792,7 @@
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2376,
+					"id": 2381,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1820,7 +1820,7 @@
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2400,
+					"id": 2405,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1848,7 +1848,7 @@
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2364,
+					"id": 2369,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1876,7 +1876,7 @@
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2293,
+					"id": 2298,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1900,7 +1900,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2382,
+					"id": 2387,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1928,7 +1928,7 @@
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2349,
+					"id": 2354,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1956,7 +1956,7 @@
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2248,
+					"id": 2253,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1980,7 +1980,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2347,
+					"id": 2352,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2004,7 +2004,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2318,
+					"id": 2323,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2032,7 +2032,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2384,
+					"id": 2389,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2060,7 +2060,7 @@
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2362,
+					"id": 2367,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2088,7 +2088,7 @@
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2338,
+					"id": 2343,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2116,7 +2116,7 @@
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2345,
+					"id": 2350,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2143,7 +2143,7 @@
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2388,
+					"id": 2393,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2171,7 +2171,7 @@
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2387,
+					"id": 2392,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2199,7 +2199,7 @@
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2346,
+					"id": 2351,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,7 +2223,7 @@
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2356,
+					"id": 2361,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,7 +2251,7 @@
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2386,
+					"id": 2391,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,7 +2279,7 @@
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2359,
+					"id": 2364,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,7 +2307,7 @@
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2348,
+					"id": 2353,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2335,7 +2335,7 @@
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2296,
+					"id": 2301,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2359,7 +2359,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2380,
+					"id": 2385,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2383,7 +2383,7 @@
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2283,
+					"id": 2288,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2407,7 +2407,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2368,
+					"id": 2373,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2435,7 +2435,7 @@
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2383,
+					"id": 2388,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2463,7 +2463,7 @@
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2309,
+					"id": 2314,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2488,7 +2488,7 @@
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2287,
+					"id": 2292,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2512,7 +2512,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2381,
+					"id": 2386,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2540,7 +2540,7 @@
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2322,
+					"id": 2327,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2568,7 +2568,7 @@
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2355,
+					"id": 2360,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2596,7 +2596,7 @@
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2336,
+					"id": 2341,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2624,7 +2624,7 @@
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2315,
+					"id": 2320,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2655,7 +2655,7 @@
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2308,
+					"id": 2313,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2679,7 +2679,7 @@
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2337,
+					"id": 2342,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2707,7 +2707,7 @@
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2369,
+					"id": 2374,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2735,7 +2735,7 @@
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2344,
+					"id": 2349,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2763,7 +2763,7 @@
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2244,
+					"id": 2249,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2787,7 +2787,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2247,
+					"id": 2252,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2811,7 +2811,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2252,
+					"id": 2257,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2835,7 +2835,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2253,
+					"id": 2258,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2859,7 +2859,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2306,
+					"id": 2311,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2874,7 +2874,7 @@
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2254,
+					"id": 2259,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2898,7 +2898,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2269,
+					"id": 2274,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2916,7 +2916,7 @@
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2342,
+					"id": 2347,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2944,7 +2944,7 @@
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2271,
+					"id": 2276,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2968,7 +2968,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2266,
+					"id": 2271,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2992,7 +2992,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2398,
+					"id": 2403,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3020,7 +3020,7 @@
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2396,
+					"id": 2401,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3048,7 +3048,7 @@
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2397,
+					"id": 2402,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3076,7 +3076,7 @@
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2399,
+					"id": 2404,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3104,7 +3104,7 @@
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2370,
+					"id": 2375,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3132,7 +3132,7 @@
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2394,
+					"id": 2399,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3160,7 +3160,7 @@
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2395,
+					"id": 2400,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3188,7 +3188,7 @@
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2392,
+					"id": 2397,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3216,7 +3216,7 @@
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2391,
+					"id": 2396,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3244,7 +3244,7 @@
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2393,
+					"id": 2398,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3272,7 +3272,7 @@
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2379,
+					"id": 2384,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3300,7 +3300,7 @@
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2377,
+					"id": 2382,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3328,7 +3328,7 @@
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2378,
+					"id": 2383,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3356,7 +3356,7 @@
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2298,
+					"id": 2303,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3380,7 +3380,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2317,
+					"id": 2322,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3408,7 +3408,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2316,
+					"id": 2321,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3436,7 +3436,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2320,
+					"id": 2325,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3464,7 +3464,7 @@
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2321,
+					"id": 2326,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3492,7 +3492,7 @@
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2350,
+					"id": 2355,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3524,7 +3524,7 @@
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2284,
+					"id": 2289,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3548,7 +3548,7 @@
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2390,
+					"id": 2395,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3576,7 +3576,7 @@
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2385,
+					"id": 2390,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3604,7 +3604,7 @@
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2361,
+					"id": 2366,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3632,7 +3632,7 @@
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2281,
+					"id": 2286,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3656,7 +3656,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2352,
+					"id": 2357,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3684,7 +3684,7 @@
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2360,
+					"id": 2365,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3717,145 +3717,145 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2357,
-						2263,
-						2256,
-						2255,
-						2261,
-						2262,
-						2264,
-						2339,
-						2312,
-						2354,
-						2311,
-						2310,
-						2353,
-						2323,
-						2326,
-						2331,
-						2325,
-						2328,
-						2332,
-						2329,
-						2334,
-						2330,
-						2327,
-						2333,
-						2324,
-						2366,
-						2260,
-						2259,
-						2258,
-						2374,
-						2257,
-						2303,
-						2250,
-						2302,
-						2375,
-						2389,
-						2351,
-						2314,
-						2319,
-						2367,
-						2372,
-						2363,
-						2365,
-						2272,
-						2275,
-						2274,
-						2273,
-						2276,
-						2277,
-						2307,
-						2301,
-						2300,
-						2285,
-						2249,
-						2313,
-						2305,
-						2371,
-						2343,
-						2358,
-						2282,
-						2286,
-						2373,
-						2340,
-						2341,
-						2299,
-						2279,
-						2280,
-						2376,
-						2400,
-						2364,
-						2293,
-						2382,
-						2349,
-						2248,
-						2347,
-						2318,
-						2384,
 						2362,
-						2338,
-						2345,
-						2388,
-						2387,
-						2346,
-						2356,
-						2386,
-						2359,
-						2348,
-						2296,
-						2380,
-						2283,
-						2368,
-						2383,
-						2309,
-						2287,
-						2381,
-						2322,
-						2355,
-						2336,
-						2315,
-						2308,
-						2337,
-						2369,
-						2344,
-						2244,
-						2247,
-						2252,
-						2253,
-						2306,
-						2254,
-						2269,
-						2342,
-						2271,
+						2268,
+						2261,
+						2260,
 						2266,
-						2398,
-						2396,
-						2397,
-						2399,
-						2370,
-						2394,
-						2395,
-						2392,
-						2391,
-						2393,
-						2379,
-						2377,
-						2378,
-						2298,
+						2267,
+						2269,
+						2344,
 						2317,
+						2359,
 						2316,
-						2320,
-						2321,
-						2350,
-						2284,
-						2390,
-						2385,
-						2361,
+						2315,
+						2358,
+						2328,
+						2331,
+						2336,
+						2330,
+						2333,
+						2337,
+						2334,
+						2339,
+						2335,
+						2332,
+						2338,
+						2329,
+						2371,
+						2265,
+						2264,
+						2263,
+						2379,
+						2262,
+						2308,
+						2255,
+						2307,
+						2380,
+						2394,
+						2356,
+						2319,
+						2324,
+						2372,
+						2377,
+						2368,
+						2370,
+						2277,
+						2280,
+						2279,
+						2278,
 						2281,
+						2282,
+						2312,
+						2306,
+						2305,
+						2290,
+						2254,
+						2318,
+						2310,
+						2376,
+						2348,
+						2363,
+						2287,
+						2291,
+						2378,
+						2345,
+						2346,
+						2304,
+						2284,
+						2285,
+						2381,
+						2405,
+						2369,
+						2298,
+						2387,
+						2354,
+						2253,
 						2352,
-						2360
+						2323,
+						2389,
+						2367,
+						2343,
+						2350,
+						2393,
+						2392,
+						2351,
+						2361,
+						2391,
+						2364,
+						2353,
+						2301,
+						2385,
+						2288,
+						2373,
+						2388,
+						2314,
+						2292,
+						2386,
+						2327,
+						2360,
+						2341,
+						2320,
+						2313,
+						2342,
+						2374,
+						2349,
+						2249,
+						2252,
+						2257,
+						2258,
+						2311,
+						2259,
+						2274,
+						2347,
+						2276,
+						2271,
+						2403,
+						2401,
+						2402,
+						2404,
+						2375,
+						2399,
+						2400,
+						2397,
+						2396,
+						2398,
+						2384,
+						2382,
+						2383,
+						2303,
+						2322,
+						2321,
+						2325,
+						2326,
+						2355,
+						2289,
+						2395,
+						2390,
+						2366,
+						2286,
+						2357,
+						2365
 					]
 				}
 			],
@@ -3868,7 +3868,7 @@
 			]
 		},
 		{
-			"id": 1876,
+			"id": 1881,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3884,7 +3884,7 @@
 			},
 			"children": [
 				{
-					"id": 1877,
+					"id": 1882,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3907,7 +3907,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1877
+						1882
 					]
 				}
 			],
@@ -3920,7 +3920,7 @@
 			]
 		},
 		{
-			"id": 1861,
+			"id": 1866,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -3936,7 +3936,7 @@
 			},
 			"children": [
 				{
-					"id": 1864,
+					"id": 1869,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3951,7 +3951,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1866,
+					"id": 1871,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3966,7 +3966,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1863,
+					"id": 1868,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3981,7 +3981,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1865,
+					"id": 1870,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3996,7 +3996,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1862,
+					"id": 1867,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4011,7 +4011,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1867,
+					"id": 1872,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,12 +4031,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1864,
-						1866,
-						1863,
-						1865,
-						1862,
-						1867
+						1869,
+						1871,
+						1868,
+						1870,
+						1867,
+						1872
 					]
 				}
 			],
@@ -4049,7 +4049,7 @@
 			]
 		},
 		{
-			"id": 1868,
+			"id": 1873,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4065,7 +4065,7 @@
 			},
 			"children": [
 				{
-					"id": 1869,
+					"id": 1874,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4083,7 +4083,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1873,
+					"id": 1878,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4101,7 +4101,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1875,
+					"id": 1880,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4119,7 +4119,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1870,
+					"id": 1875,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4137,7 +4137,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1872,
+					"id": 1877,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4155,7 +4155,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1874,
+					"id": 1879,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4184,12 +4184,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1869,
-						1873,
+						1874,
+						1878,
+						1880,
 						1875,
-						1870,
-						1872,
-						1874
+						1877,
+						1879
 					]
 				}
 			],
@@ -4202,7 +4202,7 @@
 			]
 		},
 		{
-			"id": 2023,
+			"id": 2028,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4218,7 +4218,7 @@
 			},
 			"children": [
 				{
-					"id": 2034,
+					"id": 2039,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4237,7 +4237,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 2025,
+					"id": 2030,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4266,7 +4266,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 2024,
+					"id": 2029,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4290,7 +4290,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 2030,
+					"id": 2035,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4308,7 +4308,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 2028,
+					"id": 2033,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4341,7 +4341,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 2032,
+					"id": 2037,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4365,7 +4365,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 2033,
+					"id": 2038,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4398,13 +4398,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2034,
-						2025,
-						2024,
+						2039,
 						2030,
-						2028,
-						2032,
-						2033
+						2029,
+						2035,
+						2033,
+						2037,
+						2038
 					]
 				}
 			],
@@ -4417,7 +4417,7 @@
 			]
 		},
 		{
-			"id": 2401,
+			"id": 2406,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4427,7 +4427,7 @@
 			},
 			"children": [
 				{
-					"id": 2404,
+					"id": 2409,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4442,7 +4442,7 @@
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2402,
+					"id": 2407,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4457,7 +4457,7 @@
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2403,
+					"id": 2408,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4477,9 +4477,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2404,
-						2402,
-						2403
+						2409,
+						2407,
+						2408
 					]
 				}
 			],
@@ -4492,14 +4492,14 @@
 			]
 		},
 		{
-			"id": 2234,
+			"id": 2239,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2237,
+					"id": 2242,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4517,7 +4517,7 @@
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2236,
+					"id": 2241,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4535,7 +4535,7 @@
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2235,
+					"id": 2240,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4553,7 +4553,7 @@
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2238,
+					"id": 2243,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4576,10 +4576,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2237,
-						2236,
-						2235,
-						2238
+						2242,
+						2241,
+						2240,
+						2243
 					]
 				}
 			],
@@ -4592,7 +4592,7 @@
 			]
 		},
 		{
-			"id": 3130,
+			"id": 3136,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4602,7 +4602,7 @@
 			},
 			"children": [
 				{
-					"id": 3133,
+					"id": 3139,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4617,7 +4617,7 @@
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3131,
+					"id": 3137,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4632,7 +4632,7 @@
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3134,
+					"id": 3140,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4647,7 +4647,7 @@
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3132,
+					"id": 3138,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4667,10 +4667,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3133,
-						3131,
-						3134,
-						3132
+						3139,
+						3137,
+						3140,
+						3138
 					]
 				}
 			],
@@ -4683,7 +4683,7 @@
 			]
 		},
 		{
-			"id": 3126,
+			"id": 3132,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4693,7 +4693,7 @@
 			},
 			"children": [
 				{
-					"id": 3129,
+					"id": 3135,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4708,7 +4708,7 @@
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3128,
+					"id": 3134,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4723,7 +4723,7 @@
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3127,
+					"id": 3133,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4743,9 +4743,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3129,
-						3128,
-						3127
+						3135,
+						3134,
+						3133
 					]
 				}
 			],
@@ -4758,7 +4758,7 @@
 			]
 		},
 		{
-			"id": 3122,
+			"id": 3128,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4768,7 +4768,7 @@
 			},
 			"children": [
 				{
-					"id": 3124,
+					"id": 3130,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4786,7 +4786,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3123,
+					"id": 3129,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4804,7 +4804,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3125,
+					"id": 3131,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4827,9 +4827,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3124,
-						3123,
-						3125
+						3130,
+						3129,
+						3131
 					]
 				}
 			],
@@ -4842,7 +4842,7 @@
 			]
 		},
 		{
-			"id": 2239,
+			"id": 2244,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4852,7 +4852,7 @@
 			},
 			"children": [
 				{
-					"id": 2241,
+					"id": 2246,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4870,7 +4870,7 @@
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2242,
+					"id": 2247,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4888,7 +4888,7 @@
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2240,
+					"id": 2245,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4911,9 +4911,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2241,
-						2242,
-						2240
+						2246,
+						2247,
+						2245
 					]
 				}
 			],
@@ -4926,7 +4926,7 @@
 			]
 		},
 		{
-			"id": 3139,
+			"id": 3145,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4950,7 +4950,7 @@
 			},
 			"children": [
 				{
-					"id": 3142,
+					"id": 3148,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4968,7 +4968,7 @@
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3143,
+					"id": 3149,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4986,7 +4986,7 @@
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3146,
+					"id": 3152,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5004,7 +5004,7 @@
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3149,
+					"id": 3155,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5022,7 +5022,7 @@
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3144,
+					"id": 3150,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5040,7 +5040,7 @@
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3152,
+					"id": 3158,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5058,7 +5058,7 @@
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3141,
+					"id": 3147,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5076,7 +5076,7 @@
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3147,
+					"id": 3153,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5094,7 +5094,7 @@
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3145,
+					"id": 3151,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5112,7 +5112,7 @@
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3150,
+					"id": 3156,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5130,7 +5130,7 @@
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3148,
+					"id": 3154,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5148,7 +5148,7 @@
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3151,
+					"id": 3157,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5166,7 +5166,7 @@
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3140,
+					"id": 3146,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5189,19 +5189,19 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3142,
-						3143,
-						3146,
-						3149,
-						3144,
-						3152,
-						3141,
-						3147,
-						3145,
-						3150,
 						3148,
+						3149,
+						3152,
+						3155,
+						3150,
+						3158,
+						3147,
+						3153,
 						3151,
-						3140
+						3156,
+						3154,
+						3157,
+						3146
 					]
 				}
 			],
@@ -5214,7 +5214,7 @@
 			]
 		},
 		{
-			"id": 2055,
+			"id": 2060,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5239,7 +5239,7 @@
 			},
 			"children": [
 				{
-					"id": 2091,
+					"id": 2096,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5267,7 +5267,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2083,
+					"id": 2088,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5295,7 +5295,7 @@
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2063,
+					"id": 2068,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5327,7 +5327,7 @@
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2142,
+					"id": 2147,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5355,7 +5355,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2108,
+					"id": 2113,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5383,7 +5383,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2068,
+					"id": 2073,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5415,7 +5415,7 @@
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2104,
+					"id": 2109,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5443,7 +5443,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2090,
+					"id": 2095,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5471,7 +5471,7 @@
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2152,
+					"id": 2157,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5500,7 +5500,7 @@
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2131,
+					"id": 2136,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5540,7 +5540,7 @@
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2069,
+					"id": 2074,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5568,7 +5568,7 @@
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2057,
+					"id": 2062,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5600,7 +5600,7 @@
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2115,
+					"id": 2120,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5628,7 +5628,7 @@
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2102,
+					"id": 2107,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5656,7 +5656,7 @@
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2117,
+					"id": 2122,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5684,7 +5684,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2097,
+					"id": 2102,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5712,7 +5712,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2125,
+					"id": 2130,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5736,7 +5736,7 @@
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2136,
+					"id": 2141,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5761,7 +5761,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2137,
+					"id": 2142,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5785,7 +5785,7 @@
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2130,
+					"id": 2135,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5809,7 +5809,7 @@
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2118,
+					"id": 2123,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5837,7 +5837,7 @@
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2064,
+					"id": 2069,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5873,7 +5873,7 @@
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2059,
+					"id": 2064,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5909,7 +5909,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2143,
+					"id": 2148,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5937,7 +5937,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2062,
+					"id": 2067,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5969,7 +5969,7 @@
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2113,
+					"id": 2118,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5997,7 +5997,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2129,
+					"id": 2134,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6029,7 +6029,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2081,
+					"id": 2086,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6057,7 +6057,7 @@
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2080,
+					"id": 2085,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6085,7 +6085,7 @@
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2085,
+					"id": 2090,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6114,7 +6114,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2088,
+					"id": 2093,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6142,7 +6142,7 @@
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2087,
+					"id": 2092,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6170,7 +6170,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2086,
+					"id": 2091,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6198,7 +6198,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2089,
+					"id": 2094,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6226,7 +6226,7 @@
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2096,
+					"id": 2101,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6254,7 +6254,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2095,
+					"id": 2100,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6282,7 +6282,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2061,
+					"id": 2066,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6326,7 +6326,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2110,
+					"id": 2115,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6354,7 +6354,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2099,
+					"id": 2104,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6382,7 +6382,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2067,
+					"id": 2072,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6419,7 +6419,7 @@
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2116,
+					"id": 2121,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6447,7 +6447,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2100,
+					"id": 2105,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6475,7 +6475,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2121,
+					"id": 2126,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6499,7 +6499,7 @@
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2075,
+					"id": 2080,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6527,7 +6527,7 @@
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2056,
+					"id": 2061,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6555,7 +6555,7 @@
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2146,
+					"id": 2151,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6583,7 +6583,7 @@
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2145,
+					"id": 2150,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6611,7 +6611,7 @@
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2107,
+					"id": 2112,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6639,7 +6639,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2082,
+					"id": 2087,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6671,7 +6671,7 @@
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2058,
+					"id": 2063,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6703,7 +6703,7 @@
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2111,
+					"id": 2116,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6731,7 +6731,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2078,
+					"id": 2083,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6759,7 +6759,7 @@
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2133,
+					"id": 2138,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6793,7 +6793,7 @@
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2151,
+					"id": 2156,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6821,7 +6821,7 @@
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2134,
+					"id": 2139,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6845,7 +6845,7 @@
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2092,
+					"id": 2097,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6873,7 +6873,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2112,
+					"id": 2117,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6905,7 +6905,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2141,
+					"id": 2146,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6933,7 +6933,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2060,
+					"id": 2065,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6961,7 +6961,7 @@
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2132,
+					"id": 2137,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6985,7 +6985,7 @@
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2128,
+					"id": 2133,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7025,7 +7025,7 @@
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2147,
+					"id": 2152,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7053,7 +7053,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2076,
+					"id": 2081,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7081,7 +7081,7 @@
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2122,
+					"id": 2127,
 					"name": "SageEmbedQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7105,7 +7105,7 @@
 					"defaultValue": "\"sageEmbedQuery\""
 				},
 				{
-					"id": 2123,
+					"id": 2128,
 					"name": "SageWorksheetUpdated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7129,7 +7129,7 @@
 					"defaultValue": "\"sageWorksheetUpdated\""
 				},
 				{
-					"id": 2084,
+					"id": 2089,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7157,7 +7157,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2101,
+					"id": 2106,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7185,7 +7185,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2127,
+					"id": 2132,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7225,7 +7225,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2109,
+					"id": 2114,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7253,7 +7253,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2114,
+					"id": 2119,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7281,7 +7281,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2094,
+					"id": 2099,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7309,7 +7309,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2103,
+					"id": 2108,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7337,7 +7337,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2093,
+					"id": 2098,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7365,7 +7365,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2154,
+					"id": 2159,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7393,7 +7393,7 @@
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2153,
+					"id": 2158,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7421,7 +7421,7 @@
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2155,
+					"id": 2160,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7449,7 +7449,7 @@
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2140,
+					"id": 2145,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7477,7 +7477,7 @@
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2148,
+					"id": 2153,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7505,7 +7505,7 @@
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2149,
+					"id": 2154,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7533,7 +7533,7 @@
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2144,
+					"id": 2149,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7561,7 +7561,7 @@
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2135,
+					"id": 2140,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7590,7 +7590,7 @@
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2124,
+					"id": 2129,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7614,7 +7614,7 @@
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2126,
+					"id": 2131,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7654,7 +7654,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2098,
+					"id": 2103,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7682,7 +7682,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2066,
+					"id": 2071,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7718,7 +7718,7 @@
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2065,
+					"id": 2070,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7750,7 +7750,7 @@
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2119,
+					"id": 2124,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7783,93 +7783,93 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2091,
-						2083,
-						2063,
-						2142,
-						2108,
-						2068,
-						2104,
-						2090,
-						2152,
-						2131,
-						2069,
-						2057,
-						2115,
-						2102,
-						2117,
-						2097,
-						2125,
-						2136,
-						2137,
-						2130,
-						2118,
-						2064,
-						2059,
-						2143,
-						2062,
-						2113,
-						2129,
-						2081,
-						2080,
-						2085,
-						2088,
-						2087,
-						2086,
-						2089,
 						2096,
-						2095,
-						2061,
-						2110,
-						2099,
-						2067,
-						2116,
-						2100,
-						2121,
-						2075,
-						2056,
-						2146,
-						2145,
-						2107,
-						2082,
-						2058,
-						2111,
-						2078,
-						2133,
-						2151,
-						2134,
-						2092,
-						2112,
-						2141,
-						2060,
-						2132,
-						2128,
+						2088,
+						2068,
 						2147,
-						2076,
-						2122,
-						2123,
-						2084,
-						2101,
-						2127,
+						2113,
+						2073,
 						2109,
-						2114,
-						2094,
-						2103,
-						2093,
-						2154,
-						2153,
-						2155,
-						2140,
-						2148,
-						2149,
-						2144,
+						2095,
+						2157,
+						2136,
+						2074,
+						2062,
+						2120,
+						2107,
+						2122,
+						2102,
+						2130,
+						2141,
+						2142,
 						2135,
-						2124,
-						2126,
-						2098,
+						2123,
+						2069,
+						2064,
+						2148,
+						2067,
+						2118,
+						2134,
+						2086,
+						2085,
+						2090,
+						2093,
+						2092,
+						2091,
+						2094,
+						2101,
+						2100,
 						2066,
+						2115,
+						2104,
+						2072,
+						2121,
+						2105,
+						2126,
+						2080,
+						2061,
+						2151,
+						2150,
+						2112,
+						2087,
+						2063,
+						2116,
+						2083,
+						2138,
+						2156,
+						2139,
+						2097,
+						2117,
+						2146,
 						2065,
-						2119
+						2137,
+						2133,
+						2152,
+						2081,
+						2127,
+						2128,
+						2089,
+						2106,
+						2132,
+						2114,
+						2119,
+						2099,
+						2108,
+						2098,
+						2159,
+						2158,
+						2160,
+						2145,
+						2153,
+						2154,
+						2149,
+						2140,
+						2129,
+						2131,
+						2103,
+						2071,
+						2070,
+						2124
 					]
 				}
 			],
@@ -7882,7 +7882,7 @@
 			]
 		},
 		{
-			"id": 3159,
+			"id": 3165,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7907,7 +7907,7 @@
 			},
 			"children": [
 				{
-					"id": 3160,
+					"id": 3166,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7925,7 +7925,7 @@
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3162,
+					"id": 3168,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7943,7 +7943,7 @@
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3161,
+					"id": 3167,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7966,9 +7966,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3160,
-						3162,
-						3161
+						3166,
+						3168,
+						3167
 					]
 				}
 			],
@@ -7981,7 +7981,7 @@
 			]
 		},
 		{
-			"id": 2814,
+			"id": 2820,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7991,7 +7991,7 @@
 			},
 			"children": [
 				{
-					"id": 2818,
+					"id": 2824,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8015,7 +8015,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2822,
+					"id": 2828,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8039,7 +8039,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2824,
+					"id": 2830,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8063,7 +8063,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2816,
+					"id": 2822,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8087,7 +8087,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2821,
+					"id": 2827,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8111,7 +8111,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2817,
+					"id": 2823,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8135,7 +8135,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2819,
+					"id": 2825,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8159,7 +8159,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2815,
+					"id": 2821,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8183,7 +8183,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2820,
+					"id": 2826,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8207,7 +8207,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2823,
+					"id": 2829,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8236,16 +8236,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2818,
-						2822,
 						2824,
-						2816,
+						2828,
+						2830,
+						2822,
+						2827,
+						2823,
+						2825,
 						2821,
-						2817,
-						2819,
-						2815,
-						2820,
-						2823
+						2826,
+						2829
 					]
 				}
 			],
@@ -8258,7 +8258,7 @@
 			]
 		},
 		{
-			"id": 3077,
+			"id": 3083,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8274,7 +8274,7 @@
 			},
 			"children": [
 				{
-					"id": 3078,
+					"id": 3084,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8292,7 +8292,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3079,
+					"id": 3085,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8315,8 +8315,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3078,
-						3079
+						3084,
+						3085
 					]
 				}
 			],
@@ -8329,14 +8329,14 @@
 			]
 		},
 		{
-			"id": 3071,
+			"id": 3077,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3073,
+					"id": 3079,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8351,7 +8351,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3074,
+					"id": 3080,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8366,7 +8366,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3072,
+					"id": 3078,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8386,9 +8386,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3073,
-						3074,
-						3072
+						3079,
+						3080,
+						3078
 					]
 				}
 			],
@@ -8401,7 +8401,7 @@
 			]
 		},
 		{
-			"id": 2825,
+			"id": 2831,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8418,7 +8418,7 @@
 			},
 			"children": [
 				{
-					"id": 2828,
+					"id": 2834,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8436,7 +8436,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2831,
+					"id": 2837,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8454,7 +8454,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2829,
+					"id": 2835,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8472,7 +8472,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2826,
+					"id": 2832,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8490,7 +8490,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2830,
+					"id": 2836,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8508,7 +8508,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2827,
+					"id": 2833,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8531,12 +8531,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2828,
-						2831,
-						2829,
-						2826,
-						2830,
-						2827
+						2834,
+						2837,
+						2835,
+						2832,
+						2836,
+						2833
 					]
 				}
 			],
@@ -8549,7 +8549,7 @@
 			]
 		},
 		{
-			"id": 2157,
+			"id": 2162,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8578,7 +8578,7 @@
 			},
 			"children": [
 				{
-					"id": 2179,
+					"id": 2184,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8606,7 +8606,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2168,
+					"id": 2173,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8639,7 +8639,7 @@
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2222,
+					"id": 2227,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8672,7 +8672,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2226,
+					"id": 2231,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8705,7 +8705,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2209,
+					"id": 2214,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8733,7 +8733,7 @@
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2229,
+					"id": 2234,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8766,7 +8766,7 @@
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2186,
+					"id": 2191,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8799,7 +8799,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2183,
+					"id": 2188,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8836,7 +8836,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2223,
+					"id": 2228,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8864,7 +8864,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2190,
+					"id": 2195,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8897,7 +8897,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2225,
+					"id": 2230,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8925,7 +8925,7 @@
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2231,
+					"id": 2236,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8953,7 +8953,7 @@
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2192,
+					"id": 2197,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8990,7 +8990,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2194,
+					"id": 2199,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9023,7 +9023,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2178,
+					"id": 2183,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9060,7 +9060,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2193,
+					"id": 2198,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9088,7 +9088,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2195,
+					"id": 2200,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9121,7 +9121,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2159,
+					"id": 2164,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9158,7 +9158,7 @@
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2185,
+					"id": 2190,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9196,7 +9196,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2220,
+					"id": 2225,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9229,7 +9229,7 @@
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2176,
+					"id": 2181,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9257,7 +9257,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2182,
+					"id": 2187,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9290,7 +9290,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2175,
+					"id": 2180,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9318,7 +9318,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2208,
+					"id": 2213,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9351,7 +9351,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2202,
+					"id": 2207,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9379,7 +9379,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2162,
+					"id": 2167,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9407,7 +9407,7 @@
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2213,
+					"id": 2218,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9436,7 +9436,7 @@
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2188,
+					"id": 2193,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9468,7 +9468,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2204,
+					"id": 2209,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9496,7 +9496,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2172,
+					"id": 2177,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9524,7 +9524,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2180,
+					"id": 2185,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9568,7 +9568,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2184,
+					"id": 2189,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9609,7 +9609,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2200,
+					"id": 2205,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9642,7 +9642,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2166,
+					"id": 2171,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9675,7 +9675,7 @@
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2167,
+					"id": 2172,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9712,7 +9712,7 @@
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2171,
+					"id": 2176,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9761,7 +9761,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2187,
+					"id": 2192,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9794,7 +9794,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2221,
+					"id": 2226,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9822,7 +9822,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2181,
+					"id": 2186,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9854,7 +9854,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2169,
+					"id": 2174,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9887,7 +9887,7 @@
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2211,
+					"id": 2216,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9915,7 +9915,7 @@
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2201,
+					"id": 2206,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9943,7 +9943,7 @@
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2224,
+					"id": 2229,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9971,7 +9971,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2197,
+					"id": 2202,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10004,7 +10004,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2216,
+					"id": 2221,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10041,7 +10041,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2173,
+					"id": 2178,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10069,7 +10069,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2174,
+					"id": 2179,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10097,7 +10097,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2158,
+					"id": 2163,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10126,7 +10126,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2164,
+					"id": 2169,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10159,7 +10159,7 @@
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2206,
+					"id": 2211,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10192,7 +10192,7 @@
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2205,
+					"id": 2210,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10225,7 +10225,7 @@
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2163,
+					"id": 2168,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10258,7 +10258,7 @@
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2196,
+					"id": 2201,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10286,7 +10286,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2189,
+					"id": 2194,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10319,7 +10319,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2191,
+					"id": 2196,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10352,7 +10352,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2219,
+					"id": 2224,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10385,7 +10385,7 @@
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2232,
+					"id": 2237,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10414,7 +10414,7 @@
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2199,
+					"id": 2204,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10447,7 +10447,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2198,
+					"id": 2203,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10480,7 +10480,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2218,
+					"id": 2223,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10513,7 +10513,7 @@
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2210,
+					"id": 2215,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10541,7 +10541,7 @@
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2203,
+					"id": 2208,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10586,7 +10586,7 @@
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2212,
+					"id": 2217,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10619,7 +10619,7 @@
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2214,
+					"id": 2219,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10643,7 +10643,7 @@
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2165,
+					"id": 2170,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10681,7 +10681,7 @@
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2207,
+					"id": 2212,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10714,7 +10714,7 @@
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2177,
+					"id": 2182,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10742,7 +10742,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2170,
+					"id": 2175,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10775,74 +10775,74 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2179,
-						2168,
-						2222,
-						2226,
-						2209,
-						2229,
-						2186,
+						2184,
+						2173,
+						2227,
+						2231,
+						2214,
+						2234,
+						2191,
+						2188,
+						2228,
+						2195,
+						2230,
+						2236,
+						2197,
+						2199,
 						2183,
-						2223,
+						2198,
+						2200,
+						2164,
 						2190,
 						2225,
-						2231,
-						2192,
-						2194,
-						2178,
-						2193,
-						2195,
-						2159,
-						2185,
-						2220,
-						2176,
-						2182,
-						2175,
-						2208,
-						2202,
-						2162,
-						2213,
-						2188,
-						2204,
-						2172,
-						2180,
-						2184,
-						2200,
-						2166,
-						2167,
-						2171,
-						2187,
-						2221,
 						2181,
+						2187,
+						2180,
+						2213,
+						2207,
+						2167,
+						2218,
+						2193,
+						2209,
+						2177,
+						2185,
+						2189,
+						2205,
+						2171,
+						2172,
+						2176,
+						2192,
+						2226,
+						2186,
+						2174,
+						2216,
+						2206,
+						2229,
+						2202,
+						2221,
+						2178,
+						2179,
+						2163,
 						2169,
 						2211,
-						2201,
-						2224,
-						2197,
-						2216,
-						2173,
-						2174,
-						2158,
-						2164,
-						2206,
-						2205,
-						2163,
-						2196,
-						2189,
-						2191,
-						2219,
-						2232,
-						2199,
-						2198,
-						2218,
 						2210,
+						2168,
+						2201,
+						2194,
+						2196,
+						2224,
+						2237,
+						2204,
 						2203,
+						2223,
+						2215,
+						2208,
+						2217,
+						2219,
+						2170,
 						2212,
-						2214,
-						2165,
-						2207,
-						2177,
-						2170
+						2182,
+						2175
 					]
 				}
 			],
@@ -10855,7 +10855,7 @@
 			]
 		},
 		{
-			"id": 3135,
+			"id": 3141,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10865,7 +10865,7 @@
 			},
 			"children": [
 				{
-					"id": 3137,
+					"id": 3143,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10883,7 +10883,7 @@
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3136,
+					"id": 3142,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10901,7 +10901,7 @@
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3138,
+					"id": 3144,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10924,9 +10924,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3137,
-						3136,
-						3138
+						3143,
+						3142,
+						3144
 					]
 				}
 			],
@@ -10939,7 +10939,7 @@
 			]
 		},
 		{
-			"id": 3080,
+			"id": 3086,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10955,7 +10955,7 @@
 			},
 			"children": [
 				{
-					"id": 3081,
+					"id": 3087,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10973,7 +10973,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3082,
+					"id": 3088,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10996,8 +10996,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3081,
-						3082
+						3087,
+						3088
 					]
 				}
 			],
@@ -11010,7 +11010,7 @@
 			]
 		},
 		{
-			"id": 3114,
+			"id": 3120,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11026,7 +11026,7 @@
 			},
 			"children": [
 				{
-					"id": 3118,
+					"id": 3124,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11044,7 +11044,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3119,
+					"id": 3125,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11062,7 +11062,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3115,
+					"id": 3121,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11080,7 +11080,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3116,
+					"id": 3122,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11103,7 +11103,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3120,
+					"id": 3126,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11121,7 +11121,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3117,
+					"id": 3123,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11139,7 +11139,7 @@
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3121,
+					"id": 3127,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11162,13 +11162,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3118,
-						3119,
-						3115,
-						3116,
-						3120,
-						3117,
-						3121
+						3124,
+						3125,
+						3121,
+						3122,
+						3126,
+						3123,
+						3127
 					]
 				}
 			],
@@ -11181,7 +11181,7 @@
 			]
 		},
 		{
-			"id": 3048,
+			"id": 3054,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11191,7 +11191,7 @@
 			},
 			"children": [
 				{
-					"id": 3053,
+					"id": 3059,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11219,7 +11219,7 @@
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3050,
+					"id": 3056,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11247,7 +11247,7 @@
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3052,
+					"id": 3058,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11275,7 +11275,7 @@
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3049,
+					"id": 3055,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11303,7 +11303,7 @@
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3054,
+					"id": 3060,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11331,7 +11331,7 @@
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3051,
+					"id": 3057,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11364,12 +11364,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3053,
-						3050,
-						3052,
-						3049,
-						3054,
-						3051
+						3059,
+						3056,
+						3058,
+						3055,
+						3060,
+						3057
 					]
 				}
 			],
@@ -11382,7 +11382,7 @@
 			]
 		},
 		{
-			"id": 2014,
+			"id": 2019,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11392,7 +11392,7 @@
 			},
 			"children": [
 				{
-					"id": 2017,
+					"id": 2022,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11410,7 +11410,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2020,
+					"id": 2025,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11428,7 +11428,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2015,
+					"id": 2020,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11446,7 +11446,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 2018,
+					"id": 2023,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11464,7 +11464,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2022,
+					"id": 2027,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11482,7 +11482,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 2016,
+					"id": 2021,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11500,7 +11500,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2021,
+					"id": 2026,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11523,13 +11523,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2017,
-						2020,
-						2015,
-						2018,
 						2022,
-						2016,
-						2021
+						2025,
+						2020,
+						2023,
+						2027,
+						2021,
+						2026
 					]
 				}
 			],
@@ -11542,14 +11542,14 @@
 			]
 		},
 		{
-			"id": 2803,
+			"id": 2809,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2804,
+					"id": 2810,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11564,7 +11564,7 @@
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2806,
+					"id": 2812,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11579,7 +11579,7 @@
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2805,
+					"id": 2811,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11594,7 +11594,7 @@
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2807,
+					"id": 2813,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11614,10 +11614,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2804,
-						2806,
-						2805,
-						2807
+						2810,
+						2812,
+						2811,
+						2813
 					]
 				}
 			],
@@ -11630,7 +11630,7 @@
 			]
 		},
 		{
-			"id": 3075,
+			"id": 3081,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11646,7 +11646,7 @@
 			},
 			"children": [
 				{
-					"id": 3076,
+					"id": 3082,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11669,7 +11669,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3076
+						3082
 					]
 				}
 			],
@@ -11682,7 +11682,7 @@
 			]
 		},
 		{
-			"id": 2039,
+			"id": 2044,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11692,7 +11692,7 @@
 			},
 			"children": [
 				{
-					"id": 2047,
+					"id": 2052,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11710,7 +11710,7 @@
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2052,
+					"id": 2057,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11728,7 +11728,7 @@
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2051,
+					"id": 2056,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11746,7 +11746,7 @@
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2049,
+					"id": 2054,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11764,7 +11764,7 @@
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2050,
+					"id": 2055,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11782,7 +11782,7 @@
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2046,
+					"id": 2051,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11800,7 +11800,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2048,
+					"id": 2053,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11818,7 +11818,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2040,
+					"id": 2045,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11836,7 +11836,7 @@
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2045,
+					"id": 2050,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11854,7 +11854,7 @@
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2044,
+					"id": 2049,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11872,7 +11872,7 @@
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2053,
+					"id": 2058,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11890,7 +11890,7 @@
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2043,
+					"id": 2048,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11908,7 +11908,7 @@
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2042,
+					"id": 2047,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11926,7 +11926,7 @@
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2041,
+					"id": 2046,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11944,7 +11944,7 @@
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2054,
+					"id": 2059,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11967,21 +11967,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2047,
 						2052,
+						2057,
+						2056,
+						2054,
+						2055,
 						2051,
-						2049,
-						2050,
-						2046,
-						2048,
-						2040,
-						2045,
-						2044,
 						2053,
-						2043,
-						2042,
-						2041,
-						2054
+						2045,
+						2050,
+						2049,
+						2058,
+						2048,
+						2047,
+						2046,
+						2059
 					]
 				}
 			],
@@ -11994,14 +11994,14 @@
 			]
 		},
 		{
-			"id": 3106,
+			"id": 3112,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3111,
+					"id": 3117,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12016,7 +12016,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3110,
+					"id": 3116,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12031,7 +12031,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3109,
+					"id": 3115,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12046,7 +12046,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3112,
+					"id": 3118,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12061,7 +12061,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3113,
+					"id": 3119,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12076,7 +12076,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3107,
+					"id": 3113,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12091,7 +12091,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3108,
+					"id": 3114,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12111,13 +12111,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3111,
-						3110,
-						3109,
-						3112,
+						3117,
+						3116,
+						3115,
+						3118,
+						3119,
 						3113,
-						3107,
-						3108
+						3114
 					]
 				}
 			],
@@ -12130,7 +12130,7 @@
 			]
 		},
 		{
-			"id": 1931,
+			"id": 1936,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -12159,7 +12159,7 @@
 			},
 			"children": [
 				{
-					"id": 1932,
+					"id": 1937,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -12176,7 +12176,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1933,
+							"id": 1938,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -12186,7 +12186,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1934,
+									"id": 1939,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12194,12 +12194,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2004,
+										"id": 2009,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1935,
+									"id": 1940,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12211,7 +12211,7 @@
 									}
 								},
 								{
-									"id": 1936,
+									"id": 1941,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12223,7 +12223,7 @@
 									}
 								},
 								{
-									"id": 1937,
+									"id": 1942,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12237,7 +12237,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3083,
+											"id": 3089,
 											"name": "VizPoint"
 										}
 									}
@@ -12245,14 +12245,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1931,
+								"id": 1936,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1946,
+					"id": 1951,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12268,7 +12268,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1947,
+							"id": 1952,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12279,7 +12279,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1948,
+									"id": 1953,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12308,7 +12308,7 @@
 					]
 				},
 				{
-					"id": 1949,
+					"id": 1954,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12324,7 +12324,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1950,
+							"id": 1955,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12340,7 +12340,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1951,
+									"id": 1956,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12369,7 +12369,7 @@
 					]
 				},
 				{
-					"id": 1998,
+					"id": 2003,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12385,14 +12385,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1999,
+							"id": 2004,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2000,
+									"id": 2005,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12417,7 +12417,7 @@
 					]
 				},
 				{
-					"id": 1952,
+					"id": 1957,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12433,7 +12433,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1953,
+							"id": 1958,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12444,7 +12444,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1954,
+									"id": 1959,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12456,7 +12456,7 @@
 									}
 								},
 								{
-									"id": 1955,
+									"id": 1960,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12464,12 +12464,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2039,
+										"id": 2044,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1956,
+									"id": 1961,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12515,7 +12515,7 @@
 					]
 				},
 				{
-					"id": 1988,
+					"id": 1993,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12531,7 +12531,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1989,
+							"id": 1994,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12542,7 +12542,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1990,
+									"id": 1995,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12556,7 +12556,7 @@
 									}
 								},
 								{
-									"id": 1991,
+									"id": 1996,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12584,7 +12584,7 @@
 					]
 				},
 				{
-					"id": 1966,
+					"id": 1971,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12600,7 +12600,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1967,
+							"id": 1972,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12611,7 +12611,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1968,
+									"id": 1973,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12624,7 +12624,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1969,
+									"id": 1974,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12653,7 +12653,7 @@
 					]
 				},
 				{
-					"id": 1959,
+					"id": 1964,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12669,7 +12669,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1960,
+							"id": 1965,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12680,7 +12680,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1961,
+									"id": 1966,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12693,7 +12693,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1962,
+									"id": 1967,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12712,14 +12712,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1963,
+											"id": 1968,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1964,
+													"id": 1969,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12730,7 +12730,7 @@
 													}
 												},
 												{
-													"id": 1965,
+													"id": 1970,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -12746,8 +12746,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1964,
-														1965
+														1969,
+														1970
 													]
 												}
 											]
@@ -12760,7 +12760,7 @@
 					]
 				},
 				{
-					"id": 1970,
+					"id": 1975,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12776,7 +12776,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1971,
+							"id": 1976,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12787,7 +12787,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1972,
+									"id": 1977,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12800,7 +12800,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1973,
+									"id": 1978,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12815,7 +12815,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1974,
+									"id": 1979,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12844,7 +12844,7 @@
 					]
 				},
 				{
-					"id": 1994,
+					"id": 1999,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12860,7 +12860,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1995,
+							"id": 2000,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12879,7 +12879,7 @@
 					]
 				},
 				{
-					"id": 1975,
+					"id": 1980,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12895,7 +12895,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1976,
+							"id": 1981,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12906,7 +12906,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1977,
+									"id": 1982,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12919,7 +12919,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1978,
+									"id": 1983,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12940,7 +12940,7 @@
 					]
 				},
 				{
-					"id": 1979,
+					"id": 1984,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -12956,7 +12956,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1980,
+							"id": 1985,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -12966,7 +12966,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1981,
+									"id": 1986,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12979,7 +12979,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1982,
+									"id": 1987,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -12992,7 +12992,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1983,
+									"id": 1988,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13015,7 +13015,7 @@
 					]
 				},
 				{
-					"id": 1957,
+					"id": 1962,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13031,7 +13031,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1958,
+							"id": 1963,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13050,7 +13050,7 @@
 					]
 				},
 				{
-					"id": 1992,
+					"id": 1997,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13066,7 +13066,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1993,
+							"id": 1998,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13077,14 +13077,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2004,
+								"id": 2009,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1941,
+					"id": 1946,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13100,7 +13100,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1942,
+							"id": 1947,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13122,7 +13122,7 @@
 					]
 				},
 				{
-					"id": 1996,
+					"id": 2001,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13138,7 +13138,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1997,
+							"id": 2002,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13157,7 +13157,7 @@
 					]
 				},
 				{
-					"id": 1984,
+					"id": 1989,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13173,7 +13173,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1985,
+							"id": 1990,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13193,7 +13193,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1986,
+									"id": 1991,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13208,7 +13208,7 @@
 									}
 								},
 								{
-									"id": 1987,
+									"id": 1992,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13220,7 +13220,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 2011,
+											"id": 2016,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -13231,7 +13231,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -13241,7 +13241,7 @@
 					]
 				},
 				{
-					"id": 1943,
+					"id": 1948,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13257,7 +13257,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1944,
+							"id": 1949,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13268,7 +13268,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1945,
+									"id": 1950,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13297,7 +13297,7 @@
 					]
 				},
 				{
-					"id": 2001,
+					"id": 2006,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13313,14 +13313,14 @@
 					],
 					"signatures": [
 						{
-							"id": 2002,
+							"id": 2007,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 2003,
+									"id": 2008,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13344,31 +13344,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1932
+						1937
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1946,
-						1949,
-						1998,
-						1952,
-						1988,
-						1966,
-						1959,
-						1970,
-						1994,
-						1975,
-						1979,
+						1951,
+						1954,
+						2003,
 						1957,
-						1992,
-						1941,
-						1996,
+						1993,
+						1971,
+						1964,
+						1975,
+						1999,
+						1980,
 						1984,
-						1943,
-						2001
+						1962,
+						1997,
+						1946,
+						2001,
+						1989,
+						1948,
+						2006
 					]
 				}
 			],
@@ -13381,7 +13381,7 @@
 			]
 		},
 		{
-			"id": 1047,
+			"id": 1052,
 			"name": "AppEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -13397,7 +13397,7 @@
 			},
 			"children": [
 				{
-					"id": 1048,
+					"id": 1053,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -13411,40 +13411,40 @@
 					],
 					"signatures": [
 						{
-							"id": 1049,
+							"id": 1054,
 							"name": "new AppEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1050,
+									"id": 1055,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2832,
+										"id": 2838,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 1051,
+									"id": 1056,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2707,
+										"id": 2713,
 										"name": "AppViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1047,
+								"id": 1052,
 								"name": "AppEmbed"
 							},
 							"overwrites": {
@@ -13459,7 +13459,7 @@
 					}
 				},
 				{
-					"id": 1085,
+					"id": 1090,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13475,7 +13475,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1086,
+							"id": 1091,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13505,7 +13505,7 @@
 					}
 				},
 				{
-					"id": 1265,
+					"id": 1270,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13521,7 +13521,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1266,
+							"id": 1271,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13537,7 +13537,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1267,
+									"id": 1272,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13558,7 +13558,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -13576,7 +13576,7 @@
 					}
 				},
 				{
-					"id": 1236,
+					"id": 1241,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13592,7 +13592,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1237,
+							"id": 1242,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13629,7 +13629,7 @@
 					}
 				},
 				{
-					"id": 1062,
+					"id": 1067,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13645,7 +13645,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1063,
+							"id": 1068,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13661,7 +13661,7 @@
 					]
 				},
 				{
-					"id": 1232,
+					"id": 1237,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13677,7 +13677,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1233,
+							"id": 1238,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13698,7 +13698,7 @@
 					}
 				},
 				{
-					"id": 1260,
+					"id": 1265,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13714,7 +13714,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1261,
+							"id": 1266,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13736,14 +13736,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1262,
+									"id": 1267,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1264,
+											"id": 1269,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -13755,7 +13755,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1263,
+											"id": 1268,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -13772,8 +13772,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1264,
-												1263
+												1269,
+												1268
 											]
 										}
 									]
@@ -13791,7 +13791,7 @@
 					}
 				},
 				{
-					"id": 1242,
+					"id": 1247,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13807,7 +13807,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1243,
+							"id": 1248,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13823,7 +13823,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1244,
+									"id": 1249,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -13831,20 +13831,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1245,
+											"id": 1250,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1246,
+												"id": 1251,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1247,
+														"id": 1252,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -13889,7 +13889,7 @@
 					}
 				},
 				{
-					"id": 1248,
+					"id": 1253,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13905,7 +13905,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1249,
+							"id": 1254,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13926,7 +13926,7 @@
 					}
 				},
 				{
-					"id": 1258,
+					"id": 1263,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13942,7 +13942,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1259,
+							"id": 1264,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13966,7 +13966,7 @@
 					}
 				},
 				{
-					"id": 1081,
+					"id": 1086,
 					"name": "navigateToPage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -13982,7 +13982,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1082,
+							"id": 1087,
 							"name": "navigateToPage",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -13998,7 +13998,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1083,
+									"id": 1088,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14021,7 +14021,7 @@
 									}
 								},
 								{
-									"id": 1084,
+									"id": 1089,
 									"name": "noReload",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14044,7 +14044,7 @@
 					]
 				},
 				{
-					"id": 1201,
+					"id": 1206,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14060,7 +14060,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1202,
+							"id": 1207,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14076,7 +14076,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1203,
+									"id": 1208,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14086,12 +14086,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1204,
+									"id": 1209,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14101,7 +14101,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -14122,7 +14122,7 @@
 					}
 				},
 				{
-					"id": 1100,
+					"id": 1105,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14138,7 +14138,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1101,
+							"id": 1106,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14161,38 +14161,38 @@
 							},
 							"parameters": [
 								{
-									"id": 1102,
+									"id": 1107,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1103,
+									"id": 1108,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1104,
+									"id": 1109,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -14214,7 +14214,7 @@
 					}
 				},
 				{
-					"id": 1238,
+					"id": 1243,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14230,7 +14230,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1239,
+							"id": 1244,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14240,7 +14240,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1240,
+									"id": 1245,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14255,7 +14255,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1241,
+									"id": 1246,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14289,7 +14289,7 @@
 					}
 				},
 				{
-					"id": 1250,
+					"id": 1255,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14305,7 +14305,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1251,
+							"id": 1256,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14342,7 +14342,7 @@
 					}
 				},
 				{
-					"id": 1093,
+					"id": 1098,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14358,7 +14358,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1094,
+							"id": 1099,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14371,7 +14371,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1047,
+										"id": 1052,
 										"name": "AppEmbed"
 									}
 								],
@@ -14389,7 +14389,7 @@
 					}
 				},
 				{
-					"id": 1254,
+					"id": 1259,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14405,7 +14405,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1255,
+							"id": 1260,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14435,7 +14435,7 @@
 					}
 				},
 				{
-					"id": 1256,
+					"id": 1261,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14451,7 +14451,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1257,
+							"id": 1262,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14481,7 +14481,7 @@
 					}
 				},
 				{
-					"id": 1219,
+					"id": 1224,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14497,7 +14497,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1220,
+							"id": 1225,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14508,40 +14508,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1221,
+									"id": 1226,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1222,
+									"id": 1227,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1223,
+									"id": 1228,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1224,
+									"id": 1229,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14555,7 +14555,7 @@
 									}
 								},
 								{
-									"id": 1225,
+									"id": 1230,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14580,7 +14580,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1226,
+									"id": 1231,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14629,7 +14629,7 @@
 					}
 				},
 				{
-					"id": 1227,
+					"id": 1232,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14645,7 +14645,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1228,
+							"id": 1233,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -14656,21 +14656,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1229,
+									"id": 1234,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1230,
+									"id": 1235,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14684,7 +14684,7 @@
 									}
 								},
 								{
-									"id": 1231,
+									"id": 1236,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14737,32 +14737,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1048
+						1053
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1085,
+						1090,
+						1270,
+						1241,
+						1067,
+						1237,
 						1265,
-						1236,
-						1062,
-						1232,
-						1260,
-						1242,
-						1248,
-						1258,
-						1081,
-						1201,
-						1100,
-						1238,
-						1250,
-						1093,
-						1254,
-						1256,
-						1219,
-						1227
+						1247,
+						1253,
+						1263,
+						1086,
+						1206,
+						1105,
+						1243,
+						1255,
+						1098,
+						1259,
+						1261,
+						1224,
+						1232
 					]
 				}
 			],
@@ -14781,7 +14781,7 @@
 			]
 		},
 		{
-			"id": 1370,
+			"id": 1375,
 			"name": "BodylessConversation",
 			"kind": 128,
 			"kindString": "Class",
@@ -14805,7 +14805,7 @@
 			},
 			"children": [
 				{
-					"id": 1371,
+					"id": 1376,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -14819,45 +14819,45 @@
 					],
 					"signatures": [
 						{
-							"id": 1372,
+							"id": 1377,
 							"name": "new BodylessConversation",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1373,
+									"id": 1378,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1335,
+										"id": 1340,
 										"name": "BodylessConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1370,
+								"id": 1375,
 								"name": "BodylessConversation"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1270,
+								"id": 1275,
 								"name": "SpotterAgentEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1269,
+						"id": 1274,
 						"name": "SpotterAgentEmbed.constructor"
 					}
 				},
 				{
-					"id": 1374,
+					"id": 1379,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -14873,14 +14873,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1375,
+							"id": 1380,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1376,
+									"id": 1381,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -14900,14 +14900,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1377,
+													"id": 1382,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1379,
+															"id": 1384,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14918,7 +14918,7 @@
 															}
 														},
 														{
-															"id": 1378,
+															"id": 1383,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14929,7 +14929,7 @@
 															}
 														},
 														{
-															"id": 1380,
+															"id": 1385,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14946,9 +14946,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1379,
-																1378,
-																1380
+																1384,
+																1383,
+																1385
 															]
 														}
 													]
@@ -14957,14 +14957,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1381,
+													"id": 1386,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1382,
+															"id": 1387,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14975,7 +14975,7 @@
 															}
 														},
 														{
-															"id": 1384,
+															"id": 1389,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -14986,7 +14986,7 @@
 															}
 														},
 														{
-															"id": 1383,
+															"id": 1388,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -15003,9 +15003,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1382,
-																1384,
-																1383
+																1387,
+																1389,
+																1388
 															]
 														}
 													]
@@ -15018,19 +15018,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1274,
+								"id": 1279,
 								"name": "SpotterAgentEmbed.sendMessage"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1273,
+						"id": 1278,
 						"name": "SpotterAgentEmbed.sendMessage"
 					}
 				},
 				{
-					"id": 1385,
+					"id": 1390,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15046,7 +15046,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1386,
+							"id": 1391,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15057,7 +15057,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1387,
+									"id": 1392,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15080,14 +15080,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1388,
+													"id": 1393,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1390,
+															"id": 1395,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -15099,7 +15099,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1389,
+															"id": 1394,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -15115,8 +15115,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1390,
-																1389
+																1395,
+																1394
 															]
 														}
 													]
@@ -15125,14 +15125,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1391,
+													"id": 1396,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1392,
+															"id": 1397,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -15140,14 +15140,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1393,
+																	"id": 1398,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1399,
+																			"id": 1404,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15159,7 +15159,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1398,
+																			"id": 1403,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15171,7 +15171,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1394,
+																			"id": 1399,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15183,7 +15183,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1397,
+																			"id": 1402,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15195,7 +15195,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1395,
+																			"id": 1400,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15207,7 +15207,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1396,
+																			"id": 1401,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -15224,12 +15224,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
+																				1404,
+																				1403,
 																				1399,
-																				1398,
-																				1394,
-																				1397,
-																				1395,
-																				1396
+																				1402,
+																				1400,
+																				1401
 																			]
 																		}
 																	]
@@ -15238,7 +15238,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1400,
+															"id": 1405,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -15254,8 +15254,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1392,
-																1400
+																1397,
+																1405
 															]
 														}
 													]
@@ -15268,14 +15268,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1285,
+								"id": 1290,
 								"name": "SpotterAgentEmbed.sendMessageData"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1284,
+						"id": 1289,
 						"name": "SpotterAgentEmbed.sendMessageData"
 					}
 				}
@@ -15285,15 +15285,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1371
+						1376
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1374,
-						1385
+						1379,
+						1390
 					]
 				}
 			],
@@ -15307,13 +15307,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1268,
+					"id": 1273,
 					"name": "SpotterAgentEmbed"
 				}
 			]
 		},
 		{
-			"id": 1684,
+			"id": 1689,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -15341,7 +15341,7 @@
 			},
 			"children": [
 				{
-					"id": 1685,
+					"id": 1690,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -15355,14 +15355,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1686,
+							"id": 1691,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1687,
+									"id": 1692,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15373,38 +15373,38 @@
 									}
 								},
 								{
-									"id": 1688,
+									"id": 1693,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1637,
+										"id": 1642,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1684,
+								"id": 1689,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1403,
+								"id": 1408,
 								"name": "SpotterEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1402,
+						"id": 1407,
 						"name": "SpotterEmbed.constructor"
 					}
 				},
 				{
-					"id": 1839,
+					"id": 1844,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15420,7 +15420,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1840,
+							"id": 1845,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15440,19 +15440,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1557,
+								"id": 1562,
 								"name": "SpotterEmbed.destroy"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1561,
 						"name": "SpotterEmbed.destroy"
 					}
 				},
 				{
-					"id": 1858,
+					"id": 1863,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15468,7 +15468,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1859,
+							"id": 1864,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15484,7 +15484,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1860,
+									"id": 1865,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15505,7 +15505,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -15513,19 +15513,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1576,
+								"id": 1581,
 								"name": "SpotterEmbed.getAnswerService"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1575,
+						"id": 1580,
 						"name": "SpotterEmbed.getAnswerService"
 					}
 				},
 				{
-					"id": 1827,
+					"id": 1832,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15541,7 +15541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1828,
+							"id": 1833,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15568,19 +15568,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1545,
+								"id": 1550,
 								"name": "SpotterEmbed.getCurrentContext"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1544,
+						"id": 1549,
 						"name": "SpotterEmbed.getCurrentContext"
 					}
 				},
 				{
-					"id": 1692,
+					"id": 1697,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15596,7 +15596,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1693,
+							"id": 1698,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15607,19 +15607,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1410,
+								"id": 1415,
 								"name": "SpotterEmbed.getIframeSrc"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1409,
+						"id": 1414,
 						"name": "SpotterEmbed.getIframeSrc"
 					}
 				},
 				{
-					"id": 1853,
+					"id": 1858,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15635,7 +15635,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1854,
+							"id": 1859,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15657,14 +15657,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1855,
+									"id": 1860,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1857,
+											"id": 1862,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15676,7 +15676,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1856,
+											"id": 1861,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -15693,8 +15693,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1857,
-												1856
+												1862,
+												1861
 											]
 										}
 									]
@@ -15702,19 +15702,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1571,
+								"id": 1576,
 								"name": "SpotterEmbed.getPreRenderIds"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1570,
+						"id": 1575,
 						"name": "SpotterEmbed.getPreRenderIds"
 					}
 				},
 				{
-					"id": 1833,
+					"id": 1838,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15730,7 +15730,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1834,
+							"id": 1839,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15746,7 +15746,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1835,
+									"id": 1840,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15754,20 +15754,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1836,
+											"id": 1841,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1837,
+												"id": 1842,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1838,
+														"id": 1843,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -15802,19 +15802,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1551,
+								"id": 1556,
 								"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1550,
+						"id": 1555,
 						"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 					}
 				},
 				{
-					"id": 1841,
+					"id": 1846,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15830,7 +15830,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1842,
+							"id": 1847,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15841,19 +15841,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1559,
+								"id": 1564,
 								"name": "SpotterEmbed.getUnderlyingFrameElement"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1563,
 						"name": "SpotterEmbed.getUnderlyingFrameElement"
 					}
 				},
 				{
-					"id": 1851,
+					"id": 1856,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15869,7 +15869,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1852,
+							"id": 1857,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15883,19 +15883,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1569,
+								"id": 1574,
 								"name": "SpotterEmbed.hidePreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1568,
+						"id": 1573,
 						"name": "SpotterEmbed.hidePreRender"
 					}
 				},
 				{
-					"id": 1794,
+					"id": 1799,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15911,7 +15911,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1795,
+							"id": 1800,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -15927,7 +15927,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1796,
+									"id": 1801,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15937,12 +15937,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1797,
+									"id": 1802,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -15952,7 +15952,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -15963,19 +15963,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1512,
+								"id": 1517,
 								"name": "SpotterEmbed.off"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1511,
+						"id": 1516,
 						"name": "SpotterEmbed.off"
 					}
 				},
 				{
-					"id": 1788,
+					"id": 1793,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -15991,7 +15991,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1789,
+							"id": 1794,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16011,7 +16011,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1790,
+									"id": 1795,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16021,12 +16021,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1791,
+									"id": 1796,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16036,12 +16036,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1792,
+									"id": 1797,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16051,13 +16051,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1793,
+									"id": 1798,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16076,19 +16076,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1506,
+								"id": 1511,
 								"name": "SpotterEmbed.on"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1505,
+						"id": 1510,
 						"name": "SpotterEmbed.on"
 					}
 				},
 				{
-					"id": 1829,
+					"id": 1834,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16104,7 +16104,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1830,
+							"id": 1835,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16114,7 +16114,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1831,
+									"id": 1836,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16129,7 +16129,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1832,
+									"id": 1837,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16153,19 +16153,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1547,
+								"id": 1552,
 								"name": "SpotterEmbed.preRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1546,
+						"id": 1551,
 						"name": "SpotterEmbed.preRender"
 					}
 				},
 				{
-					"id": 1843,
+					"id": 1848,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16181,7 +16181,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1844,
+							"id": 1849,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16208,19 +16208,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1561,
+								"id": 1566,
 								"name": "SpotterEmbed.prerenderGeneric"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1560,
+						"id": 1565,
 						"name": "SpotterEmbed.prerenderGeneric"
 					}
 				},
 				{
-					"id": 1694,
+					"id": 1699,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16236,7 +16236,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1695,
+							"id": 1700,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16246,7 +16246,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1401,
+										"id": 1406,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -16254,19 +16254,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1412,
+								"id": 1417,
 								"name": "SpotterEmbed.render"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1411,
+						"id": 1416,
 						"name": "SpotterEmbed.render"
 					}
 				},
 				{
-					"id": 1847,
+					"id": 1852,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16282,7 +16282,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1848,
+							"id": 1853,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16302,19 +16302,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1565,
+								"id": 1570,
 								"name": "SpotterEmbed.showPreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1564,
+						"id": 1569,
 						"name": "SpotterEmbed.showPreRender"
 					}
 				},
 				{
-					"id": 1849,
+					"id": 1854,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16330,7 +16330,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1850,
+							"id": 1855,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16350,19 +16350,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1567,
+								"id": 1572,
 								"name": "SpotterEmbed.syncPreRenderStyle"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1566,
+						"id": 1571,
 						"name": "SpotterEmbed.syncPreRenderStyle"
 					}
 				},
 				{
-					"id": 1812,
+					"id": 1817,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16378,7 +16378,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1813,
+							"id": 1818,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16389,40 +16389,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1814,
+									"id": 1819,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1815,
+									"id": 1820,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1816,
+									"id": 1821,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1817,
+									"id": 1822,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16436,7 +16436,7 @@
 									}
 								},
 								{
-									"id": 1818,
+									"id": 1823,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16461,7 +16461,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1819,
+									"id": 1824,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16500,19 +16500,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1530,
+								"id": 1535,
 								"name": "SpotterEmbed.trigger"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1529,
+						"id": 1534,
 						"name": "SpotterEmbed.trigger"
 					}
 				},
 				{
-					"id": 1820,
+					"id": 1825,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16528,7 +16528,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1821,
+							"id": 1826,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16539,21 +16539,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1822,
+									"id": 1827,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1823,
+									"id": 1828,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16567,7 +16567,7 @@
 									}
 								},
 								{
-									"id": 1824,
+									"id": 1829,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16605,14 +16605,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1538,
+								"id": 1543,
 								"name": "SpotterEmbed.triggerUIPassThrough"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1537,
+						"id": 1542,
 						"name": "SpotterEmbed.triggerUIPassThrough"
 					}
 				}
@@ -16622,30 +16622,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1685
+						1690
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1839,
+						1844,
+						1863,
+						1832,
+						1697,
 						1858,
-						1827,
-						1692,
-						1853,
-						1833,
-						1841,
-						1851,
-						1794,
-						1788,
-						1829,
-						1843,
-						1694,
-						1847,
-						1849,
-						1812,
-						1820
+						1838,
+						1846,
+						1856,
+						1799,
+						1793,
+						1834,
+						1848,
+						1699,
+						1852,
+						1854,
+						1817,
+						1825
 					]
 				}
 			],
@@ -16659,13 +16659,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1401,
+					"id": 1406,
 					"name": "SpotterEmbed"
 				}
 			]
 		},
 		{
-			"id": 626,
+			"id": 628,
 			"name": "LiveboardEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -16685,7 +16685,7 @@
 			},
 			"children": [
 				{
-					"id": 627,
+					"id": 629,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16693,46 +16693,46 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 490,
+							"line": 507,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 628,
+							"id": 630,
 							"name": "new LiveboardEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 629,
+									"id": 631,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2832,
+										"id": 2838,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 630,
+									"id": 632,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2566,
+										"id": 2571,
 										"name": "LiveboardViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 626,
+								"id": 628,
 								"name": "LiveboardEmbed"
 							},
 							"overwrites": {
@@ -16747,7 +16747,7 @@
 					}
 				},
 				{
-					"id": 684,
+					"id": 688,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16757,13 +16757,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 865,
+							"line": 913,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 685,
+							"id": 689,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16793,7 +16793,7 @@
 					}
 				},
 				{
-					"id": 857,
+					"id": 862,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16809,7 +16809,7 @@
 					],
 					"signatures": [
 						{
-							"id": 858,
+							"id": 863,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16825,7 +16825,7 @@
 							},
 							"parameters": [
 								{
-									"id": 859,
+									"id": 864,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16846,7 +16846,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -16864,7 +16864,7 @@
 					}
 				},
 				{
-					"id": 830,
+					"id": 835,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16880,7 +16880,7 @@
 					],
 					"signatures": [
 						{
-							"id": 831,
+							"id": 836,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16917,7 +16917,7 @@
 					}
 				},
 				{
-					"id": 828,
+					"id": 833,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16933,7 +16933,7 @@
 					],
 					"signatures": [
 						{
-							"id": 829,
+							"id": 834,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16954,7 +16954,7 @@
 					}
 				},
 				{
-					"id": 699,
+					"id": 704,
 					"name": "getLiveboardUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16964,13 +16964,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 924,
+							"line": 978,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 700,
+							"id": 705,
 							"name": "getLiveboardUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16987,7 +16987,7 @@
 					]
 				},
 				{
-					"id": 852,
+					"id": 857,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17003,7 +17003,7 @@
 					],
 					"signatures": [
 						{
-							"id": 853,
+							"id": 858,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17025,14 +17025,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 854,
+									"id": 859,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 856,
+											"id": 861,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17044,7 +17044,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 855,
+											"id": 860,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17061,8 +17061,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												856,
-												855
+												861,
+												860
 											]
 										}
 									]
@@ -17080,7 +17080,7 @@
 					}
 				},
 				{
-					"id": 836,
+					"id": 841,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17096,7 +17096,7 @@
 					],
 					"signatures": [
 						{
-							"id": 837,
+							"id": 842,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17112,7 +17112,7 @@
 							},
 							"parameters": [
 								{
-									"id": 838,
+									"id": 843,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17120,20 +17120,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 839,
+											"id": 844,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 840,
+												"id": 845,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 841,
+														"id": 846,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -17178,7 +17178,7 @@
 					}
 				},
 				{
-					"id": 842,
+					"id": 847,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17194,7 +17194,7 @@
 					],
 					"signatures": [
 						{
-							"id": 843,
+							"id": 848,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17215,7 +17215,7 @@
 					}
 				},
 				{
-					"id": 850,
+					"id": 855,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17231,7 +17231,7 @@
 					],
 					"signatures": [
 						{
-							"id": 851,
+							"id": 856,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17255,7 +17255,7 @@
 					}
 				},
 				{
-					"id": 694,
+					"id": 698,
 					"name": "navigateToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17265,20 +17265,20 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 905,
+							"line": 953,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 695,
+							"id": 699,
 							"name": "navigateToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 696,
+									"id": 700,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17289,7 +17289,7 @@
 									}
 								},
 								{
-									"id": 697,
+									"id": 701,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17302,8 +17302,21 @@
 									}
 								},
 								{
-									"id": 698,
+									"id": 702,
 									"name": "activeTabId",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 703,
+									"name": "personalizedViewId",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {
@@ -17323,7 +17336,7 @@
 					]
 				},
 				{
-					"id": 805,
+					"id": 810,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17339,7 +17352,7 @@
 					],
 					"signatures": [
 						{
-							"id": 806,
+							"id": 811,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17355,7 +17368,7 @@
 							},
 							"parameters": [
 								{
-									"id": 807,
+									"id": 812,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17365,12 +17378,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 808,
+									"id": 813,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17380,7 +17393,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -17401,7 +17414,7 @@
 					}
 				},
 				{
-					"id": 706,
+					"id": 711,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17417,7 +17430,7 @@
 					],
 					"signatures": [
 						{
-							"id": 707,
+							"id": 712,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17440,38 +17453,38 @@
 							},
 							"parameters": [
 								{
-									"id": 708,
+									"id": 713,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 709,
+									"id": 714,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 710,
+									"id": 715,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17493,7 +17506,7 @@
 					}
 				},
 				{
-					"id": 832,
+					"id": 837,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17509,7 +17522,7 @@
 					],
 					"signatures": [
 						{
-							"id": 833,
+							"id": 838,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17519,7 +17532,7 @@
 							},
 							"parameters": [
 								{
-									"id": 834,
+									"id": 839,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17534,7 +17547,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 835,
+									"id": 840,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17568,7 +17581,7 @@
 					}
 				},
 				{
-					"id": 844,
+					"id": 849,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17584,7 +17597,7 @@
 					],
 					"signatures": [
 						{
-							"id": 845,
+							"id": 850,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17621,7 +17634,7 @@
 					}
 				},
 				{
-					"id": 692,
+					"id": 696,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17631,13 +17644,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 894,
+							"line": 942,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 693,
+							"id": 697,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17650,7 +17663,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 626,
+										"id": 628,
 										"name": "LiveboardEmbed"
 									}
 								],
@@ -17668,7 +17681,7 @@
 					}
 				},
 				{
-					"id": 846,
+					"id": 851,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17684,7 +17697,7 @@
 					],
 					"signatures": [
 						{
-							"id": 847,
+							"id": 852,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17714,7 +17727,7 @@
 					}
 				},
 				{
-					"id": 848,
+					"id": 853,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17730,7 +17743,7 @@
 					],
 					"signatures": [
 						{
-							"id": 849,
+							"id": 854,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17760,7 +17773,7 @@
 					}
 				},
 				{
-					"id": 676,
+					"id": 680,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17770,13 +17783,13 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 846,
+							"line": 894,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 677,
+							"id": 681,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17787,40 +17800,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 678,
+									"id": 682,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 679,
+									"id": 683,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 680,
+									"id": 684,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 681,
+									"id": 685,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17834,7 +17847,7 @@
 									}
 								},
 								{
-									"id": 682,
+									"id": 686,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17859,7 +17872,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 683,
+									"id": 687,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17908,7 +17921,7 @@
 					}
 				},
 				{
-					"id": 823,
+					"id": 828,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17924,7 +17937,7 @@
 					],
 					"signatures": [
 						{
-							"id": 824,
+							"id": 829,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17935,21 +17948,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 825,
+									"id": 830,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 826,
+									"id": 831,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17963,7 +17976,7 @@
 									}
 								},
 								{
-									"id": 827,
+									"id": 832,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18016,39 +18029,39 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						627
+						629
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						684,
+						688,
+						862,
+						835,
+						833,
+						704,
 						857,
-						830,
-						828,
-						699,
-						852,
-						836,
-						842,
-						850,
-						694,
-						805,
-						706,
-						832,
-						844,
-						692,
-						846,
-						848,
-						676,
-						823
+						841,
+						847,
+						855,
+						698,
+						810,
+						711,
+						837,
+						849,
+						696,
+						851,
+						853,
+						680,
+						828
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 484,
+					"line": 501,
 					"character": 13
 				}
 			],
@@ -18060,7 +18073,7 @@
 			]
 		},
 		{
-			"id": 860,
+			"id": 865,
 			"name": "SageEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -18080,7 +18093,7 @@
 			},
 			"children": [
 				{
-					"id": 861,
+					"id": 866,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -18094,40 +18107,40 @@
 					],
 					"signatures": [
 						{
-							"id": 862,
+							"id": 867,
 							"name": "new SageEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 863,
+									"id": 868,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2832,
+										"id": 2838,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 864,
+									"id": 869,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2653,
+										"id": 2659,
 										"name": "SageViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 860,
+								"id": 865,
 								"name": "SageEmbed"
 							},
 							"overwrites": {
@@ -18142,7 +18155,7 @@
 					}
 				},
 				{
-					"id": 1025,
+					"id": 1030,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18158,7 +18171,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1026,
+							"id": 1031,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18188,7 +18201,7 @@
 					}
 				},
 				{
-					"id": 1044,
+					"id": 1049,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18204,7 +18217,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1045,
+							"id": 1050,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18220,7 +18233,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1046,
+									"id": 1051,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18241,7 +18254,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -18259,7 +18272,7 @@
 					}
 				},
 				{
-					"id": 1013,
+					"id": 1018,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18275,7 +18288,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1014,
+							"id": 1019,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18312,7 +18325,7 @@
 					}
 				},
 				{
-					"id": 870,
+					"id": 875,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18328,7 +18341,7 @@
 					],
 					"signatures": [
 						{
-							"id": 871,
+							"id": 876,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18345,7 +18358,7 @@
 					]
 				},
 				{
-					"id": 1009,
+					"id": 1014,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18361,7 +18374,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1010,
+							"id": 1015,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18382,7 +18395,7 @@
 					}
 				},
 				{
-					"id": 1039,
+					"id": 1044,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18398,7 +18411,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1040,
+							"id": 1045,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18420,14 +18433,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1041,
+									"id": 1046,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1043,
+											"id": 1048,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18439,7 +18452,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1042,
+											"id": 1047,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -18456,8 +18469,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1043,
-												1042
+												1048,
+												1047
 											]
 										}
 									]
@@ -18475,7 +18488,7 @@
 					}
 				},
 				{
-					"id": 1019,
+					"id": 1024,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18491,7 +18504,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1020,
+							"id": 1025,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18507,7 +18520,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1021,
+									"id": 1026,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18515,20 +18528,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1022,
+											"id": 1027,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1023,
+												"id": 1028,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1024,
+														"id": 1029,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -18573,7 +18586,7 @@
 					}
 				},
 				{
-					"id": 1027,
+					"id": 1032,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18589,7 +18602,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1028,
+							"id": 1033,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18610,7 +18623,7 @@
 					}
 				},
 				{
-					"id": 1037,
+					"id": 1042,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18626,7 +18639,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1038,
+							"id": 1043,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18650,7 +18663,7 @@
 					}
 				},
 				{
-					"id": 978,
+					"id": 983,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18666,7 +18679,7 @@
 					],
 					"signatures": [
 						{
-							"id": 979,
+							"id": 984,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18682,7 +18695,7 @@
 							},
 							"parameters": [
 								{
-									"id": 980,
+									"id": 985,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18692,12 +18705,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 981,
+									"id": 986,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18707,7 +18720,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -18728,7 +18741,7 @@
 					}
 				},
 				{
-					"id": 879,
+					"id": 884,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18744,7 +18757,7 @@
 					],
 					"signatures": [
 						{
-							"id": 880,
+							"id": 885,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18767,38 +18780,38 @@
 							},
 							"parameters": [
 								{
-									"id": 881,
+									"id": 886,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 882,
+									"id": 887,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 883,
+									"id": 888,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18820,7 +18833,7 @@
 					}
 				},
 				{
-					"id": 1015,
+					"id": 1020,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18836,7 +18849,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1016,
+							"id": 1021,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18846,7 +18859,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1017,
+									"id": 1022,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18861,7 +18874,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1018,
+									"id": 1023,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18895,7 +18908,7 @@
 					}
 				},
 				{
-					"id": 1029,
+					"id": 1034,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18911,7 +18924,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1030,
+							"id": 1035,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18948,7 +18961,7 @@
 					}
 				},
 				{
-					"id": 872,
+					"id": 877,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18964,7 +18977,7 @@
 					],
 					"signatures": [
 						{
-							"id": 873,
+							"id": 878,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18978,7 +18991,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 860,
+										"id": 865,
 										"name": "SageEmbed"
 									}
 								],
@@ -18996,7 +19009,7 @@
 					}
 				},
 				{
-					"id": 1033,
+					"id": 1038,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19012,7 +19025,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1034,
+							"id": 1039,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19042,7 +19055,7 @@
 					}
 				},
 				{
-					"id": 1035,
+					"id": 1040,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19058,7 +19071,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1036,
+							"id": 1041,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19088,7 +19101,7 @@
 					}
 				},
 				{
-					"id": 996,
+					"id": 1001,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19104,7 +19117,7 @@
 					],
 					"signatures": [
 						{
-							"id": 997,
+							"id": 1002,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19115,40 +19128,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 998,
+									"id": 1003,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 999,
+									"id": 1004,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1000,
+									"id": 1005,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1001,
+									"id": 1006,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19162,7 +19175,7 @@
 									}
 								},
 								{
-									"id": 1002,
+									"id": 1007,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19187,7 +19200,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1003,
+									"id": 1008,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19236,7 +19249,7 @@
 					}
 				},
 				{
-					"id": 1004,
+					"id": 1009,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19252,7 +19265,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1005,
+							"id": 1010,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19263,21 +19276,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1006,
+									"id": 1011,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1007,
+									"id": 1012,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19291,7 +19304,7 @@
 									}
 								},
 								{
-									"id": 1008,
+									"id": 1013,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19344,31 +19357,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						861
+						866
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1025,
+						1030,
+						1049,
+						1018,
+						875,
+						1014,
 						1044,
-						1013,
-						870,
-						1009,
-						1039,
-						1019,
-						1027,
-						1037,
-						978,
-						879,
-						1015,
-						1029,
-						872,
-						1033,
-						1035,
-						996,
-						1004
+						1024,
+						1032,
+						1042,
+						983,
+						884,
+						1020,
+						1034,
+						877,
+						1038,
+						1040,
+						1001,
+						1009
 					]
 				}
 			],
@@ -19446,7 +19459,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2517,
+										"id": 2522,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -19567,7 +19580,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -19985,7 +19998,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20000,7 +20013,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -20067,7 +20080,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20082,7 +20095,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
@@ -20097,7 +20110,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -20433,7 +20446,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
@@ -20452,7 +20465,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
@@ -20581,7 +20594,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -20741,7 +20754,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2832,
+										"id": 2838,
 										"name": "DOMSelector"
 									}
 								},
@@ -20753,7 +20766,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2457,
+										"id": 2462,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -20874,7 +20887,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -21324,7 +21337,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21339,7 +21352,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -21406,7 +21419,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21421,7 +21434,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
@@ -21436,7 +21449,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21772,7 +21785,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
@@ -21791,7 +21804,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
@@ -21920,7 +21933,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22037,7 +22050,7 @@
 			]
 		},
 		{
-			"id": 1268,
+			"id": 1273,
 			"name": "SpotterAgentEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -22061,7 +22074,7 @@
 			},
 			"children": [
 				{
-					"id": 1269,
+					"id": 1274,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -22075,35 +22088,35 @@
 					],
 					"signatures": [
 						{
-							"id": 1270,
+							"id": 1275,
 							"name": "new SpotterAgentEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1271,
+									"id": 1276,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1300,
+										"id": 1305,
 										"name": "SpotterAgentEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1268,
+								"id": 1273,
 								"name": "SpotterAgentEmbed"
 							}
 						}
 					]
 				},
 				{
-					"id": 1273,
+					"id": 1278,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22119,14 +22132,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1274,
+							"id": 1279,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1275,
+									"id": 1280,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22146,14 +22159,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1276,
+													"id": 1281,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1278,
+															"id": 1283,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22164,7 +22177,7 @@
 															}
 														},
 														{
-															"id": 1277,
+															"id": 1282,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22175,7 +22188,7 @@
 															}
 														},
 														{
-															"id": 1279,
+															"id": 1284,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22192,9 +22205,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1278,
-																1277,
-																1279
+																1283,
+																1282,
+																1284
 															]
 														}
 													]
@@ -22203,14 +22216,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1280,
+													"id": 1285,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1281,
+															"id": 1286,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22221,7 +22234,7 @@
 															}
 														},
 														{
-															"id": 1283,
+															"id": 1288,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22232,7 +22245,7 @@
 															}
 														},
 														{
-															"id": 1282,
+															"id": 1287,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22249,9 +22262,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1281,
-																1283,
-																1282
+																1286,
+																1288,
+																1287
 															]
 														}
 													]
@@ -22266,7 +22279,7 @@
 					]
 				},
 				{
-					"id": 1284,
+					"id": 1289,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22282,7 +22295,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1285,
+							"id": 1290,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22293,7 +22306,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1286,
+									"id": 1291,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22316,14 +22329,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1287,
+													"id": 1292,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1289,
+															"id": 1294,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22335,7 +22348,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1288,
+															"id": 1293,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22351,8 +22364,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1289,
-																1288
+																1294,
+																1293
 															]
 														}
 													]
@@ -22361,14 +22374,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1290,
+													"id": 1295,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1291,
+															"id": 1296,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22376,14 +22389,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1292,
+																	"id": 1297,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1298,
+																			"id": 1303,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22395,7 +22408,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1297,
+																			"id": 1302,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22407,7 +22420,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1293,
+																			"id": 1298,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22419,7 +22432,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1296,
+																			"id": 1301,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22431,7 +22444,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1294,
+																			"id": 1299,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22443,7 +22456,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1295,
+																			"id": 1300,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -22460,12 +22473,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
+																				1303,
+																				1302,
 																				1298,
-																				1297,
-																				1293,
-																				1296,
-																				1294,
-																				1295
+																				1301,
+																				1299,
+																				1300
 																			]
 																		}
 																	]
@@ -22474,7 +22487,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1299,
+															"id": 1304,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -22490,8 +22503,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1291,
-																1299
+																1296,
+																1304
 															]
 														}
 													]
@@ -22511,15 +22524,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1269
+						1274
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1273,
-						1284
+						1278,
+						1289
 					]
 				}
 			],
@@ -22533,13 +22546,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1370,
+					"id": 1375,
 					"name": "BodylessConversation"
 				}
 			]
 		},
 		{
-			"id": 1401,
+			"id": 1406,
 			"name": "SpotterEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -22563,7 +22576,7 @@
 			},
 			"children": [
 				{
-					"id": 1402,
+					"id": 1407,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -22577,14 +22590,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1403,
+							"id": 1408,
 							"name": "new SpotterEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1404,
+									"id": 1409,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22595,21 +22608,21 @@
 									}
 								},
 								{
-									"id": 1405,
+									"id": 1410,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1578,
+										"id": 1583,
 										"name": "SpotterEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1401,
+								"id": 1406,
 								"name": "SpotterEmbed"
 							},
 							"overwrites": {
@@ -22624,7 +22637,7 @@
 					}
 				},
 				{
-					"id": 1556,
+					"id": 1561,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22640,7 +22653,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1557,
+							"id": 1562,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22670,7 +22683,7 @@
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1580,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22686,7 +22699,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1576,
+							"id": 1581,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22702,7 +22715,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1577,
+									"id": 1582,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22723,7 +22736,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1931,
+										"id": 1936,
 										"name": "AnswerService"
 									}
 								],
@@ -22741,7 +22754,7 @@
 					}
 				},
 				{
-					"id": 1544,
+					"id": 1549,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22757,7 +22770,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1545,
+							"id": 1550,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22794,7 +22807,7 @@
 					}
 				},
 				{
-					"id": 1409,
+					"id": 1414,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22810,7 +22823,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1410,
+							"id": 1415,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22831,7 +22844,7 @@
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1575,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22847,7 +22860,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1571,
+							"id": 1576,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22869,14 +22882,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1572,
+									"id": 1577,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1574,
+											"id": 1579,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22888,7 +22901,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1573,
+											"id": 1578,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22905,8 +22918,8 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1574,
-												1573
+												1579,
+												1578
 											]
 										}
 									]
@@ -22924,7 +22937,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1555,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22940,7 +22953,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1551,
+							"id": 1556,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22956,7 +22969,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1552,
+									"id": 1557,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22964,20 +22977,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1553,
+											"id": 1558,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1554,
+												"id": 1559,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1555,
+														"id": 1560,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -23022,7 +23035,7 @@
 					}
 				},
 				{
-					"id": 1558,
+					"id": 1563,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23038,7 +23051,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1559,
+							"id": 1564,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23059,7 +23072,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1573,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23075,7 +23088,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1569,
+							"id": 1574,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23099,7 +23112,7 @@
 					}
 				},
 				{
-					"id": 1511,
+					"id": 1516,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23115,7 +23128,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1512,
+							"id": 1517,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23131,7 +23144,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1513,
+									"id": 1518,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23141,12 +23154,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1514,
+									"id": 1519,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23156,7 +23169,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								}
@@ -23177,7 +23190,7 @@
 					}
 				},
 				{
-					"id": 1505,
+					"id": 1510,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23193,7 +23206,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1506,
+							"id": 1511,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23213,7 +23226,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1507,
+									"id": 1512,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23223,12 +23236,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2055,
+										"id": 2060,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1508,
+									"id": 1513,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23238,12 +23251,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2836,
+										"id": 2842,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1509,
+									"id": 1514,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23253,13 +23266,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2833,
+										"id": 2839,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1510,
+									"id": 1515,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23288,7 +23301,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1551,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23304,7 +23317,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1547,
+							"id": 1552,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23314,7 +23327,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1548,
+									"id": 1553,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23329,7 +23342,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1549,
+									"id": 1554,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23363,7 +23376,7 @@
 					}
 				},
 				{
-					"id": 1560,
+					"id": 1565,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23379,7 +23392,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1561,
+							"id": 1566,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23416,7 +23429,7 @@
 					}
 				},
 				{
-					"id": 1411,
+					"id": 1416,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23432,7 +23445,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1412,
+							"id": 1417,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23442,7 +23455,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1401,
+										"id": 1406,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -23460,7 +23473,7 @@
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1569,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23476,7 +23489,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1565,
+							"id": 1570,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23506,7 +23519,7 @@
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1571,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23522,7 +23535,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1567,
+							"id": 1572,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23552,7 +23565,7 @@
 					}
 				},
 				{
-					"id": 1529,
+					"id": 1534,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23568,7 +23581,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1530,
+							"id": 1535,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23579,40 +23592,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1531,
+									"id": 1536,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2157,
+										"id": 2162,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1532,
+									"id": 1537,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1533,
+									"id": 1538,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2234,
+										"id": 2239,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1534,
+									"id": 1539,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23626,7 +23639,7 @@
 									}
 								},
 								{
-									"id": 1535,
+									"id": 1540,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23651,7 +23664,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1536,
+									"id": 1541,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23700,7 +23713,7 @@
 					}
 				},
 				{
-					"id": 1537,
+					"id": 1542,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23716,7 +23729,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1538,
+							"id": 1543,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23727,21 +23740,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1539,
+									"id": 1544,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3106,
+										"id": 3112,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1540,
+									"id": 1545,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23755,7 +23768,7 @@
 									}
 								},
 								{
-									"id": 1541,
+									"id": 1546,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23808,30 +23821,30 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1402
+						1407
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1556,
+						1561,
+						1580,
+						1549,
+						1414,
 						1575,
-						1544,
-						1409,
-						1570,
-						1550,
-						1558,
-						1568,
-						1511,
-						1505,
-						1546,
-						1560,
-						1411,
-						1564,
-						1566,
-						1529,
-						1537
+						1555,
+						1563,
+						1573,
+						1516,
+						1510,
+						1551,
+						1565,
+						1416,
+						1569,
+						1571,
+						1534,
+						1542
 					]
 				}
 			],
@@ -23851,13 +23864,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1684,
+					"id": 1689,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2707,
+			"id": 2713,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -23873,7 +23886,7 @@
 			},
 			"children": [
 				{
-					"id": 2749,
+					"id": 2755,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23904,20 +23917,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2750,
+							"id": 2756,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2751,
+								"id": 2757,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2752,
+										"id": 2758,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -23953,7 +23966,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2785,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -23995,7 +24008,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2733,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24032,7 +24045,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2782,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24062,7 +24075,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2401,
+						"id": 2406,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -24071,7 +24084,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2803,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24109,7 +24122,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2773,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24150,7 +24163,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2759,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24179,7 +24192,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -24188,7 +24201,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2734,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24222,12 +24235,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3122,
+						"id": 3128,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2786,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24269,7 +24282,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2716,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24307,7 +24320,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2767,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24345,7 +24358,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2751,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24383,7 +24396,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2750,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24415,7 +24428,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -24425,7 +24438,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2732,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24462,7 +24475,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2763,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24503,7 +24516,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2797,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24545,7 +24558,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2802,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24587,7 +24600,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2787,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24629,7 +24642,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2717,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24665,7 +24678,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2729,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24703,7 +24716,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2764,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24741,7 +24754,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2783,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24779,7 +24792,7 @@
 					}
 				},
 				{
-					"id": 2778,
+					"id": 2784,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24817,7 +24830,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2766,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24854,7 +24867,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2747,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24884,7 +24897,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -24893,7 +24906,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2730,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24927,7 +24940,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2752,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24963,7 +24976,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -24973,7 +24986,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2792,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25005,7 +25018,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2814,
+							"id": 2820,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -25015,7 +25028,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2790,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25047,7 +25060,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2825,
+							"id": 2831,
 							"name": "HomepageModule"
 						}
 					},
@@ -25057,7 +25070,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2789,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25089,7 +25102,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3114,
+							"id": 3120,
 							"name": "ListPageColumns"
 						}
 					},
@@ -25099,7 +25112,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2721,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25137,7 +25150,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2718,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25175,7 +25188,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2715,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25213,7 +25226,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2800,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25255,7 +25268,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2793,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25297,7 +25310,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2720,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25335,7 +25348,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2719,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25373,7 +25386,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2727,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25410,7 +25423,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2722,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25448,7 +25461,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2726,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25482,7 +25495,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2735,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25508,12 +25521,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3071,
+						"id": 3077,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2760,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25551,7 +25564,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2779,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25588,7 +25601,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2778,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25628,7 +25641,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2804,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25666,7 +25679,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2806,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25704,7 +25717,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2740,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25738,7 +25751,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2805,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25776,7 +25789,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2798,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25818,7 +25831,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2796,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25856,7 +25869,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2808,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25898,7 +25911,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2737,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25932,7 +25945,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2739,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25966,7 +25979,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2777,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26000,7 +26013,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2738,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26034,7 +26047,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2788,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26072,7 +26085,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2736,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26110,7 +26123,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2741,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26147,7 +26160,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2742,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26181,7 +26194,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2769,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26219,7 +26232,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2754,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26257,7 +26270,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2745,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26294,7 +26307,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2731,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26331,7 +26344,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2768,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26369,7 +26382,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2724,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26399,12 +26412,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2014,
+						"id": 2019,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2723,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26438,7 +26451,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2762,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26476,7 +26489,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2770,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26514,7 +26527,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2774,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26551,7 +26564,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2791,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26583,7 +26596,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2825,
+							"id": 2831,
 							"name": "HomepageModule"
 						}
 					},
@@ -26593,7 +26606,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2780,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26625,7 +26638,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -26635,7 +26648,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2781,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26667,7 +26680,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -26677,7 +26690,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2775,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26718,7 +26731,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2772,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26755,7 +26768,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2795,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26797,7 +26810,7 @@
 					}
 				},
 				{
-					"id": 2795,
+					"id": 2801,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26839,7 +26852,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2794,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26881,7 +26894,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2799,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26923,7 +26936,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2807,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26965,7 +26978,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2714,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27003,7 +27016,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2744,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27033,12 +27046,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1625,
+						"id": 1630,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2725,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27072,7 +27085,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2743,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27110,7 +27123,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2776,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27151,7 +27164,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2753,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27187,7 +27200,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -27202,91 +27215,91 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2749,
-						2779,
-						2727,
-						2776,
-						2797,
-						2767,
-						2753,
-						2728,
-						2780,
-						2710,
-						2761,
-						2745,
-						2744,
-						2726,
-						2757,
-						2791,
-						2796,
-						2781,
-						2711,
-						2723,
-						2758,
-						2777,
-						2778,
-						2760,
-						2741,
-						2724,
-						2746,
-						2786,
-						2784,
-						2783,
-						2715,
-						2712,
-						2709,
-						2794,
-						2787,
-						2714,
-						2713,
-						2721,
-						2716,
-						2720,
-						2729,
-						2754,
+						2755,
+						2785,
+						2733,
+						2782,
+						2803,
 						2773,
-						2772,
-						2798,
-						2800,
+						2759,
 						2734,
-						2799,
+						2786,
+						2716,
+						2767,
+						2751,
+						2750,
+						2732,
+						2763,
+						2797,
+						2802,
+						2787,
+						2717,
+						2729,
+						2764,
+						2783,
+						2784,
+						2766,
+						2747,
+						2730,
+						2752,
 						2792,
 						2790,
-						2802,
-						2731,
-						2733,
-						2771,
-						2732,
-						2782,
-						2730,
-						2735,
-						2736,
-						2763,
-						2748,
-						2739,
-						2725,
-						2762,
-						2718,
-						2717,
-						2756,
-						2764,
-						2768,
-						2785,
-						2774,
-						2775,
-						2769,
-						2766,
 						2789,
-						2795,
-						2788,
+						2721,
+						2718,
+						2715,
+						2800,
 						2793,
-						2801,
-						2708,
-						2738,
+						2720,
 						2719,
+						2727,
+						2722,
+						2726,
+						2735,
+						2760,
+						2779,
+						2778,
+						2804,
+						2806,
+						2740,
+						2805,
+						2798,
+						2796,
+						2808,
 						2737,
+						2739,
+						2777,
+						2738,
+						2788,
+						2736,
+						2741,
+						2742,
+						2769,
+						2754,
+						2745,
+						2731,
+						2768,
+						2724,
+						2723,
+						2762,
 						2770,
-						2747
+						2774,
+						2791,
+						2780,
+						2781,
+						2775,
+						2772,
+						2795,
+						2801,
+						2794,
+						2799,
+						2807,
+						2714,
+						2744,
+						2725,
+						2743,
+						2776,
+						2753
 					]
 				}
 			],
@@ -27305,7 +27318,7 @@
 			]
 		},
 		{
-			"id": 1878,
+			"id": 1883,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27321,14 +27334,14 @@
 			},
 			"children": [
 				{
-					"id": 1915,
+					"id": 1920,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1916,
+							"id": 1921,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27338,19 +27351,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1917,
+									"id": 1922,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1877,
+										"id": 1882,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1918,
+									"id": 1923,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27374,14 +27387,14 @@
 					]
 				},
 				{
-					"id": 1919,
+					"id": 1924,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1920,
+							"id": 1925,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27391,7 +27404,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1921,
+									"id": 1926,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27399,12 +27412,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1868,
+										"id": 1873,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1922,
+									"id": 1927,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27413,21 +27426,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1923,
+											"id": 1928,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1924,
+													"id": 1929,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1925,
+															"id": 1930,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27453,7 +27466,7 @@
 									}
 								},
 								{
-									"id": 1926,
+									"id": 1931,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27465,7 +27478,7 @@
 									}
 								},
 								{
-									"id": 1927,
+									"id": 1932,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27481,21 +27494,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1879,
+					"id": 1884,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1880,
+							"id": 1885,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27505,7 +27518,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1881,
+									"id": 1886,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27513,12 +27526,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1869,
+										"id": 1874,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1882,
+									"id": 1887,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27529,28 +27542,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1883,
+											"id": 1888,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1884,
+													"id": 1889,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1885,
+															"id": 1890,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1861,
+																"id": 1866,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27567,12 +27580,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1886,
+							"id": 1891,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27582,7 +27595,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1887,
+									"id": 1892,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27593,29 +27606,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1870,
+												"id": 1875,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1873,
+												"id": 1878,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1874,
+												"id": 1879,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1875,
+												"id": 1880,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1888,
+									"id": 1893,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27626,14 +27639,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1889,
+											"id": 1894,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1890,
+													"id": 1895,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -27650,31 +27663,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1891,
+							"id": 1896,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1892,
+									"id": 1897,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1872,
+										"id": 1877,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1893,
+									"id": 1898,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27682,21 +27695,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1894,
+											"id": 1899,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1895,
+													"id": 1900,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1896,
+															"id": 1901,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27719,40 +27732,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1897,
+					"id": 1902,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1898,
+							"id": 1903,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1899,
+									"id": 1904,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1869,
+										"id": 1874,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1900,
+									"id": 1905,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27760,28 +27773,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1901,
+											"id": 1906,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1902,
+													"id": 1907,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1903,
+															"id": 1908,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1861,
+																"id": 1866,
 																"name": "AuthFailureType"
 															}
 														}
@@ -27798,83 +27811,7 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
-								"name": "AuthEventEmitter"
-							}
-						},
-						{
-							"id": 1904,
-							"name": "once",
-							"kind": 4096,
-							"kindString": "Call signature",
-							"flags": {},
-							"parameters": [
-								{
-									"id": 1905,
-									"name": "event",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"type": {
-										"type": "union",
-										"types": [
-											{
-												"type": "reference",
-												"id": 1870,
-												"name": "SDK_SUCCESS"
-											},
-											{
-												"type": "reference",
-												"id": 1873,
-												"name": "LOGOUT"
-											},
-											{
-												"type": "reference",
-												"id": 1874,
-												"name": "WAITING_FOR_POPUP"
-											},
-											{
-												"type": "reference",
-												"id": 1875,
-												"name": "SAML_POPUP_CLOSED_NO_AUTH"
-											}
-										]
-									}
-								},
-								{
-									"id": 1906,
-									"name": "listener",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"type": {
-										"type": "reflection",
-										"declaration": {
-											"id": 1907,
-											"name": "__type",
-											"kind": 65536,
-											"kindString": "Type literal",
-											"flags": {},
-											"signatures": [
-												{
-													"id": 1908,
-													"name": "__type",
-													"kind": 4096,
-													"kindString": "Call signature",
-													"flags": {},
-													"type": {
-														"type": "intrinsic",
-														"name": "void"
-													}
-												}
-											]
-										}
-									}
-								}
-							],
-							"type": {
-								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						},
@@ -27892,9 +27829,29 @@
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
-										"type": "reference",
-										"id": 1872,
-										"name": "SUCCESS"
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"id": 1875,
+												"name": "SDK_SUCCESS"
+											},
+											{
+												"type": "reference",
+												"id": 1878,
+												"name": "LOGOUT"
+											},
+											{
+												"type": "reference",
+												"id": 1879,
+												"name": "WAITING_FOR_POPUP"
+											},
+											{
+												"type": "reference",
+												"id": 1880,
+												"name": "SAML_POPUP_CLOSED_NO_AUTH"
+											}
+										]
 									}
 								},
 								{
@@ -27918,9 +27875,65 @@
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
+													"type": {
+														"type": "intrinsic",
+														"name": "void"
+													}
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"id": 1883,
+								"name": "AuthEventEmitter"
+							}
+						},
+						{
+							"id": 1914,
+							"name": "once",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {},
+							"parameters": [
+								{
+									"id": 1915,
+									"name": "event",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"id": 1877,
+										"name": "SUCCESS"
+									}
+								},
+								{
+									"id": 1916,
+									"name": "listener",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 1917,
+											"name": "__type",
+											"kind": 65536,
+											"kindString": "Type literal",
+											"flags": {},
+											"signatures": [
+												{
+													"id": 1918,
+													"name": "__type",
+													"kind": 4096,
+													"kindString": "Call signature",
+													"flags": {},
 													"parameters": [
 														{
-															"id": 1914,
+															"id": 1919,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -27943,21 +27956,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1928,
+					"id": 1933,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1929,
+							"id": 1934,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27967,7 +27980,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1930,
+									"id": 1935,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27977,14 +27990,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1868,
+										"id": 1873,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1878,
+								"id": 1883,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -27996,11 +28009,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1915,
-						1919,
-						1879,
-						1897,
-						1928
+						1920,
+						1924,
+						1884,
+						1902,
+						1933
 					]
 				}
 			],
@@ -28013,7 +28026,7 @@
 			]
 		},
 		{
-			"id": 1335,
+			"id": 1340,
 			"name": "BodylessConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -28033,7 +28046,7 @@
 			},
 			"children": [
 				{
-					"id": 1346,
+					"id": 1351,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28064,20 +28077,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1347,
+							"id": 1352,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1348,
+								"id": 1353,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1349,
+										"id": 1354,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -28109,12 +28122,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1311,
+						"id": 1316,
 						"name": "SpotterAgentEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1363,
+					"id": 1368,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28151,12 +28164,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1328,
+						"id": 1333,
 						"name": "SpotterAgentEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1350,
+					"id": 1355,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28185,17 +28198,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1315,
+						"id": 1320,
 						"name": "SpotterAgentEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1358,
+					"id": 1363,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28229,12 +28242,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1323,
+						"id": 1328,
 						"name": "SpotterAgentEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1342,
+					"id": 1347,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28268,12 +28281,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1307,
+						"id": 1312,
 						"name": "SpotterAgentEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1341,
+					"id": 1346,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28305,18 +28318,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1306,
+						"id": 1311,
 						"name": "SpotterAgentEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1354,
+					"id": 1359,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28353,12 +28366,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1319,
+						"id": 1324,
 						"name": "SpotterAgentEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1355,
+					"id": 1360,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28392,12 +28405,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1320,
+						"id": 1325,
 						"name": "SpotterAgentEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1357,
+					"id": 1362,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28430,12 +28443,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1322,
+						"id": 1327,
 						"name": "SpotterAgentEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1338,
+					"id": 1343,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28465,17 +28478,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1303,
+						"id": 1308,
 						"name": "SpotterAgentEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1343,
+					"id": 1348,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28511,18 +28524,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1308,
+						"id": 1313,
 						"name": "SpotterAgentEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1351,
+					"id": 1356,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28556,12 +28569,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1316,
+						"id": 1321,
 						"name": "SpotterAgentEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1369,
+					"id": 1374,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28594,12 +28607,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1334,
+						"id": 1339,
 						"name": "SpotterAgentEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1368,
+					"id": 1373,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28635,12 +28648,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1333,
+						"id": 1338,
 						"name": "SpotterAgentEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1367,
+					"id": 1372,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28670,12 +28683,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1332,
+						"id": 1337,
 						"name": "SpotterAgentEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1360,
+					"id": 1365,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28709,12 +28722,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1325,
+						"id": 1330,
 						"name": "SpotterAgentEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1345,
+					"id": 1350,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28748,12 +28761,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1310,
+						"id": 1315,
 						"name": "SpotterAgentEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1359,
+					"id": 1364,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28787,12 +28800,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1324,
+						"id": 1329,
 						"name": "SpotterAgentEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1353,
+					"id": 1358,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28826,12 +28839,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1318,
+						"id": 1323,
 						"name": "SpotterAgentEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1364,
+					"id": 1369,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28864,12 +28877,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1329,
+						"id": 1334,
 						"name": "SpotterAgentEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1365,
+					"id": 1370,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28906,12 +28919,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1330,
+						"id": 1335,
 						"name": "SpotterAgentEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1362,
+					"id": 1367,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28944,12 +28957,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1327,
+						"id": 1332,
 						"name": "SpotterAgentEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1366,
+					"id": 1371,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28986,12 +28999,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1331,
+						"id": 1336,
 						"name": "SpotterAgentEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1344,
+					"id": 1349,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29027,18 +29040,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1309,
+						"id": 1314,
 						"name": "SpotterAgentEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1336,
+					"id": 1341,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29059,7 +29072,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1301,
+						"id": 1306,
 						"name": "SpotterAgentEmbedViewConfig.worksheetId"
 					}
 				}
@@ -29069,31 +29082,31 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1346,
-						1363,
-						1350,
-						1358,
-						1342,
-						1341,
-						1354,
-						1355,
-						1357,
-						1338,
-						1343,
 						1351,
-						1369,
 						1368,
-						1367,
-						1360,
-						1345,
+						1355,
+						1363,
+						1347,
+						1346,
 						1359,
-						1353,
-						1364,
-						1365,
+						1360,
 						1362,
-						1366,
-						1344,
-						1336
+						1343,
+						1348,
+						1356,
+						1374,
+						1373,
+						1372,
+						1365,
+						1350,
+						1364,
+						1358,
+						1369,
+						1370,
+						1367,
+						1371,
+						1349,
+						1341
 					]
 				}
 			],
@@ -29107,13 +29120,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1300,
+					"id": 1305,
 					"name": "SpotterAgentEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1637,
+			"id": 1642,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -29133,7 +29146,7 @@
 			},
 			"children": [
 				{
-					"id": 1660,
+					"id": 1665,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29164,20 +29177,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1661,
+							"id": 1666,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1662,
+								"id": 1667,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1663,
+										"id": 1668,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -29209,12 +29222,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1601,
+						"id": 1606,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1677,
+					"id": 1682,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29251,12 +29264,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1618,
+						"id": 1623,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1664,
+					"id": 1669,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29285,17 +29298,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1605,
+						"id": 1610,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1642,
+					"id": 1647,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29333,12 +29346,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1583,
+						"id": 1588,
 						"name": "SpotterEmbedViewConfig.dataPanelV2"
 					}
 				},
 				{
-					"id": 1672,
+					"id": 1677,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29372,12 +29385,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1613,
+						"id": 1618,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1640,
+					"id": 1645,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29411,12 +29424,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1581,
+						"id": 1586,
 						"name": "SpotterEmbedViewConfig.disableSourceSelection"
 					}
 				},
 				{
-					"id": 1656,
+					"id": 1661,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29450,12 +29463,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1597,
+						"id": 1602,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1655,
+					"id": 1660,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29487,18 +29500,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1596,
+						"id": 1601,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1668,
+					"id": 1673,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29535,12 +29548,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1609,
+						"id": 1614,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1669,
+					"id": 1674,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29574,12 +29587,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1610,
+						"id": 1615,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1651,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29613,12 +29626,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1587,
+						"id": 1592,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeFiltersfromURL"
 					}
 				},
 				{
-					"id": 1648,
+					"id": 1653,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29652,12 +29665,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1589,
+						"id": 1594,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeParametersfromURL"
 					}
 				},
 				{
-					"id": 1671,
+					"id": 1676,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29690,12 +29703,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1612,
+						"id": 1617,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1652,
+					"id": 1657,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29725,17 +29738,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1593,
+						"id": 1598,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1657,
+					"id": 1662,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29771,18 +29784,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1598,
+						"id": 1603,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1644,
+					"id": 1649,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29816,12 +29829,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1585,
+						"id": 1590,
 						"name": "SpotterEmbedViewConfig.hideSampleQuestions"
 					}
 				},
 				{
-					"id": 1641,
+					"id": 1646,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29855,12 +29868,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1582,
+						"id": 1587,
 						"name": "SpotterEmbedViewConfig.hideSourceSelection"
 					}
 				},
 				{
-					"id": 1665,
+					"id": 1670,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29894,12 +29907,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1606,
+						"id": 1611,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1683,
+					"id": 1688,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29932,12 +29945,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1624,
+						"id": 1629,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1682,
+					"id": 1687,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29973,12 +29986,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1623,
+						"id": 1628,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1681,
+					"id": 1686,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30008,12 +30021,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1622,
+						"id": 1627,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1674,
+					"id": 1679,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30047,12 +30060,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1615,
+						"id": 1620,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1659,
+					"id": 1664,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30086,12 +30099,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1600,
+						"id": 1605,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1673,
+					"id": 1678,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30125,12 +30138,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1614,
+						"id": 1619,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1667,
+					"id": 1672,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30164,12 +30177,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1608,
+						"id": 1613,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1678,
+					"id": 1683,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30202,12 +30215,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1619,
+						"id": 1624,
 						"name": "SpotterEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1645,
+					"id": 1650,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30239,18 +30252,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1586,
+						"id": 1591,
 						"name": "SpotterEmbedViewConfig.runtimeFilters"
 					}
 				},
 				{
-					"id": 1647,
+					"id": 1652,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30282,18 +30295,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1588,
+						"id": 1593,
 						"name": "SpotterEmbedViewConfig.runtimeParameters"
 					}
 				},
 				{
-					"id": 1639,
+					"id": 1644,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30316,12 +30329,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1580,
+						"id": 1585,
 						"name": "SpotterEmbedViewConfig.searchOptions"
 					}
 				},
 				{
-					"id": 1679,
+					"id": 1684,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30358,12 +30371,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1620,
+						"id": 1625,
 						"name": "SpotterEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1676,
+					"id": 1681,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30396,12 +30409,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1617,
+						"id": 1622,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1643,
+					"id": 1648,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30435,12 +30448,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1584,
+						"id": 1589,
 						"name": "SpotterEmbedViewConfig.showSpotterLimitations"
 					}
 				},
 				{
-					"id": 1650,
+					"id": 1655,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30470,17 +30483,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1625,
+						"id": 1630,
 						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1591,
+						"id": 1596,
 						"name": "SpotterEmbedViewConfig.spotterSidebarConfig"
 					}
 				},
 				{
-					"id": 1649,
+					"id": 1654,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30518,12 +30531,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1590,
+						"id": 1595,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1680,
+					"id": 1685,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30560,12 +30573,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1621,
+						"id": 1626,
 						"name": "SpotterEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1658,
+					"id": 1663,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30601,18 +30614,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1599,
+						"id": 1604,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1638,
+					"id": 1643,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30633,7 +30646,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1579,
+						"id": 1584,
 						"name": "SpotterEmbedViewConfig.worksheetId"
 					}
 				}
@@ -30643,43 +30656,43 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1660,
-						1677,
-						1664,
-						1642,
-						1672,
-						1640,
-						1656,
-						1655,
-						1668,
-						1669,
-						1646,
-						1648,
-						1671,
-						1652,
-						1657,
-						1644,
-						1641,
 						1665,
-						1683,
 						1682,
-						1681,
-						1674,
-						1659,
-						1673,
-						1667,
-						1678,
-						1645,
+						1669,
 						1647,
-						1639,
-						1679,
+						1677,
+						1645,
+						1661,
+						1660,
+						1673,
+						1674,
+						1651,
+						1653,
 						1676,
-						1643,
-						1650,
+						1657,
+						1662,
 						1649,
-						1680,
-						1658,
-						1638
+						1646,
+						1670,
+						1688,
+						1687,
+						1686,
+						1679,
+						1664,
+						1678,
+						1672,
+						1683,
+						1650,
+						1652,
+						1644,
+						1684,
+						1681,
+						1648,
+						1655,
+						1654,
+						1685,
+						1663,
+						1643
 					]
 				}
 			],
@@ -30693,13 +30706,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1578,
+					"id": 1583,
 					"name": "SpotterEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 3086,
+			"id": 3092,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -30714,7 +30727,7 @@
 			},
 			"children": [
 				{
-					"id": 3087,
+					"id": 3093,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30731,14 +30744,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3088,
+							"id": 3094,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3089,
+									"id": 3095,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30752,12 +30765,12 @@
 									],
 									"type": {
 										"type": "reference",
-										"id": 3083,
+										"id": 3089,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3090,
+									"id": 3096,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30773,7 +30786,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3083,
+											"id": 3089,
 											"name": "VizPoint"
 										}
 									}
@@ -30784,8 +30797,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3089,
-										3090
+										3095,
+										3096
 									]
 								}
 							]
@@ -30793,7 +30806,7 @@
 					}
 				},
 				{
-					"id": 3091,
+					"id": 3097,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30808,14 +30821,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3092,
+							"id": 3098,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3100,
+									"id": 3106,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30836,7 +30849,7 @@
 									}
 								},
 								{
-									"id": 3101,
+									"id": 3107,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30857,7 +30870,7 @@
 									}
 								},
 								{
-									"id": 3094,
+									"id": 3100,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30875,7 +30888,7 @@
 									}
 								},
 								{
-									"id": 3093,
+									"id": 3099,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30893,7 +30906,7 @@
 									}
 								},
 								{
-									"id": 3095,
+									"id": 3101,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -30908,14 +30921,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3096,
+											"id": 3102,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3097,
+													"id": 3103,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -30930,14 +30943,14 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3098,
+															"id": 3104,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3099,
+																	"id": 3105,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -30960,7 +30973,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3099
+																		3105
 																	]
 																}
 															]
@@ -30973,7 +30986,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3097
+														3103
 													]
 												}
 											]
@@ -30986,23 +30999,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
+										3106,
+										3107,
 										3100,
-										3101,
-										3094,
-										3093,
-										3095
+										3099,
+										3101
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3102,
+								"id": 3108,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3103,
+										"id": 3109,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -31021,7 +31034,7 @@
 					}
 				},
 				{
-					"id": 3104,
+					"id": 3110,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31035,12 +31048,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2004,
+						"id": 2009,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3105,
+					"id": 3111,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31065,10 +31078,10 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3087,
-						3091,
-						3104,
-						3105
+						3093,
+						3097,
+						3110,
+						3111
 					]
 				}
 			],
@@ -31081,7 +31094,7 @@
 			]
 		},
 		{
-			"id": 2871,
+			"id": 2877,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31091,7 +31104,7 @@
 			},
 			"children": [
 				{
-					"id": 2925,
+					"id": 2931,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31114,7 +31127,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2930,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31137,7 +31150,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2900,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31160,7 +31173,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2901,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31183,7 +31196,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2903,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31206,7 +31219,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2902,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31229,7 +31242,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2882,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31252,7 +31265,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2943,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31275,7 +31288,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2944,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31298,7 +31311,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2941,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31321,7 +31334,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2942,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31344,7 +31357,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2905,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31367,7 +31380,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2910,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31390,7 +31403,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2907,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31413,7 +31426,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2909,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31436,7 +31449,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2908,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31459,7 +31472,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2906,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31482,7 +31495,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2915,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31505,7 +31518,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2912,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31528,7 +31541,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2914,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31551,7 +31564,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2913,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31574,7 +31587,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2911,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31597,7 +31610,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2919,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31620,7 +31633,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2918,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31643,7 +31656,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2917,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31666,7 +31679,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2916,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31689,7 +31702,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2904,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31712,7 +31725,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3037,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31735,7 +31748,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3032,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31758,7 +31771,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3027,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31781,7 +31794,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3026,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31804,7 +31817,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3029,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31827,7 +31840,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3028,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31850,7 +31863,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2966,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31873,7 +31886,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2969,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31896,7 +31909,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2964,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31919,7 +31932,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2967,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31942,7 +31955,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2968,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31965,7 +31978,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2963,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31988,7 +32001,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2965,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32011,7 +32024,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2936,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32034,7 +32047,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2935,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32057,7 +32070,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2938,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32080,7 +32093,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2937,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32103,7 +32116,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2934,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32126,7 +32139,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2932,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32149,7 +32162,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2933,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32172,7 +32185,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2939,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32195,7 +32208,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2940,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32218,7 +32231,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2951,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32241,7 +32254,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2952,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32264,7 +32277,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2955,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32287,7 +32300,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2953,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32310,7 +32323,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2954,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32333,7 +32346,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2962,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32356,7 +32369,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2961,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32379,7 +32392,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2960,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32402,7 +32415,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2959,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32425,7 +32438,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3025,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32448,7 +32461,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3024,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32471,7 +32484,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3023,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32494,7 +32507,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3031,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32517,7 +32530,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3030,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32540,7 +32553,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2957,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32563,7 +32576,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2956,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32586,7 +32599,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2984,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32609,7 +32622,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 2997,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32633,7 +32646,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 2996,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32657,7 +32670,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 2994,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32681,7 +32694,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 2995,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32705,7 +32718,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 3002,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32728,7 +32741,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3000,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32751,7 +32764,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 2999,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32774,7 +32787,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2985,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32798,7 +32811,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2986,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32822,7 +32835,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 2990,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32846,7 +32859,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2978,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32870,7 +32883,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 2993,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32894,7 +32907,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 2992,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32918,7 +32931,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2983,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32942,7 +32955,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 2991,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32966,7 +32979,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2981,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32990,7 +33003,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2982,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33014,7 +33027,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2989,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33038,7 +33051,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2979,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33062,7 +33075,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2980,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33086,7 +33099,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3016,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33109,7 +33122,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3013,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33132,7 +33145,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3014,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33155,7 +33168,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3015,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33178,7 +33191,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2971,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33201,7 +33214,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3022,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33224,7 +33237,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3017,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33247,7 +33260,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3018,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33270,7 +33283,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3021,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33293,7 +33306,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3019,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33316,7 +33329,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3020,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33339,7 +33352,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2972,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33362,7 +33375,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2970,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33385,7 +33398,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2988,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33408,7 +33421,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2987,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33431,7 +33444,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3001,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33454,7 +33467,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3003,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33477,7 +33490,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3004,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33500,7 +33513,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2974,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33523,7 +33536,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2973,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33546,7 +33559,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2975,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33569,7 +33582,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2976,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33592,7 +33605,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2977,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33615,7 +33628,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3005,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33638,7 +33651,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3006,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33661,7 +33674,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2949,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33684,7 +33697,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2946,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33707,7 +33720,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2945,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33730,7 +33743,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2947,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33753,7 +33766,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2950,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33776,7 +33789,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2948,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33799,7 +33812,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2883,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33822,7 +33835,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2884,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33845,7 +33858,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3011,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33868,7 +33881,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3012,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33891,7 +33904,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3007,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33914,7 +33927,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3009,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33937,7 +33950,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3010,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33960,7 +33973,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3008,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33983,7 +33996,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2878,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34006,7 +34019,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2879,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34029,7 +34042,7 @@
 					}
 				},
 				{
-					"id": 2874,
+					"id": 2880,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34052,7 +34065,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2881,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34075,7 +34088,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3040,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34098,7 +34111,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3039,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34121,7 +34134,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3044,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34144,7 +34157,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3045,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34167,7 +34180,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3048,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34190,7 +34203,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3047,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34213,7 +34226,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3046,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34236,7 +34249,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3049,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34259,7 +34272,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3042,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34282,7 +34295,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3050,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34305,7 +34318,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3041,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34328,7 +34341,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3043,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34351,7 +34364,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2892,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34374,7 +34387,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2896,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34397,7 +34410,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2897,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34420,7 +34433,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2895,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34443,7 +34456,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2891,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34466,7 +34479,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2894,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34489,7 +34502,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2888,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34512,7 +34525,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2889,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34535,7 +34548,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2890,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34558,7 +34571,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2885,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34581,7 +34594,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2886,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34604,7 +34617,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2887,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34627,7 +34640,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2893,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34650,7 +34663,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2958,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34673,7 +34686,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 2998,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34696,7 +34709,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3036,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34719,7 +34732,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3033,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34742,7 +34755,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3034,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34765,7 +34778,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3035,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34788,7 +34801,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3038,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34811,7 +34824,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2898,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34834,7 +34847,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2899,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34857,7 +34870,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2928,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34880,7 +34893,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2926,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34903,7 +34916,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2927,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34926,7 +34939,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2923,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34949,7 +34962,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2924,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34972,7 +34985,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2925,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34995,7 +35008,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2929,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35018,7 +35031,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2920,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35041,7 +35054,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2921,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35064,7 +35077,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2922,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35092,179 +35105,179 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2925,
-						2924,
-						2894,
-						2895,
-						2897,
-						2896,
-						2876,
-						2937,
-						2938,
-						2935,
-						2936,
-						2899,
-						2904,
+						2931,
+						2930,
+						2900,
 						2901,
 						2903,
 						2902,
-						2900,
-						2909,
-						2906,
-						2908,
-						2907,
+						2882,
+						2943,
+						2944,
+						2941,
+						2942,
 						2905,
-						2913,
-						2912,
-						2911,
 						2910,
-						2898,
-						3031,
+						2907,
+						2909,
+						2908,
+						2906,
+						2915,
+						2912,
+						2914,
+						2913,
+						2911,
+						2919,
+						2918,
+						2917,
+						2916,
+						2904,
+						3037,
+						3032,
+						3027,
 						3026,
-						3021,
-						3020,
-						3023,
-						3022,
-						2960,
+						3029,
+						3028,
+						2966,
+						2969,
+						2964,
+						2967,
+						2968,
 						2963,
-						2958,
-						2961,
-						2962,
-						2957,
-						2959,
-						2930,
-						2929,
-						2932,
-						2931,
-						2928,
-						2926,
-						2927,
-						2933,
+						2965,
+						2936,
+						2935,
+						2938,
+						2937,
 						2934,
-						2945,
-						2946,
-						2949,
-						2947,
-						2948,
-						2956,
+						2932,
+						2933,
+						2939,
+						2940,
+						2951,
+						2952,
 						2955,
-						2954,
 						2953,
-						3019,
-						3018,
-						3017,
+						2954,
+						2962,
+						2961,
+						2960,
+						2959,
 						3025,
 						3024,
-						2951,
-						2950,
-						2978,
-						2991,
-						2990,
-						2988,
-						2989,
+						3023,
+						3031,
+						3030,
+						2957,
+						2956,
+						2984,
+						2997,
 						2996,
 						2994,
+						2995,
+						3002,
+						3000,
+						2999,
+						2985,
+						2986,
+						2990,
+						2978,
 						2993,
+						2992,
+						2983,
+						2991,
+						2981,
+						2982,
+						2989,
 						2979,
 						2980,
-						2984,
-						2972,
-						2987,
-						2986,
-						2977,
-						2985,
-						2975,
-						2976,
-						2983,
-						2973,
-						2974,
-						3010,
-						3007,
-						3008,
-						3009,
-						2965,
 						3016,
-						3011,
-						3012,
-						3015,
 						3013,
 						3014,
-						2966,
-						2964,
-						2982,
-						2981,
-						2995,
-						2997,
-						2998,
-						2968,
-						2967,
-						2969,
-						2970,
+						3015,
 						2971,
-						2999,
-						3000,
-						2943,
-						2940,
-						2939,
-						2941,
-						2944,
-						2942,
-						2877,
-						2878,
-						3005,
-						3006,
+						3022,
+						3017,
+						3018,
+						3021,
+						3019,
+						3020,
+						2972,
+						2970,
+						2988,
+						2987,
 						3001,
 						3003,
 						3004,
-						3002,
-						2872,
-						2873,
-						2874,
-						2875,
-						3034,
-						3033,
-						3038,
-						3039,
-						3042,
-						3041,
-						3040,
-						3043,
-						3036,
-						3044,
-						3035,
-						3037,
-						2886,
-						2890,
-						2891,
-						2889,
-						2885,
-						2888,
-						2882,
+						2974,
+						2973,
+						2975,
+						2976,
+						2977,
+						3005,
+						3006,
+						2949,
+						2946,
+						2945,
+						2947,
+						2950,
+						2948,
 						2883,
 						2884,
+						3011,
+						3012,
+						3007,
+						3009,
+						3010,
+						3008,
+						2878,
 						2879,
 						2880,
 						2881,
-						2887,
-						2952,
-						2992,
-						3030,
-						3027,
-						3028,
-						3029,
-						3032,
+						3040,
+						3039,
+						3044,
+						3045,
+						3048,
+						3047,
+						3046,
+						3049,
+						3042,
+						3050,
+						3041,
+						3043,
 						2892,
+						2896,
+						2897,
+						2895,
+						2891,
+						2894,
+						2888,
+						2889,
+						2890,
+						2885,
+						2886,
+						2887,
 						2893,
-						2922,
+						2958,
+						2998,
+						3036,
+						3033,
+						3034,
+						3035,
+						3038,
+						2898,
+						2899,
+						2928,
+						2926,
+						2927,
+						2923,
+						2924,
+						2925,
+						2929,
 						2920,
 						2921,
-						2917,
-						2918,
-						2919,
-						2923,
-						2914,
-						2915,
-						2916
+						2922
 					]
 				}
 			],
@@ -35277,7 +35290,7 @@
 			]
 		},
 		{
-			"id": 2859,
+			"id": 2865,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35287,7 +35300,7 @@
 			},
 			"children": [
 				{
-					"id": 2861,
+					"id": 2867,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35303,12 +35316,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2862,
+						"id": 2868,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2866,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35333,8 +35346,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2861,
-						2860
+						2867,
+						2866
 					]
 				}
 			],
@@ -35347,7 +35360,7 @@
 			]
 		},
 		{
-			"id": 2849,
+			"id": 2855,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35363,7 +35376,7 @@
 			},
 			"children": [
 				{
-					"id": 2851,
+					"id": 2857,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35380,14 +35393,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2852,
+							"id": 2858,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2854,
+									"id": 2860,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35417,7 +35430,7 @@
 									}
 								},
 								{
-									"id": 2855,
+									"id": 2861,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35437,7 +35450,7 @@
 									}
 								},
 								{
-									"id": 2853,
+									"id": 2859,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35480,21 +35493,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2854,
-										2855,
-										2853
+										2860,
+										2861,
+										2859
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2856,
+								"id": 2862,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2857,
+										"id": 2863,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -35513,7 +35526,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2864,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35533,7 +35546,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2856,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35549,7 +35562,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2859,
+						"id": 2865,
 						"name": "CustomStyles"
 					}
 				}
@@ -35559,9 +35572,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2851,
-						2858,
-						2850
+						2857,
+						2864,
+						2856
 					]
 				}
 			],
@@ -35574,7 +35587,7 @@
 			]
 		},
 		{
-			"id": 2405,
+			"id": 2410,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35590,7 +35603,7 @@
 			},
 			"children": [
 				{
-					"id": 2447,
+					"id": 2452,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35620,20 +35633,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2448,
+							"id": 2453,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2449,
+								"id": 2454,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2450,
+										"id": 2455,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -35665,7 +35678,7 @@
 					}
 				},
 				{
-					"id": 2408,
+					"id": 2413,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35688,7 +35701,7 @@
 					}
 				},
 				{
-					"id": 2429,
+					"id": 2434,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35730,7 +35743,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2436,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35759,7 +35772,7 @@
 					}
 				},
 				{
-					"id": 2407,
+					"id": 2412,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35776,12 +35789,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2023,
+						"id": 2028,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2420,
+					"id": 2425,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35810,7 +35823,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2437,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35843,7 +35856,7 @@
 					}
 				},
 				{
-					"id": 2423,
+					"id": 2428,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35872,7 +35885,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2461,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35905,7 +35918,7 @@
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2449,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35934,7 +35947,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2459,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35970,7 +35983,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2456,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36013,7 +36026,7 @@
 					}
 				},
 				{
-					"id": 2428,
+					"id": 2433,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36038,12 +36051,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2447,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36072,7 +36085,7 @@
 					}
 				},
 				{
-					"id": 2425,
+					"id": 2430,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36102,7 +36115,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2458,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36139,7 +36152,7 @@
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2451,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36168,7 +36181,7 @@
 					}
 				},
 				{
-					"id": 2421,
+					"id": 2426,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36201,7 +36214,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2457,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36221,7 +36234,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2446,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36250,7 +36263,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2424,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36279,7 +36292,7 @@
 					}
 				},
 				{
-					"id": 2414,
+					"id": 2419,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36313,7 +36326,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2445,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36346,12 +36359,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3048,
+						"id": 3054,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2427,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36380,7 +36393,7 @@
 					}
 				},
 				{
-					"id": 2413,
+					"id": 2418,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36413,7 +36426,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2448,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36442,7 +36455,7 @@
 					}
 				},
 				{
-					"id": 2412,
+					"id": 2417,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36466,7 +36479,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2443,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36495,7 +36508,7 @@
 					}
 				},
 				{
-					"id": 2424,
+					"id": 2429,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36528,7 +36541,7 @@
 					}
 				},
 				{
-					"id": 2415,
+					"id": 2420,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36558,7 +36571,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2422,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36587,7 +36600,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2444,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36616,7 +36629,7 @@
 					}
 				},
 				{
-					"id": 2418,
+					"id": 2423,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36645,7 +36658,7 @@
 					}
 				},
 				{
-					"id": 2427,
+					"id": 2432,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36668,7 +36681,7 @@
 					}
 				},
 				{
-					"id": 2426,
+					"id": 2431,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36697,7 +36710,7 @@
 					}
 				},
 				{
-					"id": 2406,
+					"id": 2411,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36718,7 +36731,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2435,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36741,7 +36754,7 @@
 					}
 				},
 				{
-					"id": 2411,
+					"id": 2416,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36764,7 +36777,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2460,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36797,7 +36810,7 @@
 					}
 				},
 				{
-					"id": 2409,
+					"id": 2414,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -36813,7 +36826,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2410,
+							"id": 2415,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -36841,52 +36854,52 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2447,
-						2408,
-						2429,
-						2431,
-						2407,
-						2420,
-						2432,
-						2423,
-						2456,
-						2444,
-						2454,
-						2451,
-						2428,
-						2442,
-						2425,
-						2453,
-						2446,
-						2421,
 						2452,
-						2441,
-						2419,
-						2414,
-						2440,
-						2422,
 						2413,
-						2443,
+						2434,
+						2436,
 						2412,
-						2438,
-						2424,
-						2415,
-						2417,
-						2439,
-						2418,
-						2427,
-						2426,
-						2406,
+						2425,
+						2437,
+						2428,
+						2461,
+						2449,
+						2459,
+						2456,
+						2433,
+						2447,
 						2430,
+						2458,
+						2451,
+						2426,
+						2457,
+						2446,
+						2424,
+						2419,
+						2445,
+						2427,
+						2418,
+						2448,
+						2417,
+						2443,
+						2429,
+						2420,
+						2422,
+						2444,
+						2423,
+						2432,
+						2431,
 						2411,
-						2455
+						2435,
+						2416,
+						2460
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2409
+						2414
 					]
 				}
 			],
@@ -36899,7 +36912,7 @@
 			]
 		},
 		{
-			"id": 3153,
+			"id": 3159,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36928,7 +36941,7 @@
 			},
 			"children": [
 				{
-					"id": 3156,
+					"id": 3162,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36945,12 +36958,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3139,
+						"id": 3145,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3154,
+					"id": 3160,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36967,12 +36980,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3159,
+						"id": 3165,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3155,
+					"id": 3161,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37010,9 +37023,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3156,
-						3154,
-						3155
+						3162,
+						3160,
+						3161
 					]
 				}
 			],
@@ -37024,7 +37037,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 3157,
+				"id": 3163,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -37034,7 +37047,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3158,
+						"id": 3164,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -37051,7 +37064,7 @@
 			}
 		},
 		{
-			"id": 2808,
+			"id": 2814,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37067,7 +37080,7 @@
 			},
 			"children": [
 				{
-					"id": 2810,
+					"id": 2816,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37099,7 +37112,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2817,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37135,7 +37148,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2815,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37172,9 +37185,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2810,
-						2811,
-						2809
+						2816,
+						2817,
+						2815
 					]
 				}
 			],
@@ -37186,7 +37199,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2812,
+				"id": 2818,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -37196,7 +37209,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2813,
+						"id": 2819,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -37230,7 +37243,7 @@
 			}
 		},
 		{
-			"id": 2566,
+			"id": 2571,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37246,7 +37259,7 @@
 			},
 			"children": [
 				{
-					"id": 2578,
+					"id": 2583,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37280,7 +37293,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2609,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37311,20 +37324,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2604,
+							"id": 2610,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2605,
+								"id": 2611,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2606,
+										"id": 2612,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -37360,7 +37373,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2639,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37402,7 +37415,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2636,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37432,7 +37445,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2401,
+						"id": 2406,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -37441,7 +37454,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2653,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37479,7 +37492,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2627,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37520,7 +37533,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2613,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37549,7 +37562,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -37558,7 +37571,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2640,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37600,7 +37613,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2573,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37642,7 +37655,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2621,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37680,7 +37693,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2605,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37718,7 +37731,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2604,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37750,7 +37763,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -37760,7 +37773,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2617,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37801,7 +37814,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2647,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37843,7 +37856,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2652,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37885,7 +37898,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2641,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37927,7 +37940,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2618,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37965,7 +37978,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2575,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38001,7 +38014,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2637,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38039,7 +38052,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2638,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38077,7 +38090,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2620,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38114,7 +38127,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2601,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38144,7 +38157,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -38153,7 +38166,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2572,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38187,7 +38200,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2606,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38223,7 +38236,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -38233,7 +38246,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2590,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38257,7 +38270,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 311,
+							"line": 328,
 							"character": 4
 						}
 					],
@@ -38270,7 +38283,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2650,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38312,7 +38325,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2643,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38354,7 +38367,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2585,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38378,7 +38391,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 225,
+							"line": 242,
 							"character": 4
 						}
 					],
@@ -38388,7 +38401,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2614,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38426,7 +38439,7 @@
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2633,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38463,7 +38476,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2632,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38503,7 +38516,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2654,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38541,7 +38554,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2656,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38579,7 +38592,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2595,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38603,7 +38616,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 395,
+							"line": 412,
 							"character": 4
 						}
 					],
@@ -38613,7 +38626,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2655,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38651,7 +38664,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2648,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38693,7 +38706,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2646,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38731,7 +38744,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2658,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38773,7 +38786,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2592,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38797,7 +38810,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 347,
+							"line": 364,
 							"character": 4
 						}
 					],
@@ -38807,7 +38820,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2594,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38831,7 +38844,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 379,
+							"line": 396,
 							"character": 4
 						}
 					],
@@ -38841,7 +38854,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2631,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38875,7 +38888,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2593,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38899,7 +38912,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 363,
+							"line": 380,
 							"character": 4
 						}
 					],
@@ -38909,7 +38922,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2642,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38947,7 +38960,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2596,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38974,7 +38987,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 412,
+							"line": 429,
 							"character": 4
 						}
 					],
@@ -38984,7 +38997,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2597,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39008,7 +39021,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 435,
+							"line": 452,
 							"character": 4
 						}
 					],
@@ -39018,7 +39031,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2623,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39056,7 +39069,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2576,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39090,7 +39103,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2582,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39124,7 +39137,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2608,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39162,7 +39175,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2574,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39199,7 +39212,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2622,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39237,7 +39250,41 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2584,
+					"name": "personalizedViewId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The GUID of a saved personalized view to load.\nA personalized view is a saved configuration of a Liveboard\nthat includes specific filter selections.",
+						"text": "Supported embed types: `LiveboardEmbed`",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n   liveboardId: 'liveboard-guid',\n   personalizedViewId: 'view-guid',\n   activeTabId: 'tab-guid',\n})\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.45.0 | ThoughtSpot: 26.4.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/liveboard.ts",
+							"line": 228,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2616,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39275,7 +39322,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2579,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39309,7 +39356,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2624,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39347,7 +39394,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2628,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39384,7 +39431,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2634,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39416,7 +39463,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -39426,7 +39473,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2635,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39458,7 +39505,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -39468,7 +39515,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2629,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39509,7 +39556,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2626,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39546,7 +39593,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2645,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39588,7 +39635,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2651,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39630,7 +39677,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2644,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39672,7 +39719,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2649,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39714,7 +39761,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2657,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39756,7 +39803,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2586,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39780,7 +39827,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 248,
+							"line": 265,
 							"character": 4
 						}
 					],
@@ -39790,7 +39837,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2598,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39813,7 +39860,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 451,
+							"line": 468,
 							"character": 4
 						}
 					],
@@ -39823,7 +39870,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2599,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39851,7 +39898,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 466,
+							"line": 483,
 							"character": 4
 						}
 					],
@@ -39861,7 +39908,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2630,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39902,7 +39949,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2607,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39938,7 +39985,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -39948,7 +39995,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2591,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39972,7 +40019,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 331,
+							"line": 348,
 							"character": 4
 						}
 					],
@@ -39985,7 +40032,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2580,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40022,7 +40069,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2578,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40061,78 +40108,79 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2578,
-						2603,
-						2633,
-						2630,
-						2647,
-						2621,
-						2607,
-						2634,
-						2568,
-						2615,
-						2599,
-						2598,
-						2611,
-						2641,
-						2646,
-						2635,
-						2612,
-						2570,
-						2631,
-						2632,
-						2614,
-						2595,
-						2567,
-						2600,
-						2584,
-						2644,
-						2637,
-						2579,
-						2608,
-						2627,
-						2626,
-						2648,
-						2650,
-						2589,
-						2649,
-						2642,
-						2640,
-						2652,
-						2586,
-						2588,
-						2625,
-						2587,
-						2636,
-						2590,
-						2591,
-						2617,
-						2571,
-						2577,
-						2602,
-						2569,
-						2616,
-						2610,
-						2574,
-						2618,
-						2622,
-						2628,
-						2629,
-						2623,
-						2620,
+						2583,
+						2609,
 						2639,
-						2645,
-						2638,
-						2643,
-						2651,
-						2580,
-						2592,
-						2593,
-						2624,
-						2601,
-						2585,
+						2636,
+						2653,
+						2627,
+						2613,
+						2640,
+						2573,
+						2621,
+						2605,
+						2604,
+						2617,
+						2647,
+						2652,
+						2641,
+						2618,
 						2575,
-						2573
+						2637,
+						2638,
+						2620,
+						2601,
+						2572,
+						2606,
+						2590,
+						2650,
+						2643,
+						2585,
+						2614,
+						2633,
+						2632,
+						2654,
+						2656,
+						2595,
+						2655,
+						2648,
+						2646,
+						2658,
+						2592,
+						2594,
+						2631,
+						2593,
+						2642,
+						2596,
+						2597,
+						2623,
+						2576,
+						2582,
+						2608,
+						2574,
+						2622,
+						2584,
+						2616,
+						2579,
+						2624,
+						2628,
+						2634,
+						2635,
+						2629,
+						2626,
+						2645,
+						2651,
+						2644,
+						2649,
+						2657,
+						2586,
+						2598,
+						2599,
+						2630,
+						2607,
+						2591,
+						2580,
+						2578
 					]
 				}
 			],
@@ -40159,7 +40207,7 @@
 			]
 		},
 		{
-			"id": 2035,
+			"id": 2040,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40169,7 +40217,7 @@
 			},
 			"children": [
 				{
-					"id": 2036,
+					"id": 2041,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40190,7 +40238,7 @@
 					}
 				},
 				{
-					"id": 2037,
+					"id": 2042,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40207,12 +40255,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2039,
+						"id": 2044,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2038,
+					"id": 2043,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40258,9 +40306,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2036,
-						2037,
-						2038
+						2041,
+						2042,
+						2043
 					]
 				}
 			],
@@ -40273,7 +40321,7 @@
 			]
 		},
 		{
-			"id": 3045,
+			"id": 3051,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40283,7 +40331,7 @@
 			},
 			"children": [
 				{
-					"id": 3046,
+					"id": 3052,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40304,7 +40352,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3053,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40343,8 +40391,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3046,
-						3047
+						3052,
+						3053
 					]
 				}
 			],
@@ -40357,7 +40405,7 @@
 			]
 		},
 		{
-			"id": 2653,
+			"id": 2659,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -40377,7 +40425,7 @@
 			},
 			"children": [
 				{
-					"id": 2683,
+					"id": 2689,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40408,20 +40456,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2684,
+							"id": 2690,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2685,
+								"id": 2691,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2686,
+										"id": 2692,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -40457,7 +40505,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2676,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40499,7 +40547,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2673,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40529,7 +40577,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2401,
+						"id": 2406,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -40538,7 +40586,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2706,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40579,7 +40627,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2693,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40608,7 +40656,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -40617,7 +40665,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2677,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40659,7 +40707,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2669,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40682,7 +40730,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2701,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40720,7 +40768,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2664,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40749,7 +40797,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2685,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40787,7 +40835,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2684,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40819,7 +40867,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -40829,7 +40877,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2697,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40870,7 +40918,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2678,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40912,7 +40960,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2698,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40950,7 +40998,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2674,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40988,7 +41036,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2675,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41026,7 +41074,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2700,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41063,7 +41111,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2681,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41093,7 +41141,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -41102,7 +41150,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2686,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41138,7 +41186,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -41148,7 +41196,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2666,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41177,7 +41225,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2663,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41206,7 +41254,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2668,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41240,7 +41288,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2662,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41273,7 +41321,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2665,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41302,7 +41350,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2694,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41340,7 +41388,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2712,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41377,7 +41425,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2711,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41417,7 +41465,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2710,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41451,7 +41499,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2679,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41489,7 +41537,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2703,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41527,7 +41575,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2688,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41565,7 +41613,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2702,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41603,7 +41651,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2696,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41641,7 +41689,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2707,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41678,7 +41726,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2671,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41710,7 +41758,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -41720,7 +41768,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2672,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41752,7 +41800,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -41762,7 +41810,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2670,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41796,7 +41844,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2708,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41837,7 +41885,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2705,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41874,7 +41922,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2660,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41903,7 +41951,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2667,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41932,7 +41980,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2709,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41973,7 +42021,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2687,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42009,7 +42057,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -42024,49 +42072,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2683,
-						2670,
-						2667,
-						2700,
-						2687,
-						2671,
-						2663,
-						2695,
-						2658,
-						2679,
-						2678,
-						2691,
-						2672,
-						2692,
-						2668,
-						2669,
-						2694,
-						2675,
-						2680,
-						2660,
-						2657,
-						2662,
-						2656,
-						2659,
-						2688,
-						2706,
-						2705,
-						2704,
+						2689,
+						2676,
 						2673,
-						2697,
-						2682,
-						2696,
-						2690,
+						2706,
+						2693,
+						2677,
+						2669,
 						2701,
-						2665,
-						2666,
 						2664,
-						2702,
-						2699,
-						2654,
-						2661,
+						2685,
+						2684,
+						2697,
+						2678,
+						2698,
+						2674,
+						2675,
+						2700,
+						2681,
+						2686,
+						2666,
+						2663,
+						2668,
+						2662,
+						2665,
+						2694,
+						2712,
+						2711,
+						2710,
+						2679,
 						2703,
-						2681
+						2688,
+						2702,
+						2696,
+						2707,
+						2671,
+						2672,
+						2670,
+						2708,
+						2705,
+						2660,
+						2667,
+						2709,
+						2687
 					]
 				}
 			],
@@ -42120,7 +42168,7 @@
 			]
 		},
 		{
-			"id": 2517,
+			"id": 2522,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42135,7 +42183,7 @@
 			},
 			"children": [
 				{
-					"id": 2532,
+					"id": 2537,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42166,20 +42214,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2533,
+							"id": 2538,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2534,
+								"id": 2539,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2535,
+										"id": 2540,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42215,7 +42263,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2567,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42257,7 +42305,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2564,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42287,7 +42335,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2401,
+						"id": 2406,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -42296,7 +42344,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2555,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42337,7 +42385,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2541,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42366,7 +42414,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -42375,7 +42423,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2568,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42417,7 +42465,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2524,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42451,7 +42499,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2523,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42492,7 +42540,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2549,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42530,7 +42578,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2533,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42568,7 +42616,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2532,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42600,7 +42648,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -42610,7 +42658,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2545,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42651,7 +42699,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2569,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42693,7 +42741,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2546,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42731,7 +42779,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2565,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42769,7 +42817,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2566,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42807,7 +42855,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2527,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42841,7 +42889,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2548,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42878,7 +42926,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2529,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42908,7 +42956,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42917,7 +42965,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2534,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42953,7 +43001,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -42963,7 +43011,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2542,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43001,7 +43049,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2561,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43038,7 +43086,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2560,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43078,7 +43126,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2559,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43112,7 +43160,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2570,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43150,7 +43198,7 @@
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2551,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43188,7 +43236,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2536,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43226,7 +43274,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2550,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43264,7 +43312,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2544,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43302,7 +43350,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2552,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43340,7 +43388,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2556,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43377,7 +43425,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2562,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43409,7 +43457,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -43419,7 +43467,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2563,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43451,7 +43499,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -43461,7 +43509,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2526,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43495,7 +43543,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2557,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43536,7 +43584,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2554,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43573,7 +43621,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2558,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43614,7 +43662,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2525,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43648,7 +43696,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2535,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43684,7 +43732,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -43699,45 +43747,45 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2532,
-						2562,
-						2559,
-						2550,
-						2536,
-						2563,
-						2519,
-						2518,
-						2544,
-						2528,
-						2527,
-						2540,
-						2564,
-						2541,
-						2560,
-						2561,
-						2522,
-						2543,
-						2524,
-						2529,
 						2537,
-						2556,
+						2567,
+						2564,
 						2555,
-						2554,
-						2565,
-						2546,
-						2531,
-						2545,
-						2539,
-						2547,
-						2551,
-						2557,
-						2558,
-						2521,
-						2552,
+						2541,
+						2568,
+						2524,
+						2523,
 						2549,
-						2553,
-						2520,
-						2530
+						2533,
+						2532,
+						2545,
+						2569,
+						2546,
+						2565,
+						2566,
+						2527,
+						2548,
+						2529,
+						2534,
+						2542,
+						2561,
+						2560,
+						2559,
+						2570,
+						2551,
+						2536,
+						2550,
+						2544,
+						2552,
+						2556,
+						2562,
+						2563,
+						2526,
+						2557,
+						2554,
+						2558,
+						2525,
+						2535
 					]
 				}
 			],
@@ -43760,7 +43808,7 @@
 			]
 		},
 		{
-			"id": 2457,
+			"id": 2462,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43776,7 +43824,7 @@
 			},
 			"children": [
 				{
-					"id": 2493,
+					"id": 2498,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43807,20 +43855,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2494,
+							"id": 2499,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2495,
+								"id": 2500,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2496,
+										"id": 2501,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43856,7 +43904,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2474,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43890,7 +43938,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2464,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43924,7 +43972,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2463,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43958,7 +44006,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2485,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44000,7 +44048,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2477,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44037,7 +44085,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2482,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44067,7 +44115,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2401,
+						"id": 2406,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -44076,7 +44124,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2515,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44117,7 +44165,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2502,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44146,7 +44194,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44155,7 +44203,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2478,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44193,7 +44241,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2486,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44235,7 +44283,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2470,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44269,7 +44317,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2469,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44305,7 +44353,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2510,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44343,7 +44391,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2494,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44381,7 +44429,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2493,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44413,7 +44461,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -44423,7 +44471,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2506,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44464,7 +44512,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2487,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44506,7 +44554,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2467,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44540,7 +44588,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2507,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44578,7 +44626,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2483,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44616,7 +44664,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2484,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44654,7 +44702,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2473,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44688,7 +44736,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2509,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44725,7 +44773,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2479,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44763,7 +44811,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2468,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44797,7 +44845,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2490,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44827,7 +44875,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44836,7 +44884,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2495,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44872,7 +44920,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -44882,7 +44930,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2465,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44916,7 +44964,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2466,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44950,7 +44998,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2475,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44984,7 +45032,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2503,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45022,7 +45070,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2521,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45059,7 +45107,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2520,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45099,7 +45147,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2519,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45133,7 +45181,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2488,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45171,7 +45219,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2512,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45209,7 +45257,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2497,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45247,7 +45295,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2511,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45285,7 +45333,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2505,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45323,7 +45371,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2516,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45360,7 +45408,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2480,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45392,7 +45440,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -45402,7 +45450,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2481,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45434,7 +45482,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -45444,7 +45492,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2472,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45474,7 +45522,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2471,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45503,7 +45551,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2517,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45544,7 +45592,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2514,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45581,7 +45629,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2518,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45622,7 +45670,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2476,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45652,7 +45700,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2496,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45688,7 +45736,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -45703,56 +45751,56 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2493,
-						2469,
-						2459,
-						2458,
-						2480,
-						2472,
-						2477,
-						2510,
-						2497,
-						2473,
-						2481,
-						2465,
-						2464,
-						2505,
-						2489,
-						2488,
-						2501,
-						2482,
-						2462,
-						2502,
-						2478,
-						2479,
-						2468,
-						2504,
+						2498,
 						2474,
+						2464,
 						2463,
 						2485,
-						2490,
-						2460,
-						2461,
-						2470,
-						2498,
-						2516,
+						2477,
+						2482,
 						2515,
-						2514,
-						2483,
-						2507,
-						2492,
+						2502,
+						2478,
+						2486,
+						2470,
+						2469,
+						2510,
+						2494,
+						2493,
 						2506,
-						2500,
-						2511,
-						2475,
-						2476,
+						2487,
 						2467,
-						2466,
-						2512,
+						2507,
+						2483,
+						2484,
+						2473,
 						2509,
-						2513,
+						2479,
+						2468,
+						2490,
+						2495,
+						2465,
+						2466,
+						2475,
+						2503,
+						2521,
+						2520,
+						2519,
+						2488,
+						2512,
+						2497,
+						2511,
+						2505,
+						2516,
+						2480,
+						2481,
+						2472,
 						2471,
-						2491
+						2517,
+						2514,
+						2518,
+						2476,
+						2496
 					]
 				}
 			],
@@ -45785,14 +45833,14 @@
 			]
 		},
 		{
-			"id": 2004,
+			"id": 2009,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2007,
+					"id": 2012,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45807,14 +45855,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2008,
+							"id": 2013,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2010,
+									"id": 2015,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -45832,7 +45880,7 @@
 									}
 								},
 								{
-									"id": 2009,
+									"id": 2014,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -45855,8 +45903,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2010,
-										2009
+										2015,
+										2014
 									]
 								}
 							]
@@ -45864,7 +45912,7 @@
 					}
 				},
 				{
-					"id": 2006,
+					"id": 2011,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45882,7 +45930,7 @@
 					}
 				},
 				{
-					"id": 2005,
+					"id": 2010,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45905,9 +45953,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2007,
-						2006,
-						2005
+						2012,
+						2011,
+						2010
 					]
 				}
 			],
@@ -45920,7 +45968,7 @@
 			]
 		},
 		{
-			"id": 1300,
+			"id": 1305,
 			"name": "SpotterAgentEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -45936,7 +45984,7 @@
 			},
 			"children": [
 				{
-					"id": 1311,
+					"id": 1316,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45967,20 +46015,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1312,
+							"id": 1317,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1313,
+								"id": 1318,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1314,
+										"id": 1319,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -46016,7 +46064,7 @@
 					}
 				},
 				{
-					"id": 1328,
+					"id": 1333,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46057,7 +46105,7 @@
 					}
 				},
 				{
-					"id": 1315,
+					"id": 1320,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46086,7 +46134,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -46095,7 +46143,7 @@
 					}
 				},
 				{
-					"id": 1323,
+					"id": 1328,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46133,7 +46181,7 @@
 					}
 				},
 				{
-					"id": 1307,
+					"id": 1312,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46171,7 +46219,7 @@
 					}
 				},
 				{
-					"id": 1306,
+					"id": 1311,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46203,7 +46251,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -46213,7 +46261,7 @@
 					}
 				},
 				{
-					"id": 1319,
+					"id": 1324,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46254,7 +46302,7 @@
 					}
 				},
 				{
-					"id": 1320,
+					"id": 1325,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46292,7 +46340,7 @@
 					}
 				},
 				{
-					"id": 1322,
+					"id": 1327,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46329,7 +46377,7 @@
 					}
 				},
 				{
-					"id": 1303,
+					"id": 1308,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46359,7 +46407,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -46368,7 +46416,7 @@
 					}
 				},
 				{
-					"id": 1308,
+					"id": 1313,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46404,7 +46452,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -46414,7 +46462,7 @@
 					}
 				},
 				{
-					"id": 1316,
+					"id": 1321,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46452,7 +46500,7 @@
 					}
 				},
 				{
-					"id": 1334,
+					"id": 1339,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46489,7 +46537,7 @@
 					}
 				},
 				{
-					"id": 1333,
+					"id": 1338,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46529,7 +46577,7 @@
 					}
 				},
 				{
-					"id": 1332,
+					"id": 1337,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46563,7 +46611,7 @@
 					}
 				},
 				{
-					"id": 1325,
+					"id": 1330,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46601,7 +46649,7 @@
 					}
 				},
 				{
-					"id": 1310,
+					"id": 1315,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46639,7 +46687,7 @@
 					}
 				},
 				{
-					"id": 1324,
+					"id": 1329,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46677,7 +46725,7 @@
 					}
 				},
 				{
-					"id": 1318,
+					"id": 1323,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46715,7 +46763,7 @@
 					}
 				},
 				{
-					"id": 1329,
+					"id": 1334,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46752,7 +46800,7 @@
 					}
 				},
 				{
-					"id": 1330,
+					"id": 1335,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46793,7 +46841,7 @@
 					}
 				},
 				{
-					"id": 1327,
+					"id": 1332,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46830,7 +46878,7 @@
 					}
 				},
 				{
-					"id": 1331,
+					"id": 1336,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46871,7 +46919,7 @@
 					}
 				},
 				{
-					"id": 1309,
+					"id": 1314,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46907,7 +46955,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -46917,7 +46965,7 @@
 					}
 				},
 				{
-					"id": 1301,
+					"id": 1306,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46943,31 +46991,31 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1311,
-						1328,
-						1315,
-						1323,
-						1307,
-						1306,
-						1319,
-						1320,
-						1322,
-						1303,
-						1308,
 						1316,
-						1334,
 						1333,
-						1332,
-						1325,
-						1310,
+						1320,
+						1328,
+						1312,
+						1311,
 						1324,
-						1318,
-						1329,
-						1330,
+						1325,
 						1327,
-						1331,
-						1309,
-						1301
+						1308,
+						1313,
+						1321,
+						1339,
+						1338,
+						1337,
+						1330,
+						1315,
+						1329,
+						1323,
+						1334,
+						1335,
+						1332,
+						1336,
+						1314,
+						1306
 					]
 				}
 			],
@@ -46997,13 +47045,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1335,
+					"id": 1340,
 					"name": "BodylessConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1578,
+			"id": 1583,
 			"name": "SpotterEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47019,7 +47067,7 @@
 			},
 			"children": [
 				{
-					"id": 1601,
+					"id": 1606,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47050,20 +47098,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1602,
+							"id": 1607,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1603,
+								"id": 1608,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1604,
+										"id": 1609,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47099,7 +47147,7 @@
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1623,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47140,7 +47188,7 @@
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1610,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47169,7 +47217,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2849,
+						"id": 2855,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47178,7 +47226,7 @@
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1588,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47216,7 +47264,7 @@
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1618,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47254,7 +47302,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1586,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47288,7 +47336,7 @@
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1602,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47326,7 +47374,7 @@
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1601,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47358,7 +47406,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -47368,7 +47416,7 @@
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1614,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47409,7 +47457,7 @@
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1615,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47447,7 +47495,7 @@
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1592,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47481,7 +47529,7 @@
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1594,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47515,7 +47563,7 @@
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1617,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47552,7 +47600,7 @@
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1598,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47582,7 +47630,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2814,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -47591,7 +47639,7 @@
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1603,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47627,7 +47675,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -47637,7 +47685,7 @@
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1590,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47671,7 +47719,7 @@
 					}
 				},
 				{
-					"id": 1582,
+					"id": 1587,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47705,7 +47753,7 @@
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1611,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47743,7 +47791,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1629,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47780,7 +47828,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1628,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47820,7 +47868,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1627,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47854,7 +47902,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1620,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47892,7 +47940,7 @@
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1605,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47930,7 +47978,7 @@
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1619,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47968,7 +48016,7 @@
 					}
 				},
 				{
-					"id": 1608,
+					"id": 1613,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48006,7 +48054,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1624,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48043,7 +48091,7 @@
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1591,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48075,13 +48123,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2035,
+							"id": 2040,
 							"name": "RuntimeFilter"
 						}
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1593,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48113,13 +48161,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3045,
+							"id": 3051,
 							"name": "RuntimeParameter"
 						}
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1585,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48142,7 +48190,7 @@
 					}
 				},
 				{
-					"id": 1620,
+					"id": 1625,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48183,7 +48231,7 @@
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1622,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48220,7 +48268,7 @@
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1589,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48254,7 +48302,7 @@
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1596,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48284,12 +48332,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1625,
+						"id": 1630,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1595,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48327,7 +48375,7 @@
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1626,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48368,7 +48416,7 @@
 					}
 				},
 				{
-					"id": 1599,
+					"id": 1604,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48404,7 +48452,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2243,
+							"id": 2248,
 							"name": "Action"
 						}
 					},
@@ -48414,7 +48462,7 @@
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1584,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48440,43 +48488,43 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1601,
-						1618,
-						1605,
-						1583,
-						1613,
-						1581,
-						1597,
-						1596,
-						1609,
-						1610,
-						1587,
-						1589,
-						1612,
-						1593,
-						1598,
-						1585,
-						1582,
 						1606,
-						1624,
 						1623,
-						1622,
-						1615,
-						1600,
-						1614,
-						1608,
-						1619,
-						1586,
+						1610,
 						1588,
-						1580,
-						1620,
+						1618,
+						1586,
+						1602,
+						1601,
+						1614,
+						1615,
+						1592,
+						1594,
 						1617,
-						1584,
-						1591,
+						1598,
+						1603,
 						1590,
-						1621,
-						1599,
-						1579
+						1587,
+						1611,
+						1629,
+						1628,
+						1627,
+						1620,
+						1605,
+						1619,
+						1613,
+						1624,
+						1591,
+						1593,
+						1585,
+						1625,
+						1622,
+						1589,
+						1596,
+						1595,
+						1626,
+						1604,
+						1584
 					]
 				}
 			],
@@ -48506,13 +48554,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1637,
+					"id": 1642,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1625,
+			"id": 1630,
 			"name": "SpotterSidebarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -48532,7 +48580,7 @@
 			},
 			"children": [
 				{
-					"id": 1626,
+					"id": 1631,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48565,7 +48613,7 @@
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1639,
 					"name": "spotterBestPracticesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48594,7 +48642,7 @@
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1635,
 					"name": "spotterChatDeleteLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48623,7 +48671,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1634,
 					"name": "spotterChatRenameLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48652,7 +48700,7 @@
 					}
 				},
 				{
-					"id": 1635,
+					"id": 1640,
 					"name": "spotterConversationsBatchSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48685,7 +48733,7 @@
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1636,
 					"name": "spotterDeleteConversationModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48714,7 +48762,7 @@
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1638,
 					"name": "spotterDocumentationUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48743,7 +48791,7 @@
 					}
 				},
 				{
-					"id": 1636,
+					"id": 1641,
 					"name": "spotterNewChatButtonTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48772,7 +48820,7 @@
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1637,
 					"name": "spotterPastConversationAlertMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48801,7 +48849,7 @@
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1633,
 					"name": "spotterSidebarDefaultExpanded",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48834,7 +48882,7 @@
 					}
 				},
 				{
-					"id": 1627,
+					"id": 1632,
 					"name": "spotterSidebarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48868,17 +48916,17 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1626,
-						1634,
-						1630,
-						1629,
-						1635,
 						1631,
-						1633,
+						1639,
+						1635,
+						1634,
+						1640,
 						1636,
-						1632,
-						1628,
-						1627
+						1638,
+						1641,
+						1637,
+						1633,
+						1632
 					]
 				}
 			],
@@ -48891,14 +48939,14 @@
 			]
 		},
 		{
-			"id": 2011,
+			"id": 2016,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 2012,
+					"id": 2017,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48916,7 +48964,7 @@
 					}
 				},
 				{
-					"id": 2013,
+					"id": 2018,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48939,8 +48987,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2012,
-						2013
+						2017,
+						2018
 					]
 				}
 			],
@@ -48953,14 +49001,14 @@
 			]
 		},
 		{
-			"id": 3083,
+			"id": 3089,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3084,
+					"id": 3090,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48981,7 +49029,7 @@
 					}
 				},
 				{
-					"id": 3085,
+					"id": 3091,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49007,8 +49055,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3084,
-						3085
+						3090,
+						3091
 					]
 				}
 			],
@@ -49021,7 +49069,7 @@
 			]
 		},
 		{
-			"id": 2862,
+			"id": 2868,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49031,7 +49079,7 @@
 			},
 			"children": [
 				{
-					"id": 2864,
+					"id": 2870,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49061,20 +49109,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2865,
+							"id": 2871,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2866,
+								"id": 2872,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2867,
+										"id": 2873,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -49087,7 +49135,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2868,
+										"id": 2874,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -49100,14 +49148,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2869,
+											"id": 2875,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2870,
+													"id": 2876,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -49129,7 +49177,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2869,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49148,7 +49196,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2871,
+						"id": 2877,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -49158,8 +49206,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2864,
-						2863
+						2870,
+						2869
 					]
 				}
 			],
@@ -49464,7 +49512,7 @@
 			]
 		},
 		{
-			"id": 2832,
+			"id": 2838,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49491,7 +49539,7 @@
 			}
 		},
 		{
-			"id": 2836,
+			"id": 2842,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49506,7 +49554,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2837,
+					"id": 2843,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -49529,7 +49577,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2838,
+							"id": 2844,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -49539,19 +49587,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2839,
+									"id": 2845,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2844,
+										"id": 2850,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2840,
+									"id": 2846,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -49561,7 +49609,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2841,
+											"id": 2847,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -49575,7 +49623,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2842,
+													"id": 2848,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -49585,7 +49633,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2843,
+															"id": 2849,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -49616,7 +49664,7 @@
 			}
 		},
 		{
-			"id": 2833,
+			"id": 2839,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49640,14 +49688,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2834,
+					"id": 2840,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2835,
+							"id": 2841,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49675,7 +49723,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2835
+								2841
 							]
 						}
 					],
@@ -49690,7 +49738,7 @@
 			}
 		},
 		{
-			"id": 2844,
+			"id": 2850,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -49714,14 +49762,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2845,
+					"id": 2851,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2847,
+							"id": 2853,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49739,7 +49787,7 @@
 							}
 						},
 						{
-							"id": 2848,
+							"id": 2854,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49759,7 +49807,7 @@
 							}
 						},
 						{
-							"id": 2846,
+							"id": 2852,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -49782,9 +49830,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2847,
-								2848,
-								2846
+								2853,
+								2854,
+								2852
 							]
 						}
 					],
@@ -49849,7 +49897,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1931,
+									"id": 1936,
 									"name": "AnswerService"
 								}
 							}
@@ -50111,7 +50159,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1931,
+												"id": 1936,
 												"name": "AnswerService"
 											}
 										},
@@ -50198,7 +50246,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2405,
+						"id": 2410,
 						"name": "EmbedConfig"
 					}
 				}
@@ -50298,14 +50346,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2405,
+								"id": 2410,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1878,
+						"id": 1883,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -50445,7 +50493,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2803,
+									"id": 2809,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -50573,7 +50621,7 @@
 			]
 		},
 		{
-			"id": 3163,
+			"id": 3169,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -50589,7 +50637,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3164,
+					"id": 3170,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -50783,7 +50831,7 @@
 			]
 		},
 		{
-			"id": 3055,
+			"id": 3061,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -50797,7 +50845,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3056,
+					"id": 3062,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -50807,7 +50855,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3057,
+							"id": 3063,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -50819,7 +50867,7 @@
 							}
 						},
 						{
-							"id": 3058,
+							"id": 3064,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -50830,7 +50878,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3059,
+									"id": 3065,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -50853,80 +50901,80 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2243,
-				1876,
-				1861,
-				1868,
-				2023,
-				2401,
-				2234,
-				3130,
-				3126,
-				3122,
+				2248,
+				1881,
+				1866,
+				1873,
+				2028,
+				2406,
 				2239,
-				3139,
-				2055,
-				3159,
-				2814,
+				3136,
+				3132,
+				3128,
+				2244,
+				3145,
+				2060,
+				3165,
+				2820,
+				3083,
 				3077,
-				3071,
-				2825,
-				2157,
-				3135,
-				3080,
-				3114,
-				3048,
-				2014,
-				2803,
-				3075,
-				2039,
-				3106
+				2831,
+				2162,
+				3141,
+				3086,
+				3120,
+				3054,
+				2019,
+				2809,
+				3081,
+				2044,
+				3112
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1931,
-				1047,
-				1370,
-				1684,
-				626,
-				860,
+				1936,
+				1052,
+				1375,
+				1689,
+				628,
+				865,
 				245,
 				58,
-				1268,
-				1401
+				1273,
+				1406
 			]
 		},
 		{
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2707,
-				1878,
-				1335,
-				1637,
-				3086,
-				2871,
-				2859,
-				2849,
-				2405,
-				3153,
-				2808,
-				2566,
-				2035,
-				3045,
-				2653,
-				2517,
-				2457,
-				2004,
-				1300,
-				1578,
-				1625,
-				2011,
-				3083,
-				2862,
+				2713,
+				1883,
+				1340,
+				1642,
+				3092,
+				2877,
+				2865,
+				2855,
+				2410,
+				3159,
+				2814,
+				2571,
+				2040,
+				3051,
+				2659,
+				2522,
+				2462,
+				2009,
+				1305,
+				1583,
+				1630,
+				2016,
+				3089,
+				2868,
 				21,
 				28
 			]
@@ -50935,10 +50983,10 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2832,
-				2836,
-				2833,
-				2844
+				2838,
+				2842,
+				2839,
+				2850
 			]
 		},
 		{
@@ -50955,9 +51003,9 @@
 				4,
 				7,
 				25,
-				3163,
+				3169,
 				40,
-				3055
+				3061
 			]
 		}
 	],


### PR DESCRIPTION
JIRA: https://thoughtspot.atlassian.net/browse/SCAL-290924

Earlier, when user had to open a specific personalized view in liveboard, it was passed along with liveboardId
eg: 
`liveboardId: "9bd202f5-d431-44bf-9a07-b4f7be372125?view=ae4f71bf-d8bc-4219-a15b-54fdec473efe",`
This loads correct personlised view, except when activeViewId is present. 

With this PR, we add a new Parameter as below. 
```
const embed = new LiveboardEmbed('#container', {
    liveboardId: 'liveboard-guid',
    personalizedViewId: 'view-guid',  // NEW
});
```
Expectation: 

1. **When new view ID is passed (as a new line), and old ID is removed:**
     New view ID should be honoured
2. **When new view ID is passed (as a new line), while retaining the old view ID:**
  we can simply ignore, and new view ID should take precedence as it is a deliberate action from the developer to add the new view ID. 
3. **When new view ID is not passed (i.e. existing untouched cases):**
   Old view ID should continue to be used like before

**Bug fix** - View param will now be correctly placed at end of URL (fixes issue with activeTabId)

Recording for fix: https://www.loom.com/share/1f654c767a134b339531ebc61b8be6cb