### PR TITLE
SCAL-296800 Route getter host events through UI passthrough with lega…

### DIFF
--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -8,6 +8,13 @@ export enum UIPassthroughEvent {
   GetAnswerConfig = 'getAnswerPageConfig',
   GetLiveboardConfig = 'getPinboardPageConfig',
   GetUnsavedAnswerTML = 'getUnsavedAnswerTML',
+  GetAnswerSession = 'getAnswerSession',
+  GetFilters = 'getFilters',
+  GetIframeUrl = 'getIframeUrl',
+  GetParameters = 'getParameters',
+  GetTML = 'getTML',
+  GetTabs = 'getTabs',
+  GetExportRequestForCurrentPinboard = 'getExportRequestForCurrentPinboard',
 }
 
 // UI Passthrough Contract
@@ -73,6 +80,57 @@ export type UIPassthroughContractBase = {
       tml: string;
     };
   };
+  [UIPassthroughEvent.GetAnswerSession]: {
+    request: {
+      vizId?: string;
+    };
+    response: {
+      session: any;
+      embedAnswerData?: any;
+    };
+  };
+  [UIPassthroughEvent.GetFilters]: {
+    request: {
+      vizId?: string;
+    };
+    response: {
+      liveboardFilters: any[];
+      runtimeFilters: any[];
+    };
+  };
+  [UIPassthroughEvent.GetIframeUrl]: {
+    request: any;
+    response: {
+      iframeUrl: string;
+    };
+  };
+  [UIPassthroughEvent.GetParameters]: {
+    request: any;
+    response: {
+      parameters: any[];
+    };
+  };
+  [UIPassthroughEvent.GetTML]: {
+    request: {
+      vizId?: string;
+      includeNonExecutedSearchTokens?: boolean;
+    };
+    response: any;
+  };
+  [UIPassthroughEvent.GetTabs]: {
+    request: any;
+    response: {
+      orderedTabIds: string[];
+      numberOfTabs: number;
+      Tabs: any[];
+    };
+  };
+  [UIPassthroughEvent.GetExportRequestForCurrentPinboard]: {
+    request: any;
+    response: {
+      v2Content: string;
+    };
+  };
 };
 
 // UI Passthrough Request and Response
@@ -95,6 +153,13 @@ export type UIPassthroughArrayResponse<ApiName extends keyof UIPassthroughContra
 export type EmbedApiHostEventMapping = {
   [HostEvent.Pin]: UIPassthroughEvent.PinAnswerToLiveboard;
   [HostEvent.SaveAnswer]: UIPassthroughEvent.SaveAnswer;
+  [HostEvent.GetAnswerSession]: UIPassthroughEvent.GetAnswerSession;
+  [HostEvent.GetFilters]: UIPassthroughEvent.GetFilters;
+  [HostEvent.GetIframeUrl]: UIPassthroughEvent.GetIframeUrl;
+  [HostEvent.GetParameters]: UIPassthroughEvent.GetParameters;
+  [HostEvent.GetTML]: UIPassthroughEvent.GetTML;
+  [HostEvent.GetTabs]: UIPassthroughEvent.GetTabs;
+  [HostEvent.getExportRequestForCurrentPinboard]: UIPassthroughEvent.GetExportRequestForCurrentPinboard;
 }
 
 // Host Event Request and Response

--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -1,10 +1,5 @@
 import { ContextType, HostEvent, RuntimeFilter } from '../../types';
-
-export interface BachSessionId {
-  sessionId: string;
-  genNo?: number;
-  acSession?: { sessionId: string; genNo?: number };
-}
+import { SessionInterface } from '../../utils/graphql/answerService/answerService';
 
 export interface LiveboardTab {
   id: string;
@@ -97,7 +92,7 @@ export type UIPassthroughContractBase = {
       vizId?: string;
     };
     response: {
-      session: BachSessionId;
+      session: SessionInterface;
       embedAnswerData?: Record<string, any>;
     };
   };

--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -1,4 +1,16 @@
-import { ContextType, HostEvent } from '../../types';
+import { ContextType, HostEvent, RuntimeFilter } from '../../types';
+
+export interface BachSessionId {
+  sessionId: string;
+  genNo?: number;
+  acSession?: { sessionId: string; genNo?: number };
+}
+
+export interface LiveboardTab {
+  id: string;
+  name: string;
+  [key: string]: any;
+}
 
 export enum UIPassthroughEvent {
   PinAnswerToLiveboard = 'addVizToPinboard',
@@ -85,8 +97,8 @@ export type UIPassthroughContractBase = {
       vizId?: string;
     };
     response: {
-      session: any;
-      embedAnswerData?: any;
+      session: BachSessionId;
+      embedAnswerData?: Record<string, any>;
     };
   };
   [UIPassthroughEvent.GetFilters]: {
@@ -94,20 +106,20 @@ export type UIPassthroughContractBase = {
       vizId?: string;
     };
     response: {
-      liveboardFilters: any[];
-      runtimeFilters: any[];
+      liveboardFilters: Record<string, any>[];
+      runtimeFilters: RuntimeFilter[];
     };
   };
   [UIPassthroughEvent.GetIframeUrl]: {
-    request: any;
+    request: Record<string, never>;
     response: {
       iframeUrl: string;
     };
   };
   [UIPassthroughEvent.GetParameters]: {
-    request: any;
+    request: Record<string, never>;
     response: {
-      parameters: any[];
+      parameters: Record<string, any>[];
     };
   };
   [UIPassthroughEvent.GetTML]: {
@@ -115,18 +127,18 @@ export type UIPassthroughContractBase = {
       vizId?: string;
       includeNonExecutedSearchTokens?: boolean;
     };
-    response: any;
+    response: Record<string, any>;
   };
   [UIPassthroughEvent.GetTabs]: {
-    request: any;
+    request: Record<string, never>;
     response: {
       orderedTabIds: string[];
       numberOfTabs: number;
-      Tabs: any[];
+      Tabs: LiveboardTab[];
     };
   };
   [UIPassthroughEvent.GetExportRequestForCurrentPinboard]: {
-    request: any;
+    request: Record<string, never>;
     response: {
       v2Content: string;
     };
@@ -144,7 +156,7 @@ export type UIPassthroughResponse<
 
 export type UIPassthroughArrayResponse<ApiName extends keyof UIPassthroughContractBase> =
   Array<{
-    redId?: string;
+    refId?: string;
     value?: UIPassthroughResponse<ApiName>;
     error?: any;
   }>

--- a/src/embed/hostEventClient/host-event-client.spec.ts
+++ b/src/embed/hostEventClient/host-event-client.spec.ts
@@ -205,6 +205,128 @@ describe('HostEventClient', () => {
             expect(result).toEqual(mockResponse);
         });
 
+        it('should route GetAnswerSession through passthrough and return data', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            const mockResponse = [{ value: { session: 'testSession', embedAnswerData: { id: '1' } } }];
+            mockProcessTrigger.mockResolvedValue(mockResponse);
+
+            const result = await client.triggerHostEvent(HostEvent.GetAnswerSession, { vizId: '123' });
+
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UIPassthrough,
+                mockThoughtSpotHost,
+                { type: UIPassthroughEvent.GetAnswerSession, parameters: { vizId: '123' } },
+                undefined,
+            );
+            expect(result).toEqual({ session: 'testSession', embedAnswerData: { id: '1' } });
+        });
+
+        it('should fall back to legacy host event when passthrough returns no data for GetAnswerSession', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce({ session: 'fallbackSession' });
+
+            const result = await client.triggerHostEvent(HostEvent.GetAnswerSession, { vizId: '123' });
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(mockProcessTrigger).toHaveBeenNthCalledWith(
+                2,
+                expect.anything(),
+                HostEvent.GetAnswerSession,
+                mockThoughtSpotHost,
+                { vizId: '123' },
+                undefined,
+            );
+            expect(result).toEqual({ session: 'fallbackSession' });
+        });
+
+        it('should throw real errors from passthrough without falling back', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ error: 'Permission denied' }]);
+
+            await expect(client.triggerHostEvent(HostEvent.GetAnswerSession, {}))
+                .rejects.toThrow('Permission denied');
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should route GetFilters through passthrough and return data', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            const mockResponse = [{ value: { liveboardFilters: [{ id: 'f1' }], runtimeFilters: [] as any[] } }];
+            mockProcessTrigger.mockResolvedValue(mockResponse);
+
+            const result = await client.triggerHostEvent(HostEvent.GetFilters, {});
+
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UIPassthrough,
+                mockThoughtSpotHost,
+                { type: UIPassthroughEvent.GetFilters, parameters: {} },
+                undefined,
+            );
+            expect(result).toEqual({ liveboardFilters: [{ id: 'f1' }], runtimeFilters: [] });
+        });
+
+        it('should route GetTabs through passthrough and return data', async () => {
+            const { client } = createHostEventClient();
+            const mockResponse = [{ value: { orderedTabIds: ['t1', 't2'], numberOfTabs: 2, Tabs: [] as any[] } }];
+            mockProcessTrigger.mockResolvedValue(mockResponse);
+
+            const result = await client.triggerHostEvent(HostEvent.GetTabs, {});
+
+            expect(result).toEqual({ orderedTabIds: ['t1', 't2'], numberOfTabs: 2, Tabs: [] });
+        });
+
+        it('should route GetTML through passthrough and return data', async () => {
+            const { client } = createHostEventClient();
+            const tmlData = { answer: { search_query: 'revenue by region' } };
+            mockProcessTrigger.mockResolvedValue([{ value: tmlData }]);
+
+            const result = await client.triggerHostEvent(HostEvent.GetTML, {});
+
+            expect(result).toEqual(tmlData);
+        });
+
+        it('should route GetIframeUrl through passthrough and return data', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { iframeUrl: 'https://ts.example.com/embed' } }]);
+
+            const result = await client.triggerHostEvent(HostEvent.GetIframeUrl, {});
+
+            expect(result).toEqual({ iframeUrl: 'https://ts.example.com/embed' });
+        });
+
+        it('should route GetParameters through passthrough and return data', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { parameters: [{ name: 'p1' }] } }]);
+
+            const result = await client.triggerHostEvent(HostEvent.GetParameters, {});
+
+            expect(result).toEqual({ parameters: [{ name: 'p1' }] });
+        });
+
+        it('should route getExportRequestForCurrentPinboard through passthrough and return data', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { v2Content: 'exportData' } }]);
+
+            const result = await client.triggerHostEvent(HostEvent.getExportRequestForCurrentPinboard, {});
+
+            expect(result).toEqual({ v2Content: 'exportData' });
+        });
+
+        it('should fall back to legacy for GetFilters when passthrough returns null', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce({ liveboardFilters: [], runtimeFilters: [] });
+
+            const result = await client.triggerHostEvent(HostEvent.GetFilters, {});
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(result).toEqual({ liveboardFilters: [], runtimeFilters: [] });
+        });
+
         it('should call fallback  for Pin event', async () => {
             const { client, mockIframe } = createHostEventClient();
             const hostEvent = HostEvent.Pin;
@@ -316,6 +438,130 @@ describe('HostEventClient', () => {
                 vizId: 'testVizId',
                 liveboardId: 'testLiveboard',
             });
+        });
+    });
+
+    describe('getDataWithPassthroughFallback', () => {
+        const callMethod = (client: HostEventClient, ...args: any[]) => (client as any).getDataWithPassthroughFallback(...args);
+
+        it('should return unwrapped value when passthrough succeeds', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { session: 's1', embedAnswerData: { id: 'a1' } } }]);
+
+            const result = await callMethod(
+                client, UIPassthroughEvent.GetAnswerSession, HostEvent.GetAnswerSession, { vizId: '1' },
+            );
+
+            expect(result).toEqual({ session: 's1', embedAnswerData: { id: 'a1' } });
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should fall back to legacy when passthrough returns empty array', async () => {
+            const { client } = createHostEventClient();
+            const legacyResponse = { session: 'legacy' };
+            mockProcessTrigger
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce(legacyResponse);
+
+            const result = await callMethod(
+                client, UIPassthroughEvent.GetAnswerSession, HostEvent.GetAnswerSession, { vizId: '1' },
+            );
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(result).toEqual(legacyResponse);
+        });
+
+        it('should fall back to legacy when passthrough returns null', async () => {
+            const { client } = createHostEventClient();
+            const legacyResponse = { parameters: [] as any[] };
+            mockProcessTrigger
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce(legacyResponse);
+
+            const result = await callMethod(
+                client, UIPassthroughEvent.GetParameters, HostEvent.GetParameters, {},
+            );
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(result).toEqual(legacyResponse);
+        });
+
+        it('should fall back to legacy when passthrough returns undefined', async () => {
+            const { client } = createHostEventClient();
+            const legacyResponse = { iframeUrl: 'https://ts.example.com' };
+            mockProcessTrigger
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(legacyResponse);
+
+            const result = await callMethod(
+                client, UIPassthroughEvent.GetIframeUrl, HostEvent.GetIframeUrl, {},
+            );
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(result).toEqual(legacyResponse);
+        });
+
+        it('should fall back when response array has no matching entries', async () => {
+            const { client } = createHostEventClient();
+            const legacyResponse = { v2Content: 'data' };
+            mockProcessTrigger
+                .mockResolvedValueOnce([{ redId: 'r1' }])
+                .mockResolvedValueOnce(legacyResponse);
+
+            const result = await callMethod(
+                client, UIPassthroughEvent.GetExportRequestForCurrentPinboard,
+                HostEvent.getExportRequestForCurrentPinboard, {},
+            );
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(2);
+            expect(result).toEqual(legacyResponse);
+        });
+
+        it('should throw when response has error field', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ error: 'Permission denied' }]);
+
+            await expect(callMethod(
+                client, UIPassthroughEvent.GetFilters, HostEvent.GetFilters, {},
+            )).rejects.toThrow('Permission denied');
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw when response value contains errors field', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { errors: 'Invalid vizId' } }]);
+
+            await expect(callMethod(
+                client, UIPassthroughEvent.GetTML, HostEvent.GetTML, { vizId: 'bad' },
+            )).rejects.toThrow('Invalid vizId');
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw when response value contains error field', async () => {
+            const { client } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { error: 'Not found' } }]);
+
+            await expect(callMethod(
+                client, UIPassthroughEvent.GetTabs, HostEvent.GetTabs, {},
+            )).rejects.toThrow('Not found');
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should default payload to empty object when null', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            mockProcessTrigger.mockResolvedValue([{ value: { iframeUrl: 'https://ts.example.com' } }]);
+
+            await callMethod(
+                client, UIPassthroughEvent.GetIframeUrl, HostEvent.GetIframeUrl, null,
+            );
+
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UIPassthrough,
+                mockThoughtSpotHost,
+                { type: UIPassthroughEvent.GetIframeUrl, parameters: {} },
+                undefined,
+            );
         });
     });
 });

--- a/src/embed/hostEventClient/host-event-client.spec.ts
+++ b/src/embed/hostEventClient/host-event-client.spec.ts
@@ -505,7 +505,7 @@ describe('HostEventClient', () => {
             const { client } = createHostEventClient();
             const legacyResponse = { v2Content: 'data' };
             mockProcessTrigger
-                .mockResolvedValueOnce([{ redId: 'r1' }])
+                .mockResolvedValueOnce([{ refId: 'r1' }])
                 .mockResolvedValueOnce(legacyResponse);
 
             const result = await callMethod(
@@ -544,6 +544,17 @@ describe('HostEventClient', () => {
             await expect(callMethod(
                 client, UIPassthroughEvent.GetTabs, HostEvent.GetTabs, {},
             )).rejects.toThrow('Not found');
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+        });
+
+        it('should stringify object errors instead of producing [object Object]', async () => {
+            const { client } = createHostEventClient();
+            const errorObj = { code: 403, reason: 'Forbidden' };
+            mockProcessTrigger.mockResolvedValue([{ error: errorObj }]);
+
+            await expect(callMethod(
+                client, UIPassthroughEvent.GetFilters, HostEvent.GetFilters, {},
+            )).rejects.toThrow(JSON.stringify(errorObj));
             expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
         });
 

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -44,7 +44,7 @@ export class HostEventClient {
       context?: ContextType,
   ): Promise<UIPassthroughResponse<UIPassthroughEventT>> {
       const response = (await this.triggerUIPassthroughApi(apiName, parameters, context))
-          ?.filter?.((r) => r.error || r.value)[0];
+          ?.find?.((r) => r.error || r.value);
 
       if (!response) {
           const error = `No answer found${parameters.vizId ? ` for vizId: ${parameters.vizId}` : ''}.`;
@@ -84,7 +84,7 @@ export class HostEventClient {
       const response = await this.triggerUIPassthroughApi(
           passthroughEvent, payload || {}, context,
       );
-      const matched = response?.filter?.((r) => r.error || r.value)[0];
+      const matched = response?.find?.((r) => r.error || r.value);
       if (!matched) {
           return this.hostEventFallback(hostEvent, payload, context);
       }
@@ -93,7 +93,8 @@ export class HostEventClient {
           || (matched.value as any)?.errors
           || (matched.value as any)?.error;
       if (errors) {
-          throw new Error(matched.error || errors);
+          const message = typeof errors === 'string' ? errors : JSON.stringify(errors);
+          throw new Error(message);
       }
 
       return { ...matched.value };

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -3,18 +3,42 @@ import { processTrigger as processTriggerService } from '../../utils/processTrig
 import { getEmbedConfig } from '../embedConfig';
 import {
     UIPassthroughArrayResponse,
-    UIPassthroughEvent, HostEventRequest, HostEventResponse,
+    UIPassthroughEvent,
+    HostEventRequest,
+    HostEventResponse,
     UIPassthroughRequest,
     UIPassthroughResponse,
     TriggerPayload,
     TriggerResponse,
 } from './contracts';
 
+/** Host events that use getDataWithPassthroughFallback (getter-style APIs) */
+const HOST_EVENT_PASSTHROUGH_MAP: Partial<Record<HostEvent, UIPassthroughEvent>> = {
+    [HostEvent.GetAnswerSession]: UIPassthroughEvent.GetAnswerSession,
+    [HostEvent.GetFilters]: UIPassthroughEvent.GetFilters,
+    [HostEvent.GetIframeUrl]: UIPassthroughEvent.GetIframeUrl,
+    [HostEvent.GetParameters]: UIPassthroughEvent.GetParameters,
+    [HostEvent.GetTML]: UIPassthroughEvent.GetTML,
+    [HostEvent.GetTabs]: UIPassthroughEvent.GetTabs,
+    [HostEvent.getExportRequestForCurrentPinboard]: UIPassthroughEvent.GetExportRequestForCurrentPinboard,
+};
+
 export class HostEventClient {
   iFrame: HTMLIFrameElement;
 
+  /** Host events with custom handlers 
+   * (setters or special logic) - 
+   * bound to instance for protected method access */
+  private readonly customHandlers: Partial<
+    Record<HostEvent, (payload: any, context?: ContextType) => Promise<any>>
+  >;
+
   constructor(iFrame?: HTMLIFrameElement) {
       this.iFrame = iFrame;
+      this.customHandlers = {
+          [HostEvent.Pin]: (p, c) => this.handlePinEvent(p, c),
+          [HostEvent.SaveAnswer]: (p, c) => this.handleSaveAnswerEvent(p, c),
+      };
   }
 
   /**
@@ -174,44 +198,18 @@ export class HostEventClient {
       payload?: TriggerPayload<PayloadT, HostEventT>,
       context?: ContextT,
   ): Promise<TriggerResponse<PayloadT, HostEventT, ContextType>> {
-      switch (hostEvent) {
-          case HostEvent.Pin:
-              return this.handlePinEvent(payload as HostEventRequest<HostEvent.Pin>, context as ContextType) as any;
-          case HostEvent.SaveAnswer:
-              return this.handleSaveAnswerEvent(
-                  payload as HostEventRequest<HostEvent.SaveAnswer>,
-                  context as ContextType,
-              ) as any;
-          case HostEvent.GetAnswerSession:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetAnswerSession, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.GetFilters:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetFilters, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.GetIframeUrl:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetIframeUrl, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.GetParameters:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetParameters, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.GetTML:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetTML, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.GetTabs:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetTabs, hostEvent, payload, context as ContextType,
-              ) as any;
-          case HostEvent.getExportRequestForCurrentPinboard:
-              return this.getDataWithPassthroughFallback(
-                  UIPassthroughEvent.GetExportRequestForCurrentPinboard, hostEvent, payload, context as ContextType,
-              ) as any;
-          default:
-              return this.hostEventFallback(hostEvent, payload, context);
+      const customHandler = this.customHandlers[hostEvent];
+      if (customHandler) {
+          return customHandler(payload, context as ContextType) as any;
       }
+
+      const passthroughEvent = HOST_EVENT_PASSTHROUGH_MAP[hostEvent];
+      if (passthroughEvent) {
+          return this.getDataWithPassthroughFallback(
+              passthroughEvent, hostEvent, payload, context as ContextType,
+          ) as any;
+      }
+
+      return this.hostEventFallback(hostEvent, payload, context);
   }
 }

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -80,7 +80,8 @@ export class HostEventClient {
         || (response.value as any)?.error;
 
       if (errors) {
-          throw { error: response.error };
+          const message = typeof errors === 'string' ? errors : JSON.stringify(errors);
+          throw { error: message };
       }
 
       return { ...response.value };

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -71,6 +71,35 @@ export class HostEventClient {
   }
 
   /**
+   * For getter events that return data. Tries UI passthrough first;
+   * if the app doesn't support it (no response data), falls back to
+   * the legacy host event channel. Real errors are thrown as-is.
+   */
+  private async getDataWithPassthroughFallback<UIPassthroughEventT extends UIPassthroughEvent>(
+      passthroughEvent: UIPassthroughEventT,
+      hostEvent: HostEvent,
+      payload: any,
+      context?: ContextType,
+  ): Promise<UIPassthroughResponse<UIPassthroughEventT>> {
+      const response = await this.triggerUIPassthroughApi(
+          passthroughEvent, payload || {}, context,
+      );
+      const matched = response?.filter?.((r) => r.error || r.value)[0];
+      if (!matched) {
+          return this.hostEventFallback(hostEvent, payload, context);
+      }
+
+      const errors = matched.error
+          || (matched.value as any)?.errors
+          || (matched.value as any)?.error;
+      if (errors) {
+          throw new Error(matched.error || errors);
+      }
+
+      return { ...matched.value };
+  }
+
+  /**
    * Setter for the iframe element used for host events
    * @param {HTMLIFrameElement} iFrame - the iframe element to set
    */
@@ -151,6 +180,34 @@ export class HostEventClient {
               return this.handleSaveAnswerEvent(
                   payload as HostEventRequest<HostEvent.SaveAnswer>,
                   context as ContextType,
+              ) as any;
+          case HostEvent.GetAnswerSession:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetAnswerSession, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.GetFilters:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetFilters, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.GetIframeUrl:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetIframeUrl, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.GetParameters:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetParameters, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.GetTML:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetTML, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.GetTabs:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetTabs, hostEvent, payload, context as ContextType,
+              ) as any;
+          case HostEvent.getExportRequestForCurrentPinboard:
+              return this.getDataWithPassthroughFallback(
+                  UIPassthroughEvent.GetExportRequestForCurrentPinboard, hostEvent, payload, context as ContextType,
               ) as any;
           default:
               return this.hostEventFallback(hostEvent, payload, context);


### PR DESCRIPTION
…cy fallback

Add 7 new UIPassthroughEvent entries (GetAnswerSession, GetFilters, GetIframeUrl, GetParameters, GetTML, GetTabs,
GetExportRequestForCurrentPinboard) with typed contracts and host event mappings. Introduce getDataWithPassthroughFallback to try UI passthrough first and fall back to the legacy host event channel when the app doesn't support it, while letting real errors propagate.