### PR TITLE
SCAL-296027 Redirect to home on navigate to admin page via Navigate to URL customisation

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -280,6 +280,20 @@ describe('App embed tests', () => {
         });
     });
 
+    test('should redirect to home when path is /admin', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            path: '/admin',
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false${defaultParams}${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('should apply runtime filters', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1151,13 +1151,13 @@ export class AppEmbed extends V1Embed {
         if (!path) {
             return null;
         }
-
-        // remove leading slash
-        if (path.indexOf('/') === 0) {
-            return path.substring(1);
+        const formattedPath = path.replace(/^\/+/, '');
+        const basePath = formattedPath.split(/[?#]/)[0].toLowerCase();
+        if (basePath === 'admin' || basePath.startsWith('admin/')) {
+            return 'home';
         }
 
-        return path;
+        return formattedPath;
     }
 
     /**


### PR DESCRIPTION
Root Cause: The formatPath() method had no validation to block restricted paths, allowing any path including admin routes to be passed directly to the iframe URL.


Fix: Added explicit check to redirect admin paths (/admin, /admin/*) to the home page for security/access control.