### PR TITLE
MCP Auto Render support

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,7 +12,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import replace from '@rollup/plugin-replace';
 
-import pkg from './package.json' assert {type: "json"};
+import pkg from './package.json' with {type: "json"};
 
 const plugins = [
     typescript(),

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -283,7 +283,7 @@ describe('Unit test for auth', () => {
             text: () => Promise.resolve('abc'),
         } as any));
         jest.spyOn(authService, 'fetchAuthPostService').mockImplementation(() =>
-            // eslint-disable-next-line prefer-promise-reject-errors, implicit-arrow-linebreak
+             
             Promise.reject({
                 status: 500,
             }));

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,11 +19,11 @@ import { getSessionInfo, getPreauthInfo } from './utils/sessionInfoService';
 import { ERROR_MESSAGE } from './errors';
 import { resetAllCachedServices } from './utils/resetServices';
 
-// eslint-disable-next-line import/no-mutable-exports
+ 
 export let loggedInStatus = false;
-// eslint-disable-next-line import/no-mutable-exports
+ 
 export let samlAuthWindow: Window = null;
-// eslint-disable-next-line import/no-mutable-exports
+ 
 export let samlCompletionPromise: Promise<void> = null;
 
 let releaseVersion = '';

--- a/src/authToken.spec.ts
+++ b/src/authToken.spec.ts
@@ -129,7 +129,8 @@ describe('AuthToken Unit tests', () => {
             expect(token).toBe(newToken);
             // Should not validate cached token (condition at line 23 is false)
             expect(validateAuthTokenSpy).not.toHaveBeenCalledWith(config, cachedToken, true);
-            // But should validate new token (though it returns early when disableTokenVerification is true)
+            // But should validate new token (though it returns early when
+            // disableTokenVerification is true)
             expect(validateAuthTokenSpy).toHaveBeenCalledWith(config, newToken);
             expect(getAuthTokenMock).toHaveBeenCalled();
 

--- a/src/authToken.ts
+++ b/src/authToken.ts
@@ -83,7 +83,7 @@ export const validateAuthToken = async (
 
     if (cachedAuthToken && cachedAuthToken === authToken) {
         if (!embedConfig.suppressErrorAlerts && !suppressAlert) {
-            // eslint-disable-next-line no-alert
+             
             alert(ERROR_MESSAGE.DUPLICATE_TOKEN_ERR);
         }
         throw new Error(ERROR_MESSAGE.DUPLICATE_TOKEN_ERR);

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -570,7 +570,8 @@ export interface AppViewConfig extends AllEmbedViewConfig {
     isLiveboardStylingAndGroupingEnabled?: boolean;
 
     /**
-     * This flag is used to enable/disable the png embedding of liveboard in scheduled mails
+     * This flag is used to enable/disable the png embedding of liveboard in scheduled
+     * mails
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {boolean}

--- a/src/embed/auto-frame-renderer.spec.ts
+++ b/src/embed/auto-frame-renderer.spec.ts
@@ -11,6 +11,7 @@ const thoughtSpotHost = 'tshost';
 
 describe('startAutoMCPFrameRenderer', () => {
     let renderIFrameSpy: jest.SpyInstance;
+    let getEmbedBasePathSpy: jest.SpyInstance;
 
     beforeAll(() => {
         init({
@@ -23,6 +24,12 @@ describe('startAutoMCPFrameRenderer', () => {
 
     beforeEach(() => {
         document.body.innerHTML = getDocumentBody();
+        getEmbedBasePathSpy = jest.spyOn(
+            TsEmbed.prototype as any,
+            'getEmbedBasePath',
+        ).mockImplementation(function (this: any, query: string) {
+            return `http://${thoughtSpotHost}/?${query}#`;
+        });
         renderIFrameSpy = jest.spyOn(
             TsEmbed.prototype as any,
             'renderIFrame',
@@ -31,6 +38,7 @@ describe('startAutoMCPFrameRenderer', () => {
 
     afterEach(() => {
         renderIFrameSpy.mockRestore();
+        getEmbedBasePathSpy.mockRestore();
     });
 
     describe('MutationObserver setup', () => {
@@ -151,6 +159,19 @@ describe('startAutoMCPFrameRenderer', () => {
             expect(renderIFrameSpy).toHaveBeenCalledTimes(2);
             observer.disconnect();
         });
+
+        test('should ignore iframes with invalid src URLs', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = 'about:blank';
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).not.toHaveBeenCalled();
+            observer.disconnect();
+        });
     });
 
     describe('handleInsertionIntoDOM override', () => {
@@ -197,7 +218,7 @@ describe('startAutoMCPFrameRenderer', () => {
     });
 
     describe('getMCPIframeSrc URL construction', () => {
-        test('should strip tsmcp param and merge embed params', async () => {
+        test('should strip tsmcp param and merge embed params into rendered src', async () => {
             let capturedSrc = '';
             renderIFrameSpy.mockRestore();
             renderIFrameSpy = jest.spyOn(
@@ -217,7 +238,6 @@ describe('startAutoMCPFrameRenderer', () => {
 
             expect(capturedSrc).not.toContain(`${Param.Tsmcp}=true`);
             expect(capturedSrc).toContain('customParam=hello');
-            expect(capturedSrc).toContain(`https://${thoughtSpotHost}`);
             observer.disconnect();
         });
 
@@ -239,7 +259,7 @@ describe('startAutoMCPFrameRenderer', () => {
 
             await new Promise((r) => setTimeout(r, 50));
 
-            expect(capturedSrc).toBe('#/embed/viz/lb123');
+            expect(capturedSrc).toContain('/embed/viz/lb123');
             observer.disconnect();
         });
     });

--- a/src/embed/auto-frame-renderer.spec.ts
+++ b/src/embed/auto-frame-renderer.spec.ts
@@ -239,7 +239,7 @@ describe('startAutoMCPFrameRenderer', () => {
 
             await new Promise((r) => setTimeout(r, 50));
 
-            expect(capturedSrc).toContain('#/embed/viz/lb123');
+            expect(capturedSrc).toBe('#/embed/viz/lb123');
             observer.disconnect();
         });
     });

--- a/src/embed/auto-frame-renderer.spec.ts
+++ b/src/embed/auto-frame-renderer.spec.ts
@@ -1,0 +1,246 @@
+import { startAutoMCPFrameRenderer } from './auto-frame-renderer';
+import { Param, AuthType } from '../types';
+import { init } from '../index';
+import * as authInstance from '../auth';
+import { TsEmbed } from './ts-embed';
+import {
+    getDocumentBody,
+} from '../test/test-utils';
+
+const thoughtSpotHost = 'tshost';
+
+describe('startAutoMCPFrameRenderer', () => {
+    let renderIFrameSpy: jest.SpyInstance;
+
+    beforeAll(() => {
+        init({
+            thoughtSpotHost,
+            authType: AuthType.None,
+        });
+        jest.spyOn(authInstance, 'postLoginService').mockImplementation(() => Promise.resolve(undefined));
+        jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    });
+
+    beforeEach(() => {
+        document.body.innerHTML = getDocumentBody();
+        renderIFrameSpy = jest.spyOn(
+            TsEmbed.prototype as any,
+            'renderIFrame',
+        ).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        renderIFrameSpy.mockRestore();
+    });
+
+    describe('MutationObserver setup', () => {
+        test('should return a MutationObserver', () => {
+            const observer = startAutoMCPFrameRenderer();
+            expect(observer).toBeInstanceOf(MutationObserver);
+            observer.disconnect();
+        });
+
+        test('should observe document.body with childList and subtree', () => {
+            const observeSpy = jest.spyOn(MutationObserver.prototype, 'observe');
+            const observer = startAutoMCPFrameRenderer();
+            expect(observeSpy).toHaveBeenCalledWith(document.body, {
+                childList: true,
+                subtree: true,
+            });
+            observer.disconnect();
+            observeSpy.mockRestore();
+        });
+    });
+
+    describe('iframe detection via tsmcp param', () => {
+        test('should process directly-added iframes with tsmcp=true', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/v2/?${Param.Tsmcp}=true#/embed/viz/lb1/tab1`;
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should not process iframes without tsmcp param', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/v2/?embedApp=true#/embed/viz/lb1`;
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).not.toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should process tsmcp iframes nested inside added elements', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const wrapper = document.createElement('div');
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/?${Param.Tsmcp}=true`;
+            wrapper.appendChild(iframe);
+            document.body.appendChild(wrapper);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should not process nested iframes without tsmcp param', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const wrapper = document.createElement('div');
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/?embedApp=true`;
+            wrapper.appendChild(iframe);
+            document.body.appendChild(wrapper);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).not.toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should ignore non-iframe element nodes', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const div = document.createElement('div');
+            div.textContent = `${Param.Tsmcp}=true`;
+            document.body.appendChild(div);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).not.toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should ignore text nodes', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const text = document.createTextNode('tsmcp=true');
+            document.body.appendChild(text);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).not.toHaveBeenCalled();
+            observer.disconnect();
+        });
+
+        test('should process multiple tsmcp iframes in one mutation', async () => {
+            const observer = startAutoMCPFrameRenderer();
+
+            const wrapper = document.createElement('div');
+            const iframe1 = document.createElement('iframe');
+            iframe1.src = `https://${thoughtSpotHost}/?${Param.Tsmcp}=true&id=1`;
+            const iframe2 = document.createElement('iframe');
+            iframe2.src = `https://${thoughtSpotHost}/?${Param.Tsmcp}=true&id=2`;
+            wrapper.appendChild(iframe1);
+            wrapper.appendChild(iframe2);
+            document.body.appendChild(wrapper);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(renderIFrameSpy).toHaveBeenCalledTimes(2);
+            observer.disconnect();
+        });
+    });
+
+    describe('handleInsertionIntoDOM override', () => {
+        test('should replace the original iframe when renderIFrame inserts DOM', async () => {
+            renderIFrameSpy.mockRestore();
+
+            const replaceSpy = jest.fn();
+
+            renderIFrameSpy = jest.spyOn(
+                TsEmbed.prototype as any,
+                'renderIFrame',
+            ).mockImplementation(async function (this: any) {
+                const newIframe = document.createElement('iframe');
+                newIframe.src = 'https://replaced.example.com';
+                this.frameToReplace.replaceWith = replaceSpy;
+                this.handleInsertionIntoDOM(newIframe);
+            });
+
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/?${Param.Tsmcp}=true`;
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(replaceSpy).toHaveBeenCalled();
+            observer.disconnect();
+        });
+    });
+
+    describe('viewConfig forwarding', () => {
+        test('should accept empty viewConfig', () => {
+            const observer = startAutoMCPFrameRenderer({});
+            expect(observer).toBeInstanceOf(MutationObserver);
+            observer.disconnect();
+        });
+
+        test('should accept no arguments (default empty config)', () => {
+            const observer = startAutoMCPFrameRenderer();
+            expect(observer).toBeInstanceOf(MutationObserver);
+            observer.disconnect();
+        });
+    });
+
+    describe('getMCPIframeSrc URL construction', () => {
+        test('should strip tsmcp param and merge embed params', async () => {
+            let capturedSrc = '';
+            renderIFrameSpy.mockRestore();
+            renderIFrameSpy = jest.spyOn(
+                TsEmbed.prototype as any,
+                'renderIFrame',
+            ).mockImplementation(async function (this: any, src: string) {
+                capturedSrc = src;
+            });
+
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/v2/?${Param.Tsmcp}=true&customParam=hello#/embed/viz`;
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(capturedSrc).not.toContain(`${Param.Tsmcp}=true`);
+            expect(capturedSrc).toContain('customParam=hello');
+            expect(capturedSrc).toContain(`https://${thoughtSpotHost}`);
+            observer.disconnect();
+        });
+
+        test('should preserve hash from original iframe src', async () => {
+            let capturedSrc = '';
+            renderIFrameSpy.mockRestore();
+            renderIFrameSpy = jest.spyOn(
+                TsEmbed.prototype as any,
+                'renderIFrame',
+            ).mockImplementation(async function (this: any, src: string) {
+                capturedSrc = src;
+            });
+
+            const observer = startAutoMCPFrameRenderer();
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://${thoughtSpotHost}/v2/?${Param.Tsmcp}=true#/embed/viz/lb123`;
+            document.body.appendChild(iframe);
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(capturedSrc).toContain('#/embed/viz/lb123');
+            observer.disconnect();
+        });
+    });
+});

--- a/src/embed/auto-frame-renderer.ts
+++ b/src/embed/auto-frame-renderer.ts
@@ -3,6 +3,44 @@ import { TsEmbed } from "./ts-embed";
 import { getQueryParamString } from "../utils";
 
 
+/**
+ * Starts an automatic renderer that watches the DOM for iframes containing
+ * the `tsmcp=true` query parameter and replaces them with fully configured
+ * ThoughtSpot embed iframes. The query parameter is automatically added by
+ * the ThoughtSpot MCP server.
+ *
+ * A {@link MutationObserver} is set up on `document.body` to detect both
+ * directly added iframes and iframes nested within added container elements.
+ * Each matching iframe is replaced in-place with a new ThoughtSpot embed
+ * iframe that merges the original iframe's query parameters with the SDK
+ * embed parameters.
+ *
+ * Call {@link MutationObserver.disconnect | observer.disconnect()} on the
+ * returned observer to stop monitoring the DOM.
+ *
+ * @param viewConfig - Optional configuration for the auto-rendered embeds.
+ *   Accepts all properties from {@link AutoMCPFrameRendererViewConfig}.
+ *   Defaults to an empty config.
+ * @returns A {@link MutationObserver} instance that is actively observing
+ *   `document.body`. Disconnect it when monitoring is no longer needed.
+ *
+ * @example
+ * ```js
+ * import { startAutoMCPFrameRenderer } from '@thoughtspot/visual-embed-sdk';
+ *
+ * // Start watching the DOM for tsmcp iframes
+ * const observer = startAutoMCPFrameRenderer({
+ *   // optional view config overrides
+ * });
+ *
+ * // Later, stop watching
+ * observer.disconnect();
+ * ```
+ * 
+ * @example
+ * Detailed example of how to use the auto-frame renderer:
+ * [Python React Agent Simple UI](https://github.com/thoughtspot/developer-examples/tree/main/mcp/python-react-agent-simple-ui)
+ */
 export function startAutoMCPFrameRenderer(viewConfig: AutoMCPFrameRendererViewConfig = {}) {
 
     const replaceWithMCPIframe = (iframe: HTMLIFrameElement) => {
@@ -37,6 +75,15 @@ function isTSMCPIframe(iframe: HTMLIFrameElement) {
     return src.includes(`${Param.Tsmcp}=true`);
 }
 
+/**
+ * Embed component that automatically replaces a plain iframe with a
+ * ThoughtSpot embed iframe. It merges the SDK's embed parameters with
+ * the original iframe's query parameters (stripping the `tsmcp` marker)
+ * and swaps the original iframe element in the DOM.
+ *
+ * This class is used internally by {@link startAutoMCPFrameRenderer} and
+ * is not intended to be instantiated directly.
+ */
 class AutoFrameRenderer extends TsEmbed {
     private frameToReplace: HTMLIFrameElement;
 
@@ -46,21 +93,34 @@ class AutoFrameRenderer extends TsEmbed {
         super(container, viewConfig);
     }
 
+    /**
+     * Builds the final iframe `src` by merging the SDK embed parameters
+     * with the query parameters already present on the source iframe URL.
+     * The `tsmcp` marker param is removed so it does not propagate to the
+     * ThoughtSpot application.
+     *
+     * @param sourceSrc - The original iframe's `src` URL string.
+     * @returns The constructed URL to use for the ThoughtSpot embed iframe.
+     */
     private getMCPIframeSrc(sourceSrc: string) {
         const queryParams = this.getEmbedParamsObject();
         const sourceURL = new URL(sourceSrc);
         const existingQueryParams = sourceURL.searchParams;
-        // convert existing query params to an object
         const existingQueryParamsObject = Object.fromEntries(existingQueryParams);
         delete existingQueryParamsObject[Param.Tsmcp];
 
-        // merge the existing query params with the new query params
         const mergedQueryParams = { ...queryParams, ...existingQueryParamsObject };
         const mergedQueryParamsString = getQueryParamString(mergedQueryParams);
         const frameSrc = `${sourceURL.origin}${sourceURL.pathname}?${mergedQueryParamsString}/${sourceURL.hash}`;
         return frameSrc;
     }
 
+    /**
+     * Overrides the base insertion behavior so the new embed iframe
+     * replaces the original iframe in-place rather than being appended
+     * to a container element. Falls back to the default behavior when
+     * no iframe has been set for replacement.
+     */
     protected handleInsertionIntoDOM(child: string | Node): void {
         if (this.frameToReplace) {
             this.frameToReplace.replaceWith(child);
@@ -69,6 +129,15 @@ class AutoFrameRenderer extends TsEmbed {
         }
     }
 
+    /**
+     * Replaces the given iframe with a new ThoughtSpot embed iframe.
+     *
+     * The original iframe's `src` is used to derive the embed URL, and
+     * once the new iframe is rendered it takes the original's place in
+     * the DOM tree.
+     *
+     * @param iframe - The existing `<iframe>` element to replace.
+     */
     public async replaceIframe(iframe: HTMLIFrameElement): Promise<void> {
         this.frameToReplace = iframe;
         const src = this.getMCPIframeSrc(iframe.src);

--- a/src/embed/auto-frame-renderer.ts
+++ b/src/embed/auto-frame-renderer.ts
@@ -71,8 +71,13 @@ export function startAutoMCPFrameRenderer(viewConfig: AutoMCPFrameRendererViewCo
 }
 
 function isTSMCPIframe(iframe: HTMLIFrameElement) {
-    const src = iframe.src;
-    return src.includes(`${Param.Tsmcp}=true`);
+    try {
+        const url = new URL(iframe.src);
+        return url.searchParams.get(Param.Tsmcp) === 'true';
+    } catch (e) {
+        // The iframe src might not be a valid URL (e.g., 'about:blank').
+        return false;
+    }
 }
 
 /**
@@ -111,7 +116,7 @@ class AutoFrameRenderer extends TsEmbed {
 
         const mergedQueryParams = { ...queryParams, ...existingQueryParamsObject };
         const mergedQueryParamsString = getQueryParamString(mergedQueryParams);
-        const frameSrc = `${sourceURL.origin}${sourceURL.pathname}?${mergedQueryParamsString}/${sourceURL.hash}`;
+        const frameSrc = `${this.getEmbedBasePath(mergedQueryParamsString)}${sourceURL.hash.replace('#', '')}`;
         return frameSrc;
     }
 

--- a/src/embed/auto-frame-renderer.ts
+++ b/src/embed/auto-frame-renderer.ts
@@ -1,0 +1,78 @@
+import { AutoMCPFrameRendererViewConfig, Param } from "../types";
+import { TsEmbed } from "./ts-embed";
+import { getQueryParamString } from "../utils";
+
+
+export function startAutoMCPFrameRenderer(viewConfig: AutoMCPFrameRendererViewConfig = {}) {
+
+    const replaceWithMCPIframe = (iframe: HTMLIFrameElement) => {
+        const autoMCPFrameRenderer = new AutoFrameRenderer(viewConfig);
+        autoMCPFrameRenderer.replaceIframe(iframe);
+    };
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of Array.from(mutation.addedNodes)) {
+                if (node instanceof HTMLIFrameElement && isTSMCPIframe(node)) {
+                    replaceWithMCPIframe(node);
+                }
+                if (node instanceof HTMLElement) {
+                    node.querySelectorAll('iframe').forEach((iframe) => {
+                        if (isTSMCPIframe(iframe)) {
+                            replaceWithMCPIframe(iframe);
+                        }
+                    });
+                }
+            }
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return observer;
+}
+
+function isTSMCPIframe(iframe: HTMLIFrameElement) {
+    const src = iframe.src;
+    return src.includes(`${Param.Tsmcp}=true`);
+}
+
+class AutoFrameRenderer extends TsEmbed {
+    private frameToReplace: HTMLIFrameElement;
+
+    constructor(protected viewConfig: AutoMCPFrameRendererViewConfig) {
+        viewConfig.embedComponentType = 'auto-frame-renderer';
+        const container = document.createElement('div');
+        super(container, viewConfig);
+    }
+
+    private getMCPIframeSrc(sourceSrc: string) {
+        const queryParams = this.getEmbedParamsObject();
+        const sourceURL = new URL(sourceSrc);
+        const existingQueryParams = sourceURL.searchParams;
+        // convert existing query params to an object
+        const existingQueryParamsObject = Object.fromEntries(existingQueryParams);
+        delete existingQueryParamsObject[Param.Tsmcp];
+
+        // merge the existing query params with the new query params
+        const mergedQueryParams = { ...queryParams, ...existingQueryParamsObject };
+        const mergedQueryParamsString = getQueryParamString(mergedQueryParams);
+        const frameSrc = `${sourceURL.origin}${sourceURL.pathname}?${mergedQueryParamsString}/${sourceURL.hash}`;
+        return frameSrc;
+    }
+
+    protected handleInsertionIntoDOM(child: string | Node): void {
+        if (this.frameToReplace) {
+            this.frameToReplace.replaceWith(child);
+        } else {
+            super.handleInsertionIntoDOM(child);
+        }
+    }
+
+    public async replaceIframe(iframe: HTMLIFrameElement): Promise<void> {
+        this.frameToReplace = iframe;
+        const src = this.getMCPIframeSrc(iframe.src);
+        await this.renderIFrame(src);
+    }
+}
+

--- a/src/embed/base.spec.ts
+++ b/src/embed/base.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+ 
 /* eslint-disable @typescript-eslint/no-shadow */
 import EventEmitter from 'eventemitter3';
 import { EmbedConfig } from '../index';

--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -1,5 +1,5 @@
-/* eslint-disable camelcase */
-/* eslint-disable import/no-mutable-exports */
+ 
+ 
 /**
  * Copyright (c) 2022
  *
@@ -36,8 +36,6 @@ import { getEmbedConfig, setEmbedConfig } from './embedConfig';
 import { getQueryParamString, getValueFromWindow, isWindowUndefined, storeValueInWindow } from '../utils';
 import { resetAllCachedServices } from '../utils/resetServices';
 import { reload } from '../utils/processTrigger';
-import { ERROR_MESSAGE } from '../errors';
-import { startAutoMCPFrameRenderer } from './auto-frame-renderer';
 
 const CONFIG_DEFAULTS: Partial<EmbedConfig> = {
     loginFailedMessage: 'Not logged in',
@@ -117,7 +115,7 @@ export const prefetch = (
     additionalFlags?: { [key: string]: string | number | boolean },
 ): void => {
     if (url === '') {
-        // eslint-disable-next-line no-console
+         
         logger.warn('The prefetch method does not have a valid URL');
     } else {
         const features = prefetchFeatures || [PrefetchFeatures.FullApp];
@@ -143,9 +141,9 @@ export const prefetch = (
                     iFrame.style.height = '0';
                     iFrame.style.border = '0';
 
-                    // Make it 'fixed' to keep it in a different stacking context.
-                    //   This should solve the focus behaviours inside the iframe from
-                    //   interfering with main body.
+                    // Make it 'fixed' to keep it in a different stacking
+                    // context. This should solve the focus behaviours inside
+                    // the iframe from interfering with main body.
                     iFrame.style.position = 'fixed';
                     // Push it out of viewport.
                     iFrame.style.top = '100vh';
@@ -324,7 +322,7 @@ export const renderInQueue = (fn: (next?: (val?: any) => void) => Promise<any>):
         return renderQueue;
     }
     // Sending an empty function to keep it consistent with the above usage.
-    return fn(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+    return fn(() => {});  
 };
 
 /**

--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -37,6 +37,7 @@ import { getQueryParamString, getValueFromWindow, isWindowUndefined, storeValueI
 import { resetAllCachedServices } from '../utils/resetServices';
 import { reload } from '../utils/processTrigger';
 import { ERROR_MESSAGE } from '../errors';
+import { startAutoMCPFrameRenderer } from './auto-frame-renderer';
 
 const CONFIG_DEFAULTS: Partial<EmbedConfig> = {
     loginFailedMessage: 'Not logged in',

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -48,7 +48,7 @@ export class HostEventClient {
 
       if (!response) {
           const error = `No answer found${parameters.vizId ? ` for vizId: ${parameters.vizId}` : ''}.`;
-          // eslint-disable-next-line no-throw-literal
+           
           throw { error };
       }
 
@@ -57,7 +57,7 @@ export class HostEventClient {
         || (response.value as any)?.error;
 
       if (errors) {
-      // eslint-disable-next-line no-throw-literal
+       
           throw { error: response.error };
       }
 

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -914,7 +914,8 @@ describe('Liveboard/viz embed tests', () => {
             } as LiveboardViewConfig);
             liveboardEmbed.render();
             await executeAfterWait(() => {
-                // URL should be: #/embed/viz/{id}/tab/{tabId}/{vizId}?view={viewId}
+                // URL should be:
+                // #/embed/viz/{id}/tab/{tabId}/{vizId}?view={viewId}
                 expect(getIFrameSrc()).toMatch(
                     new RegExp(
                         `#/embed/viz/${liveboardId}/tab/${activeTabId}/${vizId}\\?view=${personalizedViewId}`,
@@ -1010,7 +1011,8 @@ describe('Liveboard/viz embed tests', () => {
                 } as LiveboardViewConfig);
                 liveboardEmbed.render();
                 await executeAfterWait(() => {
-                    // URL: #/embed/viz/{id}/tab/{tabId}?view={viewId} (view at END, not middle)
+                    // URL: #/embed/viz/{id}/tab/{tabId}?view={viewId} (view at
+                    // END, not middle)
                     expect(getIFrameSrc()).toMatch(
                         new RegExp(
                             `#/embed/viz/${liveboardId}/tab/${activeTabId}\\?view=${workaroundViewId}`,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -371,7 +371,8 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      */
     isLiveboardStylingAndGroupingEnabled?: boolean;
     /**
-     * This flag is used to enable/disable the png embedding of liveboard in scheduled mails
+     * This flag is used to enable/disable the png embedding of liveboard in scheduled
+     * mails
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {boolean}
@@ -730,8 +731,9 @@ export class LiveboardEmbed extends V1Embed {
         activeTabId: string,
         personalizedViewId?: string,
     ) {
-        // Extract view from liveboardId if passed along with it (legacy approach)
-        // View must be appended as query param at the end, not embedded in path
+        // Extract view from liveboardId if passed along with it (legacy
+        // approach) View must be appended as query param at the end, not
+        // embedded in path
         let liveboardGuid = liveboardId;
         let legacyViewId: string | undefined;
 
@@ -742,7 +744,8 @@ export class LiveboardEmbed extends V1Embed {
             legacyViewId = params.get('view') || undefined;
         }
 
-        // personalizedViewId takes precedence over legacyViewId (when passed as part of liveboardId)
+        // personalizedViewId takes precedence over legacyViewId (when passed
+        // as part of liveboardId)
         const effectiveViewId = personalizedViewId || legacyViewId;
 
         let suffix = `/embed/viz/${liveboardGuid}`;

--- a/src/embed/sage.ts
+++ b/src/embed/sage.ts
@@ -147,7 +147,7 @@ export class SageEmbed extends V1Embed {
      */
     protected viewConfig: SageViewConfig;
 
-    // eslint-disable-next-line no-useless-constructor
+     
     constructor(domSelector: DOMSelector, viewConfig: SageViewConfig) {
         viewConfig.embedComponentType = 'SageEmbed';
         super(domSelector, viewConfig);

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -527,7 +527,7 @@ describe('Search embed tests', () => {
     test('should set dataPanelCustomGroupsAccordionInitialState to EXPAND_FIRST when passed', async () => {
         const searchEmbed = new SearchBarEmbed(getRootEl() as any, {
             ...defaultViewConfig,
-            // eslint-disable-next-line max-len
+             
         });
         searchEmbed.render();
         await executeAfterWait(() => {
@@ -541,7 +541,7 @@ describe('Search embed tests', () => {
     test('should set dataPanelCustomGroupsAccordionInitialState to EXPAND_FIRST when passed', async () => {
         const searchEmbed = new SearchEmbed(getRootEl(), {
             ...defaultViewConfig,
-            // eslint-disable-next-line max-len
+             
             dataPanelCustomGroupsAccordionInitialState:
                 DataPanelCustomColumnGroupsAccordionState.EXPAND_FIRST,
         });

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -3056,7 +3056,8 @@ describe('Unit test case for ts embed', () => {
                     expect.any(Object),
                     true
                 );
-                // Check that logger.error was called with the token refresh error
+                // Check that logger.error was called with the token refresh
+                // error
                 const errorCalls = (logger.error as jest.Mock).mock.calls.filter(
                     (call) => call[0]?.includes(ERROR_MESSAGE.INVALID_TOKEN_ERROR) && call[0]?.includes('Token fetch failed')
                 );

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -34,7 +34,7 @@ import {
     setStyleProperties,
     removeStyleProperties,
     isUndefined,
-} from '../utils';
+ getHostEventsConfig } from '../utils';
 import { getCustomActions } from '../utils/custom-actions';
 import {
     getThoughtSpotHost,
@@ -78,7 +78,6 @@ import { ERROR_MESSAGE } from '../errors';
 import { getPreauthInfo } from '../utils/sessionInfoService';
 import { HostEventClient } from './hostEventClient/host-event-client';
 import { getInterceptInitData, handleInterceptEvent, processApiInterceptResponse, processLegacyInterceptResponse } from '../api-intercept';
-import { getHostEventsConfig } from '../utils';
 
 const { version } = pkgInfo;
 
@@ -562,7 +561,8 @@ export class TsEmbed {
      */
     private updateAuthToken = async (_: MessagePayload, responder: any) => {
         const { authType, autoLogin: autoLoginConfig } = this.embedConfig;
-        // Default autoLogin: true for cookieless if undefined/null, otherwise false
+        // Default autoLogin: true for cookieless if undefined/null, otherwise
+        // false
         const autoLogin = autoLoginConfig ?? (authType === AuthType.TrustedAuthTokenCookieless);
         
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
     EmbedErrorDetailsEvent, 
     ErrorDetailsTypes,
     ContextType,
+    AutoMCPFrameRendererViewConfig,
 } from './types';
 import { CustomCssVariables } from './css-variables';
 import { SageEmbed, SageViewConfig } from './embed/sage';
@@ -166,6 +167,8 @@ export {
     EmbedErrorCodes,
     EmbedErrorDetailsEvent,
     ErrorDetailsTypes,
+    AutoMCPFrameRendererViewConfig,
 };
 
 export { resetCachedAuthToken } from './authToken';
+export { startAutoMCPFrameRenderer } from './embed/auto-frame-renderer';

--- a/src/react/index.spec.tsx
+++ b/src/react/index.spec.tsx
@@ -288,7 +288,8 @@ describe('React Components', () => {
             ).toBe(true);
         });
 
-        // Note: insertAsSibling is not supported for SpotterMessage as it's not part of the allowed props
+        // Note: insertAsSibling is not supported for SpotterMessage as it's
+        // not part of the allowed props
     });
 
     describe('Component Factory Coverage', () => {
@@ -416,7 +417,8 @@ describe('React Components', () => {
             const TestComponent = () => {
                 const { sendMessage } = useSpotterAgent({ worksheetId: 'test-worksheet' });
                 
-                // Call sendMessage immediately before service has time to initialize
+                // Call sendMessage immediately before service has time to
+                // initialize
                 sendMessageResult = sendMessage('test query');
                 
                 return <div>Test</div>;
@@ -727,7 +729,8 @@ describe('React Components', () => {
 
              const { rerender } = render(<TestComponent worksheetId="worksheet1" />);
              
-             // This should trigger the "if (serviceRef.current)" branch in useEffect
+             // This should trigger the "if (serviceRef.current)" branch in
+             // useEffect
              rerender(<TestComponent worksheetId="worksheet1" />);
              rerender(<TestComponent worksheetId="worksheet2" />);
              rerender(<TestComponent worksheetId="worksheet3" />);

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -86,7 +86,7 @@ const componentFactory = <T extends typeof TsEmbed, U extends EmbedProps, V exte
             });
             handleRendering(tsEmbed);
             if (forwardedRef) {
-                // eslint-disable-next-line no-param-reassign
+                 
                 forwardedRef.current = tsEmbed;
             }
             return () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1476,6 +1476,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
     useHostEventsV2?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AutoMCPFrameRendererViewConfig extends BaseViewConfig {}
 
 /**
@@ -1487,8 +1488,9 @@ export interface HomePageConfig {
      * *Liveboards* and *Answers*.
      * For example: `hiddenListColumns = [ListPageColumns.Author]`
      *
-     * **Note**: This option is available only in full app embedding and requires importing the `ListPageColumns` enum.
-     * Starting with version 10.14.0.cl, you can use this attribute to
+     * **Note**: This option is available only in full app embedding and requires
+     * importing the `ListPageColumns` enum. Starting with version 10.14.0.cl, you can
+     * use this attribute to
      * hide the columns on all list pages in the *Insights* section.
      *
      * Supported embed types: `AppEmbed`
@@ -1528,8 +1530,9 @@ export interface HomePageConfig {
     /**
      * Reorder home page modules.
      * To specify the modules, import the `HomepageModule` enum.
-     * For example: `reorderedHomepageModules = [HomepageModule.MyLibrary, HomepageModule.Watchlist]`
-     * **Note**: This attribute is not supported in the classic (v1) homepage.
+     * For example: `reorderedHomepageModules = [HomepageModule.MyLibrary,
+     * HomepageModule.Watchlist]` **Note**: This attribute is not supported in the
+     * classic (v1) homepage.
      *
      * Supported embed types: `AppEmbed`
      * @version SDK: 1.28.0 | ThoughtSpot: 9.12.5.cl, 10.1.0.sw
@@ -1843,7 +1846,9 @@ export interface LiveboardAppEmbedViewConfig {
     /**
      * This flag is used to enable/disable hide irrelevant filters in Liveboard tab
      *
-     * **Note**: This feature is supported only if compact header is enabled on your Liveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled` attribute.
+     * **Note**: This feature is supported only if compact header is enabled on your
+     * Liveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled`
+     * attribute.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @version SDK: 1.36.0 | ThoughtSpot: 10.6.0.cl
@@ -1909,9 +1914,9 @@ export interface LiveboardAppEmbedViewConfig {
      */
     coverAndFilterOptionInPDF?: boolean;
     /**
-     * This flag is used to enable or disable the new centralized Liveboard filter UX (v2).
-     * When enabled, a unified modal is used to manage and update multiple filters at once,
-     * replacing the older individual filter interactions.
+     * This flag is used to enable or disable the new centralized Liveboard filter UX
+     * (v2). When enabled, a unified modal is used to manage and update multiple filters
+     * at once, replacing the older individual filter interactions.
      * To enable this feature on your instance, contact ThoughtSpot Support.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
@@ -1943,7 +1948,8 @@ export interface LiveboardAppEmbedViewConfig {
     isLinkParametersEnabled?: boolean;
 
     /**
-     * This flag is used to enable or disable the enhanced filter interactivity in liveboard.
+     * This flag is used to enable or disable the enhanced filter interactivity in
+     * liveboard.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @version SDK: 1.42.0 | ThoughtSpot: 10.15.0.cl
@@ -2666,7 +2672,8 @@ export enum EmbedEvent {
     Download = 'download',
     /**
      * Emitted when the download action is triggered on an Answer.
-     *  Use start:true to subscribe to when download is initiated, or end:true to subscribe to when download is completed. Default is end:true.
+     *  Use start:true to subscribe to when download is initiated, or end:true to
+     *  subscribe to when download is completed. Default is end:true.
      * @version SDK: 1.21.0 | ThoughtSpot: 9.2.0.cl, 9.4.0.sw
      * @example
      * ```js
@@ -2681,7 +2688,8 @@ export enum EmbedEvent {
     DownloadAsPng = 'downloadAsPng',
     /**
      * Emitted when the Download as PDF action is triggered on an Answer
-     *  Use start:true to subscribe to when download as PDF is initiated, or end:true to subscribe to when download as PDF is completed. Default is end:true.
+     *  Use start:true to subscribe to when download as PDF is initiated, or end:true to
+     *  subscribe to when download as PDF is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2696,7 +2704,8 @@ export enum EmbedEvent {
     DownloadAsPdf = 'downloadAsPdf',
     /**
      * Emitted when the Download as CSV action is triggered on an Answer.
-     *  Use start:true to subscribe to when download as CSV is initiated, or end:true to subscribe to when download as CSV is completed. Default is end:true.
+     *  Use start:true to subscribe to when download as CSV is initiated, or end:true to
+     *  subscribe to when download as CSV is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2711,7 +2720,8 @@ export enum EmbedEvent {
     DownloadAsCsv = 'downloadAsCsv',
     /**
      * Emitted when the Download as XLSX action is triggered on an Answer.
-     *  Use start:true to subscribe to when download as XLSX is initiated, or end:true to subscribe to when download as XLSX is completed. Default is end:true.
+     *  Use start:true to subscribe to when download as XLSX is initiated, or end:true to
+     *  subscribe to when download as XLSX is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2726,7 +2736,8 @@ export enum EmbedEvent {
     DownloadAsXlsx = 'downloadAsXlsx',
     /**
      * Emitted when an Answer is deleted in the app
-     *  Use start:true to subscribe to when delete is initiated, or end:true to subscribe to when delete is completed. Default is end:true.
+     *  Use start:true to subscribe to when delete is initiated, or end:true to subscribe
+     *  to when delete is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2753,7 +2764,8 @@ export enum EmbedEvent {
     /**
      * Emitted when a user initiates the Pin action to
      *  add an Answer to a Liveboard.
-     *  Use start:true to subscribe to when pin is initiated, or end:true to subscribe to when pin is completed. Default is end:true.
+     *  Use start:true to subscribe to when pin is initiated, or end:true to subscribe to
+     *  when pin is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2867,7 +2879,8 @@ export enum EmbedEvent {
     /**
      * Emitted when the **Export TML** action is triggered on an
      * an embedded object in the app
-     *  Use start:true to subscribe to when export is initiated, or end:true to subscribe to when export is completed. Default is end:true.
+     *  Use start:true to subscribe to when export is initiated, or end:true to subscribe
+     *  to when export is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2893,7 +2906,8 @@ export enum EmbedEvent {
     SaveAsView = 'saveAsView',
     /**
      * Emitted when the user creates a copy of an Answer.
-     *  Use start:true to subscribe to when copy and edit is initiated, or end:true to subscribe to when copy and edit is completed. Default is end:true.
+     *  Use start:true to subscribe to when copy and edit is initiated, or end:true to
+     *  subscribe to when copy and edit is completed. Default is end:true.
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -3659,7 +3673,8 @@ export enum HostEvent {
      * - `autoDrillDown`: Optional. If `true`, the drill down will be done automatically
      *   on the most popular column.
      * - `vizId` (TS >= 9.8.0): Optional. The GUID of the visualization to drill in case
-     *   of a Liveboard. In Spotter embed, `vizId` refers to the Answer ID and is **required**.
+     *   of a Liveboard. In Spotter embed, `vizId` refers to the Answer ID and is
+     *   **required**.
      * @example
      * ```js
      * searchEmbed.on(EmbedEvent.VizPointDoubleClick, (payload) => {
@@ -3855,7 +3870,8 @@ export enum HostEvent {
      * the following parameters:
      *
      * @param - Includes the following keys:
-     * - `vizId`: GUID of the saved Answer or Spotter visualization ID to pin to a Liveboard.
+     * - `vizId`: GUID of the saved Answer or Spotter visualization ID to pin to a
+     * Liveboard.
      *   Optional when pinning a new chart or table generated from a Search query.
      *   **Required** in Spotter Embed.
      * - `liveboardId`: GUID of the Liveboard to pin an Answer. If there is no Liveboard,
@@ -4111,7 +4127,8 @@ export enum HostEvent {
      * This event is not supported in visualization embed and search embed.
      * @param - Object parameter. Includes the following keys:
      * - `vizId`: To trigger the action for a specific visualization in Liveboard embed,
-     *   pass in `vizId` as a key. In Spotter embed, `vizId` refers to the Answer ID and is **required**.
+     *   pass in `vizId` as a key. In Spotter embed, `vizId` refers to the Answer ID and
+     *   is **required**.
      *
      * @example
      * ```js
@@ -4480,8 +4497,9 @@ export enum HostEvent {
     /**
      * Update one or several filters applied on a Liveboard.
      * @param - Includes the following keys:
-     * - `filter`: A single filter object containing column name, filter operator, and values.
-     * - `filters`: Multiple filter objects with column name, filter operator, and values for each.
+     * - `filter`: A single filter object containing column name, filter operator, and
+     * values. - `filters`: Multiple filter objects with column name, filter operator,
+     * and values for each.
      *
      * Each filter object must include the following attributes:
      *
@@ -4750,8 +4768,8 @@ export enum HostEvent {
      * triggered with a modal to prompt users to
      * add a name and description for the Answer.
      * @param - Includes the following keys:
-     * - `vizId`: Refers to the Answer ID in Spotter embed and is **required** in Spotter embed.
-     * - `name`: Optional. Name string for the Answer.
+     * - `vizId`: Refers to the Answer ID in Spotter embed and is **required** in Spotter
+     * embed. - `name`: Optional. Name string for the Answer.
      * - `description`: Optional. Description text for the Answer.
      * @example
      * ```js
@@ -4947,8 +4965,9 @@ export enum HostEvent {
     /**
      * Triggers a new conversation in Spotter embed.
      *
-     * This feature is available only when chat history is enabled on your ThoughtSpot instance.
-     * Contact your admin or ThoughtSpot Support to enable chat history on your instance.
+     * This feature is available only when chat history is enabled on your ThoughtSpot
+     * instance. Contact your admin or ThoughtSpot Support to enable chat history on your
+     * instance.
      *
      * @example
      * ```js
@@ -6983,7 +7002,9 @@ export enum ErrorDetailsTypes {
 }
 
 /**
- * Error codes for identifying specific issues in embedded ThoughtSpot components. Use {@link EmbedErrorDetailsEvent}  and  {@link ErrorDetailsTypes} codes for precise error handling and debugging.
+ * Error codes for identifying specific issues in embedded ThoughtSpot components. Use
+ * {@link EmbedErrorDetailsEvent}  and  {@link ErrorDetailsTypes} codes for precise error
+ * handling and debugging.
  *
  * @version SDK: 1.44.2 | ThoughtSpot: 26.2.0.cl
  * @group Error Handling
@@ -7055,15 +7076,16 @@ export enum EmbedErrorCodes {
 /**
  * Error event object emitted when an error occurs in an embedded component.
  *
- * This interface defines the structure of error objects returned by the {@link EmbedEvent.Error}
- * event. It provides detailed information about what went wrong, including the error type,
- * a human-readable message, and a machine-readable error code.
+ * This interface defines the structure of error objects returned by the {@link
+ * EmbedEvent.Error} event. It provides detailed information about what went wrong,
+ * including the error type, a human-readable message, and a machine-readable error code.
  *
  * ## Properties
  *
  * - **errorType**: One of the predefined {@link ErrorDetailsTypes} values
- * - **message**: Human-readable error description (string or array of strings for multiple errors)
- * - **code**: Machine-readable error identifier {@link EmbedErrorCodes} values
+ * - **message**: Human-readable error description (string or array of strings for
+ * multiple errors) - **code**: Machine-readable error identifier {@link EmbedErrorCodes}
+ * values
  * - **[key: string]**: Additional context-specific for backward compatibility
  *
  * ## Usage

--- a/src/types.ts
+++ b/src/types.ts
@@ -1476,6 +1476,8 @@ export interface BaseViewConfig extends ApiInterceptFlags {
     useHostEventsV2?: boolean;
 }
 
+export interface AutoMCPFrameRendererViewConfig extends BaseViewConfig {}
+
 /**
  * The configuration object for Home page embeds configs.
  */
@@ -4995,6 +4997,7 @@ export enum DataSourceVisualMode {
  */
 
 export enum Param {
+    Tsmcp = 'tsmcp',
     EmbedApp = 'embedApp',
     DataSources = 'dataSources',
     DataSourceMode = 'dataSourceMode',

--- a/src/utils/graphql/answerService/answerService.ts
+++ b/src/utils/graphql/answerService/answerService.ts
@@ -14,7 +14,7 @@ export interface SessionInterface {
     acSession: { sessionId: string; genNo: number };
 }
 
-// eslint-disable-next-line no-shadow
+ 
 export enum OperationType {
     GetChartWithData = 'GetChartWithData',
     GetTableWithHeadlineData = 'GetTableWithHeadlineData',
@@ -36,10 +36,11 @@ export const DATA_TYPES = ['DATE', 'DATE_TIME', 'TIME'];
  *
  * You can use this service to:
  *
- * - Add or remove columns from Answers (`addColumns`, `removeColumns`, `addColumnsByName`)
- * - Apply filters to Answers (`addFilter`)
- * - Get data from Answers in different formats (JSON, CSV, PNG) (`fetchData`, `fetchCSVBlob`, `fetchPNGBlob`)
- * - Get data for specific points in visualizations (`getUnderlyingDataForPoint`)
+ * - Add or remove columns from Answers (`addColumns`, `removeColumns`,
+ * `addColumnsByName`) - Apply filters to Answers (`addFilter`)
+ * - Get data from Answers in different formats (JSON, CSV, PNG) (`fetchData`,
+ * `fetchCSVBlob`, `fetchPNGBlob`) - Get data for specific points in visualizations
+ * (`getUnderlyingDataForPoint`)
  * - Run custom queries (`executeQuery`)
  * - Add visualizations to Liveboards (`addDisplayedVizToLiveboard`)
  *
@@ -507,12 +508,12 @@ function getSelectedPointsForUnderlyingDataQuery(
 function getDisplayedViz(visualizations: any[], displayMode: string) {
     if (displayMode === 'CHART_MODE') {
         return visualizations.find(
-            // eslint-disable-next-line no-underscore-dangle
+             
             (viz: any) => viz.__typename === 'ChartViz',
         );
     }
     return visualizations.find(
-        // eslint-disable-next-line no-underscore-dangle
+         
         (viz: any) => viz.__typename === 'TableViz',
     );
 }

--- a/src/utils/graphql/preview-service.ts
+++ b/src/utils/graphql/preview-service.ts
@@ -1,4 +1,4 @@
-/* eslint-disable quotes */
+ 
 import { graphqlQuery } from "./graphql-request";
 
 export const getPreviewQuery = `

--- a/src/utils/processData.ts
+++ b/src/utils/processData.ts
@@ -83,10 +83,10 @@ function processNoCookieAccess(e: any, containerEl: Element) {
     } = getEmbedConfig();
     if (!ignoreNoCookieAccess) {
         if (!suppressNoCookieAccessAlert && !suppressErrorAlerts) {
-            // eslint-disable-next-line no-alert
+             
             alert(ERROR_MESSAGE.THIRD_PARTY_COOKIE_BLOCKED_ALERT);
         }
-        // eslint-disable-next-line no-param-reassign
+         
         containerEl.innerHTML = loginFailedMessage;
     }
     notifyAuthFailure(AuthFailureType.NO_COOKIE_ACCESS);
@@ -107,11 +107,11 @@ export function processAuthFailure(e: any, containerEl: Element) {
     const isTrustedAuth = authType === AuthType.TrustedAuthToken || authType === AuthType.TrustedAuthTokenCookieless;
     const isEmbeddedSSOInfoFailure = isEmbeddedSSO && e?.data?.type === AuthFailureType.UNAUTHENTICATED_FAILURE;
     if (autoLogin && isTrustedAuth) {
-        // eslint-disable-next-line no-param-reassign
+         
         containerEl.innerHTML = loginFailedMessage;
         notifyAuthFailure(AuthFailureType.IDLE_SESSION_TIMEOUT);
     } else if (authType !== AuthType.None && !disableLoginFailurePage && !isEmbeddedSSOInfoFailure) {
-        // eslint-disable-next-line no-param-reassign
+         
         containerEl.innerHTML = loginFailedMessage;
         notifyAuthFailure(AuthFailureType.OTHER);
     }
@@ -126,7 +126,7 @@ export function processAuthFailure(e: any, containerEl: Element) {
  */
 function processAuthLogout(e: any, containerEl: Element) {
     const { loginFailedMessage } = getEmbedConfig();
-    // eslint-disable-next-line no-param-reassign
+     
     containerEl.innerHTML = loginFailedMessage;
     resetCachedAuthToken();
     disableAutoLogin();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,18 @@
         "jsx": "react",
         "module": "esnext",
         "target": "es2019",
-        "lib": ["es6", "dom", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021", "es2022"],
+        "lib": [
+            "es6",
+            "dom",
+            "es2016",
+            "es2017",
+            "es2018",
+            "es2019",
+            "es2020",
+            "es2021",
+            "es2022",
+            "dom.iterable"
+        ],
         "sourceMap": true,
         "allowJs": true,
         "rootDir": "./",
@@ -29,10 +40,19 @@
         "removeComments": false,
         "allowSyntheticDefaultImports": true
     },
-    "include": ["src/**/*.ts", "src/**/*.tsx", "custom-typings/**/*.d.ts"],
-    "exclude": ["node_modules", "../node_modules"],
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "custom-typings/**/*.d.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "../node_modules"
+    ],
     "typedocOptions": {
-        "entryPoints": ["src/index.ts"],
+        "entryPoints": [
+            "src/index.ts"
+        ],
         "out": "static/typedoc",
         "json": "static/typedoc/typedoc.json",
         "excludePrivate": true,


### PR DESCRIPTION
In this PR, we introduce a new method which can be used to automatically render the iframes generated using ThoughtSpot MCP server in the context of the user. It also enables applying standard customizations like string, styling, actions etc.

Please check https://github.com/thoughtspot/developer-examples/tree/main/mcp/python-react-agent-simple-ui on sample code of how to use this.