### PR TITLE
[SCAL-271343] Add ChangePersonalisedView EmbedEvent and SelectPersonalisedView HostEvent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4834,8 +4834,8 @@ export enum HostEvent {
     /**
      * Triggers selection of a specific Personalized View on a
      * Liveboard without reloading the embed. Pass either a
-     * `viewId` (GUID) or `viewName`. If neither is provided,
-     * the Liveboard resets to the original/default view.
+     * `viewId` (GUID) or `viewName`. If both are provided, `viewId` takes precedence.
+     * If neither is provided, the Liveboard resets to the original/default view.
      * When a `viewName` is provided and multiple views share
      * the same name, the first match is selected.
      * @example

--- a/src/types.ts
+++ b/src/types.ts
@@ -3206,6 +3206,27 @@ export enum EmbedEvent {
      */
     DeletePersonalizedView = DeletePersonalisedView,
     /**
+     * Emitted when a user selects a different Personalized View or
+     * resets to the original/default view on a Liveboard.
+     * @example
+     * ```js
+     * liveboardEmbed.on(EmbedEvent.ChangePersonalizedView, (data) => {
+     *   console.log(data.viewName);    // 'Q4 Revenue' or 'Original View'
+     *   console.log(data.viewId);      // '2a021a12-...' or null (default)
+     *   console.log(data.liveboardId); // 'abc123...'
+     *   console.log(data.isPublic);    // true | false
+     * })
+     * ```
+     * @returns viewName: string - Name of the selected view,
+     *   or 'Original View' when reset to default.
+     * @returns viewId: string | null - GUID of the selected view,
+     *   or null when reset to default.
+     * @returns liveboardId: string
+     * @returns isPublic: boolean
+     * @version SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl
+     */
+    ChangePersonalizedView = 'changePersonalisedView',
+    /**
      * Emitted when a user creates a Worksheet.
      * @version SDK: 1.27.0 | ThoughtSpot: 9.8.0.cl, 9.8.0.sw
      */
@@ -4810,6 +4831,39 @@ export enum HostEvent {
      * @version SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl
      */
     UpdatePersonalizedView = UpdatePersonalisedView,    
+    /**
+     * Triggers selection of a specific Personalized View on a
+     * Liveboard without reloading the embed. Pass either a
+     * `viewId` (GUID) or `viewName`. If neither is provided,
+     * the Liveboard resets to the original/default view.
+     * When a `viewName` is provided and multiple views share
+     * the same name, the first match is selected.
+     * @example
+     * ```js
+     * liveboardEmbed.trigger(
+     *   HostEvent.SelectPersonalizedView,
+     *   { viewId: '2a021a12-1aed-425d-984b-141ee916ce72' },
+     * )
+     * ```
+     * @example
+     * ```js
+     * // Select by name
+     * liveboardEmbed.trigger(
+     *   HostEvent.SelectPersonalizedView,
+     *   { viewName: 'Dr Smith Cardiology' },
+     * )
+     * ```
+     * @example
+     * ```js
+     * // Reset to default view
+     * liveboardEmbed.trigger(
+     *   HostEvent.SelectPersonalizedView,
+     *   {},
+     * )
+     * ```
+     * @version SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl
+     */
+    SelectPersonalizedView = 'SelectPersonalisedView',
     /**
      * @hidden
      * Notify when info call is completed successfully

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2268,
+			"id": 2270,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -27,7 +27,7 @@
 			},
 			"children": [
 				{
-					"id": 2384,
+					"id": 2386,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -48,14 +48,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6298,
+							"line": 6384,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2288,
+					"id": 2290,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -76,14 +76,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5407,
+							"line": 5491,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2281,
+					"id": 2283,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -104,14 +104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5336,
+							"line": 5420,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2280,
+					"id": 2282,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -128,14 +128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5325,
+							"line": 5409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2286,
+					"id": 2288,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -152,14 +152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5388,
+							"line": 5472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2287,
+					"id": 2289,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -176,14 +176,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5397,
+							"line": 5481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2289,
+					"id": 2291,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -204,14 +204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5417,
+							"line": 5501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2364,
+					"id": 2366,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -232,14 +232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6066,
+							"line": 6152,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2337,
+					"id": 2339,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -260,14 +260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5789,
+							"line": 5875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2380,
+					"id": 2382,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -288,14 +288,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6251,
+							"line": 6337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2336,
+					"id": 2338,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -316,14 +316,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5777,
+							"line": 5863,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2335,
+					"id": 2337,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -344,14 +344,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5765,
+							"line": 5851,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2379,
+					"id": 2381,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6240,
+							"line": 6326,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2348,
+					"id": 2350,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -401,14 +401,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5901,
+							"line": 5987,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2351,
+					"id": 2353,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -429,14 +429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5935,
+							"line": 6021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2356,
+					"id": 2358,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -457,14 +457,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5990,
+							"line": 6076,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2350,
+					"id": 2352,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -485,14 +485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5924,
+							"line": 6010,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2353,
+					"id": 2355,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -513,14 +513,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5958,
+							"line": 6044,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2357,
+					"id": 2359,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -541,14 +541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6000,
+							"line": 6086,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2354,
+					"id": 2356,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -569,14 +569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5969,
+							"line": 6055,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2359,
+					"id": 2361,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -597,14 +597,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6022,
+							"line": 6108,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2355,
+					"id": 2357,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -625,14 +625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5979,
+							"line": 6065,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2352,
+					"id": 2354,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -653,14 +653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5946,
+							"line": 6032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2358,
+					"id": 2360,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -681,14 +681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6010,
+							"line": 6096,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2349,
+					"id": 2351,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -709,14 +709,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5912,
+							"line": 5998,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2393,
+					"id": 2395,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -737,14 +737,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6396,
+							"line": 6482,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2285,
+					"id": 2287,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -761,14 +761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5379,
+							"line": 5463,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2284,
+					"id": 2286,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -789,14 +789,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5370,
+							"line": 5454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2283,
+					"id": 2285,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -817,14 +817,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5358,
+							"line": 5442,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2401,
+					"id": 2403,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -845,14 +845,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6484,
+							"line": 6570,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2282,
+					"id": 2284,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -869,14 +869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5347,
+							"line": 5431,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2328,
+					"id": 2330,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -884,14 +884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5714,
+							"line": 5800,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2275,
+					"id": 2277,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -908,14 +908,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5284,
+							"line": 5368,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2327,
+					"id": 2329,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -932,14 +932,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5713,
+							"line": 5799,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2402,
+					"id": 2404,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -960,14 +960,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6494,
+							"line": 6580,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2416,
+					"id": 2418,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -988,14 +988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6654,
+							"line": 6740,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2377,
+					"id": 2379,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1016,14 +1016,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6215,
+							"line": 6301,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2339,
+					"id": 2341,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1044,14 +1044,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5809,
+							"line": 5895,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2344,
+					"id": 2346,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1072,14 +1072,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5859,
+							"line": 5945,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2394,
+					"id": 2396,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1100,14 +1100,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6408,
+							"line": 6494,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2399,
+					"id": 2401,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1128,14 +1128,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6465,
+							"line": 6551,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2390,
+					"id": 2392,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1156,14 +1156,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6365,
+							"line": 6451,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2392,
+					"id": 2394,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1184,14 +1184,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6384,
+							"line": 6470,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2297,
+					"id": 2299,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1208,14 +1208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5467,
+							"line": 5551,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2300,
+					"id": 2302,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1232,14 +1232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5500,
+							"line": 5584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2299,
+					"id": 2301,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1257,14 +1257,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5490,
+							"line": 5574,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2298,
+					"id": 2300,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1281,14 +1281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5477,
+							"line": 5561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2301,
+					"id": 2303,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1305,14 +1305,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5510,
+							"line": 5594,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2302,
+					"id": 2304,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1333,14 +1333,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5520,
+							"line": 5604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2332,
+					"id": 2334,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1357,14 +1357,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5730,
+							"line": 5816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2326,
+					"id": 2328,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1381,14 +1381,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5703,
+							"line": 5789,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2325,
+					"id": 2327,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1405,14 +1405,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5694,
+							"line": 5780,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2310,
+					"id": 2312,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1429,14 +1429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5596,
+							"line": 5680,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2274,
+					"id": 2276,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1453,14 +1453,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5275,
+							"line": 5359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2338,
+					"id": 2340,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1481,14 +1481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5798,
+							"line": 5884,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2330,
+					"id": 2332,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1496,14 +1496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5719,
+							"line": 5805,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2398,
+					"id": 2400,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1524,14 +1524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6454,
+							"line": 6540,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2368,
+					"id": 2370,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1552,14 +1552,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6110,
+							"line": 6196,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2385,
+					"id": 2387,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1580,14 +1580,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6311,
+							"line": 6397,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2307,
+					"id": 2309,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1604,14 +1604,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5564,
+							"line": 5648,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2311,
+					"id": 2313,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1628,14 +1628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5604,
+							"line": 5688,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2400,
+					"id": 2402,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1656,14 +1656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6475,
+							"line": 6561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2365,
+					"id": 2367,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1684,14 +1684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6076,
+							"line": 6162,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2366,
+					"id": 2368,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1712,14 +1712,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6087,
+							"line": 6173,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2324,
+					"id": 2326,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1736,14 +1736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5683,
+							"line": 5769,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2304,
+					"id": 2306,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1761,14 +1761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5536,
+							"line": 5620,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2305,
+					"id": 2307,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1785,14 +1785,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5546,
+							"line": 5630,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2403,
+					"id": 2405,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1813,14 +1813,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6509,
+							"line": 6595,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2427,
+					"id": 2429,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1841,14 +1841,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6766,
+							"line": 6852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2391,
+					"id": 2393,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1869,14 +1869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6375,
+							"line": 6461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2318,
+					"id": 2320,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1893,14 +1893,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5645,
+							"line": 5730,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2409,
+					"id": 2411,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1921,14 +1921,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6575,
+							"line": 6661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2375,
+					"id": 2377,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1949,14 +1949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6183,
+							"line": 6269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2273,
+					"id": 2275,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1973,14 +1973,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5266,
+							"line": 5350,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2372,
+					"id": 2374,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1997,14 +1997,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6151,
+							"line": 6237,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2343,
+					"id": 2345,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2025,14 +2025,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5849,
+							"line": 5935,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2411,
+					"id": 2413,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2053,14 +2053,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6601,
+							"line": 6687,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2389,
+					"id": 2391,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2081,14 +2081,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6354,
+							"line": 6440,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2363,
+					"id": 2365,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2109,14 +2109,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6056,
+							"line": 6142,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2370,
+					"id": 2372,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2136,14 +2136,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6131,
+							"line": 6217,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2415,
+					"id": 2417,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2164,14 +2164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6644,
+							"line": 6730,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2414,
+					"id": 2416,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2192,14 +2192,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6634,
+							"line": 6720,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2371,
+					"id": 2373,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2216,14 +2216,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6140,
+							"line": 6226,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2382,
+					"id": 2384,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2248,14 +2248,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6275,
+							"line": 6361,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2383,
+					"id": 2385,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2276,14 +2276,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6287,
+							"line": 6373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2413,
+					"id": 2415,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2304,14 +2304,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6624,
+							"line": 6710,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2386,
+					"id": 2388,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2332,14 +2332,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6322,
+							"line": 6408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2373,
+					"id": 2375,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2364,14 +2364,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6163,
+							"line": 6249,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2374,
+					"id": 2376,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2392,14 +2392,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6173,
+							"line": 6259,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2321,
+					"id": 2323,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2416,14 +2416,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5662,
+							"line": 5747,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2407,
+					"id": 2409,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2440,14 +2440,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6553,
+							"line": 6639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2308,
+					"id": 2310,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2464,14 +2464,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5574,
+							"line": 5658,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2395,
+					"id": 2397,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2492,14 +2492,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6420,
+							"line": 6506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2410,
+					"id": 2412,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2520,14 +2520,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6588,
+							"line": 6674,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2334,
+					"id": 2336,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2545,14 +2545,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5755,
+							"line": 5841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2312,
+					"id": 2314,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2569,14 +2569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5614,
+							"line": 5698,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2408,
+					"id": 2410,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2597,14 +2597,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6565,
+							"line": 6651,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2347,
+					"id": 2349,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2625,14 +2625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5890,
+							"line": 5976,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2381,
+					"id": 2383,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2653,14 +2653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6262,
+							"line": 6348,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2361,
+					"id": 2363,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2681,14 +2681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6036,
+							"line": 6122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2340,
+					"id": 2342,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2712,14 +2712,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5818,
+							"line": 5904,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2333,
+					"id": 2335,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2736,14 +2736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5739,
+							"line": 5825,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2362,
+					"id": 2364,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2764,14 +2764,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6046,
+							"line": 6132,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2396,
+					"id": 2398,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2792,14 +2792,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6432,
+							"line": 6518,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2369,
+					"id": 2371,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2820,14 +2820,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6122,
+							"line": 6208,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2269,
+					"id": 2271,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2844,14 +2844,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5235,
+							"line": 5319,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2272,
+					"id": 2274,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2868,14 +2868,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5253,
+							"line": 5337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2277,
+					"id": 2279,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2892,14 +2892,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5298,
+							"line": 5382,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2278,
+					"id": 2280,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2916,14 +2916,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5307,
+							"line": 5391,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2331,
+					"id": 2333,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2931,14 +2931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5720,
+							"line": 5806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2279,
+					"id": 2281,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2955,14 +2955,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5316,
+							"line": 5400,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2294,
+					"id": 2296,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2973,14 +2973,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5442,
+							"line": 5526,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2367,
+					"id": 2369,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3001,14 +3001,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6097,
+							"line": 6183,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2296,
+					"id": 2298,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3025,14 +3025,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5457,
+							"line": 5541,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2291,
+					"id": 2293,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3049,14 +3049,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5430,
+							"line": 5514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2425,
+					"id": 2427,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3077,14 +3077,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6744,
+							"line": 6830,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2423,
+					"id": 2425,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3105,14 +3105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6724,
+							"line": 6810,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2424,
+					"id": 2426,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3133,14 +3133,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6734,
+							"line": 6820,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2426,
+					"id": 2428,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3161,14 +3161,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6754,
+							"line": 6840,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2397,
+					"id": 2399,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3189,14 +3189,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6443,
+							"line": 6529,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2421,
+					"id": 2423,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3217,14 +3217,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6704,
+							"line": 6790,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2422,
+					"id": 2424,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3245,14 +3245,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6714,
+							"line": 6800,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2419,
+					"id": 2421,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3273,14 +3273,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6684,
+							"line": 6770,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2418,
+					"id": 2420,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3301,14 +3301,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6674,
+							"line": 6760,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2420,
+					"id": 2422,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3329,14 +3329,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6694,
+							"line": 6780,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2406,
+					"id": 2408,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3357,14 +3357,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6542,
+							"line": 6628,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2404,
+					"id": 2406,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3385,14 +3385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6520,
+							"line": 6606,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2405,
+					"id": 2407,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3413,14 +3413,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6531,
+							"line": 6617,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2323,
+					"id": 2325,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3437,14 +3437,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5675,
+							"line": 5761,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2342,
+					"id": 2344,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3465,14 +3465,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5839,
+							"line": 5925,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2341,
+					"id": 2343,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3493,14 +3493,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5828,
+							"line": 5914,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2345,
+					"id": 2347,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3521,14 +3521,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5869,
+							"line": 5955,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2346,
+					"id": 2348,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3549,14 +3549,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5879,
+							"line": 5965,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2376,
+					"id": 2378,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3581,14 +3581,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6202,
+							"line": 6288,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2309,
+					"id": 2311,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3605,14 +3605,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5586,
+							"line": 5670,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2417,
+					"id": 2419,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3633,14 +3633,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6664,
+							"line": 6750,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2412,
+					"id": 2414,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3661,14 +3661,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6613,
+							"line": 6699,
 							"character": 5
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2388,
+					"id": 2390,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3689,14 +3689,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6344,
+							"line": 6430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2306,
+					"id": 2308,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3713,14 +3713,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5555,
+							"line": 5639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2378,
+					"id": 2380,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3741,14 +3741,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6226,
+							"line": 6312,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2387,
+					"id": 2389,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3769,7 +3769,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6333,
+							"line": 6419,
 							"character": 4
 						}
 					],
@@ -3781,154 +3781,154 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2384,
+						2386,
+						2290,
+						2283,
+						2282,
 						2288,
-						2281,
-						2280,
-						2286,
-						2287,
 						2289,
-						2364,
+						2291,
+						2366,
+						2339,
+						2382,
+						2338,
 						2337,
-						2380,
-						2336,
-						2335,
-						2379,
-						2348,
-						2351,
-						2356,
+						2381,
 						2350,
 						2353,
+						2358,
+						2352,
+						2355,
+						2359,
+						2356,
+						2361,
 						2357,
 						2354,
-						2359,
-						2355,
-						2352,
-						2358,
-						2349,
-						2393,
-						2285,
-						2284,
-						2283,
-						2401,
-						2282,
-						2328,
-						2275,
-						2327,
-						2402,
-						2416,
-						2377,
-						2339,
-						2344,
-						2394,
-						2399,
-						2390,
-						2392,
-						2297,
-						2300,
-						2299,
-						2298,
-						2301,
-						2302,
-						2332,
-						2326,
-						2325,
-						2310,
-						2274,
-						2338,
-						2330,
-						2398,
-						2368,
-						2385,
-						2307,
-						2311,
-						2400,
-						2365,
-						2366,
-						2324,
-						2304,
-						2305,
-						2403,
-						2427,
-						2391,
-						2318,
-						2409,
-						2375,
-						2273,
-						2372,
-						2343,
-						2411,
-						2389,
-						2363,
-						2370,
-						2415,
-						2414,
-						2371,
-						2382,
-						2383,
-						2413,
-						2386,
-						2373,
-						2374,
-						2321,
-						2407,
-						2308,
+						2360,
+						2351,
 						2395,
-						2410,
-						2334,
-						2312,
-						2408,
-						2347,
-						2381,
-						2361,
-						2340,
-						2333,
-						2362,
-						2396,
-						2369,
-						2269,
-						2272,
+						2287,
+						2286,
+						2285,
+						2403,
+						2284,
+						2330,
 						2277,
-						2278,
-						2331,
-						2279,
-						2294,
+						2329,
+						2404,
+						2418,
+						2379,
+						2341,
+						2346,
+						2396,
+						2401,
+						2392,
+						2394,
+						2299,
+						2302,
+						2301,
+						2300,
+						2303,
+						2304,
+						2334,
+						2328,
+						2327,
+						2312,
+						2276,
+						2340,
+						2332,
+						2400,
+						2370,
+						2387,
+						2309,
+						2313,
+						2402,
 						2367,
+						2368,
+						2326,
+						2306,
+						2307,
+						2405,
+						2429,
+						2393,
+						2320,
+						2411,
+						2377,
+						2275,
+						2374,
+						2345,
+						2413,
+						2391,
+						2365,
+						2372,
+						2417,
+						2416,
+						2373,
+						2384,
+						2385,
+						2415,
+						2388,
+						2375,
+						2376,
+						2323,
+						2409,
+						2310,
+						2397,
+						2412,
+						2336,
+						2314,
+						2410,
+						2349,
+						2383,
+						2363,
+						2342,
+						2335,
+						2364,
+						2398,
+						2371,
+						2271,
+						2274,
+						2279,
+						2280,
+						2333,
+						2281,
 						2296,
-						2291,
+						2369,
+						2298,
+						2293,
+						2427,
 						2425,
+						2426,
+						2428,
+						2399,
 						2423,
 						2424,
-						2426,
-						2397,
 						2421,
-						2422,
-						2419,
-						2418,
 						2420,
+						2422,
+						2408,
 						2406,
-						2404,
-						2405,
-						2323,
-						2342,
-						2341,
-						2345,
-						2346,
-						2376,
-						2309,
-						2417,
-						2412,
-						2388,
-						2306,
+						2407,
+						2325,
+						2344,
+						2343,
+						2347,
+						2348,
 						2378,
-						2387
+						2311,
+						2419,
+						2414,
+						2390,
+						2308,
+						2380,
+						2389
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5226,
+					"line": 5310,
 					"character": 12
 				}
 			]
@@ -3961,7 +3961,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 201,
+							"line": 202,
 							"character": 4
 						}
 					],
@@ -3980,7 +3980,7 @@
 			"sources": [
 				{
 					"fileName": "auth.ts",
-					"line": 196,
+					"line": 197,
 					"character": 12
 				}
 			]
@@ -4009,12 +4009,12 @@
 					"flags": {},
 					"comment": {
 						"shortText": "The current authentication token or session has expired.",
-						"text": "Emitted when the embed receives an auth-expiry signal and starts auth refresh handling.\n"
+						"text": "Emitted when the embed receives an auth-expiry signal and starts auth refresh\nhandling.\n"
 					},
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 59,
+							"line": 60,
 							"character": 4
 						}
 					],
@@ -4033,7 +4033,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 71,
+							"line": 72,
 							"character": 4
 						}
 					],
@@ -4071,7 +4071,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 65,
+							"line": 66,
 							"character": 4
 						}
 					],
@@ -4109,7 +4109,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 77,
+							"line": 78,
 							"character": 4
 						}
 					],
@@ -4166,7 +4166,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 88,
+							"line": 89,
 							"character": 4
 						}
 					],
@@ -4184,7 +4184,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 130,
+							"line": 131,
 							"character": 4
 						}
 					],
@@ -4202,7 +4202,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 142,
+							"line": 143,
 							"character": 4
 						}
 					],
@@ -4226,7 +4226,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 104,
+							"line": 105,
 							"character": 4
 						}
 					],
@@ -4259,7 +4259,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 126,
+							"line": 127,
 							"character": 4
 						}
 					],
@@ -4283,7 +4283,7 @@
 					"sources": [
 						{
 							"fileName": "auth.ts",
-							"line": 137,
+							"line": 138,
 							"character": 4
 						}
 					],
@@ -4307,7 +4307,7 @@
 			"sources": [
 				{
 					"fileName": "auth.ts",
-					"line": 84,
+					"line": 85,
 					"character": 12
 				}
 			]
@@ -4341,7 +4341,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 171,
+							"line": 175,
 							"character": 4
 						}
 					],
@@ -4412,7 +4412,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 118,
+							"line": 121,
 							"character": 4
 						}
 					],
@@ -4445,7 +4445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 105,
+							"line": 107,
 							"character": 4
 						}
 					],
@@ -4469,7 +4469,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 143,
+							"line": 147,
 							"character": 4
 						}
 					],
@@ -4497,7 +4497,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 164,
+							"line": 168,
 							"character": 4
 						}
 					],
@@ -4528,7 +4528,7 @@
 			]
 		},
 		{
-			"id": 2428,
+			"id": 2430,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4538,7 +4538,7 @@
 			},
 			"children": [
 				{
-					"id": 2431,
+					"id": 2433,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4546,14 +4546,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6786,
+							"line": 6872,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2429,
+					"id": 2431,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4561,14 +4561,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6784,
+							"line": 6870,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2430,
+					"id": 2432,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4576,7 +4576,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6785,
+							"line": 6871,
 							"character": 4
 						}
 					],
@@ -4588,29 +4588,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2433,
 						2431,
-						2429,
-						2430
+						2432
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6783,
+					"line": 6869,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2259,
+			"id": 2261,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2262,
+					"id": 2264,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4621,14 +4621,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7202,
+							"line": 7292,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2261,
+					"id": 2263,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4639,14 +4639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7198,
+							"line": 7288,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2260,
+					"id": 2262,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4657,14 +4657,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7194,
+							"line": 7284,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2263,
+					"id": 2265,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4675,7 +4675,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7206,
+							"line": 7296,
 							"character": 4
 						}
 					],
@@ -4687,23 +4687,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2264,
+						2263,
 						2262,
-						2261,
-						2260,
-						2263
+						2265
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 7190,
+					"line": 7280,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3167,
+			"id": 3169,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4713,7 +4713,7 @@
 			},
 			"children": [
 				{
-					"id": 3170,
+					"id": 3172,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4724,14 +4724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6923,
+							"line": 7009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3168,
+					"id": 3170,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4742,14 +4742,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6896,
+							"line": 6982,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3171,
+					"id": 3173,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4760,14 +4760,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6934,
+							"line": 7020,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3169,
+					"id": 3171,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4778,7 +4778,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6910,
+							"line": 6996,
 							"character": 4
 						}
 					],
@@ -4790,23 +4790,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						3172,
 						3170,
-						3168,
-						3171,
-						3169
+						3173,
+						3171
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6886,
+					"line": 6972,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3163,
+			"id": 3165,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4816,7 +4816,7 @@
 			},
 			"children": [
 				{
-					"id": 3166,
+					"id": 3168,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4827,14 +4827,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6877,
+							"line": 6963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3165,
+					"id": 3167,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4845,14 +4845,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6869,
+							"line": 6955,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3164,
+					"id": 3166,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4863,7 +4863,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6864,
+							"line": 6950,
 							"character": 4
 						}
 					],
@@ -4875,22 +4875,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3166,
-						3165,
-						3164
+						3168,
+						3167,
+						3166
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6859,
+					"line": 6945,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3159,
+			"id": 3161,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4900,7 +4900,7 @@
 			},
 			"children": [
 				{
-					"id": 3161,
+					"id": 3163,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4918,7 +4918,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3160,
+					"id": 3162,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4936,7 +4936,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3162,
+					"id": 3164,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4959,9 +4959,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3161,
-						3160,
-						3162
+						3163,
+						3162,
+						3164
 					]
 				}
 			],
@@ -4974,7 +4974,7 @@
 			]
 		},
 		{
-			"id": 2264,
+			"id": 2266,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4984,7 +4984,7 @@
 			},
 			"children": [
 				{
-					"id": 2266,
+					"id": 2268,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4995,14 +4995,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5038,
+							"line": 5121,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2267,
+					"id": 2269,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5013,14 +5013,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5042,
+							"line": 5125,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2265,
+					"id": 2267,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5031,7 +5031,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5034,
+							"line": 5117,
 							"character": 4
 						}
 					],
@@ -5043,28 +5043,28 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2266,
-						2267,
-						2265
+						2268,
+						2269,
+						2267
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 5030,
+					"line": 5113,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3176,
+			"id": 3178,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"comment": {
-				"shortText": "Error codes for identifying specific issues in embedded ThoughtSpot components. Use {@link EmbedErrorDetailsEvent}  and  {@link ErrorDetailsTypes} codes for precise error handling and debugging.",
+				"shortText": "Error codes for identifying specific issues in embedded ThoughtSpot components. Use\n{@link EmbedErrorDetailsEvent}  and  {@link ErrorDetailsTypes} codes for precise error\nhandling and debugging.",
 				"tags": [
 					{
 						"tag": "version",
@@ -5082,7 +5082,7 @@
 			},
 			"children": [
 				{
-					"id": 3179,
+					"id": 3181,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5093,14 +5093,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7098,
+							"line": 7186,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3180,
+					"id": 3182,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5111,14 +5111,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7101,
+							"line": 7189,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3183,
+					"id": 3185,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5129,14 +5129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7110,
+							"line": 7198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3186,
+					"id": 3188,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5147,14 +5147,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7119,
+							"line": 7207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3181,
+					"id": 3183,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5165,14 +5165,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7104,
+							"line": 7192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3189,
+					"id": 3191,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5183,14 +5183,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7128,
+							"line": 7216,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3178,
+					"id": 3180,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5201,14 +5201,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7095,
+							"line": 7183,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3184,
+					"id": 3186,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5219,14 +5219,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7113,
+							"line": 7201,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3182,
+					"id": 3184,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5237,14 +5237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7107,
+							"line": 7195,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3187,
+					"id": 3189,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5255,14 +5255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7122,
+							"line": 7210,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3185,
+					"id": 3187,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5273,14 +5273,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7116,
+							"line": 7204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3188,
+					"id": 3190,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5291,14 +5291,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7125,
+							"line": 7213,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3177,
+					"id": 3179,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5309,7 +5309,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7092,
+							"line": 7180,
 							"character": 4
 						}
 					],
@@ -5321,26 +5321,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3179,
-						3180,
-						3183,
-						3186,
 						3181,
-						3189,
-						3178,
-						3184,
 						3182,
-						3187,
 						3185,
 						3188,
-						3177
+						3183,
+						3191,
+						3180,
+						3186,
+						3184,
+						3189,
+						3187,
+						3190,
+						3179
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 7090,
+					"line": 7178,
 					"character": 12
 				}
 			]
@@ -5392,7 +5392,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2750,
+							"line": 2767,
 							"character": 4
 						}
 					],
@@ -5420,7 +5420,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2629,
+							"line": 2641,
 							"character": 4
 						}
 					],
@@ -5452,14 +5452,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2393,
+							"line": 2405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2165,
+					"id": 2166,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5480,7 +5480,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3388,
+							"line": 3430,
 							"character": 4
 						}
 					],
@@ -5508,7 +5508,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2960,
+							"line": 2980,
 							"character": 4
 						}
 					],
@@ -5540,7 +5540,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2487,
+							"line": 2499,
 							"character": 4
 						}
 					],
@@ -5568,7 +5568,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2928,
+							"line": 2948,
 							"character": 4
 						}
 					],
@@ -5581,7 +5581,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when an Answer is deleted in the app\n Use start:true to subscribe to when delete is initiated, or end:true to subscribe to when delete is completed. Default is end:true.",
+						"shortText": "Emitted when an Answer is deleted in the app\n Use start:true to subscribe to when delete is initiated, or end:true to subscribe\n to when delete is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -5596,14 +5596,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2739,
+							"line": 2756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2175,
+					"id": 2176,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5625,14 +5625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3554,
+							"line": 3596,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2154,
+					"id": 2155,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5665,7 +5665,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3201,
+							"line": 3242,
 							"character": 4
 						}
 					],
@@ -5693,7 +5693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2500,
+							"line": 2512,
 							"character": 4
 						}
 					],
@@ -5725,7 +5725,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2295,
+							"line": 2307,
 							"character": 4
 						}
 					],
@@ -5753,11 +5753,55 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3036,
+							"line": 3056,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
+				},
+				{
+					"id": 2153,
+					"name": "ChangePersonalizedView",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Emitted when a user selects a different Personalized View or\nresets to the original/default view on a Liveboard.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nliveboardEmbed.on(EmbedEvent.ChangePersonalizedView, (data) => {\n  console.log(data.viewName);    // 'Q4 Revenue' or 'Original View'\n  console.log(data.viewId);      // '2a021a12-...' or null (default)\n  console.log(data.liveboardId); // 'abc123...'\n  console.log(data.isPublic);    // true | false\n})\n```"
+							},
+							{
+								"tag": "returns",
+								"text": "viewName: string - Name of the selected view,\n  or 'Original View' when reset to default."
+							},
+							{
+								"tag": "returns",
+								"text": "viewId: string | null - GUID of the selected view,\n  or null when reset to default."
+							},
+							{
+								"tag": "returns",
+								"text": "liveboardId: string"
+							},
+							{
+								"tag": "returns",
+								"text": "isPublic: boolean"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 3228,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
 					"id": 2122,
@@ -5766,7 +5810,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the user creates a copy of an Answer.\n Use start:true to subscribe to when copy and edit is initiated, or end:true to subscribe to when copy and edit is completed. Default is end:true.",
+						"shortText": "Emitted when the user creates a copy of an Answer.\n Use start:true to subscribe to when copy and edit is initiated, or end:true to\n subscribe to when copy and edit is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -5781,7 +5825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2906,
+							"line": 2926,
 							"character": 4
 						}
 					],
@@ -5809,7 +5853,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3056,
+							"line": 3076,
 							"character": 4
 						}
 					],
@@ -5837,7 +5881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2841,
+							"line": 2859,
 							"character": 4
 						}
 					],
@@ -5861,14 +5905,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3120,
+							"line": 3140,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2159,
+					"id": 2160,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5886,14 +5930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3338,
+							"line": 3380,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2160,
+					"id": 2161,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5910,14 +5954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3343,
+							"line": 3385,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2153,
+					"id": 2154,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5934,7 +5978,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3192,
+							"line": 3233,
 							"character": 4
 						}
 					],
@@ -5962,7 +6006,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3067,
+							"line": 3087,
 							"character": 4
 						}
 					],
@@ -5998,7 +6042,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2410,
+							"line": 2422,
 							"character": 4
 						}
 					],
@@ -6034,14 +6078,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2323,
+							"line": 2335,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2166,
+					"id": 2167,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6062,7 +6106,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3399,
+							"line": 3441,
 							"character": 4
 						}
 					],
@@ -6094,7 +6138,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2381,
+							"line": 2393,
 							"character": 4
 						}
 					],
@@ -6122,7 +6166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3018,
+							"line": 3038,
 							"character": 4
 						}
 					],
@@ -6158,7 +6202,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3180,
+							"line": 3200,
 							"character": 4
 						}
 					],
@@ -6190,7 +6234,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3187,
+							"line": 3207,
 							"character": 4
 						}
 					],
@@ -6218,7 +6262,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2596,
+							"line": 2608,
 							"character": 4
 						}
 					],
@@ -6246,7 +6290,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2585,
+							"line": 2597,
 							"character": 4
 						}
 					],
@@ -6275,7 +6319,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2664,
+							"line": 2676,
 							"character": 4
 						}
 					],
@@ -6288,7 +6332,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the Download as CSV action is triggered on an Answer.\n Use start:true to subscribe to when download as CSV is initiated, or end:true to subscribe to when download as CSV is completed. Default is end:true.",
+						"shortText": "Emitted when the Download as CSV action is triggered on an Answer.\n Use start:true to subscribe to when download as CSV is initiated, or end:true to\n subscribe to when download as CSV is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -6303,7 +6347,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2709,
+							"line": 2724,
 							"character": 4
 						}
 					],
@@ -6316,7 +6360,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the Download as PDF action is triggered on an Answer\n Use start:true to subscribe to when download as PDF is initiated, or end:true to subscribe to when download as PDF is completed. Default is end:true.",
+						"shortText": "Emitted when the Download as PDF action is triggered on an Answer\n Use start:true to subscribe to when download as PDF is initiated, or end:true to\n subscribe to when download as PDF is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -6331,7 +6375,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2694,
+							"line": 2708,
 							"character": 4
 						}
 					],
@@ -6344,7 +6388,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the download action is triggered on an Answer.\n Use start:true to subscribe to when download is initiated, or end:true to subscribe to when download is completed. Default is end:true.",
+						"shortText": "Emitted when the download action is triggered on an Answer.\n Use start:true to subscribe to when download is initiated, or end:true to\n subscribe to when download is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -6359,7 +6403,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2679,
+							"line": 2692,
 							"character": 4
 						}
 					],
@@ -6372,7 +6416,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the Download as XLSX action is triggered on an Answer.\n Use start:true to subscribe to when download as XLSX is initiated, or end:true to subscribe to when download as XLSX is completed. Default is end:true.",
+						"shortText": "Emitted when the Download as XLSX action is triggered on an Answer.\n Use start:true to subscribe to when download as XLSX is initiated, or end:true to\n subscribe to when download as XLSX is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -6387,7 +6431,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2724,
+							"line": 2740,
 							"character": 4
 						}
 					],
@@ -6415,7 +6459,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2830,
+							"line": 2848,
 							"character": 4
 						}
 					],
@@ -6443,7 +6487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2818,
+							"line": 2836,
 							"character": 4
 						}
 					],
@@ -6487,7 +6531,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2369,
+							"line": 2381,
 							"character": 4
 						}
 					],
@@ -6515,7 +6559,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2982,
+							"line": 3002,
 							"character": 4
 						}
 					],
@@ -6543,7 +6587,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2864,
+							"line": 2882,
 							"character": 4
 						}
 					],
@@ -6580,7 +6624,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2477,
+							"line": 2489,
 							"character": 4
 						}
 					],
@@ -6608,7 +6652,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3046,
+							"line": 3066,
 							"character": 4
 						}
 					],
@@ -6621,7 +6665,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when the **Export TML** action is triggered on an\nan embedded object in the app\n Use start:true to subscribe to when export is initiated, or end:true to subscribe to when export is completed. Default is end:true.",
+						"shortText": "Emitted when the **Export TML** action is triggered on an\nan embedded object in the app\n Use start:true to subscribe to when export is initiated, or end:true to subscribe\n to when export is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -6636,7 +6680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2880,
+							"line": 2899,
 							"character": 4
 						}
 					],
@@ -6664,7 +6708,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3097,
+							"line": 3117,
 							"character": 4
 						}
 					],
@@ -6692,7 +6736,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2542,
+							"line": 2554,
 							"character": 4
 						}
 					],
@@ -6720,14 +6764,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2283,
+							"line": 2295,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2169,
+					"id": 2170,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6748,14 +6792,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3432,
+							"line": 3474,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2168,
+					"id": 2169,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6776,7 +6820,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3421,
+							"line": 3463,
 							"character": 4
 						}
 					],
@@ -6804,7 +6848,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2949,
+							"line": 2969,
 							"character": 4
 						}
 					],
@@ -6836,7 +6880,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2618,
+							"line": 2630,
 							"character": 4
 						}
 					],
@@ -6868,7 +6912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2309,
+							"line": 2321,
 							"character": 4
 						}
 					],
@@ -6896,7 +6940,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2993,
+							"line": 3013,
 							"character": 4
 						}
 					],
@@ -6924,14 +6968,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2568,
+							"line": 2580,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2156,
+					"id": 2157,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6942,7 +6986,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following parameters:\n- `payload`: The payload received from the embed related to the Data API call.\n- `responder`: Contains elements that let developers define whether ThoughtSpot\n  will run or block the search operation, and if blocked, which error message to provide.\n- `execute` - When `execute` returns `true`, the search is run.\nWhen `execute` returns `false`, the search is not executed.\n- `error` - Developers can customize the user-facing error message when `execute`\nis `false` by using the `error` parameters in `responder`.\n- `errorText` - The error message text shown to the user.",
+								"text": "Includes the following parameters:\n- `payload`: The payload received from the embed related to the Data API call.\n- `responder`: Contains elements that let developers define whether ThoughtSpot\n  will run or block the search operation, and if blocked, which error message to\n  provide.\n- `execute` - When `execute` returns `true`, the search is run.\nWhen `execute` returns `false`, the search is not executed.\n- `error` - Developers can customize the user-facing error message when `execute`\nis `false` by using the `error` parameters in `responder`.\n- `errorText` - The error message text shown to the user.",
 								"param": "-"
 							},
 							{
@@ -6962,14 +7006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3271,
+							"line": 3313,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2174,
+					"id": 2175,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6990,14 +7034,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3488,
+							"line": 3530,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2157,
+					"id": 2158,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7014,7 +7058,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3282,
+							"line": 3324,
 							"character": 4
 						}
 					],
@@ -7027,7 +7071,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Emitted when a user initiates the Pin action to\n add an Answer to a Liveboard.\n Use start:true to subscribe to when pin is initiated, or end:true to subscribe to when pin is completed. Default is end:true.",
+						"shortText": "Emitted when a user initiates the Pin action to\n add an Answer to a Liveboard.\n Use start:true to subscribe to when pin is initiated, or end:true to subscribe to\n when pin is completed. Default is end:true.",
 						"tags": [
 							{
 								"tag": "version",
@@ -7042,7 +7086,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2770,
+							"line": 2788,
 							"character": 4
 						}
 					],
@@ -7074,14 +7118,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3008,
+							"line": 3028,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2164,
+					"id": 2165,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7102,7 +7146,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3377,
+							"line": 3419,
 							"character": 4
 						}
 					],
@@ -7130,14 +7174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2332,
+							"line": 2344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2155,
+					"id": 2156,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7154,7 +7198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3206,
+							"line": 3247,
 							"character": 4
 						}
 					],
@@ -7194,14 +7238,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3171,
+							"line": 3191,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2170,
+					"id": 2171,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7222,7 +7266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3443,
+							"line": 3485,
 							"character": 4
 						}
 					],
@@ -7250,7 +7294,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2552,
+							"line": 2564,
 							"character": 4
 						}
 					],
@@ -7274,7 +7318,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3103,
+							"line": 3123,
 							"character": 4
 						}
 					],
@@ -7298,7 +7342,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3110,
+							"line": 3130,
 							"character": 4
 						}
 					],
@@ -7326,7 +7370,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2648,
+							"line": 2660,
 							"character": 4
 						}
 					],
@@ -7354,7 +7398,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2891,
+							"line": 2910,
 							"character": 4
 						}
 					],
@@ -7398,7 +7442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3153,
+							"line": 3173,
 							"character": 4
 						}
 					],
@@ -7438,7 +7482,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3162,
+							"line": 3182,
 							"character": 4
 						}
 					],
@@ -7466,7 +7510,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2971,
+							"line": 2991,
 							"character": 4
 						}
 					],
@@ -7494,7 +7538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3027,
+							"line": 3047,
 							"character": 4
 						}
 					],
@@ -7522,7 +7566,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2806,
+							"line": 2824,
 							"character": 4
 						}
 					],
@@ -7550,7 +7594,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2917,
+							"line": 2937,
 							"character": 4
 						}
 					],
@@ -7578,14 +7622,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2788,
+							"line": 2806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2177,
+					"id": 2178,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7606,14 +7650,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3578,
+							"line": 3620,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2176,
+					"id": 2177,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7634,14 +7678,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3566,
+							"line": 3608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2178,
+					"id": 2179,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7662,14 +7706,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3590,
+							"line": 3632,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2163,
+					"id": 2164,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7690,14 +7734,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3366,
+							"line": 3408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2171,
+					"id": 2172,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7718,14 +7762,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3454,
+							"line": 3496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2172,
+					"id": 2173,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7746,14 +7790,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3465,
+							"line": 3507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2167,
+					"id": 2168,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7774,14 +7818,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3410,
+							"line": 3452,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2158,
+					"id": 2159,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7803,7 +7847,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3325,
+							"line": 3367,
 							"character": 4
 						}
 					],
@@ -7827,7 +7871,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3115,
+							"line": 3135,
 							"character": 4
 						}
 					],
@@ -7871,7 +7915,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3132,
+							"line": 3152,
 							"character": 4
 						}
 					],
@@ -7911,7 +7955,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3142,
+							"line": 3162,
 							"character": 4
 						}
 					],
@@ -7939,7 +7983,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2852,
+							"line": 2870,
 							"character": 4
 						}
 					],
@@ -7975,7 +8019,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2441,
+							"line": 2453,
 							"character": 4
 						}
 					],
@@ -8007,7 +8051,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2422,
+							"line": 2434,
 							"character": 4
 						}
 					],
@@ -8035,7 +8079,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3078,
+							"line": 3098,
 							"character": 4
 						}
 					],
@@ -8050,27 +8094,28 @@
 						2111,
 						2103,
 						2083,
-						2165,
+						2166,
 						2128,
 						2088,
 						2124,
 						2110,
-						2175,
-						2154,
+						2176,
+						2155,
 						2089,
 						2077,
 						2135,
+						2153,
 						2122,
 						2137,
 						2117,
 						2145,
-						2159,
 						2160,
-						2153,
+						2161,
+						2154,
 						2138,
 						2084,
 						2079,
-						2166,
+						2167,
 						2082,
 						2133,
 						2151,
@@ -8093,23 +8138,23 @@
 						2141,
 						2095,
 						2076,
+						2170,
 						2169,
-						2168,
 						2127,
 						2102,
 						2078,
 						2131,
 						2098,
-						2156,
-						2174,
 						2157,
+						2175,
+						2158,
 						2112,
 						2132,
-						2164,
+						2165,
 						2080,
-						2155,
+						2156,
 						2150,
-						2170,
+						2171,
 						2096,
 						2142,
 						2143,
@@ -8122,14 +8167,14 @@
 						2114,
 						2123,
 						2113,
-						2177,
-						2176,
 						2178,
-						2163,
-						2171,
+						2177,
+						2179,
+						2164,
 						2172,
-						2167,
-						2158,
+						2173,
+						2168,
+						2159,
 						2144,
 						2146,
 						2147,
@@ -8143,13 +8188,13 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2270,
+					"line": 2282,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3196,
+			"id": 3198,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8174,7 +8219,7 @@
 			},
 			"children": [
 				{
-					"id": 3197,
+					"id": 3199,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8185,14 +8230,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7054,
+							"line": 7140,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3199,
+					"id": 3201,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8203,14 +8248,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7058,
+							"line": 7144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3198,
+					"id": 3200,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8221,7 +8266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7056,
+							"line": 7142,
 							"character": 4
 						}
 					],
@@ -8233,22 +8278,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3197,
 						3199,
-						3198
+						3201,
+						3200
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 7052,
+					"line": 7138,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2851,
+			"id": 2853,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8258,7 +8303,7 @@
 			},
 			"children": [
 				{
-					"id": 2855,
+					"id": 2857,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8275,14 +8320,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 203,
+							"line": 207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2859,
+					"id": 2861,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8299,14 +8344,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 228,
+							"line": 232,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2861,
+					"id": 2863,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8323,14 +8368,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 242,
+							"line": 246,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2853,
+					"id": 2855,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8347,14 +8392,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 191,
+							"line": 195,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2858,
+					"id": 2860,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8371,14 +8416,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 221,
+							"line": 225,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2854,
+					"id": 2856,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8395,14 +8440,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 197,
+							"line": 201,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2856,
+					"id": 2858,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8419,14 +8464,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 209,
+							"line": 213,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2852,
+					"id": 2854,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8443,14 +8488,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 185,
+							"line": 189,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2857,
+					"id": 2859,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8467,14 +8512,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 215,
+							"line": 219,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2860,
+					"id": 2862,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8491,7 +8536,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 235,
+							"line": 239,
 							"character": 4
 						}
 					],
@@ -8503,29 +8548,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2855,
-						2859,
+						2857,
 						2861,
-						2853,
+						2863,
+						2855,
+						2860,
+						2856,
 						2858,
 						2854,
-						2856,
-						2852,
-						2857,
-						2860
+						2859,
+						2862
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 179,
+					"line": 183,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3114,
+			"id": 3116,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8541,7 +8586,7 @@
 			},
 			"children": [
 				{
-					"id": 3115,
+					"id": 3117,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8559,7 +8604,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3116,
+					"id": 3118,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8582,8 +8627,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3115,
-						3116
+						3117,
+						3118
 					]
 				}
 			],
@@ -8596,14 +8641,14 @@
 			]
 		},
 		{
-			"id": 3108,
+			"id": 3110,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3110,
+					"id": 3112,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8618,7 +8663,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3111,
+					"id": 3113,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8633,7 +8678,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3109,
+					"id": 3111,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8653,9 +8698,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3110,
-						3111,
-						3109
+						3112,
+						3113,
+						3111
 					]
 				}
 			],
@@ -8668,7 +8713,7 @@
 			]
 		},
 		{
-			"id": 2862,
+			"id": 2864,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8685,7 +8730,7 @@
 			},
 			"children": [
 				{
-					"id": 2865,
+					"id": 2867,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8696,14 +8741,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2142,
+							"line": 2154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2868,
+					"id": 2870,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8714,14 +8759,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2154,
+							"line": 2166,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2866,
+					"id": 2868,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8732,14 +8777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2146,
+							"line": 2158,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2863,
+					"id": 2865,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8750,14 +8795,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2134,
+							"line": 2146,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2867,
+					"id": 2869,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8768,14 +8813,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2150,
+							"line": 2162,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2864,
+					"id": 2866,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8786,7 +8831,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2138,
+							"line": 2150,
 							"character": 4
 						}
 					],
@@ -8798,25 +8843,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2865,
-						2868,
-						2866,
-						2863,
 						2867,
-						2864
+						2870,
+						2868,
+						2865,
+						2869,
+						2866
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2130,
+					"line": 2142,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2180,
+			"id": 2181,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -8845,7 +8890,7 @@
 			},
 			"children": [
 				{
-					"id": 2202,
+					"id": 2203,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8866,14 +8911,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4041,
+							"line": 4085,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2191,
+					"id": 2192,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8899,14 +8944,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3851,
+							"line": 3894,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2247,
+					"id": 2249,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8932,14 +8977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4897,
+							"line": 4979,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2251,
+					"id": 2253,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8965,14 +9010,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4939,
+							"line": 5021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2232,
+					"id": 2233,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8993,14 +9038,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4692,
+							"line": 4740,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2254,
+					"id": 2256,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9026,14 +9071,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4977,
+							"line": 5059,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2209,
+					"id": 2210,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9059,14 +9104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4177,
+							"line": 4222,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2206,
+					"id": 2207,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9096,14 +9141,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4115,
+							"line": 4159,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2248,
+					"id": 2250,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9124,14 +9169,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4906,
+							"line": 4988,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2213,
+					"id": 2214,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9157,14 +9202,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4260,
+							"line": 4305,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2250,
+					"id": 2252,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9185,14 +9230,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4924,
+							"line": 5006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2256,
+					"id": 2258,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9213,14 +9258,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4997,
+							"line": 5079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2215,
+					"id": 2216,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9250,14 +9295,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4308,
+							"line": 4353,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2217,
+					"id": 2218,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9283,14 +9328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4359,
+							"line": 4405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2201,
+					"id": 2202,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9320,14 +9365,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4031,
+							"line": 4075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2216,
+					"id": 2217,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9348,14 +9393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4332,
+							"line": 4378,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2218,
+					"id": 2219,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9381,14 +9426,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4386,
+							"line": 4432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2182,
+					"id": 2183,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9398,7 +9443,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `points`: An object containing `selectedPoints` and/or `clickedPoint`\n  to drill to. For example, `{ selectedPoints: [] }`.\n- `columnGuid`: Optional. GUID of the column to drill by. If not provided,\n  it will auto drill by the configured column.\n- `autoDrillDown`: Optional. If `true`, the drill down will be done automatically\n  on the most popular column.\n- `vizId` (TS >= 9.8.0): Optional. The GUID of the visualization to drill in case\n  of a Liveboard. In Spotter embed, `vizId` refers to the Answer ID and is **required**.",
+								"text": "Includes the following keys:\n- `points`: An object containing `selectedPoints` and/or `clickedPoint`\n  to drill to. For example, `{ selectedPoints: [] }`.\n- `columnGuid`: Optional. GUID of the column to drill by. If not provided,\n  it will auto drill by the configured column.\n- `autoDrillDown`: Optional. If `true`, the drill down will be done automatically\n  on the most popular column.\n- `vizId` (TS >= 9.8.0): Optional. The GUID of the visualization to drill in case\n  of a Liveboard. In Spotter embed, `vizId` refers to the Answer ID and is\n  **required**.",
 								"param": "-"
 							},
 							{
@@ -9418,14 +9463,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3730,
+							"line": 3773,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2208,
+					"id": 2209,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9436,7 +9481,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Object parameter. Includes the following keys:\n- `vizId`: To trigger the action for a specific visualization in Liveboard embed,\n  pass in `vizId` as a key. In Spotter embed, `vizId` refers to the Answer ID and is **required**.\n",
+								"text": "Object parameter. Includes the following keys:\n- `vizId`: To trigger the action for a specific visualization in Liveboard embed,\n  pass in `vizId` as a key. In Spotter embed, `vizId` refers to the Answer ID and\n  is **required**.\n",
 								"param": "-"
 							},
 							{
@@ -9456,14 +9501,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4160,
+							"line": 4205,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2245,
+					"id": 2247,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9489,14 +9534,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4877,
+							"line": 4959,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2199,
+					"id": 2200,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9517,14 +9562,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3995,
+							"line": 4039,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2205,
+					"id": 2206,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9550,14 +9595,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4098,
+							"line": 4142,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2198,
+					"id": 2199,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9578,14 +9623,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3985,
+							"line": 4029,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2231,
+					"id": 2232,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9611,14 +9656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4682,
+							"line": 4730,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2225,
+					"id": 2226,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9639,14 +9684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4509,
+							"line": 4555,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2185,
+					"id": 2186,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9667,14 +9712,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3750,
+							"line": 3793,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2237,
+					"id": 2238,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9696,14 +9741,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4767,
+							"line": 4815,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2211,
+					"id": 2212,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9732,14 +9777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4224,
+							"line": 4269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2227,
+					"id": 2228,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9760,14 +9805,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4611,
+							"line": 4659,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2195,
+					"id": 2196,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9788,14 +9833,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3957,
+							"line": 4001,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2203,
+					"id": 2204,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9832,14 +9877,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4074,
+							"line": 4118,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2207,
+					"id": 2208,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9873,14 +9918,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4136,
+							"line": 4180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2223,
+					"id": 2224,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9906,14 +9951,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4486,
+							"line": 4532,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2189,
+					"id": 2190,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9939,14 +9984,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3821,
+							"line": 3864,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2190,
+					"id": 2191,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9976,14 +10021,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3841,
+							"line": 3884,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2194,
+					"id": 2195,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9993,7 +10038,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `vizId`: GUID of the saved Answer or Spotter visualization ID to pin to a Liveboard.\n  Optional when pinning a new chart or table generated from a Search query.\n  **Required** in Spotter Embed.\n- `liveboardId`: GUID of the Liveboard to pin an Answer. If there is no Liveboard,\n  specify the `newLiveboardName` parameter to create a new Liveboard.\n- `tabId`: GUID of the Liveboard tab. Adds the Answer to the Liveboard tab\n  specified in the code.\n- `newVizName`: Name string for the Answer or visualization. If defined,\n  this parameter adds a new visualization object or creates a copy of the\n  Answer or visualization specified in `vizId`.\n  Required.\n- `newLiveboardName`: Name string for the Liveboard.\n  Creates a new Liveboard object with the specified name.\n- `newTabName`: Name of the tab. Adds a new tab Liveboard specified\n  in the code.\n",
+								"text": "Includes the following keys:\n- `vizId`: GUID of the saved Answer or Spotter visualization ID to pin to a\nLiveboard.\n  Optional when pinning a new chart or table generated from a Search query.\n  **Required** in Spotter Embed.\n- `liveboardId`: GUID of the Liveboard to pin an Answer. If there is no Liveboard,\n  specify the `newLiveboardName` parameter to create a new Liveboard.\n- `tabId`: GUID of the Liveboard tab. Adds the Answer to the Liveboard tab\n  specified in the code.\n- `newVizName`: Name string for the Answer or visualization. If defined,\n  this parameter adds a new visualization object or creates a copy of the\n  Answer or visualization specified in `vizId`.\n  Required.\n- `newLiveboardName`: Name string for the Liveboard.\n  Creates a new Liveboard object with the specified name.\n- `newTabName`: Name of the tab. Adds a new tab Liveboard specified\n  in the code.\n",
 								"param": "-"
 							},
 							{
@@ -10025,14 +10070,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3947,
+							"line": 3991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2210,
+					"id": 2211,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10058,14 +10103,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4194,
+							"line": 4239,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2246,
+					"id": 2248,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10086,14 +10131,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4886,
+							"line": 4968,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2204,
+					"id": 2205,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10122,14 +10167,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4088,
+							"line": 4132,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2192,
+					"id": 2193,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10155,14 +10200,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3861,
+							"line": 3904,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2234,
+					"id": 2235,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10187,14 +10232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4719,
+							"line": 4767,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2235,
+					"id": 2236,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10215,14 +10260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4728,
+							"line": 4776,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2224,
+					"id": 2225,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10243,14 +10288,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4498,
+							"line": 4544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2249,
+					"id": 2251,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10271,14 +10316,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4915,
+							"line": 4997,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2220,
+					"id": 2221,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10304,14 +10349,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4439,
+							"line": 4485,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2241,
+					"id": 2243,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10321,7 +10366,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `vizId`: Refers to the Answer ID in Spotter embed and is **required** in Spotter embed.\n- `name`: Optional. Name string for the Answer.\n- `description`: Optional. Description text for the Answer.",
+								"text": "Includes the following keys:\n- `vizId`: Refers to the Answer ID in Spotter embed and is **required** in Spotter\nembed.\n- `name`: Optional. Name string for the Answer.\n- `description`: Optional. Description text for the Answer.",
 								"param": "-"
 							},
 							{
@@ -10341,14 +10386,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4826,
+							"line": 4908,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2196,
+					"id": 2197,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10369,14 +10414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3966,
+							"line": 4010,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2197,
+					"id": 2198,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10397,14 +10442,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3975,
+							"line": 4019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2181,
+					"id": 2182,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10426,14 +10471,50 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3680,
+							"line": 3722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2187,
+					"id": 2241,
+					"name": "SelectPersonalizedView",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Triggers selection of a specific Personalized View on a\nLiveboard without reloading the embed. Pass either a\n`viewId` (GUID) or `viewName`. If neither is provided,\nthe Liveboard resets to the original/default view.\nWhen a `viewName` is provided and multiple views share\nthe same name, the first match is selected.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nliveboardEmbed.trigger(\n  HostEvent.SelectPersonalizedView,\n  { viewId: '2a021a12-1aed-425d-984b-141ee916ce72' },\n)\n```"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Select by name\nliveboardEmbed.trigger(\n  HostEvent.SelectPersonalizedView,\n  { viewName: 'Dr Smith Cardiology' },\n)\n```"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Reset to default view\nliveboardEmbed.trigger(\n  HostEvent.SelectPersonalizedView,\n  {},\n)\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 4866,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"SelectPersonalisedView\""
+				},
+				{
+					"id": 2188,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10459,14 +10540,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3775,
+							"line": 3818,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2229,
+					"id": 2230,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10492,14 +10573,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4637,
+							"line": 4685,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2228,
+					"id": 2229,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10525,14 +10606,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4624,
+							"line": 4672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2186,
+					"id": 2187,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10558,14 +10639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3763,
+							"line": 3806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2219,
+					"id": 2220,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10586,14 +10667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4399,
+							"line": 4445,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2212,
+					"id": 2213,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10619,14 +10700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4243,
+							"line": 4288,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2214,
+					"id": 2215,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10652,14 +10733,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4280,
+							"line": 4325,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2244,
+					"id": 2246,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10685,21 +10766,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4867,
+							"line": 4949,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2257,
+					"id": 2259,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
 						"shortText": "Triggers a new conversation in Spotter embed.",
-						"text": "This feature is available only when chat history is enabled on your ThoughtSpot instance.\nContact your admin or ThoughtSpot Support to enable chat history on your instance.\n",
+						"text": "This feature is available only when chat history is enabled on your ThoughtSpot\ninstance. Contact your admin or ThoughtSpot Support to enable chat history on your\ninstance.\n",
 						"tags": [
 							{
 								"tag": "example",
@@ -10714,14 +10795,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5010,
+							"line": 5093,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2222,
+					"id": 2223,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10747,14 +10828,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4470,
+							"line": 4516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2221,
+					"id": 2222,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10780,14 +10861,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4454,
+							"line": 4500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2243,
+					"id": 2245,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10813,14 +10894,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4851,
+							"line": 4933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2233,
+					"id": 2234,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10841,14 +10922,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4708,
+							"line": 4756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2226,
+					"id": 2227,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10858,7 +10939,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and values.\n- `filters`: Multiple filter objects with column name, filter operator, and values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].",
+								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and\nvalues.\n- `filters`: Multiple filter objects with column name, filter operator,\nand values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].",
 								"param": "-"
 							},
 							{
@@ -10886,14 +10967,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4598,
+							"line": 4646,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2236,
+					"id": 2237,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10919,14 +11000,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4747,
+							"line": 4795,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2238,
+					"id": 2239,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10947,14 +11028,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4777,
+							"line": 4825,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2239,
+					"id": 2240,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10971,14 +11052,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4785,
+							"line": 4833,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2188,
+					"id": 2189,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11009,14 +11090,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3809,
+							"line": 3852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2230,
+					"id": 2231,
 					"name": "UpdateSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11042,14 +11123,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4652,
+							"line": 4700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateSageQuery\""
 				},
 				{
-					"id": 2200,
+					"id": 2201,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11070,14 +11151,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4004,
+							"line": 4048,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2193,
+					"id": 2194,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11098,7 +11179,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3877,
+							"line": 3920,
 							"character": 4
 						}
 					],
@@ -11110,89 +11191,90 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2202,
-						2191,
-						2247,
-						2251,
-						2232,
-						2254,
-						2209,
-						2206,
-						2248,
-						2213,
-						2250,
+						2203,
+						2192,
+						2249,
+						2253,
+						2233,
 						2256,
-						2215,
-						2217,
-						2201,
+						2210,
+						2207,
+						2250,
+						2214,
+						2252,
+						2258,
 						2216,
 						2218,
-						2182,
-						2208,
-						2245,
-						2199,
-						2205,
-						2198,
-						2231,
-						2225,
-						2185,
-						2237,
-						2211,
-						2227,
-						2195,
-						2203,
-						2207,
-						2223,
-						2189,
-						2190,
-						2194,
-						2210,
-						2246,
-						2204,
-						2192,
-						2234,
-						2235,
-						2224,
-						2249,
-						2220,
-						2241,
-						2196,
-						2197,
-						2181,
-						2187,
-						2229,
-						2228,
-						2186,
+						2202,
+						2217,
 						2219,
+						2183,
+						2209,
+						2247,
+						2200,
+						2206,
+						2199,
+						2232,
+						2226,
+						2186,
+						2238,
 						2212,
-						2214,
-						2244,
-						2257,
-						2222,
+						2228,
+						2196,
+						2204,
+						2208,
+						2224,
+						2190,
+						2191,
+						2195,
+						2211,
+						2248,
+						2205,
+						2193,
+						2235,
+						2236,
+						2225,
+						2251,
 						2221,
 						2243,
-						2233,
-						2226,
-						2236,
-						2238,
-						2239,
+						2197,
+						2198,
+						2182,
+						2241,
 						2188,
 						2230,
-						2200,
-						2193
+						2229,
+						2187,
+						2220,
+						2213,
+						2215,
+						2246,
+						2259,
+						2223,
+						2222,
+						2245,
+						2234,
+						2227,
+						2237,
+						2239,
+						2240,
+						2189,
+						2231,
+						2201,
+						2194
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 3660,
+					"line": 3702,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3172,
+			"id": 3174,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11202,7 +11284,7 @@
 			},
 			"children": [
 				{
-					"id": 3174,
+					"id": 3176,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11213,14 +11295,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7236,
+							"line": 7326,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3173,
+					"id": 3175,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11231,14 +11313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7232,
+							"line": 7322,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3175,
+					"id": 3177,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11249,7 +11331,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7240,
+							"line": 7330,
 							"character": 4
 						}
 					],
@@ -11261,22 +11343,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3174,
-						3173,
-						3175
+						3176,
+						3175,
+						3177
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 7228,
+					"line": 7318,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3117,
+			"id": 3119,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11292,7 +11374,7 @@
 			},
 			"children": [
 				{
-					"id": 3118,
+					"id": 3120,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11310,7 +11392,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3119,
+					"id": 3121,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11333,8 +11415,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3118,
-						3119
+						3120,
+						3121
 					]
 				}
 			],
@@ -11347,7 +11429,7 @@
 			]
 		},
 		{
-			"id": 3151,
+			"id": 3153,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11363,7 +11445,7 @@
 			},
 			"children": [
 				{
-					"id": 3155,
+					"id": 3157,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11374,14 +11456,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2180,
+							"line": 2192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3156,
+					"id": 3158,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11392,14 +11474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2184,
+							"line": 2196,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3152,
+					"id": 3154,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11410,14 +11492,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2167,
+							"line": 2179,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3153,
+					"id": 3155,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11434,14 +11516,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2172,
+							"line": 2184,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3157,
+					"id": 3159,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11452,14 +11534,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2188,
+							"line": 2200,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3154,
+					"id": 3156,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11470,14 +11552,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2176,
+							"line": 2188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3158,
+					"id": 3160,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11488,7 +11570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2192,
+							"line": 2204,
 							"character": 4
 						}
 					],
@@ -11500,26 +11582,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3155,
-						3156,
-						3152,
-						3153,
 						3157,
+						3158,
 						3154,
-						3158
+						3155,
+						3159,
+						3156,
+						3160
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2163,
+					"line": 2175,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3085,
+			"id": 3087,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11529,7 +11611,7 @@
 			},
 			"children": [
 				{
-					"id": 3090,
+					"id": 3092,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11550,14 +11632,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7008,
+							"line": 7094,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3087,
+					"id": 3089,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11578,14 +11660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6969,
+							"line": 7055,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3089,
+					"id": 3091,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11606,14 +11688,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6994,
+							"line": 7080,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3086,
+					"id": 3088,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11634,14 +11716,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6957,
+							"line": 7043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3091,
+					"id": 3093,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11662,14 +11744,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7020,
+							"line": 7106,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3088,
+					"id": 3090,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11690,7 +11772,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6981,
+							"line": 7067,
 							"character": 4
 						}
 					],
@@ -11702,19 +11784,19 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3090,
-						3087,
+						3092,
 						3089,
-						3086,
 						3091,
-						3088
+						3088,
+						3093,
+						3090
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6944,
+					"line": 7030,
 					"character": 12
 				}
 			]
@@ -11880,14 +11962,14 @@
 			]
 		},
 		{
-			"id": 2840,
+			"id": 2842,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2841,
+					"id": 2843,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11895,14 +11977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6773,
+							"line": 6859,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2843,
+					"id": 2845,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11910,14 +11992,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6775,
+							"line": 6861,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2842,
+					"id": 2844,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11925,14 +12007,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6774,
+							"line": 6860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2844,
+					"id": 2846,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11940,7 +12022,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6776,
+							"line": 6862,
 							"character": 4
 						}
 					],
@@ -11952,23 +12034,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2841,
 						2843,
-						2842,
-						2844
+						2845,
+						2844,
+						2846
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6772,
+					"line": 6858,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3112,
+			"id": 3114,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11984,7 +12066,7 @@
 			},
 			"children": [
 				{
-					"id": 3113,
+					"id": 3115,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12007,7 +12089,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3113
+						3115
 					]
 				}
 			],
@@ -12041,7 +12123,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2090,
+							"line": 2102,
 							"character": 4
 						}
 					],
@@ -12059,7 +12141,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2110,
+							"line": 2122,
 							"character": 4
 						}
 					],
@@ -12077,7 +12159,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2106,
+							"line": 2118,
 							"character": 4
 						}
 					],
@@ -12095,7 +12177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2098,
+							"line": 2110,
 							"character": 4
 						}
 					],
@@ -12113,7 +12195,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2102,
+							"line": 2114,
 							"character": 4
 						}
 					],
@@ -12131,7 +12213,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2086,
+							"line": 2098,
 							"character": 4
 						}
 					],
@@ -12149,7 +12231,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2094,
+							"line": 2106,
 							"character": 4
 						}
 					],
@@ -12167,7 +12249,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2062,
+							"line": 2074,
 							"character": 4
 						}
 					],
@@ -12185,7 +12267,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2082,
+							"line": 2094,
 							"character": 4
 						}
 					],
@@ -12203,7 +12285,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2078,
+							"line": 2090,
 							"character": 4
 						}
 					],
@@ -12221,7 +12303,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2114,
+							"line": 2126,
 							"character": 4
 						}
 					],
@@ -12239,7 +12321,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2074,
+							"line": 2086,
 							"character": 4
 						}
 					],
@@ -12257,7 +12339,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2070,
+							"line": 2082,
 							"character": 4
 						}
 					],
@@ -12275,7 +12357,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2066,
+							"line": 2078,
 							"character": 4
 						}
 					],
@@ -12293,7 +12375,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2118,
+							"line": 2130,
 							"character": 4
 						}
 					],
@@ -12326,20 +12408,20 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2058,
+					"line": 2070,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3143,
+			"id": 3145,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3148,
+					"id": 3150,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12354,7 +12436,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3147,
+					"id": 3149,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12369,7 +12451,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3146,
+					"id": 3148,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12384,7 +12466,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3149,
+					"id": 3151,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12399,7 +12481,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3150,
+					"id": 3152,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12414,7 +12496,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3144,
+					"id": 3146,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12429,7 +12511,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3145,
+					"id": 3147,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12449,13 +12531,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3148,
-						3147,
-						3146,
-						3149,
 						3150,
-						3144,
-						3145
+						3149,
+						3148,
+						3151,
+						3152,
+						3146,
+						3147
 					]
 				}
 			],
@@ -12475,7 +12557,7 @@
 			"flags": {},
 			"comment": {
 				"shortText": "AnswerService provides a simple way to work with ThoughtSpot Answers.",
-				"text": "This service allows you to interact with ThoughtSpot Answers programmatically,\nmaking it easy to customize visualizations, filter data, and extract insights\ndirectly from your application.\n\nYou can use this service to:\n\n- Add or remove columns from Answers (`addColumns`, `removeColumns`, `addColumnsByName`)\n- Apply filters to Answers (`addFilter`)\n- Get data from Answers in different formats (JSON, CSV, PNG) (`fetchData`, `fetchCSVBlob`, `fetchPNGBlob`)\n- Get data for specific points in visualizations (`getUnderlyingDataForPoint`)\n- Run custom queries (`executeQuery`)\n- Add visualizations to Liveboards (`addDisplayedVizToLiveboard`)\n",
+				"text": "This service allows you to interact with ThoughtSpot Answers programmatically,\nmaking it easy to customize visualizations, filter data, and extract insights\ndirectly from your application.\n\nYou can use this service to:\n\n- Add or remove columns from Answers (`addColumns`, `removeColumns`,\n`addColumnsByName`)\n- Apply filters to Answers (`addFilter`)\n- Get data from Answers in different formats (JSON, CSV, PNG) (`fetchData`,\n`fetchCSVBlob`, `fetchPNGBlob`)\n- Get data for specific points in visualizations\n(`getUnderlyingDataForPoint`)\n- Run custom queries (`executeQuery`)\n- Add visualizations to Liveboards (`addDisplayedVizToLiveboard`)\n",
 				"tags": [
 					{
 						"tag": "example",
@@ -12508,7 +12590,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 90,
+							"line": 92,
 							"character": 4
 						}
 					],
@@ -12575,7 +12657,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3120,
+											"id": 3122,
 											"name": "VizPoint"
 										}
 									}
@@ -12600,7 +12682,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 131,
+							"line": 133,
 							"character": 17
 						}
 					],
@@ -12656,7 +12738,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 156,
+							"line": 158,
 							"character": 17
 						}
 					],
@@ -12717,7 +12799,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 421,
+							"line": 423,
 							"character": 17
 						}
 					],
@@ -12765,7 +12847,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 169,
+							"line": 171,
 							"character": 17
 						}
 					],
@@ -12863,7 +12945,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 371,
+							"line": 373,
 							"character": 17
 						}
 					],
@@ -12932,7 +13014,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 250,
+							"line": 252,
 							"character": 17
 						}
 					],
@@ -13001,7 +13083,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 222,
+							"line": 224,
 							"character": 17
 						}
 					],
@@ -13108,7 +13190,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 266,
+							"line": 268,
 							"character": 17
 						}
 					],
@@ -13192,7 +13274,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 394,
+							"line": 396,
 							"character": 17
 						}
 					],
@@ -13227,7 +13309,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 284,
+							"line": 286,
 							"character": 11
 						}
 					],
@@ -13288,7 +13370,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 295,
+							"line": 297,
 							"character": 11
 						}
 					],
@@ -13363,7 +13445,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 205,
+							"line": 207,
 							"character": 17
 						}
 					],
@@ -13412,7 +13494,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 390,
+							"line": 392,
 							"character": 11
 						}
 					],
@@ -13446,7 +13528,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 104,
+							"line": 106,
 							"character": 17
 						}
 					],
@@ -13484,7 +13566,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 405,
+							"line": 407,
 							"character": 17
 						}
 					],
@@ -13519,7 +13601,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 316,
+							"line": 318,
 							"character": 17
 						}
 					],
@@ -13603,7 +13685,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 117,
+							"line": 119,
 							"character": 17
 						}
 					],
@@ -13659,7 +13741,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 433,
+							"line": 435,
 							"character": 11
 						}
 					],
@@ -13701,7 +13783,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 196,
+							"line": 198,
 							"character": 17
 						}
 					],
@@ -13777,7 +13859,7 @@
 			"sources": [
 				{
 					"fileName": "utils/graphql/answerService/answerService.ts",
-					"line": 78,
+					"line": 80,
 					"character": 13
 				}
 			]
@@ -13807,7 +13889,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 771,
+							"line": 772,
 							"character": 4
 						}
 					],
@@ -13827,7 +13909,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2871,
 										"name": "DOMSelector"
 									}
 								},
@@ -13839,7 +13921,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2740,
+										"id": 2742,
 										"name": "AppViewConfig"
 									}
 								}
@@ -13871,7 +13953,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1237,
+							"line": 1238,
 							"character": 11
 						}
 					],
@@ -13917,7 +13999,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -13988,7 +14070,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -14041,7 +14123,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1106,
+							"line": 1107,
 							"character": 11
 						}
 					],
@@ -14073,7 +14155,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1468,
+							"line": 1469,
 							"character": 11
 						}
 					],
@@ -14110,7 +14192,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -14203,7 +14285,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -14301,7 +14383,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -14338,7 +14420,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -14378,7 +14460,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1211,
+							"line": 1212,
 							"character": 11
 						}
 					],
@@ -14456,7 +14538,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -14503,7 +14585,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -14534,7 +14616,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1874,
+							"line": 1875,
 							"character": 11
 						}
 					],
@@ -14582,7 +14664,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -14594,7 +14676,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -14626,7 +14708,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -14701,7 +14783,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -14754,7 +14836,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1266,
+							"line": 1267,
 							"character": 17
 						}
 					],
@@ -14801,7 +14883,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -14847,7 +14929,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -14893,7 +14975,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -14917,7 +14999,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -14936,7 +15018,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -15041,7 +15123,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -15065,7 +15147,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -15171,7 +15253,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 766,
+					"line": 767,
 					"character": 13
 				}
 			],
@@ -15816,7 +15898,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1547,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -15864,7 +15946,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -15937,7 +16019,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -16031,7 +16113,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -16126,7 +16208,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -16226,7 +16308,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -16265,7 +16347,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -16307,7 +16389,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -16354,7 +16436,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -16387,7 +16469,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1258,
+							"line": 1259,
 							"character": 11
 						}
 					],
@@ -16438,7 +16520,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -16453,7 +16535,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -16500,7 +16582,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -16577,7 +16659,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -16678,7 +16760,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -16726,7 +16808,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -16774,7 +16856,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -16798,7 +16880,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -16817,7 +16899,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -16924,7 +17006,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -16948,7 +17030,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -17095,7 +17177,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 532,
+							"line": 533,
 							"character": 4
 						}
 					],
@@ -17115,7 +17197,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2871,
 										"name": "DOMSelector"
 									}
 								},
@@ -17127,7 +17209,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2595,
+										"id": 2597,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -17159,7 +17241,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 950,
+							"line": 954,
 							"character": 11
 						}
 					],
@@ -17205,7 +17287,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -17276,7 +17358,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -17329,7 +17411,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1468,
+							"line": 1469,
 							"character": 11
 						}
 					],
@@ -17366,7 +17448,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1015,
+							"line": 1019,
 							"character": 11
 						}
 					],
@@ -17399,7 +17481,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -17492,7 +17574,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -17590,7 +17672,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -17627,7 +17709,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -17667,7 +17749,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 990,
+							"line": 994,
 							"character": 11
 						}
 					],
@@ -17748,7 +17830,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -17795,7 +17877,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -17826,7 +17908,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1874,
+							"line": 1875,
 							"character": 11
 						}
 					],
@@ -17874,7 +17956,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -17886,7 +17968,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17918,7 +18000,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -17993,7 +18075,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -18046,7 +18128,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 979,
+							"line": 983,
 							"character": 17
 						}
 					],
@@ -18093,7 +18175,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -18139,7 +18221,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -18185,7 +18267,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 931,
+							"line": 935,
 							"character": 11
 						}
 					],
@@ -18209,7 +18291,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -18228,7 +18310,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -18333,7 +18415,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -18357,7 +18439,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -18463,7 +18545,7 @@
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 526,
+					"line": 527,
 					"character": 13
 				}
 			],
@@ -18503,7 +18585,7 @@
 					"sources": [
 						{
 							"fileName": "embed/sage.ts",
-							"line": 151,
+							"line": 150,
 							"character": 4
 						}
 					],
@@ -18523,7 +18605,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2871,
 										"name": "DOMSelector"
 									}
 								},
@@ -18535,7 +18617,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2685,
+										"id": 2687,
 										"name": "SageViewConfig"
 									}
 								}
@@ -18567,7 +18649,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1547,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -18613,7 +18695,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -18684,7 +18766,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -18737,7 +18819,7 @@
 					"sources": [
 						{
 							"fileName": "embed/sage.ts",
-							"line": 200,
+							"line": 199,
 							"character": 11
 						}
 					],
@@ -18770,7 +18852,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1468,
+							"line": 1469,
 							"character": 11
 						}
 					],
@@ -18807,7 +18889,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -18900,7 +18982,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -18998,7 +19080,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -19035,7 +19117,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -19075,7 +19157,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -19122,7 +19204,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -19153,7 +19235,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1874,
+							"line": 1875,
 							"character": 11
 						}
 					],
@@ -19201,7 +19283,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -19213,7 +19295,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -19245,7 +19327,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -19320,7 +19402,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -19373,7 +19455,7 @@
 					"sources": [
 						{
 							"fileName": "embed/sage.ts",
-							"line": 225,
+							"line": 224,
 							"character": 17
 						}
 					],
@@ -19421,7 +19503,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -19467,7 +19549,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -19513,7 +19595,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -19537,7 +19619,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -19556,7 +19638,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -19661,7 +19743,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -19685,7 +19767,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19861,7 +19943,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2545,
+										"id": 2547,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -19893,7 +19975,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1547,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -19939,7 +20021,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -20010,7 +20092,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -20063,7 +20145,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1468,
+							"line": 1469,
 							"character": 11
 						}
 					],
@@ -20100,7 +20182,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -20193,7 +20275,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -20291,7 +20373,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -20328,7 +20410,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -20368,7 +20450,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -20415,7 +20497,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -20446,7 +20528,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1258,
+							"line": 1259,
 							"character": 11
 						}
 					],
@@ -20497,7 +20579,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -20512,7 +20594,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -20557,7 +20639,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -20632,7 +20714,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -20732,7 +20814,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -20778,7 +20860,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -20824,7 +20906,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -20848,7 +20930,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -20867,7 +20949,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -20972,7 +21054,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -20996,7 +21078,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -21156,7 +21238,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2871,
 										"name": "DOMSelector"
 									}
 								},
@@ -21168,7 +21250,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2484,
+										"id": 2486,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -21200,7 +21282,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1547,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -21246,7 +21328,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -21317,7 +21399,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -21402,7 +21484,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1468,
+							"line": 1469,
 							"character": 11
 						}
 					],
@@ -21439,7 +21521,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -21532,7 +21614,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -21630,7 +21712,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -21667,7 +21749,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -21707,7 +21789,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -21754,7 +21836,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -21785,7 +21867,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1258,
+							"line": 1259,
 							"character": 11
 						}
 					],
@@ -21836,7 +21918,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -21851,7 +21933,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21896,7 +21978,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -21971,7 +22053,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -22071,7 +22153,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -22117,7 +22199,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -22163,7 +22245,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -22187,7 +22269,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -22206,7 +22288,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -22311,7 +22393,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -22335,7 +22417,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -23049,7 +23131,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1547,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -23095,7 +23177,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1761,
+							"line": 1762,
 							"character": 17
 						}
 					],
@@ -23166,7 +23248,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1481,
+							"line": 1482,
 							"character": 17
 						}
 					],
@@ -23256,7 +23338,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1748,
+							"line": 1749,
 							"character": 11
 						}
 					],
@@ -23349,7 +23431,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1517,
+							"line": 1518,
 							"character": 11
 						}
 					],
@@ -23447,7 +23529,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1570,
+							"line": 1571,
 							"character": 11
 						}
 					],
@@ -23484,7 +23566,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1717,
+							"line": 1718,
 							"character": 11
 						}
 					],
@@ -23524,7 +23606,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1287,
+							"line": 1288,
 							"character": 11
 						}
 					],
@@ -23571,7 +23653,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								}
@@ -23602,7 +23684,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1258,
+							"line": 1259,
 							"character": 11
 						}
 					],
@@ -23653,7 +23735,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2873,
+										"id": 2875,
 										"name": "MessageCallback"
 									}
 								},
@@ -23668,7 +23750,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2870,
+										"id": 2872,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23713,7 +23795,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1495,
+							"line": 1496,
 							"character": 17
 						}
 					],
@@ -23788,7 +23870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1581,
+							"line": 1582,
 							"character": 17
 						}
 					],
@@ -23885,7 +23967,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1629,
+							"line": 1630,
 							"character": 17
 						}
 					],
@@ -23931,7 +24013,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1699,
 							"character": 11
 						}
 					],
@@ -23977,7 +24059,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1397,
+							"line": 1398,
 							"character": 17
 						}
 					],
@@ -24001,7 +24083,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2180,
+										"id": 2181,
 										"name": "HostEvent"
 									}
 								},
@@ -24020,7 +24102,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2259,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -24125,7 +24207,7 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1444,
+							"line": 1445,
 							"character": 17
 						}
 					],
@@ -24149,7 +24231,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3143,
+										"id": 3145,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -24272,7 +24354,7 @@
 			]
 		},
 		{
-			"id": 2740,
+			"id": 2742,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -24288,7 +24370,7 @@
 			},
 			"children": [
 				{
-					"id": 2785,
+					"id": 2787,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24312,27 +24394,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2786,
+							"id": 2788,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2787,
+								"id": 2789,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2788,
+										"id": 2790,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -24368,7 +24450,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2818,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24396,7 +24478,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1672,
+							"line": 1681,
 							"character": 4
 						}
 					],
@@ -24410,7 +24492,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2762,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24447,7 +24529,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2815,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24471,13 +24553,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1630,
+							"line": 1639,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2428,
+						"id": 2430,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -24486,7 +24568,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2836,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24510,7 +24592,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1908,
+							"line": 1919,
 							"character": 4
 						}
 					],
@@ -24524,7 +24606,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2806,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24556,7 +24638,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -24573,7 +24655,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2791,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24596,13 +24678,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -24611,7 +24693,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2763,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24645,12 +24727,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3159,
+						"id": 3161,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2819,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24678,7 +24760,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1688,
+							"line": 1697,
 							"character": 4
 						}
 					],
@@ -24692,7 +24774,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2745,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24730,7 +24812,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2799,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24754,7 +24836,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -24768,7 +24850,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2783,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24792,7 +24874,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -24806,7 +24888,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2782,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24830,7 +24912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -24838,7 +24920,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -24848,7 +24930,7 @@
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2761,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24885,7 +24967,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2795,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24912,7 +24994,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -24926,7 +25008,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2830,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24954,7 +25036,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1806,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -24968,7 +25050,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2835,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -24996,7 +25078,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1892,
+							"line": 1903,
 							"character": 4
 						}
 					],
@@ -25010,7 +25092,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2820,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25038,7 +25120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1704,
+							"line": 1713,
 							"character": 4
 						}
 					],
@@ -25052,7 +25134,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2777,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25076,7 +25158,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 759,
+							"line": 760,
 							"character": 4
 						}
 					],
@@ -25086,7 +25168,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2802,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25110,7 +25192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -25124,7 +25206,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2773,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25152,7 +25234,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 688,
+							"line": 689,
 							"character": 4
 						}
 					],
@@ -25162,7 +25244,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2746,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25200,7 +25282,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2758,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25238,7 +25320,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2796,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25262,7 +25344,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -25276,7 +25358,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2816,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25300,7 +25382,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1652,
 							"character": 4
 						}
 					],
@@ -25314,7 +25396,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2817,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25338,7 +25420,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1656,
+							"line": 1665,
 							"character": 4
 						}
 					],
@@ -25352,7 +25434,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2798,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25375,7 +25457,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -25389,7 +25471,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2779,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25413,13 +25495,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -25428,7 +25510,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2759,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25462,7 +25544,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2784,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25490,7 +25572,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -25498,7 +25580,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -25508,7 +25590,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2825,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25532,7 +25614,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1566,
+							"line": 1575,
 							"character": 4
 						}
 					],
@@ -25540,7 +25622,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2851,
+							"id": 2853,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -25550,7 +25632,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2823,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25574,7 +25656,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1525,
+							"line": 1533,
 							"character": 4
 						}
 					],
@@ -25582,7 +25664,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2862,
+							"id": 2864,
 							"name": "HomepageModule"
 						}
 					},
@@ -25592,7 +25674,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2822,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25601,7 +25683,7 @@
 					},
 					"comment": {
 						"shortText": "Hide columns on list pages such as\n*Liveboards* and *Answers*.\nFor example: `hiddenListColumns = [ListPageColumns.Author]`",
-						"text": "**Note**: This option is available only in full app embedding and requires importing the `ListPageColumns` enum.\nStarting with version 10.14.0.cl, you can use this attribute to\nhide the columns on all list pages in the *Insights* section.\n\nSupported embed types: `AppEmbed`",
+						"text": "**Note**: This option is available only in full app embedding and requires\nimporting the `ListPageColumns` enum. Starting with version 10.14.0.cl, you can\nuse this attribute to\nhide the columns on all list pages in the *Insights* section.\n\nSupported embed types: `AppEmbed`",
 						"tags": [
 							{
 								"tag": "version",
@@ -25616,7 +25698,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1504,
+							"line": 1512,
 							"character": 4
 						}
 					],
@@ -25624,7 +25706,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3151,
+							"id": 3153,
 							"name": "ListPageColumns"
 						}
 					},
@@ -25634,7 +25716,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2750,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25672,7 +25754,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2747,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25710,7 +25792,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2744,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25748,7 +25830,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2833,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25757,7 +25839,7 @@
 					},
 					"comment": {
 						"shortText": "This flag is used to enable/disable hide irrelevant filters in Liveboard tab",
-						"text": "**Note**: This feature is supported only if compact header is enabled on your Liveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled` attribute.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`",
+						"text": "**Note**: This feature is supported only if compact header is enabled on your\nLiveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled`\nattribute.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
 								"tag": "version",
@@ -25776,7 +25858,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1859,
+							"line": 1870,
 							"character": 4
 						}
 					],
@@ -25790,7 +25872,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2826,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25818,7 +25900,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1742,
+							"line": 1751,
 							"character": 4
 						}
 					],
@@ -25832,7 +25914,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2749,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25870,7 +25952,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2748,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25908,7 +25990,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2756,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25945,7 +26027,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2751,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -25983,7 +26065,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2755,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26017,7 +26099,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2764,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26043,12 +26125,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3108,
+						"id": 3110,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2792,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26072,7 +26154,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -26086,7 +26168,7 @@
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2812,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26109,7 +26191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -26123,7 +26205,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2811,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26146,7 +26228,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -26163,7 +26245,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2837,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26171,7 +26253,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable or disable the new centralized Liveboard filter UX (v2).\nWhen enabled, a unified modal is used to manage and update multiple filters at once,\nreplacing the older individual filter interactions.\nTo enable this feature on your instance, contact ThoughtSpot Support.",
+						"shortText": "This flag is used to enable or disable the new centralized Liveboard filter UX\n(v2). When enabled, a unified modal is used to manage and update multiple filters\nat once, replacing the older individual filter interactions.\nTo enable this feature on your instance, contact ThoughtSpot Support.",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -26187,7 +26269,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 1937,
 							"character": 4
 						}
 					],
@@ -26201,7 +26283,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2839,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26209,7 +26291,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable or disable the enhanced filter interactivity in liveboard.",
+						"shortText": "This flag is used to enable or disable the enhanced filter interactivity in\nliveboard.",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -26225,7 +26307,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1957,
+							"line": 1969,
 							"character": 4
 						}
 					],
@@ -26239,7 +26321,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2769,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26263,7 +26345,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 621,
+							"line": 622,
 							"character": 4
 						}
 					],
@@ -26273,7 +26355,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2838,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26297,7 +26379,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1941,
+							"line": 1952,
 							"character": 4
 						}
 					],
@@ -26311,7 +26393,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2831,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26339,7 +26421,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1823,
+							"line": 1832,
 							"character": 4
 						}
 					],
@@ -26353,7 +26435,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2829,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26377,7 +26459,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1789,
+							"line": 1798,
 							"character": 4
 						}
 					],
@@ -26391,7 +26473,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2841,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26419,7 +26501,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2001,
 							"character": 4
 						}
 					],
@@ -26433,7 +26515,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2766,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26470,7 +26552,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2768,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26494,7 +26576,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 604,
+							"line": 605,
 							"character": 4
 						}
 					],
@@ -26504,7 +26586,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2810,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26524,7 +26606,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -26538,7 +26620,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2767,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26546,7 +26628,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable/disable the png embedding of liveboard in scheduled mails",
+						"shortText": "This flag is used to enable/disable the png embedding of liveboard in scheduled\nmails",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -26562,7 +26644,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 587,
+							"line": 588,
 							"character": 4
 						}
 					],
@@ -26572,7 +26654,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2821,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26596,7 +26678,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1720,
+							"line": 1729,
 							"character": 4
 						}
 					],
@@ -26610,7 +26692,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2765,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26648,7 +26730,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2770,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26675,7 +26757,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 638,
+							"line": 639,
 							"character": 4
 						}
 					],
@@ -26685,7 +26767,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2771,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26709,7 +26791,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 662,
+							"line": 663,
 							"character": 4
 						}
 					],
@@ -26719,7 +26801,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2801,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26743,7 +26825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -26757,7 +26839,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2786,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26781,7 +26863,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -26795,7 +26877,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2776,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26822,7 +26904,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 743,
+							"line": 744,
 							"character": 4
 						}
 					],
@@ -26832,7 +26914,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2760,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26869,7 +26951,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2800,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26893,7 +26975,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -26907,7 +26989,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2753,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26942,7 +27024,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2752,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26976,7 +27058,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2794,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27000,7 +27082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -27014,7 +27096,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2803,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27038,7 +27120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1236,
+							"line": 1240,
 							"character": 4
 						}
 					],
@@ -27052,7 +27134,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2807,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27075,7 +27157,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -27089,7 +27171,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2824,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27097,7 +27179,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Reorder home page modules.\nTo specify the modules, import the `HomepageModule` enum.\nFor example: `reorderedHomepageModules = [HomepageModule.MyLibrary, HomepageModule.Watchlist]`\n**Note**: This attribute is not supported in the classic (v1) homepage.",
+						"shortText": "Reorder home page modules.\nTo specify the modules, import the `HomepageModule` enum.\nFor example: `reorderedHomepageModules = [HomepageModule.MyLibrary,\nHomepageModule.Watchlist]` **Note**: This attribute is not supported in the\nclassic (v1) homepage.",
 						"text": "Supported embed types: `AppEmbed`",
 						"tags": [
 							{
@@ -27113,7 +27195,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1545,
+							"line": 1554,
 							"character": 4
 						}
 					],
@@ -27121,7 +27203,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2862,
+							"id": 2864,
 							"name": "HomepageModule"
 						}
 					},
@@ -27131,7 +27213,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2813,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27155,7 +27237,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1594,
+							"line": 1603,
 							"character": 4
 						}
 					],
@@ -27173,7 +27255,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2814,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27197,7 +27279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1615,
+							"line": 1624,
 							"character": 4
 						}
 					],
@@ -27205,7 +27287,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -27215,7 +27297,7 @@
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2808,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27242,7 +27324,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -27256,7 +27338,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2805,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27279,7 +27361,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -27293,7 +27375,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2828,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27321,7 +27403,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1774,
+							"line": 1783,
 							"character": 4
 						}
 					],
@@ -27335,7 +27417,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2834,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27363,7 +27445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1876,
+							"line": 1887,
 							"character": 4
 						}
 					],
@@ -27377,7 +27459,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2827,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27405,7 +27487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1758,
+							"line": 1767,
 							"character": 4
 						}
 					],
@@ -27419,7 +27501,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2832,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27447,7 +27529,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1849,
 							"character": 4
 						}
 					],
@@ -27461,7 +27543,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2840,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27489,7 +27571,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1973,
+							"line": 1985,
 							"character": 4
 						}
 					],
@@ -27503,7 +27585,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2743,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27541,7 +27623,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2775,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27565,7 +27647,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 726,
+							"line": 727,
 							"character": 4
 						}
 					],
@@ -27576,7 +27658,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2774,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27600,7 +27682,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 708,
+							"line": 709,
 							"character": 4
 						}
 					],
@@ -27611,7 +27693,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2754,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27645,7 +27727,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2772,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27673,7 +27755,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 678,
+							"line": 679,
 							"character": 4
 						}
 					],
@@ -27683,7 +27765,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2809,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27710,7 +27792,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -27724,7 +27806,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2785,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27752,7 +27834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -27760,7 +27842,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -27775,95 +27857,95 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2785,
-						2816,
-						2760,
-						2813,
-						2834,
-						2804,
-						2789,
-						2761,
-						2817,
-						2743,
-						2797,
-						2781,
-						2780,
-						2759,
-						2793,
-						2828,
-						2833,
+						2787,
 						2818,
-						2775,
-						2800,
-						2771,
-						2744,
-						2756,
-						2794,
-						2814,
-						2815,
-						2796,
-						2777,
-						2757,
-						2782,
-						2823,
-						2821,
-						2820,
-						2748,
-						2745,
-						2742,
-						2831,
-						2824,
-						2747,
-						2746,
-						2754,
-						2749,
-						2753,
 						2762,
-						2790,
-						2810,
-						2809,
-						2835,
-						2837,
-						2767,
+						2815,
 						2836,
-						2829,
-						2827,
-						2839,
-						2764,
-						2766,
-						2808,
-						2765,
-						2819,
-						2763,
-						2768,
-						2769,
-						2799,
-						2784,
-						2774,
-						2758,
-						2798,
-						2751,
-						2750,
-						2792,
-						2801,
-						2805,
-						2822,
-						2811,
-						2812,
 						2806,
-						2803,
-						2826,
-						2832,
-						2825,
+						2791,
+						2763,
+						2819,
+						2745,
+						2799,
+						2783,
+						2782,
+						2761,
+						2795,
 						2830,
-						2838,
-						2741,
+						2835,
+						2820,
+						2777,
+						2802,
 						2773,
-						2772,
-						2752,
+						2746,
+						2758,
+						2796,
+						2816,
+						2817,
+						2798,
+						2779,
+						2759,
+						2784,
+						2825,
+						2823,
+						2822,
+						2750,
+						2747,
+						2744,
+						2833,
+						2826,
+						2749,
+						2748,
+						2756,
+						2751,
+						2755,
+						2764,
+						2792,
+						2812,
+						2811,
+						2837,
+						2839,
+						2769,
+						2838,
+						2831,
+						2829,
+						2841,
+						2766,
+						2768,
+						2810,
+						2767,
+						2821,
+						2765,
 						2770,
+						2771,
+						2801,
+						2786,
+						2776,
+						2760,
+						2800,
+						2753,
+						2752,
+						2794,
+						2803,
 						2807,
-						2783
+						2824,
+						2813,
+						2814,
+						2808,
+						2805,
+						2828,
+						2834,
+						2827,
+						2832,
+						2840,
+						2743,
+						2775,
+						2774,
+						2754,
+						2772,
+						2809,
+						2785
 					]
 				}
 			],
@@ -28584,8 +28666,1129 @@
 			"sources": [
 				{
 					"fileName": "auth.ts",
-					"line": 149,
+					"line": 150,
 					"character": 17
+				}
+			]
+		},
+		{
+			"id": 3202,
+			"name": "AutoMCPFrameRendererViewConfig",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"children": [
+				{
+					"id": 3212,
+					"name": "additionalFlags",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "This is an object (key/val) of override flags which will be applied\nto the internal embedded object. This can be used to add any\nURL flag.\nIf the same flags are passed in init, they will be overridden by the values here.\nWarning: This option is for advanced use only and is used internally\nto control embed behavior in non-regular ways. We do not publish the\nlist of supported keys and values associated with each.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.9.0 | ThoughtSpot: 8.1.0.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  additionalFlags: {\n       flag1: 'value1',\n       flag2: 'value2'\n    },\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1042,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 3213,
+							"name": "__type",
+							"kind": 65536,
+							"kindString": "Type literal",
+							"flags": {},
+							"indexSignature": {
+								"id": 3214,
+								"name": "__index",
+								"kind": 8192,
+								"kindString": "Index signature",
+								"flags": {},
+								"parameters": [
+									{
+										"id": 3215,
+										"name": "key",
+										"kind": 32768,
+										"flags": {},
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"type": {
+									"type": "union",
+									"types": [
+										{
+											"type": "intrinsic",
+											"name": "string"
+										},
+										{
+											"type": "intrinsic",
+											"name": "number"
+										},
+										{
+											"type": "intrinsic",
+											"name": "boolean"
+										}
+									]
+								}
+							}
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.additionalFlags"
+					}
+				},
+				{
+					"id": 3231,
+					"name": "customActions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom Actions allows users to define interactive UI actions (like buttons or menu\nitems) that appear in ThoughtSpot's visualizations, answers, and Liveboards. These\nactions enable users to trigger custom workflows — such as navigating to an\nexternal app, calling an API, or opening a modal — based on the data context of\nwhat they clicked can be used to trigger custom logic when the action is clicked.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | ThoughtSpot: 10.14.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```ts\nimport {\n  CustomActionPayload,\n  CustomActionsPosition,\n  CustomActionTarget,\n} from '@thoughtspot/visual-embed-sdk';\n// Use supported embed types such as AppEmbed or LiveboardEmbed\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  ... // other embed config options\n  customActions: [\n    {\n      // Unique identifier for the custom action\n      id: 'my-custom-action',\n\n      // Display name shown to users in the UI\n      name: 'My Custom Action',\n\n      // Where the action appears in the UI\n      // PRIMARY: Shows as a primary button (e.g., in the toolbar)\n      // MENU: Shows in the \"More\" menu (three dots menu)\n      // CONTEXTMENU: Shows in the right-click context menu\n      position: CustomActionsPosition.PRIMARY,\n\n      // What type of content this action applies to\n      // ANSWER: Available on answer pages\n      target: CustomActionTarget.ANSWER,\n\n      // Optional: Restrict where this action appears based on data models\n      // dataModelIds: {\n      //     // Restrict to specific data models\n      //     modelIds: ['model-id-1', 'model-id-2'],\n      //     // Restrict to specific columns within models\n      //     modelColumnNames: ['model-id::column-name']\n      // },\n\n      // Optional: Restrict where this action appears based on metadata\n      // metadataIds: {\n      //     // Restrict to specific answers\n      //     answerIds: ['answer-id-1', 'answer-id-2'],\n      // },\n      //     // Restrict to specific groups (for group-based access control)\n      //     groupIds: ['group-id-1', 'group-id-2'],\n      //     // Restrict to specific organizations (for multi-org deployments)\n      //     orgIds: ['org-id-1', 'org-id-2'],\n    }\n  ],\n})\n\n// to trigger a custom flow on custom action click listen to Custom action embed event\nembed.on(EmbedEvent.CustomAction, (payload: CustomActionPayload) => {\n  console.log('Custom Action event:', payload);\n})\n```"
+							},
+							{
+								"tag": "example",
+								"text": "\n```ts\nimport {\n  CustomActionsPosition,\n  CustomActionTarget,\n} from '@thoughtspot/visual-embed-sdk';\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  ... // other embed config options\n  customActions: [\n    {\n      // Unique identifier for the custom action\n      id: 'my-custom-action',\n\n      // Display name shown to users in the UI\n      name: 'My Custom Action',\n\n      // Where the action appears in the UI\n      // MENU: Shows in the \"More\" menu (three dots menu)\n      // CONTEXTMENU: Shows in the right-click context menu\n      position: CustomActionsPosition.MENU,\n\n      // What type of content this action applies to\n      // SPOTTER: Available in Spotter (AI-powered search)\n      target: CustomActionTarget.SPOTTER,\n\n      // Optional: Restrict where this action appears based on data models\n      // dataModelIds: {\n      //     // Restrict to specific data models\n      //     modelIds: ['model-id-1', 'model-id-2'],\n      // },\n      //     // Restrict to specific groups (for group-based access control)\n      //     groupIds: ['group-id-1'],\n      //     // Restrict to specific organizations (for multi-org deployments)\n      //     orgIds: ['org-id-1'],\n    }\n  ],\n})\n```"
+							},
+							{
+								"tag": "example",
+								"text": "\n```ts\nimport {\n  CustomActionsPosition,\n  CustomActionTarget,\n} from '@thoughtspot/visual-embed-sdk';\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  ... // other embed config options\n  customActions: [\n    {\n      // Unique identifier for the custom action\n      id: 'my-liveboard-custom-action',\n\n      // Display name shown to users in the UI\n      name: 'My Liveboard Custom Action',\n\n      // Where the action appears in the UI\n      // PRIMARY: Shows as a primary button (e.g., in the toolbar)\n      // MENU: Shows in the \"More\" menu (three dots menu)\n      position: CustomActionsPosition.PRIMARY,\n\n      // What type of content this action applies to\n      // LIVEBOARD: Available on liveboard pages\n      target: CustomActionTarget.LIVEBOARD,\n\n      // Optional: Restrict where this action appears based on metadata\n      // metadataIds: {\n      //     // Restrict to specific liveboards\n      //     liveboardIds: ['liveboard-id-1', 'liveboard-id-2'],\n      // },\n      //     // Restrict to specific groups (for group-based access control)\n      //     groupIds: ['group-id-1', 'group-id-2'],\n      //     // Restrict to specific organizations (for multi-org deployments)\n      //     orgIds: ['org-id-1', 'org-id-2'],\n    },\n    {\n      // Unique identifier for the custom action\n      id: 'my-viz-custom-action',\n\n      // Display name shown to users in the UI\n      name: 'My Viz Custom Action',\n\n      // Where the action appears in the UI\n      // PRIMARY: Shows as a primary button (e.g., in the toolbar)\n      // MENU: Shows in the \"More\" menu (three dots menu)\n      // CONTEXTMENU: Shows in the right-click context menu\n      position: CustomActionsPosition.PRIMARY,\n\n      // What type of content this action applies to\n      // VIZ: Available on individual visualizations\n      target: CustomActionTarget.VIZ,\n\n      // Optional: Restrict where this action appears based on metadata\n      // metadataIds: {\n      //     // Restrict to specific answers\n      //     answerIds: ['answer-id-1', 'answer-id-2'],\n      //     // Restrict to specific liveboard. If liveboardId is\n      //     // passed, custom actions will appear on all vizzes of liveboard\n      //     liveboardIds: ['liveboard-id-1'],\n      //     // Restrict to specific vizIds\n      //     vizIds: ['viz-id-1']\n      // },\n      // dataModelIds: {\n      //     // Restrict to specific data models\n      //     modelIds: ['model-id-1', 'model-id-2'],\n      //     // Restrict to specific columns within models\n      //     modelColumnNames: ['model-id::column-name']\n      // },\n      //     // Restrict to specific groups (for group-based access control)\n      //     groupIds: ['group-id-1', 'group-id-2'],\n      //     // Restrict to specific organizations (for multi-org deployments)\n      //     orgIds: ['org-id-1', 'org-id-2'],\n    }\n  ],\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1439,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"name": "CustomAction"
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.customActions"
+					}
+				},
+				{
+					"id": 3216,
+					"name": "customizations",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Dynamic CSSUrl and customCSS to be injected in the loaded application.\nYou would also need to set `style-src` in the CSP settings.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.17.2 | ThoughtSpot: 8.4.1.sw, 8.4.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "''\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1049,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 2888,
+						"name": "CustomisationsInterface"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.customizations"
+					}
+				},
+				{
+					"id": 3224,
+					"name": "disableRedirectionLinksInNewTab",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "This flag can be used to disable links inside the embedded app,\nand disable redirection of links in a new tab.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.32.1 | ThoughtSpot: 10.3.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n  ... // other embed view config\n  disableRedirectionLinksInNewTab: true,\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1157,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.disableRedirectionLinksInNewTab"
+					}
+				},
+				{
+					"id": 3208,
+					"name": "disabledActionReason",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The tooltip to display for disabled actions.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   disabledActions: [Action.Download, Action.Save],\n   disabledActionReason: \"Reason for disabling\",\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 964,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.disabledActionReason"
+					}
+				},
+				{
+					"id": 3207,
+					"name": "disabledActions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The list of actions to disable from the primary menu, more menu\n(...), and the contextual menu. These actions will be disabled\nfor the user.\nUse this to disable actions.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   disabledActions: [Action.Download, Action.Save],\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 948,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 2270,
+							"name": "Action"
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.disabledActions"
+					}
+				},
+				{
+					"id": 3220,
+					"name": "doNotTrackPreRenderSize",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Determines if the PreRender component should dynamically track the size\nof its embedding element and adjust its own size accordingly.\nEnabling this option allows the PreRender component to automatically adapt\nits dimensions based on changes to the size of the embedding element.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1113,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.doNotTrackPreRenderSize"
+					}
+				},
+				{
+					"id": 3227,
+					"name": "enableLinkOverridesV2",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Enables the V2 link override mechanism with improved\nhandling. When enabled, navigation links within the\nembedded ThoughtSpot app are intercepted and routed\nthrough the SDK via the `EmbedEvent.DialogOpen`\nevent.",
+						"text": "The SDK automatically sends {@link linkOverride}\nalongside this flag for backward compatibility with\nolder ThoughtSpot versions.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`,\n`SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`,\n`SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.46.0 | ThoughtSpot: 26.2.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n   ... // other embed view config\n   enableLinkOverridesV2: true,\n});\n\nembed.on(EmbedEvent.DialogOpen, (payload) => {\n   console.log('Link clicked:', payload);\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1224,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.enableLinkOverridesV2"
+					}
+				},
+				{
+					"id": 3221,
+					"name": "enableV2Shell_experimental",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Enable the V2 shell. This can provide performance benefits\ndue to a lighter-weight shell.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.31.2 | ThoughtSpot: 10.0.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  enableV2Shell_experimental: true,\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1130,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.enableV2Shell_experimental"
+					}
+				},
+				{
+					"id": 3223,
+					"name": "exposeTranslationIDs",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "This flag can be used to expose translation IDs on the embedded app.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.37.0 | ThoughtSpot: 10.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1141,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.exposeTranslationIDs"
+					}
+				},
+				{
+					"id": 3204,
+					"name": "frameParams",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The width and height dimensions to render an embedded\nobject inside your app.  Specify the values in pixels or percentage.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.1.0 | ThoughtSpot: ts7.may.cl, 7.2.1"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   frameParams: {\n       width: '500px' | '50%',\n       height: '400px' | '60%',\n   },\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 921,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 2847,
+						"name": "FrameParams"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.frameParams"
+					}
+				},
+				{
+					"id": 3209,
+					"name": "hiddenActions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The list of actions to hide from the embedded view.\nThese actions will be hidden from the user.\nUse this to hide an action.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+							},
+							{
+								"tag": "important",
+								"text": "\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 982,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 2270,
+							"name": "Action"
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.hiddenActions"
+					}
+				},
+				{
+					"id": 3217,
+					"name": "insertAsSibling",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Insert as a sibling of the target container, instead of appending to a\nchild inside it.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.2.0 | ThoughtSpot: 9.0.0.cl, 9.0.0.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   insertAsSibling:true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1065,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.insertAsSibling"
+					}
+				},
+				{
+					"id": 3237,
+					"name": "interceptTimeout",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The timeout for the intercept, default is 30000ms\nthe api will error out if the timeout is reached",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.ALL],\n  interceptTimeout: 1000,\n})\n```\n"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | ThoughtSpot: 10.15.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 7374,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.interceptTimeout"
+					}
+				},
+				{
+					"id": 3236,
+					"name": "interceptUrls",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "This allows to intercept the urls passed, once intercepted the api will only\nrun based on the response from the responder of ApiIntercept event.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | ThoughtSpot: 10.15.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 7357,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.interceptUrls"
+					}
+				},
+				{
+					"id": 3235,
+					"name": "isOnBeforeGetVizDataInterceptEnabled",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Flag that allows using `EmbedEvent.OnBeforeGetVizDataIntercept`.",
+						"text": "Can be used for Search and App Embed from SDK 1.29.0\n",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.43.0 | ThoughtSpot: 10.15.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 7341,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.isOnBeforeGetVizDataInterceptEnabled"
+					}
+				},
+				{
+					"id": 3226,
+					"name": "linkOverride",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Flag to override the *Open Link in New Tab* context\nmenu option.",
+						"text": "For improved link override handling, use\n{@link enableLinkOverridesV2} instead.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`,\n`SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`,\n`SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.21.0 | ThoughtSpot: 9.2.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n   ... // other embed view config\n   linkOverride: true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1196,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.linkOverride"
+					}
+				},
+				{
+					"id": 3211,
+					"name": "locale",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The locale settings to apply to the embedded view.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.9.4 | ThoughtSpot: 8.1.0.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   locale:'en',\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1018,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.locale"
+					}
+				},
+				{
+					"id": 3225,
+					"name": "overrideOrgId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Overrides an Org context for embedding application users.\nThis parameter allows a user authenticated to one Org to view the\nobjects from another Org.\nThe `overrideOrgId` setting is honoured only if the\nPer Org URL feature is enabled on your ThoughtSpot instance.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.35.0 | ThoughtSpot: 10.5.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n  ... // other embed view config\n  overrideOrgId: 142536,\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1176,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.overrideOrgId"
+					}
+				},
+				{
+					"id": 3219,
+					"name": "preRenderId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "PreRender id to be used for PreRendering the embed.\nUse PreRender to render the embed in the background and then\nshow or hide the rendered embed using showPreRender or hidePreRender respectively.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1092,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.preRenderId"
+					}
+				},
+				{
+					"id": 3228,
+					"name": "primaryAction",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The primary action to display on top of the viz for Liveboard and App Embed.\nUse this to set the primary action.",
+						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.39.0 | ThoughtSpot: 10.11.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  primaryAction: Action.Download\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.primaryAction"
+					}
+				},
+				{
+					"id": 3232,
+					"name": "refreshAuthTokenOnNearExpiry",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Refresh the auth token when the token is near expiry.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.45.2 | ThoughtSpot: 26.3.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new AppEmbed('#tsEmbed', {\n   ... // other embed view config\n   refreshAuthTokenOnNearExpiry: true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1453,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.refreshAuthTokenOnNearExpiry"
+					}
+				},
+				{
+					"id": 3233,
+					"name": "shouldBypassPayloadValidation",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "This flag skips payload validation so events can be processed even if the payload is old, incomplete, or from a trusted system.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.45.2 | ThoughtSpot: 26.3.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new AppEmbed('#tsEmbed', {\n   ... // other embed view config\n   shouldBypassPayloadValidation:true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1466,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.shouldBypassPayloadValidation"
+					}
+				},
+				{
+					"id": 3230,
+					"name": "showAlerts",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Show alert messages and toast messages in the embed.\nSupported in all embed types.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new AppEmbed('#tsEmbed', {\n   ... // other embed view config\n   showAlerts:true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1260,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.showAlerts"
+					}
+				},
+				{
+					"id": 3234,
+					"name": "useHostEventsV2",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Flag to use host events v2. This is used to enable the new host events v2 API.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.45.2 | ThoughtSpot: 26.3.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new AppEmbed('#tsEmbed', {\n   ... // other embed view config\n   useHostEventsV2:true,\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1480,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.useHostEventsV2"
+					}
+				},
+				{
+					"id": 3210,
+					"name": "visibleActions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "The list of actions to display from the primary menu, more menu\n(...), and the contextual menu. These will be only actions that\nare visible to the user.\nUse this to hide all actions except the ones you want to show.",
+						"text": "Use either this or hiddenActions.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`, `SageEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw"
+							},
+							{
+								"tag": "important",
+								"text": ""
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1003,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 2270,
+							"name": "Action"
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.visibleActions"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						3212,
+						3231,
+						3216,
+						3224,
+						3208,
+						3207,
+						3220,
+						3227,
+						3221,
+						3223,
+						3204,
+						3209,
+						3217,
+						3237,
+						3236,
+						3235,
+						3226,
+						3211,
+						3225,
+						3219,
+						3228,
+						3232,
+						3233,
+						3230,
+						3234,
+						3210
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "types.ts",
+					"line": 1484,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"name": "BaseViewConfig"
 				}
 			]
 		},
@@ -28634,7 +29837,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
@@ -28723,7 +29926,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -28764,13 +29967,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -28804,7 +30007,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -28843,7 +30046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -28882,7 +30085,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -28890,7 +30093,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -28928,7 +30131,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -28967,7 +30170,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -29006,7 +30209,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -29044,7 +30247,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -29083,13 +30286,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -29127,7 +30330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -29135,7 +30338,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -29170,7 +30373,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -29208,7 +30411,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -29246,7 +30449,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -29284,7 +30487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -29323,7 +30526,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -29362,7 +30565,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -29401,7 +30604,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -29440,7 +30643,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -29478,7 +30681,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -29520,7 +30723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -29558,7 +30761,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -29600,7 +30803,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -29643,7 +30846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -29651,7 +30854,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -29782,7 +30985,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
@@ -29871,7 +31074,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -29912,13 +31115,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -29995,7 +31198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -30073,7 +31276,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -30112,7 +31315,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -30120,7 +31323,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -30158,7 +31361,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -30197,7 +31400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -30279,7 +31482,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -30395,7 +31598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -30434,13 +31637,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -30478,7 +31681,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -30486,7 +31689,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -30599,7 +31802,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -30637,7 +31840,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -30675,7 +31878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -30713,7 +31916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -30752,7 +31955,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -30791,7 +31994,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -30830,7 +32033,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -30869,7 +32072,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -30907,7 +32110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -30997,7 +32200,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -31063,7 +32266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -31101,7 +32304,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -31305,7 +32508,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -31348,7 +32551,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -31356,7 +32559,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -31457,7 +32660,7 @@
 			]
 		},
 		{
-			"id": 3123,
+			"id": 3125,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31472,7 +32675,7 @@
 			},
 			"children": [
 				{
-					"id": 3124,
+					"id": 3126,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31482,21 +32685,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6817,
+							"line": 6903,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3125,
+							"id": 3127,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3126,
+									"id": 3128,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31504,18 +32707,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6818,
+											"line": 6904,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3120,
+										"id": 3122,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3127,
+									"id": 3129,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31523,7 +32726,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6819,
+											"line": 6905,
 											"character": 8
 										}
 									],
@@ -31531,7 +32734,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3120,
+											"id": 3122,
 											"name": "VizPoint"
 										}
 									}
@@ -31542,8 +32745,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3126,
-										3127
+										3128,
+										3129
 									]
 								}
 							]
@@ -31551,7 +32754,7 @@
 					}
 				},
 				{
-					"id": 3128,
+					"id": 3130,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31559,21 +32762,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6821,
+							"line": 6907,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3129,
+							"id": 3131,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3137,
+									"id": 3139,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31581,7 +32784,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6829,
+											"line": 6915,
 											"character": 8
 										}
 									],
@@ -31594,7 +32797,7 @@
 									}
 								},
 								{
-									"id": 3138,
+									"id": 3140,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31602,7 +32805,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6830,
+											"line": 6916,
 											"character": 8
 										}
 									],
@@ -31615,7 +32818,7 @@
 									}
 								},
 								{
-									"id": 3131,
+									"id": 3133,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31623,25 +32826,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6823,
-											"character": 8
-										}
-									],
-									"type": {
-										"type": "intrinsic",
-										"name": "string"
-									}
-								},
-								{
-									"id": 3130,
-									"name": "name",
-									"kind": 1024,
-									"kindString": "Property",
-									"flags": {},
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 6822,
+											"line": 6909,
 											"character": 8
 										}
 									],
@@ -31652,6 +32837,24 @@
 								},
 								{
 									"id": 3132,
+									"name": "name",
+									"kind": 1024,
+									"kindString": "Property",
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "types.ts",
+											"line": 6908,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 3134,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -31659,21 +32862,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 6824,
+											"line": 6910,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3133,
+											"id": 3135,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3134,
+													"id": 3136,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -31681,21 +32884,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 6825,
+															"line": 6911,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3135,
+															"id": 3137,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3136,
+																	"id": 3138,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -31703,7 +32906,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 6826,
+																			"line": 6912,
 																			"character": 16
 																		}
 																	],
@@ -31718,7 +32921,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3136
+																		3138
 																	]
 																}
 															]
@@ -31731,7 +32934,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3134
+														3136
 													]
 												}
 											]
@@ -31744,23 +32947,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3137,
-										3138,
-										3131,
-										3130,
-										3132
+										3139,
+										3140,
+										3133,
+										3132,
+										3134
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3139,
+								"id": 3141,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3140,
+										"id": 3142,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -31779,7 +32982,7 @@
 					}
 				},
 				{
-					"id": 3141,
+					"id": 3143,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31787,7 +32990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6833,
+							"line": 6919,
 							"character": 4
 						}
 					],
@@ -31798,7 +33001,7 @@
 					}
 				},
 				{
-					"id": 3142,
+					"id": 3144,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31808,7 +33011,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6834,
+							"line": 6920,
 							"character": 4
 						}
 					],
@@ -31823,23 +33026,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3124,
-						3128,
-						3141,
-						3142
+						3126,
+						3130,
+						3143,
+						3144
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6816,
+					"line": 6902,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2908,
+			"id": 2910,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31849,7 +33052,7 @@
 			},
 			"children": [
 				{
-					"id": 2962,
+					"id": 2964,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31872,7 +33075,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2963,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31895,7 +33098,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2933,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31918,7 +33121,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2934,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31941,7 +33144,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2936,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31964,7 +33167,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2935,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31987,7 +33190,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2915,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32010,7 +33213,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2976,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32033,7 +33236,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2977,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32056,7 +33259,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2974,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32079,7 +33282,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2975,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32102,7 +33305,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2938,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32125,7 +33328,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2943,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32148,7 +33351,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2940,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32171,7 +33374,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2942,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32194,7 +33397,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2941,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32217,7 +33420,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2939,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32240,7 +33443,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2948,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32263,7 +33466,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2945,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32286,7 +33489,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2947,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32309,7 +33512,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2946,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32332,7 +33535,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2944,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32355,7 +33558,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2952,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32378,7 +33581,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2951,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32401,7 +33604,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2950,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32424,7 +33627,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2949,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32447,7 +33650,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2937,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32470,7 +33673,7 @@
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3070,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32483,7 +33686,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 849,
+							"line": 883,
 							"character": 4
 						}
 					],
@@ -32493,7 +33696,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3065,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32506,7 +33709,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 824,
+							"line": 858,
 							"character": 4
 						}
 					],
@@ -32516,7 +33719,7 @@
 					}
 				},
 				{
-					"id": 3058,
+					"id": 3060,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32529,7 +33732,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 799,
+							"line": 833,
 							"character": 4
 						}
 					],
@@ -32539,7 +33742,7 @@
 					}
 				},
 				{
-					"id": 3057,
+					"id": 3059,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32552,7 +33755,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 794,
+							"line": 828,
 							"character": 4
 						}
 					],
@@ -32562,7 +33765,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3062,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32575,7 +33778,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 809,
+							"line": 843,
 							"character": 4
 						}
 					],
@@ -32585,7 +33788,7 @@
 					}
 				},
 				{
-					"id": 3059,
+					"id": 3061,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32598,7 +33801,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 804,
+							"line": 838,
 							"character": 4
 						}
 					],
@@ -32608,7 +33811,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 2999,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32631,7 +33834,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3002,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32654,7 +33857,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 2997,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32677,7 +33880,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3000,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32700,7 +33903,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3001,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32723,7 +33926,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 2996,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32746,7 +33949,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 2998,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32769,7 +33972,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2969,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32792,7 +33995,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2968,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32815,7 +34018,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2971,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32838,7 +34041,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2970,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32861,7 +34064,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2967,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32884,7 +34087,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2965,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32907,7 +34110,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2966,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32930,7 +34133,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2972,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32953,7 +34156,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2973,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32976,7 +34179,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2984,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32999,7 +34202,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2985,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33022,7 +34225,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 2988,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33045,7 +34248,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 2986,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33068,7 +34271,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 2987,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33091,7 +34294,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 2995,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33114,7 +34317,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 2994,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33137,7 +34340,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 2993,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33160,7 +34363,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 2992,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33183,7 +34386,7 @@
 					}
 				},
 				{
-					"id": 3056,
+					"id": 3058,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33196,7 +34399,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 789,
+							"line": 823,
 							"character": 4
 						}
 					],
@@ -33206,7 +34409,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3057,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33219,7 +34422,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 784,
+							"line": 818,
 							"character": 4
 						}
 					],
@@ -33229,7 +34432,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3056,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33242,7 +34445,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 779,
+							"line": 813,
 							"character": 4
 						}
 					],
@@ -33252,7 +34455,7 @@
 					}
 				},
 				{
-					"id": 3062,
+					"id": 3064,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33265,7 +34468,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 819,
+							"line": 853,
 							"character": 4
 						}
 					],
@@ -33275,7 +34478,7 @@
 					}
 				},
 				{
-					"id": 3061,
+					"id": 3063,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33288,7 +34491,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 814,
+							"line": 848,
 							"character": 4
 						}
 					],
@@ -33298,7 +34501,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 2990,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33321,7 +34524,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 2989,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33344,7 +34547,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3017,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33357,7 +34560,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 562,
+							"line": 574,
 							"character": 4
 						}
 					],
@@ -33367,7 +34570,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3030,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33376,12 +34579,12 @@
 					},
 					"comment": {
 						"shortText": "Background color of the filter chips in the Liveboard on active.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 649,
+							"line": 683,
 							"character": 4
 						}
 					],
@@ -33391,7 +34594,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3029,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33400,78 +34603,7 @@
 					},
 					"comment": {
 						"shortText": "Background color of the filter chips in the Liveboard on hover.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 642,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3025,
-					"name": "--ts-var-liveboard-chip-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the filter chips in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 628,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3026,
-					"name": "--ts-var-liveboard-chip-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the filter chips in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 635,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3033,
-					"name": "--ts-var-liveboard-cross-filter-layout-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the cross filter layout in the Liveboard."
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
@@ -33486,7 +34618,78 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3027,
+					"name": "--ts-var-liveboard-chip-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the filter chips in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 656,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3028,
+					"name": "--ts-var-liveboard-chip-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the filter chips in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 665,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3035,
+					"name": "--ts-var-liveboard-cross-filter-layout-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the cross filter layout in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 708,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3033,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33499,7 +34702,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 664,
+							"line": 698,
 							"character": 4
 						}
 					],
@@ -33509,7 +34712,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3032,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33522,7 +34725,151 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 659,
+							"line": 693,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3018,
+					"name": "--ts-var-liveboard-group-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 583,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3019,
+					"name": "--ts-var-liveboard-group-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 592,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3023,
+					"name": "--ts-var-liveboard-group-description-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the description of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 620,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3011,
+					"name": "--ts-var-liveboard-group-padding",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Padding of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 524,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3026,
+					"name": "--ts-var-liveboard-group-tile-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the tiles inside the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 647,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3025,
+					"name": "--ts-var-liveboard-group-tile-description-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the description of the tiles inside the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 638,
 							"character": 4
 						}
 					],
@@ -33533,15 +34880,15 @@
 				},
 				{
 					"id": 3016,
-					"name": "--ts-var-liveboard-group-background",
+					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"shortText": "Padding of the group tiles in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
@@ -33556,117 +34903,21 @@
 					}
 				},
 				{
-					"id": 3017,
-					"name": "--ts-var-liveboard-group-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 576,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3021,
-					"name": "--ts-var-liveboard-group-description-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the description of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 600,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3009,
-					"name": "--ts-var-liveboard-group-padding",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Padding of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 522,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
 					"id": 3024,
-					"name": "--ts-var-liveboard-group-tile-background",
+					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the tiles inside the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"shortText": "Font color of the title of the tiles inside the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 621,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3023,
-					"name": "--ts-var-liveboard-group-tile-description-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the description of the tiles inside the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 614,
+							"line": 629,
 							"character": 4
 						}
 					],
@@ -33677,20 +34928,44 @@
 				},
 				{
 					"id": 3014,
-					"name": "--ts-var-liveboard-group-tile-padding",
+					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Padding of the group tiles in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"shortText": "Font size of the title of the tiles inside the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 557,
+							"line": 551,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3015,
+					"name": "--ts-var-liveboard-group-tile-title-font-weight",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font weight of the title of the tiles inside the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 560,
 							"character": 4
 						}
 					],
@@ -33701,20 +34976,20 @@
 				},
 				{
 					"id": 3022,
-					"name": "--ts-var-liveboard-group-tile-title-font-color",
+					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the title of the tiles inside the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"shortText": "Font color of the title of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 607,
+							"line": 611,
 							"character": 4
 						}
 					],
@@ -33725,20 +35000,20 @@
 				},
 				{
 					"id": 3012,
-					"name": "--ts-var-liveboard-group-tile-title-font-size",
+					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font size of the title of the tiles inside the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"shortText": "Font size of the title of the groups in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 543,
+							"line": 533,
 							"character": 4
 						}
 					],
@@ -33749,78 +35024,6 @@
 				},
 				{
 					"id": 3013,
-					"name": "--ts-var-liveboard-group-tile-title-font-weight",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font weight of the title of the tiles inside the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 550,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3020,
-					"name": "--ts-var-liveboard-group-title-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the title of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 593,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3010,
-					"name": "--ts-var-liveboard-group-title-font-size",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font size of the title of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 529,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3011,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33829,12 +35032,12 @@
 					},
 					"comment": {
 						"shortText": "Font weight of the title of the groups in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and then set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying this CSS variable.\n"
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 536,
+							"line": 542,
 							"character": 4
 						}
 					],
@@ -33844,7 +35047,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3049,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33857,7 +35060,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 744,
+							"line": 778,
 							"character": 4
 						}
 					],
@@ -33867,7 +35070,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3046,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33880,7 +35083,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 729,
+							"line": 763,
 							"character": 4
 						}
 					],
@@ -33890,7 +35093,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3047,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33903,7 +35106,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 734,
+							"line": 768,
 							"character": 4
 						}
 					],
@@ -33913,7 +35116,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3048,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33926,7 +35129,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 739,
+							"line": 773,
 							"character": 4
 						}
 					],
@@ -33936,7 +35139,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3004,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33959,7 +35162,7 @@
 					}
 				},
 				{
-					"id": 3053,
+					"id": 3055,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33972,7 +35175,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 774,
+							"line": 808,
 							"character": 4
 						}
 					],
@@ -33982,7 +35185,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3050,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33995,7 +35198,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 749,
+							"line": 783,
 							"character": 4
 						}
 					],
@@ -34005,7 +35208,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3051,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34018,7 +35221,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 754,
+							"line": 788,
 							"character": 4
 						}
 					],
@@ -34028,7 +35231,7 @@
 					}
 				},
 				{
-					"id": 3052,
+					"id": 3054,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34041,7 +35244,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 769,
+							"line": 803,
 							"character": 4
 						}
 					],
@@ -34051,7 +35254,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3052,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34064,7 +35267,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 759,
+							"line": 793,
 							"character": 4
 						}
 					],
@@ -34074,7 +35277,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3053,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34087,7 +35290,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 764,
+							"line": 798,
 							"character": 4
 						}
 					],
@@ -34097,7 +35300,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3005,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34120,7 +35323,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3003,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34143,7 +35346,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3021,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34156,7 +35359,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 586,
+							"line": 602,
 							"character": 4
 						}
 					],
@@ -34166,7 +35369,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3020,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34179,7 +35382,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 581,
+							"line": 597,
 							"character": 4
 						}
 					],
@@ -34189,7 +35392,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3034,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34202,7 +35405,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 669,
+							"line": 703,
 							"character": 4
 						}
 					],
@@ -34212,7 +35415,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3036,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34225,7 +35428,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 679,
+							"line": 713,
 							"character": 4
 						}
 					],
@@ -34235,7 +35438,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3037,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34248,7 +35451,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 684,
+							"line": 718,
 							"character": 4
 						}
 					],
@@ -34258,7 +35461,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3007,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34281,7 +35484,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3006,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34304,7 +35507,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3008,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34327,7 +35530,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3009,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34350,7 +35553,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3010,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34373,7 +35576,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3038,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34386,7 +35589,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 689,
+							"line": 723,
 							"character": 4
 						}
 					],
@@ -34396,7 +35599,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3039,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34409,7 +35612,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 694,
+							"line": 728,
 							"character": 4
 						}
 					],
@@ -34419,7 +35622,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2982,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34442,7 +35645,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2979,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34465,7 +35668,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2978,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34488,7 +35691,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2980,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34511,7 +35714,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2983,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34534,7 +35737,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2981,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34557,7 +35760,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2916,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34580,7 +35783,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2917,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34603,7 +35806,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3044,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34616,7 +35819,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 719,
+							"line": 753,
 							"character": 4
 						}
 					],
@@ -34626,7 +35829,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3045,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34639,7 +35842,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 724,
+							"line": 758,
 							"character": 4
 						}
 					],
@@ -34649,7 +35852,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3040,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34662,7 +35865,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 699,
+							"line": 733,
 							"character": 4
 						}
 					],
@@ -34672,7 +35875,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3042,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34685,7 +35888,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 709,
+							"line": 743,
 							"character": 4
 						}
 					],
@@ -34695,7 +35898,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3043,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34708,7 +35911,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 714,
+							"line": 748,
 							"character": 4
 						}
 					],
@@ -34718,7 +35921,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3041,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34731,7 +35934,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 704,
+							"line": 738,
 							"character": 4
 						}
 					],
@@ -34741,7 +35944,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2911,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34764,7 +35967,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2912,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34787,7 +35990,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2913,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34810,7 +36013,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2914,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34833,7 +36036,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3073,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34846,7 +36049,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 864,
+							"line": 898,
 							"character": 4
 						}
 					],
@@ -34856,7 +36059,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3072,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34869,7 +36072,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 859,
+							"line": 893,
 							"character": 4
 						}
 					],
@@ -34879,7 +36082,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3077,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34892,7 +36095,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 884,
+							"line": 918,
 							"character": 4
 						}
 					],
@@ -34902,7 +36105,7 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3078,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34915,7 +36118,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 889,
+							"line": 923,
 							"character": 4
 						}
 					],
@@ -34925,7 +36128,7 @@
 					}
 				},
 				{
-					"id": 3079,
+					"id": 3081,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34938,7 +36141,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 904,
+							"line": 938,
 							"character": 4
 						}
 					],
@@ -34948,7 +36151,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3080,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34961,7 +36164,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 899,
+							"line": 933,
 							"character": 4
 						}
 					],
@@ -34971,7 +36174,7 @@
 					}
 				},
 				{
-					"id": 3077,
+					"id": 3079,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34984,7 +36187,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 894,
+							"line": 928,
 							"character": 4
 						}
 					],
@@ -34994,7 +36197,7 @@
 					}
 				},
 				{
-					"id": 3080,
+					"id": 3082,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35007,7 +36210,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 909,
+							"line": 943,
 							"character": 4
 						}
 					],
@@ -35017,7 +36220,7 @@
 					}
 				},
 				{
-					"id": 3073,
+					"id": 3075,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35030,7 +36233,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 874,
+							"line": 908,
 							"character": 4
 						}
 					],
@@ -35040,7 +36243,7 @@
 					}
 				},
 				{
-					"id": 3081,
+					"id": 3083,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35053,7 +36256,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 914,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -35063,7 +36266,7 @@
 					}
 				},
 				{
-					"id": 3072,
+					"id": 3074,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35076,7 +36279,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 869,
+							"line": 903,
 							"character": 4
 						}
 					],
@@ -35086,7 +36289,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3076,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35099,7 +36302,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 879,
+							"line": 913,
 							"character": 4
 						}
 					],
@@ -35109,7 +36312,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2925,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35132,7 +36335,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2929,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35155,7 +36358,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2930,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35178,7 +36381,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2928,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35201,7 +36404,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2924,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35224,7 +36427,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2927,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35247,7 +36450,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2921,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35270,7 +36473,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2922,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35293,7 +36496,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2923,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35316,7 +36519,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2918,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35339,7 +36542,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2919,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35362,7 +36565,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2920,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35385,7 +36588,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2926,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35408,7 +36611,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 2991,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35431,7 +36634,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3031,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35444,7 +36647,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 654,
+							"line": 688,
 							"character": 4
 						}
 					],
@@ -35454,7 +36657,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3069,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35467,7 +36670,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 844,
+							"line": 878,
 							"character": 4
 						}
 					],
@@ -35477,7 +36680,7 @@
 					}
 				},
 				{
-					"id": 3064,
+					"id": 3066,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35490,7 +36693,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 829,
+							"line": 863,
 							"character": 4
 						}
 					],
@@ -35500,7 +36703,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3067,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35513,7 +36716,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 834,
+							"line": 868,
 							"character": 4
 						}
 					],
@@ -35523,7 +36726,7 @@
 					}
 				},
 				{
-					"id": 3066,
+					"id": 3068,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35536,7 +36739,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 839,
+							"line": 873,
 							"character": 4
 						}
 					],
@@ -35546,7 +36749,7 @@
 					}
 				},
 				{
-					"id": 3069,
+					"id": 3071,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35559,7 +36762,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 854,
+							"line": 888,
 							"character": 4
 						}
 					],
@@ -35569,7 +36772,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2931,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35592,7 +36795,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2932,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35615,7 +36818,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2961,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35638,7 +36841,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2959,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35661,7 +36864,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2960,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35684,7 +36887,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2956,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35707,7 +36910,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2957,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35730,7 +36933,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2958,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35753,7 +36956,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2962,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35776,7 +36979,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2953,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35799,7 +37002,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2954,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35822,7 +37025,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2955,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35850,179 +37053,179 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2962,
-						2961,
-						2931,
-						2932,
-						2934,
+						2964,
+						2963,
 						2933,
-						2913,
+						2934,
+						2936,
+						2935,
+						2915,
+						2976,
+						2977,
 						2974,
 						2975,
-						2972,
-						2973,
-						2936,
-						2941,
 						2938,
-						2940,
-						2939,
-						2937,
-						2946,
 						2943,
-						2945,
-						2944,
+						2940,
 						2942,
+						2941,
+						2939,
+						2948,
+						2945,
+						2947,
+						2946,
+						2944,
+						2952,
+						2951,
 						2950,
 						2949,
-						2948,
-						2947,
-						2935,
-						3068,
-						3063,
-						3058,
-						3057,
+						2937,
+						3070,
+						3065,
 						3060,
 						3059,
-						2997,
-						3000,
-						2995,
-						2998,
-						2999,
-						2994,
-						2996,
-						2967,
-						2966,
-						2969,
-						2968,
-						2965,
-						2963,
-						2964,
-						2970,
-						2971,
-						2982,
-						2983,
-						2986,
-						2984,
-						2985,
-						2993,
-						2992,
-						2991,
-						2990,
-						3056,
-						3055,
-						3054,
 						3062,
 						3061,
+						2999,
+						3002,
+						2997,
+						3000,
+						3001,
+						2996,
+						2998,
+						2969,
+						2968,
+						2971,
+						2970,
+						2967,
+						2965,
+						2966,
+						2972,
+						2973,
+						2984,
+						2985,
 						2988,
+						2986,
 						2987,
-						3015,
-						3028,
-						3027,
-						3025,
-						3026,
-						3033,
-						3031,
-						3030,
-						3016,
+						2995,
+						2994,
+						2993,
+						2992,
+						3058,
+						3057,
+						3056,
+						3064,
+						3063,
+						2990,
+						2989,
 						3017,
-						3021,
-						3009,
-						3024,
+						3030,
+						3029,
+						3027,
+						3028,
+						3035,
+						3033,
+						3032,
+						3018,
+						3019,
 						3023,
+						3011,
+						3026,
+						3025,
+						3016,
+						3024,
 						3014,
+						3015,
 						3022,
 						3012,
 						3013,
-						3020,
-						3010,
-						3011,
-						3047,
-						3044,
-						3045,
-						3046,
-						3002,
-						3053,
-						3048,
 						3049,
-						3052,
+						3046,
+						3047,
+						3048,
+						3004,
+						3055,
 						3050,
 						3051,
-						3003,
-						3001,
-						3019,
-						3018,
-						3032,
-						3034,
-						3035,
+						3054,
+						3052,
+						3053,
 						3005,
-						3004,
-						3006,
-						3007,
-						3008,
+						3003,
+						3021,
+						3020,
+						3034,
 						3036,
 						3037,
-						2980,
-						2977,
-						2976,
-						2978,
-						2981,
-						2979,
-						2914,
-						2915,
-						3042,
-						3043,
+						3007,
+						3006,
+						3008,
+						3009,
+						3010,
 						3038,
-						3040,
-						3041,
 						3039,
-						2909,
-						2910,
-						2911,
-						2912,
-						3071,
-						3070,
-						3075,
-						3076,
-						3079,
-						3078,
-						3077,
-						3080,
-						3073,
-						3081,
-						3072,
-						3074,
-						2923,
-						2927,
-						2928,
-						2926,
-						2922,
-						2925,
-						2919,
-						2920,
-						2921,
+						2982,
+						2979,
+						2978,
+						2980,
+						2983,
+						2981,
 						2916,
 						2917,
-						2918,
-						2924,
-						2989,
-						3029,
-						3067,
-						3064,
-						3065,
-						3066,
-						3069,
+						3044,
+						3045,
+						3040,
+						3042,
+						3043,
+						3041,
+						2911,
+						2912,
+						2913,
+						2914,
+						3073,
+						3072,
+						3077,
+						3078,
+						3081,
+						3080,
+						3079,
+						3082,
+						3075,
+						3083,
+						3074,
+						3076,
+						2925,
 						2929,
 						2930,
+						2928,
+						2924,
+						2927,
+						2921,
+						2922,
+						2923,
+						2918,
+						2919,
+						2920,
+						2926,
+						2991,
+						3031,
+						3069,
+						3066,
+						3067,
+						3068,
+						3071,
+						2931,
+						2932,
+						2961,
 						2959,
+						2960,
+						2956,
 						2957,
 						2958,
+						2962,
+						2953,
 						2954,
-						2955,
-						2956,
-						2960,
-						2951,
-						2952,
-						2953
+						2955
 					]
 				}
 			],
@@ -36035,7 +37238,7 @@
 			]
 		},
 		{
-			"id": 2896,
+			"id": 2898,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36045,7 +37248,7 @@
 			},
 			"children": [
 				{
-					"id": 2898,
+					"id": 2900,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36055,18 +37258,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 294,
+							"line": 298,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2899,
+						"id": 2901,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2899,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36076,7 +37279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 293,
+							"line": 297,
 							"character": 4
 						}
 					],
@@ -36091,21 +37294,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2898,
-						2897
+						2900,
+						2899
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 292,
+					"line": 296,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2886,
+			"id": 2888,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36121,7 +37324,7 @@
 			},
 			"children": [
 				{
-					"id": 2888,
+					"id": 2890,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36131,21 +37334,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 330,
+							"line": 334,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2889,
+							"id": 2891,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2891,
+									"id": 2893,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36155,7 +37358,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 335,
+											"line": 339,
 											"character": 8
 										}
 									],
@@ -36175,7 +37378,7 @@
 									}
 								},
 								{
-									"id": 2892,
+									"id": 2894,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36185,7 +37388,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 336,
+											"line": 340,
 											"character": 8
 										}
 									],
@@ -36195,7 +37398,7 @@
 									}
 								},
 								{
-									"id": 2890,
+									"id": 2892,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36213,7 +37416,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 334,
+											"line": 338,
 											"character": 8
 										}
 									],
@@ -36238,21 +37441,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2891,
-										2892,
-										2890
+										2893,
+										2894,
+										2892
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2893,
+								"id": 2895,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2894,
+										"id": 2896,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36271,7 +37474,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2897,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36281,7 +37484,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 339,
+							"line": 343,
 							"character": 4
 						}
 					],
@@ -36291,7 +37494,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2889,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36301,13 +37504,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 329,
+							"line": 333,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2896,
+						"id": 2898,
 						"name": "CustomStyles"
 					}
 				}
@@ -36317,22 +37520,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2888,
-						2895,
-						2887
+						2890,
+						2897,
+						2889
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 328,
+					"line": 332,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2432,
+			"id": 2434,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36348,7 +37551,7 @@
 			},
 			"children": [
 				{
-					"id": 2474,
+					"id": 2476,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36371,27 +37574,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 651,
+							"line": 655,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2475,
+							"id": 2477,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2476,
+								"id": 2478,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2477,
+										"id": 2479,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36423,7 +37626,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2437,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36436,7 +37639,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 365,
+							"line": 369,
 							"character": 4
 						}
 					],
@@ -36446,7 +37649,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2458,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36469,7 +37672,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 528,
+							"line": 532,
 							"character": 4
 						}
 					],
@@ -36488,7 +37691,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2460,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36507,7 +37710,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 541,
+							"line": 545,
 							"character": 4
 						}
 					],
@@ -36517,7 +37720,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2436,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36528,7 +37731,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 357,
+							"line": 361,
 							"character": 4
 						}
 					],
@@ -36539,7 +37742,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2449,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36558,7 +37761,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 456,
+							"line": 460,
 							"character": 4
 						}
 					],
@@ -36568,7 +37771,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2461,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36591,7 +37794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 548,
+							"line": 552,
 							"character": 4
 						}
 					],
@@ -36601,7 +37804,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2452,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36620,7 +37823,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 478,
+							"line": 482,
 							"character": 4
 						}
 					],
@@ -36630,7 +37833,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2485,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36653,7 +37856,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 859,
+							"line": 863,
 							"character": 4
 						}
 					],
@@ -36663,7 +37866,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2473,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36682,7 +37885,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 610,
+							"line": 614,
 							"character": 4
 						}
 					],
@@ -36692,7 +37895,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2483,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36723,7 +37926,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 846,
+							"line": 850,
 							"character": 4
 						}
 					],
@@ -36736,7 +37939,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2480,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36759,7 +37962,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 667,
+							"line": 671,
 							"character": 4
 						}
 					],
@@ -36779,7 +37982,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2457,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36798,18 +38001,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 513,
+							"line": 517,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2471,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36828,7 +38031,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 600,
+							"line": 604,
 							"character": 4
 						}
 					],
@@ -36838,7 +38041,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2454,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36858,7 +38061,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 498,
+							"line": 502,
 							"character": 4
 						}
 					],
@@ -36868,7 +38071,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2482,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36895,7 +38098,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 684,
+							"line": 688,
 							"character": 4
 						}
 					],
@@ -36905,7 +38108,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2475,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36924,7 +38127,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 631,
+							"line": 635,
 							"character": 4
 						}
 					],
@@ -36934,7 +38137,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2450,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36957,7 +38160,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 466,
+							"line": 470,
 							"character": 4
 						}
 					],
@@ -36967,7 +38170,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2481,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36977,7 +38180,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 669,
+							"line": 673,
 							"character": 4
 						}
 					],
@@ -36987,7 +38190,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2470,
 					"name": "disableSDKTracking",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37006,7 +38209,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 595,
+							"line": 599,
 							"character": 4
 						}
 					],
@@ -37016,7 +38219,7 @@
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2448,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37035,7 +38238,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 449,
+							"line": 453,
 							"character": 4
 						}
 					],
@@ -37045,7 +38248,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2443,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37069,7 +38272,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 410,
+							"line": 414,
 							"character": 4
 						}
 					],
@@ -37079,7 +38282,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2469,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37106,18 +38309,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 590,
+							"line": 594,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3085,
+						"id": 3087,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2451,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37136,7 +38339,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 472,
+							"line": 476,
 							"character": 4
 						}
 					],
@@ -37146,7 +38349,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2442,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37169,7 +38372,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 399,
+							"line": 403,
 							"character": 4
 						}
 					],
@@ -37179,7 +38382,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2472,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37198,7 +38401,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 605,
+							"line": 609,
 							"character": 4
 						}
 					],
@@ -37208,7 +38411,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2441,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37222,7 +38425,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 390,
+							"line": 394,
 							"character": 4
 						}
 					],
@@ -37232,7 +38435,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2467,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37251,7 +38454,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 565,
+							"line": 569,
 							"character": 4
 						}
 					],
@@ -37261,7 +38464,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2453,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37284,7 +38487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 487,
+							"line": 491,
 							"character": 4
 						}
 					],
@@ -37294,7 +38497,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2444,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37314,7 +38517,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 420,
+							"line": 424,
 							"character": 4
 						}
 					],
@@ -37324,7 +38527,7 @@
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2446,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37343,7 +38546,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 431,
+							"line": 435,
 							"character": 4
 						}
 					],
@@ -37353,7 +38556,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2468,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37372,7 +38575,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 571,
+							"line": 575,
 							"character": 4
 						}
 					],
@@ -37382,7 +38585,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2447,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37401,7 +38604,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 441,
+							"line": 445,
 							"character": 4
 						}
 					],
@@ -37411,7 +38614,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2456,
 					"name": "suppressSageEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37424,7 +38627,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 508,
+							"line": 512,
 							"character": 4
 						}
 					],
@@ -37434,7 +38637,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2455,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37453,7 +38656,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 503,
+							"line": 507,
 							"character": 4
 						}
 					],
@@ -37463,7 +38666,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2435,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37474,7 +38677,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 353,
+							"line": 357,
 							"character": 4
 						}
 					],
@@ -37484,7 +38687,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2459,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37497,7 +38700,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 535,
+							"line": 539,
 							"character": 4
 						}
 					],
@@ -37507,7 +38710,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2440,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37520,7 +38723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 382,
+							"line": 386,
 							"character": 4
 						}
 					],
@@ -37530,7 +38733,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2484,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37553,7 +38756,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 853,
+							"line": 857,
 							"character": 4
 						}
 					],
@@ -37563,7 +38766,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2438,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -37573,13 +38776,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 377,
+							"line": 381,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 2437,
+							"id": 2439,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -37607,72 +38810,72 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2474,
-						2435,
-						2456,
+						2476,
+						2437,
 						2458,
-						2434,
-						2447,
-						2459,
-						2450,
-						2483,
-						2471,
-						2481,
-						2478,
-						2455,
-						2469,
-						2452,
-						2480,
-						2473,
-						2448,
-						2479,
-						2468,
-						2446,
-						2441,
-						2467,
+						2460,
+						2436,
 						2449,
-						2440,
+						2461,
+						2452,
+						2485,
+						2473,
+						2483,
+						2480,
+						2457,
+						2471,
+						2454,
+						2482,
+						2475,
+						2450,
+						2481,
 						2470,
-						2439,
-						2465,
+						2448,
+						2443,
+						2469,
 						2451,
 						2442,
-						2444,
-						2466,
-						2445,
-						2454,
+						2472,
+						2441,
+						2467,
 						2453,
-						2433,
-						2457,
-						2438,
-						2482
+						2444,
+						2446,
+						2468,
+						2447,
+						2456,
+						2455,
+						2435,
+						2459,
+						2440,
+						2484
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2436
+						2438
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 349,
+					"line": 353,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3190,
+			"id": 3192,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"comment": {
 				"shortText": "Error event object emitted when an error occurs in an embedded component.",
-				"text": "This interface defines the structure of error objects returned by the {@link EmbedEvent.Error}\nevent. It provides detailed information about what went wrong, including the error type,\na human-readable message, and a machine-readable error code.\n\n## Properties\n\n- **errorType**: One of the predefined {@link ErrorDetailsTypes} values\n- **message**: Human-readable error description (string or array of strings for multiple errors)\n- **code**: Machine-readable error identifier {@link EmbedErrorCodes} values\n- **[key: string]**: Additional context-specific for backward compatibility\n\n## Usage\n\nListen to the {@link EmbedEvent.Error} event to receive instances of this object\nand implement appropriate error handling logic based on the `errorType`.\n",
+				"text": "This interface defines the structure of error objects returned by the {@link\nEmbedEvent.Error} event. It provides detailed information about what went wrong,\nincluding the error type, a human-readable message, and a machine-readable error code.\n\n## Properties\n\n- **errorType**: One of the predefined {@link ErrorDetailsTypes} values\n- **message**: Human-readable error description (string or array of strings for\nmultiple errors)\n- **code**: Machine-readable error identifier {@link EmbedErrorCodes}\nvalues\n- **[key: string]**: Additional context-specific for backward compatibility\n\n## Usage\n\nListen to the {@link EmbedEvent.Error} event to receive instances of this object\nand implement appropriate error handling logic based on the `errorType`.\n",
 				"tags": [
 					{
 						"tag": "version",
@@ -37694,7 +38897,7 @@
 			},
 			"children": [
 				{
-					"id": 3193,
+					"id": 3195,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37705,18 +38908,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7185,
+							"line": 7275,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3176,
+						"id": 3178,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3191,
+					"id": 3193,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37727,18 +38930,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7181,
+							"line": 7271,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3196,
+						"id": 3198,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3192,
+					"id": 3194,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37749,7 +38952,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7183,
+							"line": 7273,
 							"character": 4
 						}
 					],
@@ -37776,21 +38979,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
+						3195,
 						3193,
-						3191,
-						3192
+						3194
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 7179,
+					"line": 7269,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3194,
+				"id": 3196,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -37800,7 +39003,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3195,
+						"id": 3197,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -37817,7 +39020,7 @@
 			}
 		},
 		{
-			"id": 2845,
+			"id": 2847,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -37833,7 +39036,7 @@
 			},
 			"children": [
 				{
-					"id": 2847,
+					"id": 2849,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37846,7 +39049,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 877,
+							"line": 881,
 							"character": 4
 						}
 					],
@@ -37865,7 +39068,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2850,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37878,7 +39081,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 883,
+							"line": 887,
 							"character": 4
 						}
 					],
@@ -37901,7 +39104,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2848,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37914,7 +39117,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 873,
+							"line": 877,
 							"character": 4
 						}
 					],
@@ -37938,21 +39141,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2847,
-						2848,
-						2846
+						2849,
+						2850,
+						2848
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 869,
+					"line": 873,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 2849,
+				"id": 2851,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -37962,7 +39165,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2850,
+						"id": 2852,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -37996,7 +39199,7 @@
 			}
 		},
 		{
-			"id": 2595,
+			"id": 2597,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -38012,7 +39215,7 @@
 			},
 			"children": [
 				{
-					"id": 2607,
+					"id": 2609,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38046,7 +39249,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2636,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38070,27 +39273,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2635,
+							"id": 2637,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2636,
+								"id": 2638,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2637,
+										"id": 2639,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -38126,7 +39329,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2667,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38154,7 +39357,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1672,
+							"line": 1681,
 							"character": 4
 						}
 					],
@@ -38168,7 +39371,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2664,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38192,13 +39395,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1630,
+							"line": 1639,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2428,
+						"id": 2430,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -38207,7 +39410,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2681,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38231,7 +39434,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1908,
+							"line": 1919,
 							"character": 4
 						}
 					],
@@ -38245,7 +39448,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2655,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38277,7 +39480,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -38294,7 +39497,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2640,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38317,13 +39520,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -38332,7 +39535,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2668,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38360,7 +39563,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1688,
+							"line": 1697,
 							"character": 4
 						}
 					],
@@ -38374,7 +39577,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2599,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38416,7 +39619,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2648,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38440,7 +39643,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -38454,7 +39657,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2632,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38478,7 +39681,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -38492,7 +39695,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2631,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38516,7 +39719,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -38524,7 +39727,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -38534,7 +39737,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2644,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38561,7 +39764,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -38575,7 +39778,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2675,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38603,7 +39806,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1806,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -38617,7 +39820,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2680,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38645,7 +39848,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1892,
+							"line": 1903,
 							"character": 4
 						}
 					],
@@ -38659,7 +39862,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2669,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38687,7 +39890,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1704,
+							"line": 1713,
 							"character": 4
 						}
 					],
@@ -38701,7 +39904,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2651,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38725,7 +39928,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -38739,7 +39942,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2645,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38763,7 +39966,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -38777,7 +39980,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2601,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38814,7 +40017,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2665,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38838,7 +40041,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1652,
 							"character": 4
 						}
 					],
@@ -38852,7 +40055,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2666,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38876,7 +40079,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1656,
+							"line": 1665,
 							"character": 4
 						}
 					],
@@ -38890,7 +40093,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2647,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38913,7 +40116,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -38927,7 +40130,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2628,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38951,13 +40154,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -38966,7 +40169,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2598,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39000,7 +40203,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2633,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39028,7 +40231,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -39036,7 +40239,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -39046,7 +40249,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2616,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39083,7 +40286,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2678,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39092,7 +40295,7 @@
 					},
 					"comment": {
 						"shortText": "This flag is used to enable/disable hide irrelevant filters in Liveboard tab",
-						"text": "**Note**: This feature is supported only if compact header is enabled on your Liveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled` attribute.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`",
+						"text": "**Note**: This feature is supported only if compact header is enabled on your\nLiveboard. To enable compact header, use the `isLiveboardCompactHeaderEnabled`\nattribute.\n\nSupported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
 								"tag": "version",
@@ -39111,7 +40314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1859,
+							"line": 1870,
 							"character": 4
 						}
 					],
@@ -39125,7 +40328,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2671,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39153,7 +40356,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1742,
+							"line": 1751,
 							"character": 4
 						}
 					],
@@ -39167,7 +40370,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2611,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39201,7 +40404,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2641,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39225,7 +40428,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -39239,7 +40442,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2661,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39262,7 +40465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -39276,7 +40479,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2660,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39299,7 +40502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -39316,7 +40519,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2682,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39324,7 +40527,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable or disable the new centralized Liveboard filter UX (v2).\nWhen enabled, a unified modal is used to manage and update multiple filters at once,\nreplacing the older individual filter interactions.\nTo enable this feature on your instance, contact ThoughtSpot Support.",
+						"shortText": "This flag is used to enable or disable the new centralized Liveboard filter UX\n(v2). When enabled, a unified modal is used to manage and update multiple filters\nat once, replacing the older individual filter interactions.\nTo enable this feature on your instance, contact ThoughtSpot Support.",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -39340,7 +40543,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 1937,
 							"character": 4
 						}
 					],
@@ -39354,7 +40557,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2684,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39362,7 +40565,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable or disable the enhanced filter interactivity in liveboard.",
+						"shortText": "This flag is used to enable or disable the enhanced filter interactivity in\nliveboard.",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -39378,7 +40581,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1957,
+							"line": 1969,
 							"character": 4
 						}
 					],
@@ -39392,7 +40595,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2621,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39416,7 +40619,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 420,
+							"line": 421,
 							"character": 4
 						}
 					],
@@ -39426,7 +40629,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2683,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39450,7 +40653,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1941,
+							"line": 1952,
 							"character": 4
 						}
 					],
@@ -39464,7 +40667,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2676,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39492,7 +40695,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1823,
+							"line": 1832,
 							"character": 4
 						}
 					],
@@ -39506,7 +40709,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2674,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39530,7 +40733,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1789,
+							"line": 1798,
 							"character": 4
 						}
 					],
@@ -39544,7 +40747,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2686,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39572,7 +40775,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2001,
 							"character": 4
 						}
 					],
@@ -39586,7 +40789,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2618,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39623,7 +40826,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2620,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39647,7 +40850,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 404,
+							"line": 405,
 							"character": 4
 						}
 					],
@@ -39657,7 +40860,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2659,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39677,7 +40880,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -39691,7 +40894,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2619,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39699,7 +40902,7 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "This flag is used to enable/disable the png embedding of liveboard in scheduled mails",
+						"shortText": "This flag is used to enable/disable the png embedding of liveboard in scheduled\nmails",
 						"text": "Supported embed types: `AppEmbed`, `LiveboardEmbed`",
 						"tags": [
 							{
@@ -39715,7 +40918,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 388,
+							"line": 389,
 							"character": 4
 						}
 					],
@@ -39725,7 +40928,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2670,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39749,7 +40952,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1720,
+							"line": 1729,
 							"character": 4
 						}
 					],
@@ -39763,7 +40966,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2622,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39790,7 +40993,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 436,
+							"line": 437,
 							"character": 4
 						}
 					],
@@ -39800,7 +41003,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2623,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39824,7 +41027,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 459,
+							"line": 460,
 							"character": 4
 						}
 					],
@@ -39834,7 +41037,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2650,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39858,7 +41061,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -39872,7 +41075,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2602,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39906,7 +41109,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2608,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39940,7 +41143,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2635,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39964,7 +41167,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -39978,7 +41181,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2600,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40015,7 +41218,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2649,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40039,7 +41242,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -40053,7 +41256,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2610,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40087,7 +41290,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2643,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40111,7 +41314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -40125,7 +41328,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2605,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40159,7 +41362,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2652,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40183,7 +41386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1236,
+							"line": 1240,
 							"character": 4
 						}
 					],
@@ -40197,7 +41400,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2656,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40220,7 +41423,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -40234,7 +41437,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2662,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40258,7 +41461,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1594,
+							"line": 1603,
 							"character": 4
 						}
 					],
@@ -40276,7 +41479,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2663,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40300,7 +41503,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1615,
+							"line": 1624,
 							"character": 4
 						}
 					],
@@ -40308,7 +41511,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -40318,7 +41521,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2657,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40345,7 +41548,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -40359,7 +41562,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2654,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40382,7 +41585,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -40396,7 +41599,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2673,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40424,7 +41627,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1774,
+							"line": 1783,
 							"character": 4
 						}
 					],
@@ -40438,7 +41641,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2679,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40466,7 +41669,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1876,
+							"line": 1887,
 							"character": 4
 						}
 					],
@@ -40480,7 +41683,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2672,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40508,7 +41711,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1758,
+							"line": 1767,
 							"character": 4
 						}
 					],
@@ -40522,7 +41725,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2677,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40550,7 +41753,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1849,
 							"character": 4
 						}
 					],
@@ -40564,7 +41767,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2685,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40592,7 +41795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1973,
+							"line": 1985,
 							"character": 4
 						}
 					],
@@ -40606,7 +41809,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2612,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40640,7 +41843,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2624,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40663,7 +41866,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 475,
+							"line": 476,
 							"character": 4
 						}
 					],
@@ -40673,7 +41876,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2626,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40697,7 +41900,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 508,
+							"line": 509,
 							"character": 4
 						}
 					],
@@ -40708,7 +41911,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2625,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40736,7 +41939,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 490,
+							"line": 491,
 							"character": 4
 						}
 					],
@@ -40746,7 +41949,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2658,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40773,7 +41976,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -40787,7 +41990,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2634,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40815,7 +42018,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -40823,7 +42026,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -40833,7 +42036,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2617,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40870,7 +42073,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2606,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40907,7 +42110,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2604,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40946,81 +42149,81 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2607,
-						2634,
-						2665,
-						2662,
-						2679,
-						2653,
-						2638,
-						2666,
-						2597,
-						2646,
-						2630,
-						2629,
-						2642,
-						2673,
-						2678,
-						2667,
-						2649,
-						2643,
-						2599,
-						2663,
-						2664,
-						2645,
-						2626,
-						2596,
-						2631,
-						2614,
-						2676,
-						2669,
 						2609,
-						2639,
-						2659,
-						2658,
-						2680,
-						2682,
-						2619,
+						2636,
+						2667,
+						2664,
 						2681,
-						2674,
-						2672,
-						2684,
-						2616,
-						2618,
-						2657,
-						2617,
-						2668,
-						2620,
-						2621,
-						2648,
-						2600,
-						2606,
-						2633,
-						2598,
-						2647,
-						2608,
-						2641,
-						2603,
-						2650,
-						2654,
-						2660,
-						2661,
 						2655,
-						2652,
-						2671,
-						2677,
-						2670,
-						2675,
-						2683,
-						2610,
-						2622,
-						2624,
-						2623,
-						2656,
+						2640,
+						2668,
+						2599,
+						2648,
 						2632,
-						2615,
-						2604,
-						2602
+						2631,
+						2644,
+						2675,
+						2680,
+						2669,
+						2651,
+						2645,
+						2601,
+						2665,
+						2666,
+						2647,
+						2628,
+						2598,
+						2633,
+						2616,
+						2678,
+						2671,
+						2611,
+						2641,
+						2661,
+						2660,
+						2682,
+						2684,
+						2621,
+						2683,
+						2676,
+						2674,
+						2686,
+						2618,
+						2620,
+						2659,
+						2619,
+						2670,
+						2622,
+						2623,
+						2650,
+						2602,
+						2608,
+						2635,
+						2600,
+						2649,
+						2610,
+						2643,
+						2605,
+						2652,
+						2656,
+						2662,
+						2663,
+						2657,
+						2654,
+						2673,
+						2679,
+						2672,
+						2677,
+						2685,
+						2612,
+						2624,
+						2626,
+						2625,
+						2658,
+						2634,
+						2617,
+						2606,
+						2604
 					]
 				}
 			],
@@ -41068,7 +42271,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2203,
+							"line": 2215,
 							"character": 4
 						}
 					],
@@ -41089,7 +42292,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2207,
+							"line": 2219,
 							"character": 4
 						}
 					],
@@ -41111,7 +42314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2213,
+							"line": 2225,
 							"character": 4
 						}
 					],
@@ -41155,13 +42358,13 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2199,
+					"line": 2211,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3082,
+			"id": 3084,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41171,7 +42374,7 @@
 			},
 			"children": [
 				{
-					"id": 3083,
+					"id": 3085,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41182,7 +42385,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2223,
+							"line": 2235,
 							"character": 4
 						}
 					],
@@ -41192,7 +42395,7 @@
 					}
 				},
 				{
-					"id": 3084,
+					"id": 3086,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41203,7 +42406,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2227,
+							"line": 2239,
 							"character": 4
 						}
 					],
@@ -41231,21 +42434,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3083,
-						3084
+						3085,
+						3086
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2219,
+					"line": 2231,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2685,
+			"id": 2687,
 			"name": "SageViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41265,7 +42468,7 @@
 			},
 			"children": [
 				{
-					"id": 2715,
+					"id": 2717,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41289,27 +42492,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2716,
+							"id": 2718,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2717,
+								"id": 2719,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2718,
+										"id": 2720,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -41345,7 +42548,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2704,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41373,7 +42576,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1672,
+							"line": 1681,
 							"character": 4
 						}
 					],
@@ -41387,7 +42590,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2701,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41411,13 +42614,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1630,
+							"line": 1639,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2428,
+						"id": 2430,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -41426,7 +42629,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2735,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41458,7 +42661,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -41475,7 +42678,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2721,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41498,13 +42701,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -41513,7 +42716,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2705,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41541,7 +42744,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1688,
+							"line": 1697,
 							"character": 4
 						}
 					],
@@ -41555,7 +42758,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2697,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41578,7 +42781,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2729,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41602,7 +42805,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -41616,7 +42819,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2692,
 					"name": "disableWorksheetChange",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41645,7 +42848,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2713,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41669,7 +42872,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -41683,7 +42886,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2712,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41707,7 +42910,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -41715,7 +42918,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -41725,7 +42928,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2725,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41752,7 +42955,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -41766,7 +42969,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2706,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41794,7 +42997,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1704,
+							"line": 1713,
 							"character": 4
 						}
 					],
@@ -41808,7 +43011,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2732,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41832,7 +43035,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -41846,7 +43049,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2726,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41870,7 +43073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -41884,7 +43087,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2702,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41908,7 +43111,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1652,
 							"character": 4
 						}
 					],
@@ -41922,7 +43125,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2703,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41946,7 +43149,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1656,
+							"line": 1665,
 							"character": 4
 						}
 					],
@@ -41960,7 +43163,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2728,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41983,7 +43186,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -41997,7 +43200,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2709,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42021,13 +43224,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42036,7 +43239,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2714,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42064,7 +43267,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -42072,7 +43275,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -42082,7 +43285,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2694,
 					"name": "hideAutocompleteSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42111,7 +43314,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2691,
 					"name": "hideSageAnswerHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42140,7 +43343,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2696,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42174,7 +43377,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2690,
 					"name": "hideSearchBarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42207,7 +43410,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2693,
 					"name": "hideWorksheetSelector",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42236,7 +43439,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2722,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42260,7 +43463,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -42274,7 +43477,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2741,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42297,7 +43500,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -42311,7 +43514,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2740,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42334,7 +43537,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -42351,7 +43554,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2739,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42371,7 +43574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -42385,7 +43588,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2707,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42409,7 +43612,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1720,
+							"line": 1729,
 							"character": 4
 						}
 					],
@@ -42423,7 +43626,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2731,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42447,7 +43650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -42461,7 +43664,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2716,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42485,7 +43688,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -42499,7 +43702,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2730,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42523,7 +43726,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -42537,7 +43740,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2724,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42561,7 +43764,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -42575,7 +43778,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2736,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42598,7 +43801,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -42612,7 +43815,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2699,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42636,7 +43839,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1594,
+							"line": 1603,
 							"character": 4
 						}
 					],
@@ -42654,7 +43857,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2700,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42678,7 +43881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1615,
+							"line": 1624,
 							"character": 4
 						}
 					],
@@ -42686,7 +43889,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -42696,7 +43899,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2698,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42730,7 +43933,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2737,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42757,7 +43960,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -42771,7 +43974,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2734,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42794,7 +43997,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -42808,7 +44011,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2688,
 					"name": "showObjectResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42837,7 +44040,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2695,
 					"name": "showObjectSuggestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42866,7 +44069,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2738,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42893,7 +44096,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -42907,7 +44110,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2715,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42935,7 +44138,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -42943,7 +44146,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -42958,50 +44161,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2715,
-						2702,
-						2699,
-						2733,
-						2719,
-						2703,
-						2695,
-						2727,
-						2690,
-						2711,
-						2710,
-						2723,
+						2717,
 						2704,
+						2701,
+						2735,
+						2721,
+						2705,
+						2697,
+						2729,
+						2692,
+						2713,
+						2712,
+						2725,
+						2706,
+						2732,
+						2726,
+						2702,
+						2703,
+						2728,
+						2709,
+						2714,
+						2694,
+						2691,
+						2696,
+						2690,
+						2693,
+						2722,
+						2741,
+						2740,
+						2739,
+						2707,
+						2731,
+						2716,
 						2730,
 						2724,
-						2700,
-						2701,
-						2726,
-						2707,
-						2712,
-						2692,
-						2689,
-						2694,
-						2688,
-						2691,
-						2720,
-						2739,
-						2738,
-						2737,
-						2705,
-						2729,
-						2714,
-						2728,
-						2722,
-						2734,
-						2697,
-						2698,
-						2696,
-						2735,
-						2732,
-						2686,
-						2693,
 						2736,
-						2713
+						2699,
+						2700,
+						2698,
+						2737,
+						2734,
+						2688,
+						2695,
+						2738,
+						2715
 					]
 				}
 			],
@@ -43055,7 +44258,7 @@
 			]
 		},
 		{
-			"id": 2545,
+			"id": 2547,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43070,7 +44273,7 @@
 			},
 			"children": [
 				{
-					"id": 2560,
+					"id": 2562,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43094,27 +44297,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2561,
+							"id": 2563,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2562,
+								"id": 2564,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2563,
+										"id": 2565,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43150,7 +44353,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2593,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43178,7 +44381,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1672,
+							"line": 1681,
 							"character": 4
 						}
 					],
@@ -43192,7 +44395,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2590,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43216,13 +44419,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1630,
+							"line": 1639,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2428,
+						"id": 2430,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -43231,7 +44434,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2581,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43263,7 +44466,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -43280,7 +44483,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2566,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43303,13 +44506,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -43318,7 +44521,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2594,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43346,7 +44549,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1688,
+							"line": 1697,
 							"character": 4
 						}
 					],
@@ -43360,7 +44563,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2549,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43394,7 +44597,7 @@
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2548,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43435,7 +44638,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2574,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43459,7 +44662,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -43473,7 +44676,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2558,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43497,7 +44700,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -43511,7 +44714,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2557,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43535,7 +44738,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -43543,7 +44746,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -43553,7 +44756,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2570,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43580,7 +44783,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -43594,7 +44797,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2595,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43622,7 +44825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1704,
+							"line": 1713,
 							"character": 4
 						}
 					],
@@ -43636,7 +44839,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2577,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43660,7 +44863,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -43674,7 +44877,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2571,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43698,7 +44901,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -43712,7 +44915,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2591,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43736,7 +44939,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1652,
 							"character": 4
 						}
 					],
@@ -43750,7 +44953,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2592,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43774,7 +44977,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1656,
+							"line": 1665,
 							"character": 4
 						}
 					],
@@ -43788,7 +44991,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2552,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43822,7 +45025,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2573,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43845,7 +45048,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -43859,7 +45062,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2554,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43883,13 +45086,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -43898,7 +45101,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2559,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43926,7 +45129,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -43934,7 +45137,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -43944,7 +45147,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2567,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43968,7 +45171,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -43982,7 +45185,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2587,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44005,7 +45208,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -44019,7 +45222,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2586,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44042,7 +45245,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -44059,7 +45262,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2585,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44079,7 +45282,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -44093,7 +45296,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2596,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44117,7 +45320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1720,
+							"line": 1729,
 							"character": 4
 						}
 					],
@@ -44131,7 +45334,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2576,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44155,7 +45358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -44169,7 +45372,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2561,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44193,7 +45396,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -44207,7 +45410,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2575,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44231,7 +45434,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -44245,7 +45448,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2569,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44269,7 +45472,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -44283,7 +45486,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2578,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44307,7 +45510,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1236,
+							"line": 1240,
 							"character": 4
 						}
 					],
@@ -44321,7 +45524,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2582,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44344,7 +45547,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -44358,7 +45561,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2588,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44382,7 +45585,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1594,
+							"line": 1603,
 							"character": 4
 						}
 					],
@@ -44400,7 +45603,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2589,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44424,7 +45627,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1615,
+							"line": 1624,
 							"character": 4
 						}
 					],
@@ -44432,7 +45635,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -44442,7 +45645,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2551,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44476,7 +45679,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2583,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44503,7 +45706,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -44517,7 +45720,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2580,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44540,7 +45743,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -44554,7 +45757,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2584,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44581,7 +45784,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -44595,7 +45798,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2550,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44629,7 +45832,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2560,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44657,7 +45860,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -44665,7 +45868,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -44680,46 +45883,46 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2560,
-						2591,
-						2588,
-						2579,
-						2564,
-						2592,
-						2547,
-						2546,
-						2572,
-						2556,
-						2555,
-						2568,
+						2562,
 						2593,
+						2590,
+						2581,
+						2566,
+						2594,
+						2549,
+						2548,
+						2574,
+						2558,
+						2557,
+						2570,
+						2595,
+						2577,
+						2571,
+						2591,
+						2592,
+						2552,
+						2573,
+						2554,
+						2559,
+						2567,
+						2587,
+						2586,
+						2585,
+						2596,
+						2576,
+						2561,
 						2575,
 						2569,
-						2589,
-						2590,
-						2550,
-						2571,
-						2552,
-						2557,
-						2565,
-						2585,
-						2584,
-						2583,
-						2594,
-						2574,
-						2559,
-						2573,
-						2567,
-						2576,
-						2580,
-						2586,
-						2587,
-						2549,
-						2581,
 						2578,
 						2582,
-						2548,
-						2558
+						2588,
+						2589,
+						2551,
+						2583,
+						2580,
+						2584,
+						2550,
+						2560
 					]
 				}
 			],
@@ -44742,7 +45945,7 @@
 			]
 		},
 		{
-			"id": 2484,
+			"id": 2486,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44758,7 +45961,7 @@
 			},
 			"children": [
 				{
-					"id": 2520,
+					"id": 2522,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44782,27 +45985,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2521,
+							"id": 2523,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2522,
+								"id": 2524,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2523,
+										"id": 2525,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -44838,7 +46041,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2498,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44872,7 +46075,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2488,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44906,7 +46109,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2487,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44940,7 +46143,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2509,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44968,7 +46171,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1672,
+							"line": 1681,
 							"character": 4
 						}
 					],
@@ -44982,7 +46185,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2501,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45019,7 +46222,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2506,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45043,13 +46246,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1630,
+							"line": 1639,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2428,
+						"id": 2430,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -45058,7 +46261,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2540,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45090,7 +46293,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -45107,7 +46310,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2526,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45130,13 +46333,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -45145,7 +46348,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2502,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45183,7 +46386,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2510,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45211,7 +46414,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1688,
+							"line": 1697,
 							"character": 4
 						}
 					],
@@ -45225,7 +46428,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2494,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45259,7 +46462,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2493,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45295,7 +46498,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2534,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45319,7 +46522,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -45333,7 +46536,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2518,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45357,7 +46560,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -45371,7 +46574,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2517,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45395,7 +46598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -45403,7 +46606,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -45413,7 +46616,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2530,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45440,7 +46643,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -45454,7 +46657,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2511,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45482,7 +46685,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1704,
+							"line": 1713,
 							"character": 4
 						}
 					],
@@ -45496,7 +46699,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2537,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45520,7 +46723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -45534,7 +46737,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2491,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45568,7 +46771,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2531,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45592,7 +46795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -45606,7 +46809,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2507,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45630,7 +46833,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1652,
 							"character": 4
 						}
 					],
@@ -45644,7 +46847,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2508,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45668,7 +46871,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1656,
+							"line": 1665,
 							"character": 4
 						}
 					],
@@ -45682,7 +46885,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2497,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45716,7 +46919,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2533,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45739,7 +46942,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -45753,7 +46956,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2503,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45791,7 +46994,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2492,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45825,7 +47028,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2514,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45849,13 +47052,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45864,7 +47067,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2519,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45892,7 +47095,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -45900,7 +47103,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -45910,7 +47113,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2489,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45944,7 +47147,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2490,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45978,7 +47181,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2499,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46012,7 +47215,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2527,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46036,7 +47239,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -46050,7 +47253,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2546,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46073,7 +47276,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -46087,7 +47290,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2545,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46110,7 +47313,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -46127,7 +47330,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2544,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46147,7 +47350,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -46161,7 +47364,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2512,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46185,7 +47388,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1720,
+							"line": 1729,
 							"character": 4
 						}
 					],
@@ -46199,7 +47402,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2536,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46223,7 +47426,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -46237,7 +47440,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2521,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46261,7 +47464,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -46275,7 +47478,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2535,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46299,7 +47502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -46313,7 +47516,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2529,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46337,7 +47540,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -46351,7 +47554,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2541,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46374,7 +47577,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -46388,7 +47591,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2504,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46412,7 +47615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1594,
+							"line": 1603,
 							"character": 4
 						}
 					],
@@ -46430,7 +47633,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2505,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46454,7 +47657,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1615,
+							"line": 1624,
 							"character": 4
 						}
 					],
@@ -46462,7 +47665,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46472,7 +47675,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2496,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46502,7 +47705,7 @@
 					}
 				},
 				{
-					"id": 2493,
+					"id": 2495,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46531,7 +47734,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2542,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46558,7 +47761,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -46572,7 +47775,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2539,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46595,7 +47798,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -46609,7 +47812,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2543,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46636,7 +47839,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -46650,7 +47853,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2500,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46680,7 +47883,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2520,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46708,7 +47911,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -46716,7 +47919,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -46731,57 +47934,57 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2520,
-						2496,
-						2486,
-						2485,
-						2507,
-						2499,
-						2504,
-						2538,
-						2524,
-						2500,
-						2508,
-						2492,
-						2491,
-						2532,
-						2516,
-						2515,
-						2528,
-						2509,
-						2535,
-						2489,
-						2529,
-						2505,
-						2506,
-						2495,
-						2531,
-						2501,
-						2490,
-						2512,
-						2517,
-						2487,
+						2522,
+						2498,
 						2488,
-						2497,
-						2525,
-						2544,
-						2543,
-						2542,
-						2510,
-						2534,
-						2519,
-						2533,
-						2527,
-						2539,
+						2487,
+						2509,
+						2501,
+						2506,
+						2540,
+						2526,
 						2502,
-						2503,
+						2510,
 						2494,
 						2493,
-						2540,
+						2534,
+						2518,
+						2517,
+						2530,
+						2511,
 						2537,
+						2491,
+						2531,
+						2507,
+						2508,
+						2497,
+						2533,
+						2503,
+						2492,
+						2514,
+						2519,
+						2489,
+						2490,
+						2499,
+						2527,
+						2546,
+						2545,
+						2544,
+						2512,
+						2536,
+						2521,
+						2535,
+						2529,
 						2541,
-						2498,
-						2518
+						2504,
+						2505,
+						2496,
+						2495,
+						2542,
+						2539,
+						2543,
+						2500,
+						2520
 					]
 				}
 			],
@@ -46989,7 +48192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
@@ -47077,7 +48280,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -47117,13 +48320,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47156,7 +48359,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -47194,7 +48397,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -47232,7 +48435,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -47240,7 +48443,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -47277,7 +48480,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -47315,7 +48518,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -47353,7 +48556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -47390,7 +48593,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -47428,13 +48631,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -47471,7 +48674,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -47479,7 +48682,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -47513,7 +48716,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -47550,7 +48753,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -47587,7 +48790,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -47624,7 +48827,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -47662,7 +48865,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -47700,7 +48903,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -47738,7 +48941,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -47776,7 +48979,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -47813,7 +49016,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -47854,7 +49057,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -47891,7 +49094,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -47932,7 +49135,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -47974,7 +49177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -47982,7 +49185,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -48210,7 +49413,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
@@ -48298,7 +49501,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1435,
+							"line": 1439,
 							"character": 4
 						}
 					],
@@ -48338,13 +49541,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1045,
+							"line": 1049,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2886,
+						"id": 2888,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -48415,7 +49618,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1153,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -48487,7 +49690,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 960,
+							"line": 964,
 							"character": 4
 						}
 					],
@@ -48525,7 +49728,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 944,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -48533,7 +49736,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -48570,7 +49773,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1109,
+							"line": 1113,
 							"character": 4
 						}
 					],
@@ -48608,7 +49811,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1220,
+							"line": 1224,
 							"character": 4
 						}
 					],
@@ -48684,7 +49887,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1126,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -48789,7 +49992,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1137,
+							"line": 1141,
 							"character": 4
 						}
 					],
@@ -48827,13 +50030,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 921,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2845,
+						"id": 2847,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48870,7 +50073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -48878,7 +50081,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -48980,7 +50183,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1061,
+							"line": 1065,
 							"character": 4
 						}
 					],
@@ -49017,7 +50220,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7284,
+							"line": 7374,
 							"character": 4
 						}
 					],
@@ -49054,7 +50257,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7357,
 							"character": 4
 						}
 					],
@@ -49091,7 +50294,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7251,
+							"line": 7341,
 							"character": 4
 						}
 					],
@@ -49129,7 +50332,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1192,
+							"line": 1196,
 							"character": 4
 						}
 					],
@@ -49167,7 +50370,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1014,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -49205,7 +50408,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1172,
+							"line": 1176,
 							"character": 4
 						}
 					],
@@ -49243,7 +50446,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1088,
+							"line": 1092,
 							"character": 4
 						}
 					],
@@ -49280,7 +50483,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1449,
+							"line": 1453,
 							"character": 4
 						}
 					],
@@ -49364,7 +50567,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3082,
+							"id": 3084,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -49420,7 +50623,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1462,
+							"line": 1466,
 							"character": 4
 						}
 					],
@@ -49457,7 +50660,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1256,
+							"line": 1260,
 							"character": 4
 						}
 					],
@@ -49640,7 +50843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1476,
+							"line": 1480,
 							"character": 4
 						}
 					],
@@ -49682,7 +50885,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 999,
+							"line": 1003,
 							"character": 4
 						}
 					],
@@ -49690,7 +50893,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2268,
+							"id": 2270,
 							"name": "Action"
 						}
 					},
@@ -50195,7 +51398,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 24,
+							"line": 23,
 							"character": 4
 						}
 					],
@@ -50213,7 +51416,7 @@
 					"sources": [
 						{
 							"fileName": "utils/graphql/answerService/answerService.ts",
-							"line": 25,
+							"line": 24,
 							"character": 4
 						}
 					],
@@ -50236,20 +51439,20 @@
 			"sources": [
 				{
 					"fileName": "utils/graphql/answerService/answerService.ts",
-					"line": 23,
+					"line": 22,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3120,
+			"id": 3122,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3121,
+					"id": 3123,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50257,7 +51460,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6809,
+							"line": 6895,
 							"character": 4
 						}
 					],
@@ -50270,7 +51473,7 @@
 					}
 				},
 				{
-					"id": 3122,
+					"id": 3124,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50278,7 +51481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6810,
+							"line": 6896,
 							"character": 4
 						}
 					],
@@ -50296,21 +51499,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3121,
-						3122
+						3123,
+						3124
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6808,
+					"line": 6894,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2899,
+			"id": 2901,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -50320,7 +51523,7 @@
 			},
 			"children": [
 				{
-					"id": 2901,
+					"id": 2903,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50343,27 +51546,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 283,
+							"line": 287,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2902,
+							"id": 2904,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2903,
+								"id": 2905,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2904,
+										"id": 2906,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -50376,7 +51579,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2905,
+										"id": 2907,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -50384,19 +51587,19 @@
 										"sources": [
 											{
 												"fileName": "types.ts",
-												"line": 284,
+												"line": 288,
 												"character": 28
 											}
 										],
 										"indexSignature": {
-											"id": 2906,
+											"id": 2908,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2907,
+													"id": 2909,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -50418,7 +51621,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2902,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50431,13 +51634,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 257,
+							"line": 261,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -50447,15 +51650,15 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2901,
-						2900
+						2903,
+						2902
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 250,
+					"line": 254,
 					"character": 17
 				}
 			]
@@ -50478,7 +51681,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 53,
+							"line": 50,
 							"character": 4
 						}
 					],
@@ -50498,7 +51701,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 52,
+							"line": 49,
 							"character": 4
 						}
 					],
@@ -50529,7 +51732,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 51,
+							"line": 48,
 							"character": 4
 						}
 					],
@@ -50556,7 +51759,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 50,
+					"line": 47,
 					"character": 17
 				}
 			]
@@ -50579,7 +51782,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 63,
+							"line": 60,
 							"character": 4
 						}
 					],
@@ -50608,7 +51811,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 61,
+							"line": 58,
 							"character": 4
 						}
 					],
@@ -50628,7 +51831,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 62,
+							"line": 59,
 							"character": 4
 						}
 					],
@@ -50646,7 +51849,7 @@
 					"sources": [
 						{
 							"fileName": "embed/base.ts",
-							"line": 57,
+							"line": 54,
 							"character": 4
 						}
 					],
@@ -50670,7 +51873,7 @@
 										"sources": [
 											{
 												"fileName": "embed/base.ts",
-												"line": 58,
+												"line": 55,
 												"character": 8
 											}
 										],
@@ -50690,7 +51893,7 @@
 										"sources": [
 											{
 												"fileName": "embed/base.ts",
-												"line": 59,
+												"line": 56,
 												"character": 8
 											}
 										],
@@ -50747,13 +51950,13 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 56,
+					"line": 53,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2869,
+			"id": 2871,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -50761,7 +51964,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 244,
+					"line": 248,
 					"character": 12
 				}
 			],
@@ -50780,7 +51983,7 @@
 			}
 		},
 		{
-			"id": 2873,
+			"id": 2875,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -50788,14 +51991,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2026,
+					"line": 2038,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2874,
+					"id": 2876,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -50812,13 +52015,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2026,
+							"line": 2038,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2875,
+							"id": 2877,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -50828,19 +52031,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2876,
+									"id": 2878,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2881,
+										"id": 2883,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2877,
+									"id": 2879,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -50850,7 +52053,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2878,
+											"id": 2880,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -50858,13 +52061,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2033,
+													"line": 2045,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2879,
+													"id": 2881,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -50874,7 +52077,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2880,
+															"id": 2882,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -50905,7 +52108,7 @@
 			}
 		},
 		{
-			"id": 2870,
+			"id": 2872,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -50922,21 +52125,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2015,
+					"line": 2027,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2871,
+					"id": 2873,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2872,
+							"id": 2874,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -50949,7 +52152,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2020,
+									"line": 2032,
 									"character": 4
 								}
 							],
@@ -50964,14 +52167,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2872
+								2874
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2015,
+							"line": 2027,
 							"character": 29
 						}
 					]
@@ -50979,7 +52182,7 @@
 			}
 		},
 		{
-			"id": 2881,
+			"id": 2883,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -50996,21 +52199,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2002,
+					"line": 2014,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2882,
+					"id": 2884,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2884,
+							"id": 2886,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -51018,7 +52221,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2006,
+									"line": 2018,
 									"character": 4
 								}
 							],
@@ -51028,7 +52231,7 @@
 							}
 						},
 						{
-							"id": 2885,
+							"id": 2887,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -51038,7 +52241,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2008,
+									"line": 2020,
 									"character": 4
 								}
 							],
@@ -51048,7 +52251,7 @@
 							}
 						},
 						{
-							"id": 2883,
+							"id": 2885,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -51056,7 +52259,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2004,
+									"line": 2016,
 									"character": 4
 								}
 							],
@@ -51071,16 +52274,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2884,
-								2885,
-								2883
+								2886,
+								2887,
+								2885
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2002,
+							"line": 2014,
 							"character": 29
 						}
 					]
@@ -51182,7 +52385,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 352,
+					"line": 348,
 					"character": 13
 				}
 			],
@@ -51250,7 +52453,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 419,
+					"line": 415,
 					"character": 13
 				}
 			],
@@ -51487,7 +52690,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2432,
+						"id": 2434,
 						"name": "EmbedConfig"
 					}
 				}
@@ -51546,7 +52749,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 243,
+					"line": 239,
 					"character": 13
 				}
 			],
@@ -51587,7 +52790,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2432,
+								"id": 2434,
 								"name": "EmbedConfig"
 							}
 						}
@@ -51611,7 +52814,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 302,
+					"line": 298,
 					"character": 13
 				}
 			],
@@ -51678,7 +52881,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 113,
+					"line": 110,
 					"character": 13
 				}
 			],
@@ -51734,7 +52937,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2840,
+									"id": 2842,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -51816,7 +53019,7 @@
 			"sources": [
 				{
 					"fileName": "embed/base.ts",
-					"line": 473,
+					"line": 469,
 					"character": 13
 				}
 			],
@@ -51862,7 +53065,7 @@
 			]
 		},
 		{
-			"id": 3200,
+			"id": 3238,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -51872,13 +53075,13 @@
 			"sources": [
 				{
 					"fileName": "authToken.ts",
-					"line": 104,
+					"line": 103,
 					"character": 13
 				}
 			],
 			"signatures": [
 				{
-					"id": 3201,
+					"id": 3239,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -51903,6 +53106,66 @@
 					"type": {
 						"type": "intrinsic",
 						"name": "void"
+					}
+				}
+			]
+		},
+		{
+			"id": 3240,
+			"name": "startAutoMCPFrameRenderer",
+			"kind": 64,
+			"kindString": "Function",
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "embed/auto-frame-renderer.ts",
+					"line": 44,
+					"character": 16
+				}
+			],
+			"signatures": [
+				{
+					"id": 3241,
+					"name": "startAutoMCPFrameRenderer",
+					"kind": 4096,
+					"kindString": "Call signature",
+					"flags": {},
+					"comment": {
+						"shortText": "Starts an automatic renderer that watches the DOM for iframes containing\nthe `tsmcp=true` query parameter and replaces them with fully configured\nThoughtSpot embed iframes. The query parameter is automatically added by\nthe ThoughtSpot MCP server.",
+						"text": "A {@link MutationObserver} is set up on `document.body` to detect both\ndirectly added iframes and iframes nested within added container elements.\nEach matching iframe is replaced in-place with a new ThoughtSpot embed\niframe that merges the original iframe's query parameters with the SDK\nembed parameters.\n\nCall {@link MutationObserver.disconnect | observer.disconnect()} on the\nreturned observer to stop monitoring the DOM.\n",
+						"returns": "A {@link MutationObserver} instance that is actively observing\n  `document.body`. Disconnect it when monitoring is no longer needed.\n",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nimport { startAutoMCPFrameRenderer } from '@thoughtspot/visual-embed-sdk';\n\n// Start watching the DOM for tsmcp iframes\nconst observer = startAutoMCPFrameRenderer({\n  // optional view config overrides\n});\n\n// Later, stop watching\nobserver.disconnect();\n```\n"
+							},
+							{
+								"tag": "example",
+								"text": "\nDetailed example of how to use the auto-frame renderer:\n[Python React Agent Simple UI](https://github.com/thoughtspot/developer-examples/tree/main/mcp/python-react-agent-simple-ui)\n"
+							}
+						]
+					},
+					"parameters": [
+						{
+							"id": 3242,
+							"name": "viewConfig",
+							"kind": 32768,
+							"kindString": "Parameter",
+							"flags": {},
+							"comment": {
+								"text": "Optional configuration for the auto-rendered embeds.\n  Accepts all properties from {@link AutoMCPFrameRendererViewConfig}.\n  Defaults to an empty config."
+							},
+							"type": {
+								"type": "reference",
+								"id": 3202,
+								"name": "AutoMCPFrameRendererViewConfig"
+							},
+							"defaultValue": "{}"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "MutationObserver"
 					}
 				}
 			]
@@ -52072,7 +53335,7 @@
 			]
 		},
 		{
-			"id": 3092,
+			"id": 3094,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -52086,7 +53349,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3093,
+					"id": 3095,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -52096,7 +53359,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3094,
+							"id": 3096,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -52108,7 +53371,7 @@
 							}
 						},
 						{
-							"id": 3095,
+							"id": 3097,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -52119,7 +53382,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3096,
+									"id": 3098,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -52142,34 +53405,34 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2268,
+				2270,
 				1892,
 				1877,
 				1884,
 				2043,
-				2428,
-				2259,
-				3167,
-				3163,
-				3159,
-				2264,
-				3176,
+				2430,
+				2261,
+				3169,
+				3165,
+				3161,
+				2266,
+				3178,
 				2075,
-				3196,
-				2851,
-				3114,
-				3108,
-				2862,
-				2180,
-				3172,
-				3117,
-				3151,
-				3085,
+				3198,
+				2853,
+				3116,
+				3110,
+				2864,
+				2181,
+				3174,
+				3119,
+				3153,
+				3087,
 				2034,
-				2840,
-				3112,
+				2842,
+				3114,
 				2059,
-				3143
+				3145
 			]
 		},
 		{
@@ -52192,31 +53455,32 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2740,
+				2742,
 				1894,
+				3202,
 				1341,
 				1650,
-				3123,
-				2908,
-				2896,
-				2886,
-				2432,
-				3190,
-				2845,
-				2595,
+				3125,
+				2910,
+				2898,
+				2888,
+				2434,
+				3192,
+				2847,
+				2597,
 				2055,
-				3082,
-				2685,
-				2545,
-				2484,
+				3084,
+				2687,
+				2547,
+				2486,
 				2024,
 				1305,
 				1635,
 				1585,
 				1638,
 				2031,
-				3120,
-				2899,
+				3122,
+				2901,
 				21,
 				28
 			]
@@ -52225,10 +53489,10 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				2869,
-				2873,
-				2870,
-				2881
+				2871,
+				2875,
+				2872,
+				2883
 			]
 		},
 		{
@@ -52245,9 +53509,10 @@
 				4,
 				7,
 				25,
-				3200,
+				3238,
+				3240,
 				40,
-				3092
+				3094
 			]
 		}
 	],


### PR DESCRIPTION


---

**Title:** `[SCAL-271343] Add ChangePersonalisedView EmbedEvent and SelectPersonalisedView HostEvent`

---

**## Summary**

Adds two new SDK additions to support programmatic interaction with Personalised Views on Liveboards:

- **`EmbedEvent.ChangePersonalisedView`** — Emitted when a user selects a different Personalised View or resets to the original/default view on a Liveboard. Returns:
  - `viewName: string` — name of the selected view, or `'Original View'` when reset to default
  - `viewId: string | null` — GUID of the selected view, or `null` when reset to default
  - `liveboardId: string`
  - `isPublic: boolean`

- **`HostEvent.SelectPersonalisedView`** — Triggers selection of a specific Personalised View on a Liveboard without reloading the embed. Supports:
  - Selection by `viewId` (GUID)
  - Selection by `viewName` (first match if duplicates exist)
  - Reset to original/default view when neither is provided

**## Version**
`SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl`

**## Changes**
- `src/types.ts` — Added `ChangePersonalisedView` to `EmbedEvent` enum and `SelectPersonalisedView` to `HostEvent` enum with full JSDoc documentation and examples
- `static/typedoc/typedoc.json` — Regenerated to reflect the new entries



[SCAL-271343]: https://thoughtspot.atlassian.net/browse/SCAL-271343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ