### PR TITLE
SCAL-319872: Add SpotterAnalyst action overrides for 26.8.0.cl

### DIFF
--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -634,6 +634,16 @@ describe('SpotterEmbed APP_INIT embedParams', () => {
         expect(response.data.embedParams.spotterSidebarConfig.spotterAnalystLabel).toBe('My Analyst');
     });
 
+    it('should include spotterAnalystsLabel in embedParams.spotterSidebarConfig when set', async () => {
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterSidebarConfig: {
+                spotterAnalystsLabel: 'My Analysts',
+            },
+        });
+        expect(response.data.embedParams.spotterSidebarConfig.spotterAnalystsLabel).toBe('My Analysts');
+    });
+
     it('should call handleError and exclude spotterDocumentationUrl from embedParams when URL is invalid', async () => {
         const embed = new SpotterEmbed(getRootEl(), {
             worksheetId: 'ws1',

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -465,6 +465,12 @@ describe('ConversationEmbed', () => {
             ['SpotterChatConnectorResources', Action.SpotterChatConnectorResources],
             ['SpotterChatConnectors', Action.SpotterChatConnectors],
             ['SpotterChatModeSwitcher', Action.SpotterChatModeSwitcher],
+            ['SpotterAnalystShare', Action.SpotterAnalystShare],
+            ['SpotterAnalystEdit', Action.SpotterAnalystEdit],
+            ['SpotterAnalystCreate', Action.SpotterAnalystCreate],
+            ['SpotterAnalystDelete', Action.SpotterAnalystDelete],
+            ['SpotterAnalystMakeACopy', Action.SpotterAnalystMakeACopy],
+            ['SpotterAnalystSidebar', Action.SpotterAnalystSidebar],
         ])('should render with hiddenActions for %s', async (_, action) => {
             const viewConfig: SpotterEmbedViewConfig = {
                 worksheetId: 'worksheetId',
@@ -503,6 +509,12 @@ describe('ConversationEmbed', () => {
             ['SpotterChatConnectorResources', Action.SpotterChatConnectorResources],
             ['SpotterChatConnectors', Action.SpotterChatConnectors],
             ['SpotterChatModeSwitcher', Action.SpotterChatModeSwitcher],
+            ['SpotterAnalystShare', Action.SpotterAnalystShare],
+            ['SpotterAnalystEdit', Action.SpotterAnalystEdit],
+            ['SpotterAnalystCreate', Action.SpotterAnalystCreate],
+            ['SpotterAnalystDelete', Action.SpotterAnalystDelete],
+            ['SpotterAnalystMakeACopy', Action.SpotterAnalystMakeACopy],
+            ['SpotterAnalystSidebar', Action.SpotterAnalystSidebar],
         ])('should render with disabledActions for %s', async (_, action) => {
             const disabledReason = 'testing disabled reason';
             const viewConfig: SpotterEmbedViewConfig = {
@@ -610,6 +622,16 @@ describe('SpotterEmbed APP_INIT embedParams', () => {
     it('should not include embedParams when neither spotterSidebarConfig nor standalone flag is set', async () => {
         const response = await getAppInitResponse({ worksheetId: 'ws1' });
         expect(response.data.embedParams).toBeUndefined();
+    });
+
+    it('should include spotterAnalystLabel in embedParams.spotterSidebarConfig when set', async () => {
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterSidebarConfig: {
+                spotterAnalystLabel: 'My Analyst',
+            },
+        });
+        expect(response.data.embedParams.spotterSidebarConfig.spotterAnalystLabel).toBe('My Analyst');
     });
 
     it('should call handleError and exclude spotterDocumentationUrl from embedParams when URL is invalid', async () => {

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -91,14 +91,14 @@ export interface SpotterSidebarViewConfig {
     spotterNewChatButtonTitle?: string;
     /**
      * Custom label text for the Spotter Analyst section in the sidebar.
-     * Defaults to translated "Analyst" text.
      * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
+     * @default Analyst
      */
     spotterAnalystLabel?: string;
     /**
      * Custom label text for the Spotter Analysts section in the sidebar.
-     * Defaults to translated "Analysts" text.
      * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
+     * @default Analysts
      */
     spotterAnalystsLabel?: string;
 }

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -91,7 +91,7 @@ export interface SpotterSidebarViewConfig {
     spotterNewChatButtonTitle?: string;
     /**
      * Custom label text for the Spotter Analyst section in the sidebar.
-     * @default Analyst
+     * Defaults to translated "Analyst" text.
      * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
      */
     spotterAnalystLabel?: string;

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -95,6 +95,12 @@ export interface SpotterSidebarViewConfig {
      * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
      */
     spotterAnalystLabel?: string;
+    /**
+     * Custom label text for the Spotter Analysts section in the sidebar.
+     * Defaults to translated "Analysts" text.
+     * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
+     */
+    spotterAnalystsLabel?: string;
 }
 
 /**

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -89,6 +89,12 @@ export interface SpotterSidebarViewConfig {
      * @version SDK: 1.47.0 | ThoughtSpot: 26.4.0.cl
      */
     spotterNewChatButtonTitle?: string;
+    /**
+     * Custom label text for the Spotter Analyst section in the sidebar.
+     * @default Analyst
+     * @version SDK: 1.51.0 | ThoughtSpot: 26.8.0.cl
+     */
+    spotterAnalystLabel?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6187,9 +6187,10 @@ export type SpotterFileUploadFileTypes = {
  * for various user-initiated operations. These actions are represented
  * as enumeration members in the SDK. To control actions in the embedded view:
  * - disabledActions — the action is grayed out and still visible, but non-interactive
- * (user can see but not click). - hiddenActions — the action is completely removed from
- * the UI (user cannot see it at all). - visibleActions — allowlist, only these actions
- * are shown; all others are hidden.
+ *   (user can see but not click).
+ * - hiddenActions — the action is completely removed from the UI (user cannot see
+ *   it at all).
+ * - visibleActions — allowlist, only these actions are shown; all others are hidden.
  *
  * Use disabledActions to disable (gray out) an action.
  * Use hiddenActions to hide (fully remove) an action.

--- a/src/types.ts
+++ b/src/types.ts
@@ -7933,7 +7933,73 @@ export enum Action {
      * ```
      * @version SDK: 1.49.0 | ThoughtSpot Cloud: 26.6.0.cl
      */
-    RefreshLiveboardBrowserCache = 'refreshLiveboardBrowserCache',    
+    RefreshLiveboardBrowserCache = 'refreshLiveboardBrowserCache',
+    /**
+     * Controls visibility and disable state of the share action
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystShare]
+     * disabledActions: [Action.SpotterAnalystShare]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystShare = 'spotterAnalystShare',
+    /**
+     * Controls visibility and disable state of the edit action
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystEdit]
+     * disabledActions: [Action.SpotterAnalystEdit]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystEdit = 'spotterAnalystEdit',
+    /**
+     * Controls visibility and disable state of the create action
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystCreate]
+     * disabledActions: [Action.SpotterAnalystCreate]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystCreate = 'spotterAnalystCreate',
+    /**
+     * Controls visibility and disable state of the delete action
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystDelete]
+     * disabledActions: [Action.SpotterAnalystDelete]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystDelete = 'spotterAnalystDelete',
+    /**
+     * Controls visibility and disable state of the make a copy action
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystMakeACopy]
+     * disabledActions: [Action.SpotterAnalystMakeACopy]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystMakeACopy = 'spotterAnalystMakeACopy',
+    /**
+     * Controls visibility and disable state of the sidebar
+     * in the Spotter Analyst interface.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystSidebar]
+     * disabledActions: [Action.SpotterAnalystSidebar]
+     * ```
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
+     */
+    SpotterAnalystSidebar = 'spotterAnalystSidebar',
 }
 export interface AnswerServiceType {
     getAnswer?: (offset: number, batchSize: number) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6186,10 +6186,8 @@ export type SpotterFileUploadFileTypes = {
  * ThoughtSpot application pages include actions and menu commands
  * for various user-initiated operations. These actions are represented
  * as enumeration members in the SDK. To control actions in the embedded view:
- * - disabledActions — the action is grayed out and still visible, but non-interactive
- *   (user can see but not click).
- * - hiddenActions — the action is completely removed from the UI (user cannot see
- *   it at all).
+ * - disabledActions — the action is grayed out and still visible, but non-interactive (user can see but not click).
+ * - hiddenActions — the action is completely removed from the UI (user cannot see it at all).
  * - visibleActions — allowlist, only these actions are shown; all others are hidden.
  *
  * Use disabledActions to disable (gray out) an action.

--- a/src/types.ts
+++ b/src/types.ts
@@ -963,7 +963,8 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * The list of actions to completely remove from the embedded view.
      * Hidden actions are not visible to the user at all (fully removed from the UI).
      * Use this when you want to remove an action entirely.
-     * To keep an action visible but non-interactive (grayed out), use {@link disabledActions} instead.
+     * To keep an action visible but non-interactive (grayed out), use {@link
+     * disabledActions} instead.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`
      * @version SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw
@@ -983,7 +984,8 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * (...), and the contextual menu. These will be only actions that
      * are visible to the user.
      * Use this as an allowlist — only the actions listed here will be shown.
-     * All other actions will be hidden. Use either this or {@link hiddenActions}, not both.
+     * All other actions will be hidden. Use either this or {@link hiddenActions}, not
+     * both.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`
      * @version SDK: 1.6.0 | ThoughtSpot: ts8.nov.cl, 8.4.1.sw
@@ -3721,10 +3723,11 @@ export enum EmbedEvent {
     EmbedPageContextChanged = 'EmbedPageContextChanged',
 
     /**
-     * Represents a special embed event that is triggered whenever any host event is subscribed.
+     * Represents a special embed event that is triggered whenever any host event is
+     * subscribed.
      *
-     * You can listen to this event when you need to dispatch a host event during load or render,
-     * particularly in situations where timing issues may occur.
+     * You can listen to this event when you need to dispatch a host event during load or
+     * render, particularly in situations where timing issues may occur.
      *
      * @example
      * ```js
@@ -6183,9 +6186,10 @@ export type SpotterFileUploadFileTypes = {
  * ThoughtSpot application pages include actions and menu commands
  * for various user-initiated operations. These actions are represented
  * as enumeration members in the SDK. To control actions in the embedded view:
- * - disabledActions — the action is grayed out and still visible, but non-interactive (user can see but not click).
- * - hiddenActions — the action is completely removed from the UI (user cannot see it at all).
- * - visibleActions — allowlist, only these actions are shown; all others are hidden.
+ * - disabledActions — the action is grayed out and still visible, but non-interactive
+ * (user can see but not click). - hiddenActions — the action is completely removed from
+ * the UI (user cannot see it at all). - visibleActions — allowlist, only these actions
+ * are shown; all others are hidden.
  *
  * Use disabledActions to disable (gray out) an action.
  * Use hiddenActions to hide (fully remove) an action.
@@ -7937,67 +7941,67 @@ export enum Action {
     /**
      * Controls visibility and disable state of the share action
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystShare]
      * disabledActions: [Action.SpotterAnalystShare]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystShare = 'spotterAnalystShare',
     /**
      * Controls visibility and disable state of the edit action
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystEdit]
      * disabledActions: [Action.SpotterAnalystEdit]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystEdit = 'spotterAnalystEdit',
     /**
      * Controls visibility and disable state of the create action
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystCreate]
      * disabledActions: [Action.SpotterAnalystCreate]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystCreate = 'spotterAnalystCreate',
     /**
      * Controls visibility and disable state of the delete action
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystDelete]
      * disabledActions: [Action.SpotterAnalystDelete]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystDelete = 'spotterAnalystDelete',
     /**
      * Controls visibility and disable state of the make a copy action
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystMakeACopy]
      * disabledActions: [Action.SpotterAnalystMakeACopy]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystMakeACopy = 'spotterAnalystMakeACopy',
     /**
      * Controls visibility and disable state of the sidebar
      * in the Spotter Analyst interface.
+     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * hiddenActions: [Action.SpotterAnalystSidebar]
      * disabledActions: [Action.SpotterAnalystSidebar]
      * ```
-     * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     SpotterAnalystSidebar = 'spotterAnalystSidebar',
 }


### PR DESCRIPTION
## Summary
- Add 6 new `Action` enum entries (`SpotterAnalystShare`, `SpotterAnalystEdit`, `SpotterAnalystCreate`, `SpotterAnalystDelete`, `SpotterAnalystMakeACopy`, `SpotterAnalystSidebar`) to `types.ts` for the 26.8.0.cl release
- Add `spotterAnalystLabel` field to `SpotterSidebarViewConfig` in `conversation.ts`
- Add `hiddenActions`, `disabledActions`, and `APP_INIT` tests for the new actions/config in `conversation.spec.ts`

## Test plan
- [ ] All 49 tests in `conversation.spec.ts` pass
- [ ] `hiddenActions` verified for all 6 `SpotterAnalyst*` actions
- [ ] `disabledActions` verified for all 6 `SpotterAnalyst*` actions
- [ ] `spotterAnalystLabel` forwarded correctly in `embedParams.spotterSidebarConfig` via APP_INIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)