### PR TITLE
SCAL-320072:Focused homepage should also enable updatedSpotterChatPrompt

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -522,7 +522,7 @@ describe('App embed tests', () => {
         });
     });
 
-    test('Should add homepageVersion=v4 when homePage is Focused to the iframe src', async () => {
+    test('Should add homepageVersion=v4 and updatedSpotterChatPrompt=true when homePage is Focused to the iframe src', async () => {
         await testUrlParams(
             {
                 ...defaultViewConfig,
@@ -530,7 +530,20 @@ describe('App embed tests', () => {
                     homePage: HomePage.Focused,
                 },
             } as AppViewConfig,
-            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&homepageVersion=v4${defaultParams}${defaultParamsPost}#/home`,
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&homepageVersion=v4&updatedSpotterChatPrompt=true${defaultParams}${defaultParamsPost}#/home`,
+        );
+    });
+
+    test('Should respect explicit updatedSpotterChatPrompt=false even when homePage is Focused', async () => {
+        await testUrlParams(
+            {
+                ...defaultViewConfig,
+                discoveryExperience: {
+                    homePage: HomePage.Focused,
+                },
+                updatedSpotterChatPrompt: false,
+            } as AppViewConfig,
+            `http://${thoughtSpotHost}/?embedApp=true&primaryNavHidden=true&profileAndHelpInNavBarHidden=false&modularHomeExperience=false&navigationVersion=v2&homepageVersion=v4&updatedSpotterChatPrompt=false${defaultParams}${defaultParamsPost}#/home`,
         );
     });
 

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1142,6 +1142,12 @@ export class AppEmbed extends V1Embed {
 
             if (discoveryExperience.homePage === HomePage.Focused) {
                 params[Param.HomepageVersion] = HomePage.Focused;
+                // The Focused (V4) homepage experience requires the updated
+                // Spotter chat prompt. Enable it automatically unless the
+                // developer has explicitly set updatedSpotterChatPrompt.
+                if (isUndefined(updatedSpotterChatPrompt)) {
+                    params[Param.UpdatedSpotterChatPrompt] = true;
+                }
             }
         }
 


### PR DESCRIPTION
Before:
<img width="1360" height="764" alt="Screenshot 2026-06-25 at 9 30 01 AM" src="https://github.com/user-attachments/assets/943132bd-959b-4070-8e1f-63c5704d7fb3" />

<img width="1464" height="764" alt="Screenshot 2026-06-25 at 9 30 28 AM" src="https://github.com/user-attachments/assets/38af4236-4009-477c-856f-f9968ce1c497" />

After:
<img width="1508" height="764" alt="Screenshot 2026-06-25 at 8 55 12 AM" src="https://github.com/user-attachments/assets/38797839-db08-4588-ae1f-b3ca3b1a70e0" />
