### PR TITLE
SCAL-321279 Additional flag should be top level override, show analyse and fix it SDK

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -143,6 +143,23 @@ describe('App embed tests', () => {
         });
     });
 
+    test('additionalFlags override the directly-set app flags', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            additionalFlags: {
+                isFullAppEmbed: false,
+                enableDataPanelV2: false,
+            },
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+                isFullAppEmbed: false,
+                enableDataPanelV2: false,
+            });
+        });
+    });
+
     test('should hide the primary nav bar', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1227,6 +1227,8 @@ export class AppEmbed extends V1Embed {
             }
         }
 
+        params = this.applyAdditionalFlagsOverride(params);
+
         const queryParams = getQueryParamString(params, true);
 
         return queryParams;

--- a/src/embed/bodyless-conversation.spec.ts
+++ b/src/embed/bodyless-conversation.spec.ts
@@ -232,10 +232,93 @@ describe('SpotterAgentEmbed', () => {
 
         const spotterAgentEmbed = new SpotterAgentEmbed(viewConfig);
         const result = await spotterAgentEmbed.sendMessage('userMessage');
-        
+
         // Verify the iframe src contains the hideActions parameter
         const iframeSrc = getIFrameSrc(result.container);
         expect(iframeSrc).toContain('hideAction');
+    });
+
+    test('additionalFlags override the directly-set spotter agent flags', async () => {
+        fetchMock.mockResponses(
+            JSON.stringify({
+                data: {
+                    ConvAssist__createConversation: {
+                        convId: 'conversationId',
+                        initialCtx: {
+                            type: 'TS_ANSWER',
+                            tsAnsCtx: {
+                                sessionId: 'sessionId',
+                                genNo: 1,
+                                stateKey: {
+                                    transactionId: 'transactionId',
+                                    generationNumber: 1,
+                                },
+                                worksheet: {
+                                    worksheetId: 'worksheetId',
+                                    worksheetName: 'GTM',
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+            JSON.stringify({
+                data: {
+                    ConvAssist__sendMessage: {
+                        responses: [
+                            {
+                                msgId: 'msgId',
+                                data: {
+                                    asstRespData: {
+                                        tool: 'TS_NLS',
+                                        asstRespText: '',
+                                        nlsAnsData: {
+                                            sageQuerySuggestions: [
+                                                {
+                                                    tokens: ['sum sales'],
+                                                    tmlTokens: ['sum [sales]'],
+                                                    worksheetId: 'worksheetId',
+                                                    sessionId: 'sessionId',
+                                                    genNo: 2,
+                                                    stateKey: {
+                                                        transactionId: 'transactionId',
+                                                        generationNumber: 1,
+                                                        __typename: 'sage_auto_complete_v2_ACStateKey',
+                                                    },
+                                                    __typename: 'eureka_SageQuerySuggestion',
+                                                },
+                                            ],
+                                            responseType: 'ANSWER',
+                                            __typename: 'convassist_nls_tool_NLSToolAsstRespData',
+                                        },
+                                        __typename: 'convassist_AsstResponseData',
+                                    },
+                                    __typename: 'convassist_MessageData',
+                                },
+                                type: 'ASST_RESPONSE',
+                                __typename: 'convassist_MessagePayload',
+                            },
+                        ],
+                        __typename: 'convassist_SendMessageResponse',
+                    },
+                },
+            }),
+        );
+
+        const viewConfig: SpotterAgentEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            additionalFlags: {
+                isSpotterAgentEmbed: false,
+            },
+        };
+
+        const spotterAgentEmbed = new SpotterAgentEmbed(viewConfig);
+        const result = await spotterAgentEmbed.sendMessage('userMessage');
+
+        const iframeSrc = getIFrameSrc(result.container);
+        expectUrlToHaveParamsWithValues(iframeSrc, {
+            isSpotterAgentEmbed: false,
+        });
     });
 
     test('should handle disabledActions and disabledActionReason parameters correctly', async () => {

--- a/src/embed/bodyless-conversation.ts
+++ b/src/embed/bodyless-conversation.ts
@@ -43,7 +43,7 @@ export class ConversationMessage extends TsEmbed {
         const queryParams = this.getBaseQueryParams();
         queryParams[Param.HideActions] = [...(queryParams[Param.HideActions] ?? [])];
         queryParams[Param.isSpotterAgentEmbed] = true;
-        return queryParams;
+        return this.applyAdditionalFlagsOverride(queryParams);
     }
 
     public getIframeSrc() {

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -45,6 +45,24 @@ describe('ConversationEmbed', () => {
         );
     });
 
+    it('additionalFlags override the directly-set conversation flags', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+            additionalFlags: {
+                isSpotterExperienceEnabled: false,
+            },
+        };
+
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+            isSpotterExperienceEnabled: false,
+        });
+    });
+
     it('should render the conversation embed with worksheets disabled', async () => {
         const viewConfig: SpotterEmbedViewConfig = {
             worksheetId: 'worksheetId',

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -499,7 +499,7 @@ export class SpotterEmbed extends TsEmbed {
             }
         }
 
-        return queryParams;
+        return this.applyAdditionalFlagsOverride(queryParams);
     }
 
     public getIframeSrc(): string {

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -80,6 +80,26 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
+    test('additionalFlags override the directly-set liveboard flags', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            isLiveboardHeaderSticky: true,
+            dataPanelV2: true,
+            additionalFlags: {
+                isLiveboardHeaderSticky: false,
+                enableDataPanelV2: false,
+            },
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+                isLiveboardHeaderSticky: false,
+                enableDataPanelV2: false,
+            });
+        });
+    });
+
     test('should render liveboard with data panel v2 flag set to false by default', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -851,9 +851,7 @@ export class LiveboardEmbed extends V1Embed {
         params[Param.EnableCustomColumnGroups] = enableCustomColumnGroups;
         params[Param.CoverAndFilterOptionInPDF] = coverAndFilterOptionInPDF;
 
-        const queryParams = getQueryParamString(params, true);
-
-        return params;
+        return this.applyAdditionalFlagsOverride(params);
     }
 
     private getIframeSuffixSrc(

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -15,6 +15,7 @@ import {
     fixedEncodeURI,
     defaultParamsWithoutHiddenActions as defaultParams,
     expectUrlMatchesWithParams,
+    expectUrlToHaveParamsWithValues,
     getIFrameEl,
     postMessageToParent,
     testVisualOverridesInEmbed,
@@ -59,6 +60,22 @@ describe('Search embed tests', () => {
                 getIFrameSrc(),
                 `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&enableDataPanelV2=true&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
             );
+        });
+    });
+
+    test('additionalFlags override the directly-set search flags', async () => {
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            dataPanelV2: true,
+            additionalFlags: {
+                enableDataPanelV2: false,
+            },
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+                enableDataPanelV2: false,
+            });
         });
     });
 

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -516,7 +516,7 @@ export class SearchEmbed extends TsEmbed {
 
             queryParams[Param.DataPanelCustomGroupsAccordionInitialState] = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL;
         }
-        return queryParams;
+        return this.applyAdditionalFlagsOverride(queryParams);
     }
 
     protected getEmbedParams() {

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -2076,6 +2076,126 @@ describe('Unit test case for ts embed', () => {
             );
         });
 
+        describe('getAdditionalFlags', () => {
+            it('returns an empty object when no additional flags are set', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                expect((searchEmbed as any).getAdditionalFlags()).toEqual({});
+            });
+
+            it('returns only the init-level additional flags when view config has none', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                    additionalFlags: {
+                        foo: 'bar',
+                        baz: 1,
+                    },
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                expect((searchEmbed as any).getAdditionalFlags()).toEqual({
+                    foo: 'bar',
+                    baz: 1,
+                });
+            });
+
+            it('returns only the view-level additional flags when init config has none', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {
+                    additionalFlags: {
+                        viewFlag: true,
+                    },
+                });
+                expect((searchEmbed as any).getAdditionalFlags()).toEqual({
+                    viewFlag: true,
+                });
+            });
+
+            it('merges init and view additional flags, with view config taking precedence', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                    additionalFlags: {
+                        foo: 'fromInit',
+                        initOnly: 1,
+                    },
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {
+                    additionalFlags: {
+                        foo: 'fromView',
+                        viewOnly: false,
+                    },
+                });
+                expect((searchEmbed as any).getAdditionalFlags()).toEqual({
+                    foo: 'fromView',
+                    initOnly: 1,
+                    viewOnly: false,
+                });
+            });
+        });
+
+        describe('applyAdditionalFlagsOverride', () => {
+            it('applies additional flags onto the provided query params', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                    additionalFlags: {
+                        foo: 'bar',
+                    },
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                const queryParams = { existing: 'value' };
+                const result = (searchEmbed as any).applyAdditionalFlagsOverride(queryParams);
+                expect(result).toEqual({ existing: 'value', foo: 'bar' });
+            });
+
+            it('overrides existing query params with the same key', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                    additionalFlags: {
+                        foo: 'fromAdditionalFlags',
+                    },
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                const queryParams = { foo: 'fromDirectFlag' };
+                const result = (searchEmbed as any).applyAdditionalFlagsOverride(queryParams);
+                expect(result.foo).toBe('fromAdditionalFlags');
+            });
+
+            it('mutates and returns the same query params object', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                    additionalFlags: {
+                        foo: 'bar',
+                    },
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                const queryParams: Record<string, any> = {};
+                const result = (searchEmbed as any).applyAdditionalFlagsOverride(queryParams);
+                expect(result).toBe(queryParams);
+                expect(queryParams.foo).toBe('bar');
+            });
+
+            it('does not add any keys when there are no additional flags', () => {
+                init({
+                    thoughtSpotHost: 'http://tshost',
+                    authType: AuthType.None,
+                });
+                const searchEmbed = new SearchEmbed(getRootEl(), {});
+                const queryParams = { existing: 'value' };
+                const result = (searchEmbed as any).applyAdditionalFlagsOverride(queryParams);
+                expect(result).toEqual({ existing: 'value' });
+            });
+        });
+
         it('Sets the showAlerts param', async () => {
             const appEmbed = new AppEmbed(getRootEl(), {
                 frameParams: {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -710,6 +710,24 @@ export class TsEmbed {
         return queryParams;
     }
 
+    protected getAdditionalFlags(): { [key: string]: string | number | boolean } {
+        return {
+            ...this.embedConfig?.additionalFlags,
+            ...this.viewConfig?.additionalFlags,
+        };
+    }
+
+    protected applyAdditionalFlagsOverride(queryParams: Record<any, any>) {
+        if (!queryParams) {
+            return queryParams;
+        }
+        const additionalFlags = this.getAdditionalFlags();
+        if (isObject(additionalFlags) && !isEmpty(additionalFlags)) {
+            Object.assign(queryParams, additionalFlags);
+        }
+        return queryParams;
+    }
+
     /**
      * Common query params set for all the embed modes.
      * @param queryParams
@@ -762,7 +780,6 @@ export class TsEmbed {
             hiddenTabs,
             visibleTabs,
             showAlerts,
-            additionalFlags: additionalFlagsFromView,
             locale,
             customizations,
             contextMenuTrigger,
@@ -774,13 +791,6 @@ export class TsEmbed {
             exposeTranslationIDs,
             primaryAction,
         } = this.viewConfig;
-
-        const { additionalFlags: additionalFlagsFromInit } = this.embedConfig;
-
-        const additionalFlags = {
-            ...additionalFlagsFromInit,
-            ...additionalFlagsFromView,
-        };
 
         if (Array.isArray(visibleActions) && Array.isArray(hiddenActions)) {
             this.handleError({
@@ -877,13 +887,11 @@ export class TsEmbed {
         queryParams[Param.OverrideNativeConsole] = true;
         queryParams[Param.ClientLogLevel] = this.embedConfig.logLevel;
 
-        if (isObject(additionalFlags) && !isEmpty(additionalFlags)) {
-            Object.assign(queryParams, additionalFlags);
-        }
-
-        // Do not add any flags below this, as we want additional flags to
-        // override other flags
-
+        // `additionalFlags` are applied as the final override via
+        // `applyAdditionalFlagsOverride` at the end of each embed's param
+        // builder, so they win even over flags added by individual embeds
+        // after `getBaseQueryParams` runs. They are intentionally NOT applied
+        // here for that reason.
         return queryParams;
     }
 
@@ -910,7 +918,7 @@ export class TsEmbed {
 
     protected getEmbedParamsObject() {
         const params = this.getBaseQueryParams();
-        return params;
+        return this.applyAdditionalFlagsOverride(params);
     }
 
     protected getRootIframeSrc() {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -887,11 +887,6 @@ export class TsEmbed {
         queryParams[Param.OverrideNativeConsole] = true;
         queryParams[Param.ClientLogLevel] = this.embedConfig.logLevel;
 
-        // `additionalFlags` are applied as the final override via
-        // `applyAdditionalFlagsOverride` at the end of each embed's param
-        // builder, so they win even over flags added by individual embeds
-        // after `getBaseQueryParams` runs. They are intentionally NOT applied
-        // here for that reason.
         return queryParams;
     }
 


### PR DESCRIPTION
**WILL MERGE AFTER FEW TESTING**

    /**
     * Merges the `additionalFlags` provided at init time (via the global
     * embed config) with those provided per-embed (via the view config).
     * View-level flags take precedence over init-level flags.
     * @returns The merged map of additional URL flags.
     */
     
     
     
     
         /**
     * Applies `additionalFlags` on top of the provided query params so that
     * they always override any other flag with the same key. This must be the
     * last mutation applied to the query params, regardless of the embed type,
     * because individual embeds add their own flags after `getBaseQueryParams`
     * runs. Calling this at the final step guarantees `additionalFlags` wins
     * across every embed type.
     * @param queryParams The query params to apply the additional flags on.
     * @returns The same query params object with additional flags applied.
     */