### PR TITLE
SCAL-323201: Expose full Spotter Share-by-URL embed surface in SDK

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -770,6 +770,66 @@ describe('App embed tests', () => {
         });
     });
 
+    test('should include spotterShareConversationConfig in APP_INIT embedParams when provided', async () => {
+        const spotterShareConversationConfig = {
+            enableShareConversation: true,
+            spotterShareLabel: 'Share',
+            spotterShareModalTitle: 'Share conversation',
+            spotterShareIcon: 'share',
+        };
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            spotterShareConversationConfig,
+        } as AppViewConfig);
+
+        mockMessageChannel();
+        appEmbed.render();
+
+        const mockPort: any = { postMessage: jest.fn() };
+        await executeAfterWait(() => {
+            postMessageToParent(
+                getIFrameEl().contentWindow,
+                { type: EmbedEvent.APP_INIT, data: {} },
+                mockPort,
+            );
+        });
+        await executeAfterWait(() => {
+            expect(mockPort.postMessage).toHaveBeenCalledWith({
+                type: EmbedEvent.APP_INIT,
+                data: expect.objectContaining({
+                    embedParams: expect.objectContaining({
+                        spotterShareConversationConfig,
+                    }),
+                }),
+            });
+        });
+    });
+
+    test('should not include spotterShareConversationConfig in APP_INIT when not provided', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+        } as AppViewConfig);
+
+        mockMessageChannel();
+        appEmbed.render();
+
+        const mockPort: any = { postMessage: jest.fn() };
+        await executeAfterWait(() => {
+            postMessageToParent(
+                getIFrameEl().contentWindow,
+                { type: EmbedEvent.APP_INIT, data: {} },
+                mockPort,
+            );
+        });
+        await executeAfterWait(() => {
+            const callArgs = mockPort.postMessage.mock.calls[0][0];
+            expect(callArgs.type).toBe(EmbedEvent.APP_INIT);
+            if (callArgs.data.embedParams) {
+                expect(callArgs.data.embedParams.spotterShareConversationConfig).toBeUndefined();
+            }
+        });
+    });
+
     test('should set toolResponseCardBrandingLabel in url via spotterChatConfig', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -808,7 +808,7 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      * Configuration for the Spotter conversation sharing feature.
      *
      * Supported embed types: `AppEmbed`
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @example
      * ```js
      * const embed = new AppEmbed('#tsEmbed', {

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -22,8 +22,8 @@ import {
     SpotterFileUploadFileTypes,
 } from '../types';
 import { V1Embed } from './ts-embed';
-import { SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterQueryMode } from './conversation';
-import { buildSpotterSidebarAppInitData } from './spotter-utils';
+import { SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterQueryMode, SpotterShareConversationConfig } from './conversation';
+import { buildSpotterSidebarAppInitData, buildSpotterShareConversationAppInitData } from './spotter-utils';
 import { SpotterVizConfig, buildSpotterVizAppInitData } from './spotter-viz-utils';
 
 /**
@@ -805,6 +805,22 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      */
     spotterChatConfig?: SpotterChatViewConfig;
     /**
+     * Configuration for the Spotter conversation sharing feature.
+     *
+     * Supported embed types: `AppEmbed`
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterShareConversationConfig: {
+     *        enableShareConversation: true,
+     *    },
+     * })
+     * ```
+     */
+    spotterShareConversationConfig?: SpotterShareConversationConfig;
+    /**
      * Configuration for the SpotterViz interface shown on the Liveboard.
      * Customize the brand name, description, chat input placeholder,
      * starter prompts, and visibility of starter prompts in the SpotterViz panel.
@@ -910,6 +926,7 @@ export interface AppEmbedAppInitData extends DefaultAppInitData {
     embedParams?: {
         spotterSidebarConfig?: SpotterSidebarViewConfig;
         spotterVizConfig?: SpotterVizConfig;
+        spotterShareConversationConfig?: SpotterShareConversationConfig;
     };
 }
 
@@ -959,7 +976,8 @@ export class AppEmbed extends V1Embed {
             this.viewConfig,
             this.handleError.bind(this),
         );
-        return buildSpotterVizAppInitData(sidebarInitData, this.viewConfig);
+        const vizInitData = buildSpotterVizAppInitData(sidebarInitData, this.viewConfig);
+        return buildSpotterShareConversationAppInitData(vizInitData, this.viewConfig);
     }
 
     /**

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -45,6 +45,40 @@ describe('ConversationEmbed', () => {
         );
     });
 
+    it('should deep-link to the shared-conversation reader view when sharedConversationId is set', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+            sharedConversationId: 'conv-123',
+        };
+
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true#/embed/insights/conv-assist/s/conv-123?worksheet=worksheetId&query=searchQuery`,
+        );
+    });
+
+    it('should URL-encode the sharedConversationId in the reader-view path', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+            sharedConversationId: 'conv/1',
+        };
+
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true#/embed/insights/conv-assist/s/conv%2F1?worksheet=worksheetId&query=searchQuery`,
+        );
+    });
+
     it('should render the conversation embed with worksheets disabled', async () => {
         const viewConfig: SpotterEmbedViewConfig = {
             worksheetId: 'worksheetId',
@@ -695,6 +729,40 @@ describe('SpotterEmbed APP_INIT embedParams', () => {
             }),
         );
         expect(mockPort.postMessage.mock.calls[0]?.[0].data.embedParams?.spotterSidebarConfig?.spotterDocumentationUrl).toBeUndefined();
+    });
+
+    it('should include spotterShareConversationConfig in embedParams when provided', async () => {
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterShareConversationConfig: { enableShareConversation: true },
+        });
+        expect(response.data.embedParams.spotterShareConversationConfig).toEqual({
+            enableShareConversation: true,
+        });
+    });
+
+    it('should pass spotterShareConversationConfig label/icon overrides through embedParams', async () => {
+        const spotterShareConversationConfig = {
+            enableShareConversation: true,
+            spotterShareLabel: 'Share',
+            spotterShareModalTitle: 'Share conversation',
+            spotterShareIcon: 'share',
+        };
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterShareConversationConfig,
+        });
+        expect(response.data.embedParams.spotterShareConversationConfig).toEqual(spotterShareConversationConfig);
+    });
+
+    it('should include spotterShareConversationConfig alongside spotterSidebarConfig', async () => {
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterSidebarConfig: { enablePastConversationsSidebar: true },
+            spotterShareConversationConfig: { enableShareConversation: true },
+        });
+        expect(response.data.embedParams.spotterSidebarConfig.enablePastConversationsSidebar).toBe(true);
+        expect(response.data.embedParams.spotterShareConversationConfig.enableShareConversation).toBe(true);
     });
 
 });

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -1,8 +1,7 @@
-import isUndefined from 'lodash/isUndefined';
 import { ERROR_MESSAGE } from '../errors';
 import { Param, BaseViewConfig, RuntimeFilter, RuntimeParameter, ErrorDetailsTypes, EmbedErrorCodes, DefaultAppInitData, VisualizationOverrides, SpotterFileUploadFileTypes } from '../types';
 import { TsEmbed } from './ts-embed';
-import { buildSpotterSidebarAppInitData } from './spotter-utils';
+import { buildSpotterSidebarAppInitData, buildSpotterShareConversationAppInitData } from './spotter-utils';
 import { getQueryParamString, getFilterQuery, getRuntimeParameters, setParamIfDefined } from '../utils';
 
 /**
@@ -110,6 +109,97 @@ export interface SpotterSidebarViewConfig {
      * @default Analysts
      */
     spotterAnalystsLabel?: string;
+}
+
+/**
+ * Configuration for the Spotter conversation sharing feature.
+ * Can be used in SpotterEmbed and AppEmbed.
+ * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+ * @group Embed components
+ */
+export interface SpotterShareConversationConfig {
+    /**
+     * Enables sharing of the conversation.
+     * @default false
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    enableShareConversation?: boolean;
+    /**
+     * Header Share button + sidebar Share item label.
+     * @default "Share"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareLabel?: string;
+    /**
+     * Share modal title.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareModalTitle?: string;
+    /**
+     * Modal confirm button label.
+     * @default "Share"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareConfirmLabel?: string;
+    /**
+     * Modal cancel button label.
+     * @default "Cancel"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareCancelLabel?: string;
+    /**
+     * "Add users or groups" label.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareAddUsersLabel?: string;
+    /**
+     * Empty-state title ("No users added yet").
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareEmptyTitle?: string;
+    /**
+     * Empty-state subtitle ("Not shared with any user").
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareEmptySubtitle?: string;
+    /**
+     * "Include new messages since last shared version" checkbox label.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareIncludeNewMessagesLabel?: string;
+    /**
+     * Footer note when the snapshot is current ("…up to the current moment…").
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareUpToCurrentLabel?: string;
+    /**
+     * Stale-snapshot info banner text ("All added users and groups will receive…").
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareStaleInfoLabel?: string;
+    /**
+     * Read-only shared-view data-access banner message.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterSharedConversationBannerMessage?: string;
+    /**
+     * Read-only shared-view Exit button label.
+     * @default "Exit"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterSharedConversationExitLabel?: string;
+    /**
+     * Share icon id (radiant IconID string).
+     * @default "share"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareIcon?: string;
+    /**
+     * Empty-state group icon id (radiant IconID string).
+     * @default "userGroup"
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    spotterShareGroupIcon?: string;
 }
 
 /**
@@ -404,6 +494,44 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      * ```
      */
     spotterChatConfig?: SpotterChatViewConfig;
+    /**
+     * Configuration for the Spotter conversation sharing feature.
+     *
+     * Supported embed types: `SpotterEmbed`, `AppEmbed`
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    spotterShareConversationConfig: {
+     *        enableShareConversation: true,
+     *    },
+     * })
+     * ```
+     */
+    spotterShareConversationConfig?: SpotterShareConversationConfig;
+    /**
+     * The ID of a shared Spotter conversation to open directly in the read-only
+     * reader view. Use this to land a share recipient in the shared conversation
+     * when they open a host-configured `CONVERSATION_URL` share link: read the
+     * `{conversation-id}` from your page URL and pass it here.
+     *
+     * Requires the Spotter conversation-sharing feature to be enabled
+     * (`spotterShareConversationConfig.enableShareConversation`). The recipient
+     * must be an authorized sharee — the server returns access-denied otherwise.
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @example
+     * ```js
+     * const convId = new URLSearchParams(window.location.search).get('conversation-id');
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    sharedConversationId: convId,
+     * })
+     * ```
+     */
+    sharedConversationId?: string;
 }
 
 /**
@@ -422,6 +550,7 @@ export interface ConversationViewConfig extends SpotterEmbedViewConfig {}
 export interface SpotterAppInitData extends DefaultAppInitData {
     embedParams?: {
         spotterSidebarConfig?: SpotterSidebarViewConfig;
+        spotterShareConversationConfig?: SpotterShareConversationConfig;
         visualOverridesParams?: VisualizationOverrides | null;
     };
 }
@@ -466,7 +595,12 @@ export class SpotterEmbed extends TsEmbed {
      */
     protected async getAppInitData(): Promise<SpotterAppInitData> {
         const defaultAppInitData = await super.getAppInitData();
-        return buildSpotterSidebarAppInitData(defaultAppInitData, this.viewConfig, this.handleError.bind(this));
+        const sidebarInitData = buildSpotterSidebarAppInitData(
+            defaultAppInitData,
+            this.viewConfig,
+            this.handleError.bind(this),
+        );
+        return buildSpotterShareConversationAppInitData(sidebarInitData, this.viewConfig);
     }
 
     protected getEmbedParamsObject() {
@@ -539,8 +673,15 @@ export class SpotterEmbed extends TsEmbed {
             excludeRuntimeFiltersfromURL,
             runtimeParameters,
             excludeRuntimeParametersfromURL,
+            sharedConversationId,
         } = this.viewConfig;
-        const path = 'insights/conv-assist';
+        // Deep-link into the read-only shared-conversation reader view when a
+        // shared conversation id is supplied (e.g. a recipient landing from a
+        // host-configured CONVERSATION_URL share link); otherwise the normal
+        // Spotter conversation surface.
+        const path = sharedConversationId
+            ? `insights/conv-assist/s/${encodeURIComponent(sharedConversationId)}`
+            : 'insights/conv-assist';
         const queryParams = this.getEmbedParamsObject();
 
         let query = '';

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -114,90 +114,90 @@ export interface SpotterSidebarViewConfig {
 /**
  * Configuration for the Spotter conversation sharing feature.
  * Can be used in SpotterEmbed and AppEmbed.
- * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+ * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
  * @group Embed components
  */
 export interface SpotterShareConversationConfig {
     /**
      * Enables sharing of the conversation.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default false
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     enableShareConversation?: boolean;
     /**
      * Header Share button + sidebar Share item label.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "Share"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterShareLabel?: string;
     /**
      * Share modal title.
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareModalTitle?: string;
     /**
      * Modal confirm button label.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "Share"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterShareConfirmLabel?: string;
     /**
      * Modal cancel button label.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "Cancel"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterShareCancelLabel?: string;
     /**
      * "Add users or groups" label.
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareAddUsersLabel?: string;
     /**
      * Empty-state title ("No users added yet").
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareEmptyTitle?: string;
     /**
      * Empty-state subtitle ("Not shared with any user").
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareEmptySubtitle?: string;
     /**
      * "Include new messages since last shared version" checkbox label.
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareIncludeNewMessagesLabel?: string;
     /**
      * Footer note when the snapshot is current ("…up to the current moment…").
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareUpToCurrentLabel?: string;
     /**
      * Stale-snapshot info banner text ("All added users and groups will receive…").
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterShareStaleInfoLabel?: string;
     /**
      * Read-only shared-view data-access banner message.
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     spotterSharedConversationBannerMessage?: string;
     /**
      * Read-only shared-view Exit button label.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "Exit"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterSharedConversationExitLabel?: string;
     /**
      * Share icon id (radiant IconID string).
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "share"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterShareIcon?: string;
     /**
      * Empty-state group icon id (radiant IconID string).
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @default "userGroup"
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
      */
     spotterShareGroupIcon?: string;
 }
@@ -498,7 +498,7 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      * Configuration for the Spotter conversation sharing feature.
      *
      * Supported embed types: `SpotterEmbed`, `AppEmbed`
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @example
      * ```js
      * const embed = new SpotterEmbed('#tsEmbed', {
@@ -521,7 +521,7 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      * must be an authorized sharee — the server returns access-denied otherwise.
      *
      * Supported embed types: `SpotterEmbed`
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @example
      * ```js
      * const convId = new URLSearchParams(window.location.search).get('conversation-id');

--- a/src/embed/events.spec.ts
+++ b/src/embed/events.spec.ts
@@ -523,6 +523,16 @@ describe('EmbedEvent basic routing', () => {
         ['SpotterVizClosed', EmbedEvent.SpotterVizClosed],
         ['RefreshLiveboardBrowserCache', EmbedEvent.RefreshLiveboardBrowserCache],
         ['V1Data', EmbedEvent.V1Data],
+        ['SpotterShareConversationButtonHeaderClicked', EmbedEvent.SpotterShareConversationButtonHeaderClicked],
+        ['SpotterShareConversationMenuItemSidebarClicked', EmbedEvent.SpotterShareConversationMenuItemSidebarClicked],
+        ['SpotterConversationShared', EmbedEvent.SpotterConversationShared],
+        ['SpotterConversationShareRevoked', EmbedEvent.SpotterConversationShareRevoked],
+        ['SpotterSharedConversationViewed', EmbedEvent.SpotterSharedConversationViewed],
+        ['SpotterShareIncludeNewMessagesCheckboxToggled', EmbedEvent.SpotterShareIncludeNewMessagesCheckboxToggled],
+        ['SpotterShareStaleInfoBannerDismissed', EmbedEvent.SpotterShareStaleInfoBannerDismissed],
+        ['SpotterShareModalConfirmButtonClicked', EmbedEvent.SpotterShareModalConfirmButtonClicked],
+        ['SpotterShareModalCancelButtonClicked', EmbedEvent.SpotterShareModalCancelButtonClicked],
+        ['SpotterSharedConversationExitButtonClicked', EmbedEvent.SpotterSharedConversationExitButtonClicked],
     ];
 
     test.each(UNCOVERED_EVENTS)(

--- a/src/embed/host-events.spec.ts
+++ b/src/embed/host-events.spec.ts
@@ -1757,3 +1757,42 @@ describe('HostEvent.DownloadAsCsv — additional cases', () => {
         expect(result).toBeNull();
     });
 });
+
+// ---------------------------------------------------------------------------
+// Spotter share-conversation HostEvents 
+// ---------------------------------------------------------------------------
+describe('Spotter share-conversation HostEvents', () => {
+    const shareEvents: Array<[string, HostEvent, string, any]> = [
+        ['ShareSpotterConversation', HostEvent.ShareSpotterConversation, 'ShareSpotterConversation', { conversationId: 'abc' }],
+        ['CloseSpotterShareConversation', HostEvent.CloseSpotterShareConversation, 'CloseSpotterShareConversation', {}],
+        ['ExitSpotterSharedConversation', HostEvent.ExitSpotterSharedConversation, 'ExitSpotterSharedConversation', {}],
+    ];
+
+    test.each(shareEvents)(
+        '%s: postMessage type is the matching string value',
+        async (name, event, typeString, payload) => {
+            mockMessageChannel();
+            const { lb, iframe } = await renderLiveboard();
+            await executeAfterWait(() => {
+                lb.trigger(event, payload as any);
+                expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: typeString }),
+                    thoughtSpotHost,
+                    expect.anything(),
+                );
+            });
+        },
+    );
+
+    test.each(shareEvents)(
+        '%s: returns null and calls handleError when !isRendered',
+        async (name, event, typeString, payload) => {
+            const lb = unrenderedLiveboard();
+            const result = await lb.trigger(event, payload as any);
+            expect(result).toBeNull();
+            expect((lb as any).handleError).toHaveBeenCalledWith(
+                expect.objectContaining({ code: EmbedErrorCodes.RENDER_NOT_CALLED }),
+            );
+        },
+    );
+});

--- a/src/embed/spotter-utils.spec.ts
+++ b/src/embed/spotter-utils.spec.ts
@@ -1,4 +1,8 @@
-import { resolveEnablePastConversationsSidebar, buildSpotterSidebarAppInitData } from './spotter-utils';
+import {
+    resolveEnablePastConversationsSidebar,
+    buildSpotterSidebarAppInitData,
+    buildSpotterShareConversationAppInitData,
+} from './spotter-utils';
 import { ErrorDetailsTypes, EmbedErrorCodes } from '../types';
 import { ERROR_MESSAGE } from '../errors';
 
@@ -104,5 +108,53 @@ describe('buildSpotterSidebarAppInitData', () => {
         }, noopError);
         expect(result.embedParams?.visualOverridesParams).toBeUndefined();
         expect(result.embedParams?.spotterSidebarConfig?.enablePastConversationsSidebar).toBe(true);
+    });
+});
+
+describe('buildSpotterShareConversationAppInitData', () => {
+    const base = { type: 'APP_INIT' } as any;
+
+    it('returns base unchanged when no spotterShareConversationConfig', () => {
+        const result = buildSpotterShareConversationAppInitData(base, {});
+        expect(result).toBe(base);
+    });
+
+    it('nests spotterShareConversationConfig under embedParams', () => {
+        const result = buildSpotterShareConversationAppInitData(base, {
+            spotterShareConversationConfig: { enableShareConversation: true },
+        });
+        expect(result.embedParams?.spotterShareConversationConfig).toEqual({
+            enableShareConversation: true,
+        });
+    });
+
+    it('passes label/icon override fields through untouched', () => {
+        const spotterShareConversationConfig = {
+            enableShareConversation: true,
+            spotterShareLabel: 'Share',
+            spotterShareModalTitle: 'Share conversation',
+            spotterShareConfirmLabel: 'Share',
+            spotterShareCancelLabel: 'Cancel',
+            spotterShareAddUsersLabel: 'Add users or groups',
+            spotterShareEmptyTitle: 'No users added yet',
+            spotterShareEmptySubtitle: 'Not shared with any user',
+            spotterShareIncludeNewMessagesLabel: 'Include new messages',
+            spotterShareUpToCurrentLabel: 'Share up to current moment',
+            spotterShareStaleInfoLabel: 'This snapshot may be stale',
+            spotterShareIcon: 'share',
+        };
+        const result = buildSpotterShareConversationAppInitData(base, {
+            spotterShareConversationConfig,
+        });
+        expect(result.embedParams?.spotterShareConversationConfig).toEqual(spotterShareConversationConfig);
+    });
+
+    it('preserves existing embedParams when nesting the share config', () => {
+        const withParams = { type: 'APP_INIT', embedParams: { existing: 'keep' } } as any;
+        const result = buildSpotterShareConversationAppInitData(withParams, {
+            spotterShareConversationConfig: { enableShareConversation: true },
+        });
+        expect(result.embedParams?.existing).toBe('keep');
+        expect(result.embedParams?.spotterShareConversationConfig?.enableShareConversation).toBe(true);
     });
 });

--- a/src/embed/spotter-utils.ts
+++ b/src/embed/spotter-utils.ts
@@ -1,7 +1,7 @@
 import { DefaultAppInitData, ErrorDetailsTypes, EmbedErrorCodes } from '../types';
 import { validateHttpUrl } from '../utils';
 import { ERROR_MESSAGE } from '../errors';
-import type { SpotterSidebarViewConfig } from './conversation';
+import type { SpotterSidebarViewConfig, SpotterShareConversationConfig } from './conversation';
 import type { VisualizationOverrides } from '../types';
 
 /**
@@ -76,6 +76,21 @@ export function buildSpotterSidebarAppInitData<T extends DefaultAppInitData>(
             ...((defaultAppInitData as any).embedParams || {}),
             spotterSidebarConfig: resolvedSidebarConfig,
             ...(visualOverrides !== undefined ? { visualOverridesParams: visualOverrides } : {}),
+        },
+    };
+}
+
+export function buildSpotterShareConversationAppInitData<T extends DefaultAppInitData>(
+    initData: T,
+    viewConfig: { spotterShareConversationConfig?: SpotterShareConversationConfig },
+): T & { embedParams?: { spotterShareConversationConfig?: SpotterShareConversationConfig } } {
+    const { spotterShareConversationConfig } = viewConfig;
+    if (!spotterShareConversationConfig) return initData;
+    return {
+        ...initData,
+        embedParams: {
+            ...((initData as T & { embedParams?: Record<string, unknown> }).embedParams || {}),
+            spotterShareConversationConfig,
         },
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { PinboardEmbed, LiveboardViewConfig, LiveboardEmbed } from './embed/live
 import { SearchEmbed, SearchViewConfig } from './embed/search';
 import { SearchBarEmbed, SearchBarViewConfig } from './embed/search-bar';
 import { SpotterAgentEmbed, SpotterAgentEmbedViewConfig, BodylessConversation, BodylessConversationViewConfig} from './embed/bodyless-conversation';
-import { SpotterEmbed, SpotterEmbedViewConfig, SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterQueryMode, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
+import { SpotterEmbed, SpotterEmbedViewConfig, SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterQueryMode, SpotterShareConversationConfig, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
 import { SpotterVizConfig, SpotterVizStarterPrompt, SpotterVizLoaderTip } from './embed/spotter-viz-utils';
 import {
     AuthFailureType, AuthStatus, AuthEvent, AuthEventEmitter,
@@ -118,6 +118,7 @@ export {
     SpotterChatViewConfig,
     SpotterSidebarViewConfig,
     SpotterQueryMode,
+    SpotterShareConversationConfig,
     ConversationViewConfig,
     ConversationEmbed,
     AuthFailureType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6111,20 +6111,12 @@ export enum HostEvent {
      */
     ResetSpotterConversation = 'ResetSpotterConversation',
     /**
-     * Opens the Spotter share-conversation modal. `conversationId` is optional
-     * and defaults to the active conversation; pass it only to share a different
-     * (non-active) conversation. No-op when sharing is disabled
-     * (enableShareConversation off) or when already in the read-only shared view,
-     * and — only when there is neither a `conversationId` nor an active
-     * conversation — blink emits a validation error and no-ops.
+     * Opens the Spotter share-conversation modal for the given conversation.
+     * `conversationId` is **mandatory** — you must pass the id of the
+     * conversation to share. Also no-op when sharing is disabled
+     * (enableShareConversation off) or when already in the read-only shared view.
      * @example
      * ```js
-     * // Share the active conversation.
-     * spotterEmbed.trigger(HostEvent.ShareSpotterConversation);
-     * ```
-     * @example
-     * ```js
-     * // Share a specific (non-active) conversation.
      * spotterEmbed.trigger(HostEvent.ShareSpotterConversation, { conversationId: 'abc' });
      * ```
      * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl

--- a/src/types.ts
+++ b/src/types.ts
@@ -3751,6 +3751,134 @@ export enum EmbedEvent {
      */
     SpotterConversationDeleted = 'spotterConversationDeleted',
     /**
+     * Emitted when the header Share button is clicked. Fires `Start` then `End`
+     * to bracket the interaction. App→host counterpart of the
+     * `ShareSpotterConversation` host event (user-driven vs programmatic open).
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareConversationButtonHeaderClicked, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareConversationButtonHeaderClicked = 'spotterShareConversationButtonHeaderClicked',
+    /**
+     * Emitted when the sidebar Share item is clicked. Fires `Start` then `End`
+     * to bracket the interaction.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareConversationMenuItemSidebarClicked, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareConversationMenuItemSidebarClicked = 'spotterShareConversationMenuItemSidebarClicked',
+    /**
+     * Emitted when a Spotter conversation is shared (recipients added, or a new
+     * share created). The host builds its own link from shareId/convId + its
+     * configured CONVERSATION_URL — no link string is sent. Distinct from
+     * `SpotterShareModalConfirmButtonClicked`, which fires at click time before
+     * the save resolves.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationShared, (payload) => {
+     *     // payload: { convId: string, shareId: string,
+     *     //            recipientsAdded: string[], recipientsRemoved: string[] }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterConversationShared = 'spotterConversationShared',
+    /**
+     * Emitted when access to a shared Spotter conversation is revoked
+     * (recipients removed). `fullyRevoked` is true when the last sharee is removed
+     * and the share is deleted entirely.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationShareRevoked, (payload) => {
+     *     // payload: { convId: string, shareId: string,
+     *     //            recipientsRemoved: string[], fullyRevoked: boolean }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterConversationShareRevoked = 'spotterConversationShareRevoked',
+    /**
+     * Emitted when a recipient opens a shared Spotter conversation (read-only
+     * view). No shareId available viewer-side.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterSharedConversationViewed, (payload) => {
+     *     // payload: { convId: string, sourceConvId: string }
+     *     // convId = resolved snapshot conv id; sourceConvId = the shared URL id
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterSharedConversationViewed = 'spotterSharedConversationViewed',
+    /**
+     * Emitted when the user toggles the share-modal "include new messages since
+     * last shared version" checkbox.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareIncludeNewMessagesCheckboxToggled, (payload) => {
+     *     // payload: { convId: string, includeNewMessages: boolean }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareIncludeNewMessagesCheckboxToggled = 'spotterShareIncludeNewMessagesCheckboxToggled',
+    /**
+     * Emitted when the user dismisses the stale-snapshot info banner via its
+     * cross (distinct from the include-new-messages checkbox toggle).
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareStaleInfoBannerDismissed, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareStaleInfoBannerDismissed = 'spotterShareStaleInfoBannerDismissed',
+    /**
+     * Emitted when the modal Share (confirm) button is clicked — fires at click
+     * time, before the save resolves. Distinct from the `SpotterConversationShared`
+     * / `SpotterConversationShareRevoked` result events.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareModalConfirmButtonClicked, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareModalConfirmButtonClicked = 'spotterShareModalConfirmButtonClicked',
+    /**
+     * Emitted when the share modal is dismissed via the Cancel button.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterShareModalCancelButtonClicked, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareModalCancelButtonClicked = 'spotterShareModalCancelButtonClicked',
+    /**
+     * Emitted when a recipient leaves the read-only shared view via the Exit
+     * button.
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterSharedConversationExitButtonClicked, (payload) => {
+     *     // payload: { convId: string }
+     * })
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterSharedConversationExitButtonClicked = 'spotterSharedConversationExitButtonClicked',
+    /**
      * Emitted when a Spotter conversation is selected/clicked.
      * @example
      * ```js
@@ -5983,6 +6111,36 @@ export enum HostEvent {
      */
     ResetSpotterConversation = 'ResetSpotterConversation',
     /**
+     * Opens the Spotter share-conversation modal for the given conversation.
+     * `conversationId` is **required** — blink emits a validation error and no-ops
+     * if it is missing. Also no-op when sharing is disabled (enableShareConversation
+     * off) or when already in the read-only shared view.
+     * @example
+     * ```js
+     * spotterEmbed.trigger(HostEvent.ShareSpotterConversation, { conversationId: 'abc' });
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    ShareSpotterConversation = 'ShareSpotterConversation',
+    /**
+     * Closes the Spotter share-conversation modal. No-op if none is open.
+     * @example
+     * ```js
+     * spotterEmbed.trigger(HostEvent.CloseSpotterShareConversation);
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    CloseSpotterShareConversation = 'CloseSpotterShareConversation',
+    /**
+     * Exits the read-only shared-conversation view.
+     * @example
+     * ```js
+     * spotterEmbed.trigger(HostEvent.ExitSpotterSharedConversation);
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    ExitSpotterSharedConversation = 'ExitSpotterSharedConversation',
+    /**
      * Deletes the last prompt in spotter embed.
      * @example
      * ```js
@@ -7975,6 +8133,89 @@ export enum Action {
      * @version SDK: 1.46.0 | ThoughtSpot Cloud: 26.3.0.cl
      */
     SpotterChatRename = 'spotterChatRename',
+    /**
+     * Controls visibility and disable state of the Spotter conversation Share
+     * button in the chat header. Only takes effect once sharing is enabled
+     * (enableShareConversation on).
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterShareConversationButtonHeader]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareConversationButtonHeader = 'spotterShareConversationButtonHeader',
+    /**
+     * Controls visibility and disable state of the Share item in the Spotter
+     * conversation history (sidebar) edit menu. Independent of the header button
+     * above, so a host can show Share in one entry point and hide it in the other.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterShareConversationMenuItemSidebar]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareConversationMenuItemSidebar = 'spotterShareConversationMenuItemSidebar',
+    /**
+     * Controls visibility of the entire read-only shared-conversation data-access
+     * banner shown when a recipient opens a shared view. Hide-only.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterSharedConversationBanner]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterSharedConversationBanner = 'spotterSharedConversationBanner',
+    /**
+     * Controls visibility and disable state of the cross/close button on the
+     * read-only shared-conversation data-access banner (keeps the banner itself).
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterSharedConversationBannerDismissButton]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterSharedConversationBannerDismissButton = 'spotterSharedConversationBannerDismissButton',
+    /**
+     * Controls visibility and disable state of the Exit button in the read-only
+     * shared-view header. Hiding it does not disable the ExitSpotterSharedConversation
+     * host event.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterSharedConversationExitButton]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterSharedConversationExitButton = 'spotterSharedConversationExitButton',
+    /**
+     * Controls visibility of the share-modal footer note ("Chat will be shared up
+     * to the current moment…"). Hide-only.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterShareUpToCurrentInfo]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareUpToCurrentInfo = 'spotterShareUpToCurrentInfo',
+    /**
+     * Controls visibility and disable state of the share-modal "include new
+     * messages since last shared version" checkbox.
+     * @example
+     * ```js
+     * disabledActions: [Action.SpotterShareIncludeNewMessagesCheckbox]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareIncludeNewMessagesCheckbox = 'spotterShareIncludeNewMessagesCheckbox',
+    /**
+     * Controls visibility and disable state of the cross on the share-modal
+     * stale-snapshot info banner.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterShareStaleInfoBannerDismissButton]
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     */
+    SpotterShareStaleInfoBannerDismissButton = 'spotterShareStaleInfoBannerDismissButton',
     /**
      * Controls visibility and disable state of the delete action
      * in the Spotter conversation edit menu.

--- a/src/types.ts
+++ b/src/types.ts
@@ -3760,7 +3760,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareConversationButtonHeaderClicked = 'spotterShareConversationButtonHeaderClicked',
     /**
@@ -3772,7 +3772,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareConversationMenuItemSidebarClicked = 'spotterShareConversationMenuItemSidebarClicked',
     /**
@@ -3788,7 +3788,7 @@ export enum EmbedEvent {
      *     //            recipientsAdded: string[], recipientsRemoved: string[] }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterConversationShared = 'spotterConversationShared',
     /**
@@ -3802,7 +3802,7 @@ export enum EmbedEvent {
      *     //            recipientsRemoved: string[], fullyRevoked: boolean }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterConversationShareRevoked = 'spotterConversationShareRevoked',
     /**
@@ -3815,7 +3815,7 @@ export enum EmbedEvent {
      *     // convId = resolved snapshot conv id; sourceConvId = the shared URL id
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterSharedConversationViewed = 'spotterSharedConversationViewed',
     /**
@@ -3827,7 +3827,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string, includeNewMessages: boolean }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareIncludeNewMessagesCheckboxToggled = 'spotterShareIncludeNewMessagesCheckboxToggled',
     /**
@@ -3839,7 +3839,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareStaleInfoBannerDismissed = 'spotterShareStaleInfoBannerDismissed',
     /**
@@ -3852,7 +3852,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareModalConfirmButtonClicked = 'spotterShareModalConfirmButtonClicked',
     /**
@@ -3863,7 +3863,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareModalCancelButtonClicked = 'spotterShareModalCancelButtonClicked',
     /**
@@ -3875,7 +3875,7 @@ export enum EmbedEvent {
      *     // payload: { convId: string }
      * })
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterSharedConversationExitButtonClicked = 'spotterSharedConversationExitButtonClicked',
     /**
@@ -6111,15 +6111,23 @@ export enum HostEvent {
      */
     ResetSpotterConversation = 'ResetSpotterConversation',
     /**
-     * Opens the Spotter share-conversation modal for the given conversation.
-     * `conversationId` is **required** — blink emits a validation error and no-ops
-     * if it is missing. Also no-op when sharing is disabled (enableShareConversation
-     * off) or when already in the read-only shared view.
+     * Opens the Spotter share-conversation modal. `conversationId` is optional
+     * and defaults to the active conversation; pass it only to share a different
+     * (non-active) conversation. No-op when sharing is disabled
+     * (enableShareConversation off) or when already in the read-only shared view,
+     * and — only when there is neither a `conversationId` nor an active
+     * conversation — blink emits a validation error and no-ops.
      * @example
      * ```js
+     * // Share the active conversation.
+     * spotterEmbed.trigger(HostEvent.ShareSpotterConversation);
+     * ```
+     * @example
+     * ```js
+     * // Share a specific (non-active) conversation.
      * spotterEmbed.trigger(HostEvent.ShareSpotterConversation, { conversationId: 'abc' });
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     ShareSpotterConversation = 'ShareSpotterConversation',
     /**
@@ -6128,7 +6136,7 @@ export enum HostEvent {
      * ```js
      * spotterEmbed.trigger(HostEvent.CloseSpotterShareConversation);
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     CloseSpotterShareConversation = 'CloseSpotterShareConversation',
     /**
@@ -6137,7 +6145,7 @@ export enum HostEvent {
      * ```js
      * spotterEmbed.trigger(HostEvent.ExitSpotterSharedConversation);
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     ExitSpotterSharedConversation = 'ExitSpotterSharedConversation',
     /**
@@ -8141,7 +8149,7 @@ export enum Action {
      * ```js
      * disabledActions: [Action.SpotterShareConversationButtonHeader]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareConversationButtonHeader = 'spotterShareConversationButtonHeader',
     /**
@@ -8152,7 +8160,7 @@ export enum Action {
      * ```js
      * disabledActions: [Action.SpotterShareConversationMenuItemSidebar]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareConversationMenuItemSidebar = 'spotterShareConversationMenuItemSidebar',
     /**
@@ -8162,7 +8170,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.SpotterSharedConversationBanner]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterSharedConversationBanner = 'spotterSharedConversationBanner',
     /**
@@ -8172,7 +8180,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.SpotterSharedConversationBannerDismissButton]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterSharedConversationBannerDismissButton = 'spotterSharedConversationBannerDismissButton',
     /**
@@ -8183,7 +8191,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.SpotterSharedConversationExitButton]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterSharedConversationExitButton = 'spotterSharedConversationExitButton',
     /**
@@ -8193,7 +8201,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.SpotterShareUpToCurrentInfo]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareUpToCurrentInfo = 'spotterShareUpToCurrentInfo',
     /**
@@ -8203,7 +8211,7 @@ export enum Action {
      * ```js
      * disabledActions: [Action.SpotterShareIncludeNewMessagesCheckbox]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareIncludeNewMessagesCheckbox = 'spotterShareIncludeNewMessagesCheckbox',
     /**
@@ -8213,7 +8221,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.SpotterShareStaleInfoBannerDismissButton]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.9.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     SpotterShareStaleInfoBannerDismissButton = 'spotterShareStaleInfoBannerDismissButton',
     /**


### PR DESCRIPTION
Typed public API for Spotter Share-by-URL (SDK declaration layer; blink already handles these by string value off `embedParams`).

## Changes
- **`Action`** (8): header button, sidebar menu item, shared-view banner + dismiss, exit button, up-to-current info, include-new-messages checkbox, stale-info banner dismiss.
- **`EmbedEvent`** (10): 2 click events, Shared / ShareRevoked / Viewed, checkbox toggled, stale-banner dismissed, modal confirm / cancel clicked, exit clicked.
- **`HostEvent`** (3): `ShareSpotterConversation` (`conversationId` required), `CloseSpotterShareConversation`, `ExitSpotterSharedConversation`.
- **`SpotterShareConversationConfig`**: label/icon override fields.
- Specs mirroring existing `spotterSidebarConfig` / `spotterViz` coverage.

Version tag: SDK 1.52.0 | ThoughtSpot 26.9.0.cl. Epic SCAL-308315.

## Test
- `tsc` clean; 210/210 unit tests pass across the 3 affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)