### PR TITLE
SCAL-298895: Add optional applicability field to UpdateFilters and fi…

### DIFF
--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -7,6 +7,39 @@ export interface LiveboardTab {
   [key: string]: any;
 }
 
+/**
+ * Scopes a filter or parameter to a specific target, e.g. a single Liveboard tab.
+ */
+export interface Applicability {
+  level: 'TAB';
+  targetId: string;
+}
+
+export interface UpdateFiltersFilter {
+  column: string;
+  oper: string;
+  values: string[];
+  type?: string;
+  applicability?: Applicability;
+}
+
+export interface UpdateParametersParameter {
+  name: string;
+  value: unknown;
+  isVisibleToUser?: boolean;
+  applicability?: Applicability;
+}
+
+export interface LiveboardFilter {
+  applicability?: Applicability;
+  [key: string]: any;
+}
+
+export interface LiveboardParameter {
+  applicability?: Applicability;
+  [key: string]: any;
+}
+
 export enum UIPassthroughEvent {
   PinAnswerToLiveboard = 'addVizToPinboard',
   SaveAnswer = 'saveAnswer',
@@ -103,7 +136,7 @@ export type UIPassthroughContractBase = {
       vizId?: string;
     };
     response: {
-      liveboardFilters: Record<string, any>[];
+      liveboardFilters: LiveboardFilter[];
       runtimeFilters: RuntimeFilter[];
     };
   };
@@ -116,7 +149,7 @@ export type UIPassthroughContractBase = {
   [UIPassthroughEvent.GetParameters]: {
     request: Record<string, never>;
     response: {
-      parameters: Record<string, any>[];
+      parameters: LiveboardParameter[];
     };
   };
   [UIPassthroughEvent.GetTML]: {
@@ -143,18 +176,8 @@ export type UIPassthroughContractBase = {
   };
   [UIPassthroughEvent.UpdateFilters]: {
     request: {
-      filter?: {
-        column: string;
-        oper: string;
-        values: string[];
-        type?: string;
-      };
-      filters?: {
-        column: string;
-        oper: string;
-        values: string[];
-        type?: string;
-      }[];
+      filter?: UpdateFiltersFilter;
+      filters?: UpdateFiltersFilter[];
     };
     response: unknown;
   };

--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -8,11 +8,14 @@ export interface LiveboardTab {
 }
 
 /**
- * Scopes a filter or parameter to a specific target, e.g. a single Liveboard tab.
+ * Scopes a filter or parameter to a specific target.
+ * Supported levels are `LIVEBOARD`, `TAB`, and `GROUP`.
+ * At `LIVEBOARD` level the filter applies to the whole Liveboard, so `targetId`
+ * is not required.
  */
 export interface Applicability {
-  level: 'TAB';
-  targetId: string;
+  level: string;
+  targetId?: string;
 }
 
 export interface UpdateFiltersFilter {

--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -8,13 +8,21 @@ export interface LiveboardTab {
 }
 
 /**
+ * Levels at which a filter or parameter can be applied.
+ */
+export enum ApplicabilityLevel {
+  Liveboard = 'LIVEBOARD',
+  Tab = 'TAB',
+  Group = 'GROUP',
+}
+
+/**
  * Scopes a filter or parameter to a specific target.
- * Supported levels are `LIVEBOARD`, `TAB`, and `GROUP`.
  * At `LIVEBOARD` level the filter applies to the whole Liveboard, so `targetId`
  * is not required.
  */
 export interface Applicability {
-  level: string;
+  level: ApplicabilityLevel;
   targetId?: string;
 }
 

--- a/src/embed/hostEventClient/contracts.ts
+++ b/src/embed/hostEventClient/contracts.ts
@@ -18,18 +18,11 @@ export interface Applicability {
   targetId?: string;
 }
 
-export interface UpdateFiltersFilter {
+export interface FilterUpdate {
   column: string;
   oper: string;
   values: string[];
   type?: string;
-  applicability?: Applicability;
-}
-
-export interface UpdateParametersParameter {
-  name: string;
-  value: unknown;
-  isVisibleToUser?: boolean;
   applicability?: Applicability;
 }
 
@@ -179,8 +172,8 @@ export type UIPassthroughContractBase = {
   };
   [UIPassthroughEvent.UpdateFilters]: {
     request: {
-      filter?: UpdateFiltersFilter;
-      filters?: UpdateFiltersFilter[];
+      filter?: FilterUpdate;
+      filters?: FilterUpdate[];
     };
     response: unknown;
   };

--- a/src/embed/hostEventClient/host-event-client.spec.ts
+++ b/src/embed/hostEventClient/host-event-client.spec.ts
@@ -311,6 +311,70 @@ describe('HostEventClient', () => {
             );
         });
 
+        it('should dispatch UpdateParameters over the legacy channel', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            const payload = [
+                { name: 'param1', value: 10, applicability: { level: 'TAB', targetId: 'tab-guid-1' } },
+            ] as any;
+            mockProcessTrigger.mockResolvedValueOnce({ success: true });
+
+            const result = await client.triggerHostEvent(HostEvent.UpdateParameters, payload);
+
+            expect(mockProcessTrigger).toHaveBeenCalledTimes(1);
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UpdateParameters,
+                mockThoughtSpotHost,
+                payload,
+                undefined,
+            );
+            expect(result).toEqual({ success: true });
+        });
+
+        it('should forward UpdateParameters with null applicability', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            const payload = [{ name: 'param1', value: 10, applicability: null }] as any;
+            mockProcessTrigger.mockResolvedValueOnce({ success: true });
+
+            await client.triggerHostEvent(HostEvent.UpdateParameters, payload);
+
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UpdateParameters,
+                mockThoughtSpotHost,
+                payload,
+                undefined,
+            );
+        });
+
+        it('should throw when UpdateParameters entry has invalid applicability', async () => {
+            const { client } = createHostEventClient();
+            const invalidPayload = [
+                { name: 'param1', value: 10, applicability: { level: 'TAB' } }, // missing targetId
+            ] as any;
+
+            await expect(client.triggerHostEvent(HostEvent.UpdateParameters, invalidPayload))
+                .rejects.toThrow('UpdateParameters received an invalid applicability');
+            expect(mockProcessTrigger).not.toHaveBeenCalled();
+        });
+
+        it('should pass context to UpdateParameters event', async () => {
+            const { client, mockIframe } = createHostEventClient();
+            const payload = [{ name: 'param1', value: 10 }] as any;
+            const context = { vizId: 'viz-1' } as any;
+            mockProcessTrigger.mockResolvedValueOnce({ success: true });
+
+            await client.triggerHostEvent(HostEvent.UpdateParameters, payload, context);
+
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                mockIframe,
+                HostEvent.UpdateParameters,
+                mockThoughtSpotHost,
+                payload,
+                context,
+            );
+        });
+
         it('should throw when DrillDown payload has no valid points', async () => {
             const { client } = createHostEventClient();
             const invalidPayload = {} as any;

--- a/src/embed/hostEventClient/host-event-client.ts
+++ b/src/embed/hostEventClient/host-event-client.ts
@@ -3,8 +3,10 @@ import { processTrigger as processTriggerService } from '../../utils/processTrig
 import { getEmbedConfig } from '../embedConfig';
 import {
     isValidUpdateFiltersPayload,
+    isValidUpdateParametersPayload,
     isValidDrillDownPayload,
     throwUpdateFiltersValidationError,
+    throwUpdateParametersValidationError,
     throwDrillDownValidationError,
 } from './utils';
 import {
@@ -58,6 +60,7 @@ export class HostEventClient {
           [HostEvent.Pin]: (p, c) => this.handlePinEvent(p, c),
           [HostEvent.SaveAnswer]: (p, c) => this.handleSaveAnswerEvent(p, c),
           [HostEvent.UpdateFilters]: (p, c) => this.handleUpdateFiltersEvent(p, c),
+          [HostEvent.UpdateParameters]: (p, c) => this.handleUpdateParametersEvent(p, c),
           [HostEvent.DrillDown]: (p, c) => this.handleDrillDownEvent(p, c),
       };
   }
@@ -241,6 +244,18 @@ export class HostEventClient {
     }
 
     return this.handleHostEventWithParam(UIPassthroughEvent.UpdateFilters, payload, context as ContextType);
+  }
+
+  protected handleUpdateParametersEvent(
+    payload: HostEventRequest<HostEvent.UpdateParameters>,
+    context?: ContextType,
+  ): Promise<any> {
+    if (!isValidUpdateParametersPayload(payload)) {
+      throwUpdateParametersValidationError();
+    }
+
+    // UpdateParameters has no UI passthrough contract; dispatch over the legacy channel
+    return this.hostEventFallback(HostEvent.UpdateParameters, payload, context);
   }
 
   protected handleDrillDownEvent(

--- a/src/embed/hostEventClient/utils.spec.ts
+++ b/src/embed/hostEventClient/utils.spec.ts
@@ -114,6 +114,84 @@ describe('hostEventClient utils', () => {
                 filters: [{ column: 'y' }], // invalid
             } as any)).toBe(true);
         });
+
+        it('returns true for filter without applicability', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: { column: 'x', oper: 'EQ', values: ['a'] },
+            } as any)).toBe(true);
+        });
+
+        it('returns true for filter with valid applicability', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { level: 'TAB', targetId: 'tab-guid-1' },
+                },
+            } as any)).toBe(true);
+        });
+
+        it('returns true for filters array with applicability on some filters', () => {
+            expect(isValidUpdateFiltersPayload({
+                filters: [
+                    {
+                        column: 'x',
+                        oper: 'IN',
+                        values: ['a', 'b'],
+                        applicability: { level: 'TAB', targetId: 'tab-guid-1' },
+                    },
+                    { column: 'y', oper: 'EQ', values: ['c'] },
+                ],
+            } as any)).toBe(true);
+        });
+
+        it('returns false for applicability missing targetId', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { level: 'TAB' },
+                },
+            } as any)).toBe(false);
+        });
+
+        it('returns false for applicability missing level', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { targetId: 'tab-guid-1' },
+                },
+            } as any)).toBe(false);
+        });
+
+        it('returns false for applicability with non-string level', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { level: 123, targetId: 'tab-guid-1' },
+                },
+            } as any)).toBe(false);
+        });
+
+        it('returns false if one filter in filters array has invalid applicability', () => {
+            expect(isValidUpdateFiltersPayload({
+                filters: [
+                    { column: 'x', oper: 'EQ', values: ['a'] },
+                    {
+                        column: 'y',
+                        oper: 'EQ',
+                        values: ['b'],
+                        applicability: { level: 'TAB' }, // missing targetId
+                    },
+                ],
+            } as any)).toBe(false);
+        });
     });
 
     // =========================

--- a/src/embed/hostEventClient/utils.spec.ts
+++ b/src/embed/hostEventClient/utils.spec.ts
@@ -1,8 +1,10 @@
 import {
     isValidUpdateFiltersPayload,
+    isValidUpdateParametersPayload,
     isValidDrillDownPayload,
     createValidationError,
     throwUpdateFiltersValidationError,
+    throwUpdateParametersValidationError,
     throwDrillDownValidationError,
 } from './utils';
 import { ERROR_MESSAGE } from '../../errors';
@@ -157,6 +159,17 @@ describe('hostEventClient utils', () => {
             } as any)).toBe(false);
         });
 
+        it('returns false for applicability with empty targetId', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { level: 'TAB', targetId: '' },
+                },
+            } as any)).toBe(false);
+        });
+
         it('returns false for null applicability', () => {
             expect(isValidUpdateFiltersPayload({
                 filter: {
@@ -224,6 +237,79 @@ describe('hostEventClient utils', () => {
                     },
                 ],
             } as any)).toBe(false);
+        });
+    });
+
+    // =========================
+    // UpdateParameters Validation
+    // =========================
+    describe('isValidUpdateParametersPayload', () => {
+        it('returns true for undefined payload', () => {
+            expect(isValidUpdateParametersPayload(undefined)).toBe(true);
+        });
+
+        it('returns true for non-array payload', () => {
+            expect(isValidUpdateParametersPayload({ name: 'p', value: 1 })).toBe(true);
+        });
+
+        it('returns true for parameters without applicability', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p1', value: 1 },
+                { name: 'p2', value: 'a' },
+            ])).toBe(true);
+        });
+
+        it('returns true for null applicability', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: null },
+            ])).toBe(true);
+        });
+
+        it('returns true for valid TAB applicability with targetId', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: { level: 'TAB', targetId: 'tab-guid-1' } },
+            ])).toBe(true);
+        });
+
+        it('returns true for LIVEBOARD level applicability without targetId', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: { level: 'LIVEBOARD' } },
+            ])).toBe(true);
+        });
+
+        it('returns false for applicability missing targetId', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: { level: 'TAB' } },
+            ])).toBe(false);
+        });
+
+        it('returns false for applicability with empty targetId', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: { level: 'GROUP', targetId: ' ' } },
+            ])).toBe(false);
+        });
+
+        it('returns false for applicability with invalid level', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: { level: 'VIZ', targetId: 'guid-1' } },
+            ])).toBe(false);
+        });
+
+        it('returns false for non-object applicability', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p', value: 1, applicability: 'TAB' },
+            ])).toBe(false);
+        });
+
+        it('returns false if one parameter has invalid applicability', () => {
+            expect(isValidUpdateParametersPayload([
+                { name: 'p1', value: 1 },
+                { name: 'p2', value: 2, applicability: { level: 'GROUP' } }, // missing targetId
+            ])).toBe(false);
+        });
+
+        it('returns true for non-object entries', () => {
+            expect(isValidUpdateParametersPayload(['p', 1, null])).toBe(true);
         });
     });
 
@@ -324,6 +410,13 @@ describe('hostEventClient utils', () => {
         it('throws with UPDATEFILTERS_INVALID_PAYLOAD message', () => {
             expect(() => throwUpdateFiltersValidationError())
                 .toThrow(ERROR_MESSAGE.UPDATEFILTERS_INVALID_PAYLOAD);
+        });
+    });
+
+    describe('throwUpdateParametersValidationError', () => {
+        it('throws with UPDATEPARAMETERS_INVALID_PAYLOAD message', () => {
+            expect(() => throwUpdateParametersValidationError())
+                .toThrow(ERROR_MESSAGE.UPDATEPARAMETERS_INVALID_PAYLOAD);
         });
     });
 

--- a/src/embed/hostEventClient/utils.spec.ts
+++ b/src/embed/hostEventClient/utils.spec.ts
@@ -157,6 +157,39 @@ describe('hostEventClient utils', () => {
             } as any)).toBe(false);
         });
 
+        it('returns false for null applicability', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: null,
+                },
+            } as any)).toBe(false);
+        });
+
+        it('returns false for non-object applicability', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: 'TAB',
+                },
+            } as any)).toBe(false);
+        });
+
+        it('returns true for LIVEBOARD level applicability without targetId', () => {
+            expect(isValidUpdateFiltersPayload({
+                filter: {
+                    column: 'x',
+                    oper: 'EQ',
+                    values: ['a'],
+                    applicability: { level: 'LIVEBOARD' },
+                },
+            } as any)).toBe(true);
+        });
+
         it('returns false for applicability missing level', () => {
             expect(isValidUpdateFiltersPayload({
                 filter: {

--- a/src/embed/hostEventClient/utils.ts
+++ b/src/embed/hostEventClient/utils.ts
@@ -1,3 +1,6 @@
+import isPlainObject from 'lodash/isPlainObject';
+import isString from 'lodash/isString';
+import isUndefined from 'lodash/isUndefined';
 import { EmbedErrorCodes, EmbedEvent, ErrorDetailsTypes, HostEvent } from '../../types';
 import { ERROR_MESSAGE } from '../../errors';
 import { HostEventRequest } from './contracts';
@@ -9,11 +12,11 @@ export function isValidUpdateFiltersPayload(
   if (!payload) return false;
 
   const isValidApplicability = (a?: { level?: string; targetId?: string }) => {
-    if (a === undefined) return true;
+    if (isUndefined(a)) return true;
     // targetId is not required at LIVEBOARD level, since the filter applies to the whole Liveboard
-    return typeof a === 'object' && a !== null
-        && typeof a.level === 'string'
-        && (a.level === 'LIVEBOARD' || typeof a.targetId === 'string');
+    return isPlainObject(a)
+        && isString(a.level)
+        && (a.level === 'LIVEBOARD' || isString(a.targetId));
   };
 
   const isValidFilter = (f: {

--- a/src/embed/hostEventClient/utils.ts
+++ b/src/embed/hostEventClient/utils.ts
@@ -9,8 +9,11 @@ export function isValidUpdateFiltersPayload(
   if (!payload) return false;
 
   const isValidApplicability = (a?: { level?: string; targetId?: string }) => {
-    if (!a) return true;
-    return typeof a.level === 'string' && typeof a.targetId === 'string';
+    if (a === undefined) return true;
+    // targetId is not required at LIVEBOARD level, since the filter applies to the whole Liveboard
+    return typeof a === 'object' && a !== null
+        && typeof a.level === 'string'
+        && (a.level === 'LIVEBOARD' || typeof a.targetId === 'string');
   };
 
   const isValidFilter = (f: {

--- a/src/embed/hostEventClient/utils.ts
+++ b/src/embed/hostEventClient/utils.ts
@@ -3,7 +3,7 @@ import isString from 'lodash/isString';
 import isUndefined from 'lodash/isUndefined';
 import { EmbedErrorCodes, EmbedEvent, ErrorDetailsTypes, HostEvent } from '../../types';
 import { ERROR_MESSAGE } from '../../errors';
-import { HostEventRequest } from './contracts';
+import { ApplicabilityLevel, HostEventRequest } from './contracts';
 import { embedEventStatus } from '../../utils';
 
 export function isValidUpdateFiltersPayload(
@@ -15,8 +15,8 @@ export function isValidUpdateFiltersPayload(
     if (isUndefined(a)) return true;
     // targetId is not required at LIVEBOARD level, since the filter applies to the whole Liveboard
     return isPlainObject(a)
-        && isString(a.level)
-        && (a.level === 'LIVEBOARD' || isString(a.targetId));
+        && Object.values(ApplicabilityLevel).includes(a.level as ApplicabilityLevel)
+        && (a.level === ApplicabilityLevel.Liveboard || isString(a.targetId));
   };
 
   const isValidFilter = (f: {

--- a/src/embed/hostEventClient/utils.ts
+++ b/src/embed/hostEventClient/utils.ts
@@ -8,20 +8,26 @@ export function isValidUpdateFiltersPayload(
 ): boolean {
   if (!payload) return false;
 
-  const isValidFilter = (f: { 
-    column?: string; 
-    oper?: string; 
-    values?: unknown[]; 
-    type?: string; 
-    columnName?: string; 
-    operator?: string 
+  const isValidApplicability = (a?: { level?: string; targetId?: string }) => {
+    if (!a) return true;
+    return typeof a.level === 'string' && typeof a.targetId === 'string';
+  };
+
+  const isValidFilter = (f: {
+    column?: string;
+    oper?: string;
+    values?: unknown[];
+    type?: string;
+    columnName?: string;
+    operator?: string;
+    applicability?: { level?: string; targetId?: string };
   }) => {
     const hasColumn = typeof f.column === 'string' || typeof f.columnName === 'string';
     const hasOperator = typeof f.oper === 'string' || typeof f.operator === 'string';
     const hasValues = Array.isArray(f.values);
     const validType = !f.type || typeof f.type === 'string';
-  
-    return hasColumn && hasOperator && hasValues && validType;
+
+    return hasColumn && hasOperator && hasValues && validType && isValidApplicability(f.applicability);
   };
 
   const hasValidFilter = payload.filter && isValidFilter(payload.filter);

--- a/src/embed/hostEventClient/utils.ts
+++ b/src/embed/hostEventClient/utils.ts
@@ -1,3 +1,4 @@
+import isNil from 'lodash/isNil';
 import isPlainObject from 'lodash/isPlainObject';
 import isString from 'lodash/isString';
 import isUndefined from 'lodash/isUndefined';
@@ -6,18 +7,18 @@ import { ERROR_MESSAGE } from '../../errors';
 import { ApplicabilityLevel, HostEventRequest } from './contracts';
 import { embedEventStatus } from '../../utils';
 
+const isValidApplicability = (a?: { level?: string; targetId?: string }) => {
+  if (isUndefined(a)) return true;
+  // targetId is not required at LIVEBOARD level, since the filter applies to the whole Liveboard
+  return isPlainObject(a)
+      && Object.values(ApplicabilityLevel).includes(a.level as ApplicabilityLevel)
+      && (a.level === ApplicabilityLevel.Liveboard || (isString(a.targetId) && a.targetId.trim().length > 0));
+};
+
 export function isValidUpdateFiltersPayload(
   payload: HostEventRequest<HostEvent.UpdateFilters> | undefined,
 ): boolean {
   if (!payload) return false;
-
-  const isValidApplicability = (a?: { level?: string; targetId?: string }) => {
-    if (isUndefined(a)) return true;
-    // targetId is not required at LIVEBOARD level, since the filter applies to the whole Liveboard
-    return isPlainObject(a)
-        && Object.values(ApplicabilityLevel).includes(a.level as ApplicabilityLevel)
-        && (a.level === ApplicabilityLevel.Liveboard || isString(a.targetId));
-  };
 
   const isValidFilter = (f: {
     column?: string;
@@ -40,6 +41,16 @@ export function isValidUpdateFiltersPayload(
   const hasValidFilters = Array.isArray(payload.filters) && payload.filters.length > 0 && payload.filters.every(isValidFilter);
 
   return !!(hasValidFilter || hasValidFilters);
+}
+
+export function isValidUpdateParametersPayload(payload: unknown): boolean {
+  // Only validates the applicability of each parameter (null treated as absent); the rest is forwarded as-is for backward compatibility.
+  if (!Array.isArray(payload)) return true;
+  return payload.every((p) => {
+      if (!isPlainObject(p)) return true;
+      const { applicability } = p as { applicability?: { level?: string; targetId?: string } };
+      return isNil(applicability) || isValidApplicability(applicability);
+  });
 }
 
 export function isValidDrillDownPayload(
@@ -83,4 +94,8 @@ export function throwUpdateFiltersValidationError(): never {
 
 export function throwDrillDownValidationError(): never {
   createValidationError(ERROR_MESSAGE.DRILLDOWN_INVALID_PAYLOAD);
+}
+
+export function throwUpdateParametersValidationError(): never {
+  createValidationError(ERROR_MESSAGE.UPDATEPARAMETERS_INVALID_PAYLOAD);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,6 +31,7 @@ export const ERROR_MESSAGE = {
     INVALID_SPOTTER_DOCUMENTATION_URL: 'Invalid spotterDocumentationUrl. Please provide a valid http or https URL.',
     UPDATEFILTERS_INVALID_PAYLOAD: 'UpdateFilters requires a valid filter or filters array. Expected: { filter: { column, oper, values } } or { filters: [{ column, oper, values }, ...] }',
     DRILLDOWN_INVALID_PAYLOAD: 'DrillDown requires a valid points object. Expected: { points: { clickedPoint?, selectedPoints? }, autoDrillDown?, vizId? }',
+    UPDATEPARAMETERS_INVALID_PAYLOAD: 'UpdateParameters received an invalid applicability. Expected: { level: LIVEBOARD | TAB | GROUP, targetId } where targetId is required for TAB and GROUP levels',
 };
 
 export const CUSTOM_ACTIONS_ERROR_MESSAGE = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5320,8 +5320,11 @@ export enum HostEvent {
      * Get details of filters applied on the Liveboard.
      * Returns arrays containing Liveboard filter and runtime filter elements.
      * Each Liveboard filter may include an `applicability` attribute
-     * (`{ level, targetId }`) indicating the scope of the filter,
-     * for example, a specific Liveboard tab.
+     * indicating the scope of the filter. It contains a `level`
+     * (`LIVEBOARD`, `TAB`, or `GROUP`) and, when `level` is `TAB` or
+     * `GROUP`, a `targetId` with the GUID of the target. At `LIVEBOARD`
+     * level there is no `targetId`, since the filter applies to the
+     * whole Liveboard.
      * The `applicability` attribute is available from SDK: 1.51.0 |
      * ThoughtSpot: 26.10.0.cl.
      * @example
@@ -5370,8 +5373,9 @@ export enum HostEvent {
      *
      *  - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.
      *  - `targetId`: The GUID of the target, for example, the tab GUID.
-     *    Not required when `level` is `LIVEBOARD`, since the filter applies
-     *    to the whole Liveboard.
+     *    Required when `level` is `TAB` or `GROUP`. Do not pass it when
+     *    `level` is `LIVEBOARD`, since the filter applies to the whole
+     *    Liveboard.
      * @example
      * ```js
      *
@@ -5614,6 +5618,15 @@ export enum HostEvent {
      * - `name`: Name of the parameter.
      * - `value`: The value to set for the parameter.
      * - `isVisibleToUser`: Optional. To control the visibility of the parameter chip.
+     * - `applicability`: Optional. Scopes the parameter to a specific target,
+     * for example, a single Liveboard tab. Available from SDK: 1.51.0 |
+     * ThoughtSpot: 26.10.0.cl. Includes the following attributes:
+     *
+     *    - `level`: The scope of the parameter: `LIVEBOARD`, `TAB`, or `GROUP`.
+     *    - `targetId`: The GUID of the target, for example, the tab GUID.
+     *      Required when `level` is `TAB` or `GROUP`. Do not pass it when
+     *      `level` is `LIVEBOARD`, since the parameter applies to the whole
+     *      Liveboard.
      *
      * @example
      * ```js
@@ -5621,6 +5634,18 @@ export enum HostEvent {
      *   name: "Integer Range Param",
      *   value: 10,
      *   isVisibleToUser: false
+     * }])
+     * ```
+     * @example
+     * ```js
+     * // Scope the parameter to a specific Liveboard tab
+     * liveboardEmbed.trigger(HostEvent.UpdateParameters, [{
+     *   name: "Integer Range Param",
+     *   value: 10,
+     *   applicability: {
+     *     level: "TAB",
+     *     targetId: "e0836cad-4fdf-42d4-bd97-567a6b2a6058"
+     *   }
      * }])
      * ```
      * @example
@@ -5639,8 +5664,11 @@ export enum HostEvent {
     /**
      * Triggers GetParameters to fetch the runtime Parameters.
      * Each parameter may include an `applicability` attribute
-     * (`{ level, targetId }`) indicating the scope of the parameter,
-     * for example, a specific Liveboard tab.
+     * indicating the scope of the parameter. It contains a `level`
+     * (`LIVEBOARD`, `TAB`, or `GROUP`) and, when `level` is `TAB` or
+     * `GROUP`, a `targetId` with the GUID of the target. At `LIVEBOARD`
+     * level there is no `targetId`, since the parameter applies to the
+     * whole Liveboard.
      * The `applicability` attribute is available from SDK: 1.51.0 |
      * ThoughtSpot: 26.10.0.cl.
      * @param - `vizId` refers to the Answer ID in Spotter embed and is required in Spotter embed.

--- a/src/types.ts
+++ b/src/types.ts
@@ -5319,6 +5319,9 @@ export enum HostEvent {
     /**
      * Get details of filters applied on the Liveboard.
      * Returns arrays containing Liveboard filter and runtime filter elements.
+     * Each Liveboard filter may include an `applicability` attribute
+     * (`{ level, targetId }`) indicating the scope of the filter,
+     * for example, a specific Liveboard tab.
      * @example
      * ```js
      * const data = await liveboardEmbed.trigger(HostEvent.GetFilters);
@@ -5358,6 +5361,12 @@ export enum HostEvent {
      *
      * `type`  - To update filters for date time, specify the date format type.
      * For more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].
+     *
+     * `applicability` - Optional. Scopes the filter to a specific target,
+     * for example, a single Liveboard tab. Includes the following attributes:
+     *
+     *  - `level`: The scope of the filter, for example, `TAB`.
+     *  - `targetId`: The GUID of the target, for example, the tab GUID.
      * @example
      * ```js
      *
@@ -5433,6 +5442,21 @@ export enum HostEvent {
      *         values: ["shoes", "boots"]
      *     }
      * }, ContextType.Liveboard);
+     * ```
+     * @example
+     * ```js
+     * // Scope the filter to a specific Liveboard tab
+     * liveboardEmbed.trigger(HostEvent.UpdateFilters, {
+     *     filter: {
+     *         column: "item type",
+     *         oper: "IN",
+     *         values: ["bags", "shirts"],
+     *         applicability: {
+     *             level: "TAB",
+     *             targetId: "e0836cad-4fdf-42d4-bd97-567a6b2a6058"
+     *         }
+     *     }
+     * });
      * ```
      * @version SDK: 1.23.0 | ThoughtSpot: 9.4.0.cl
      */
@@ -5609,6 +5633,9 @@ export enum HostEvent {
     UpdateParameters = 'UpdateParameters',
     /**
      * Triggers GetParameters to fetch the runtime Parameters.
+     * Each parameter may include an `applicability` attribute
+     * (`{ level, targetId }`) indicating the scope of the parameter,
+     * for example, a specific Liveboard tab.
      * @param - `vizId` refers to the Answer ID in Spotter embed and is required in Spotter embed.
      * ```js
      * liveboardEmbed.trigger(HostEvent.GetParameters).then((parameter) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5365,8 +5365,10 @@ export enum HostEvent {
      * `applicability` - Optional. Scopes the filter to a specific target,
      * for example, a single Liveboard tab. Includes the following attributes:
      *
-     *  - `level`: The scope of the filter, for example, `TAB`.
+     *  - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.
      *  - `targetId`: The GUID of the target, for example, the tab GUID.
+     *    Not required when `level` is `LIVEBOARD`, since the filter applies
+     *    to the whole Liveboard.
      * @example
      * ```js
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -5322,6 +5322,8 @@ export enum HostEvent {
      * Each Liveboard filter may include an `applicability` attribute
      * (`{ level, targetId }`) indicating the scope of the filter,
      * for example, a specific Liveboard tab.
+     * The `applicability` attribute is available from SDK: 1.51.0 |
+     * ThoughtSpot: 26.10.0.cl.
      * @example
      * ```js
      * const data = await liveboardEmbed.trigger(HostEvent.GetFilters);
@@ -5363,7 +5365,8 @@ export enum HostEvent {
      * For more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].
      *
      * `applicability` - Optional. Scopes the filter to a specific target,
-     * for example, a single Liveboard tab. Includes the following attributes:
+     * for example, a single Liveboard tab. Available from SDK: 1.51.0 |
+     * ThoughtSpot: 26.10.0.cl. Includes the following attributes:
      *
      *  - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.
      *  - `targetId`: The GUID of the target, for example, the tab GUID.
@@ -5638,6 +5641,8 @@ export enum HostEvent {
      * Each parameter may include an `applicability` attribute
      * (`{ level, targetId }`) indicating the scope of the parameter,
      * for example, a specific Liveboard tab.
+     * The `applicability` attribute is available from SDK: 1.51.0 |
+     * ThoughtSpot: 26.10.0.cl.
      * @param - `vizId` refers to the Answer ID in Spotter embed and is required in Spotter embed.
      * ```js
      * liveboardEmbed.trigger(HostEvent.GetParameters).then((parameter) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8505,6 +8505,9 @@ export enum EmbedErrorCodes {
 
     /** DrillDown payload is invalid - missing or malformed points */
     DRILLDOWN_INVALID_PAYLOAD = 'DRILLDOWN_INVALID_PAYLOAD',
+
+    /** UpdateParameters payload is invalid - malformed applicability */
+    UPDATEPARAMETERS_INVALID_PAYLOAD = 'UPDATEPARAMETERS_INVALID_PAYLOAD',
 }
 
 /**

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2178,
+			"id": 2179,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2301,
+					"id": 2302,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -49,14 +49,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7487,
+							"line": 7494,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2198,
+					"id": 2199,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -77,14 +77,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6520,
+							"line": 6527,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2191,
+					"id": 2192,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -105,14 +105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6449,
+							"line": 6456,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2190,
+					"id": 2191,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -129,14 +129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6438,
+							"line": 6445,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2196,
+					"id": 2197,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -153,14 +153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6501,
+							"line": 6508,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2197,
+					"id": 2198,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -177,14 +177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6510,
+							"line": 6517,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2199,
+					"id": 2200,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -205,14 +205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6530,
+							"line": 6537,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2281,
+					"id": 2282,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -233,14 +233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7255,
+							"line": 7262,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2251,
+					"id": 2252,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -261,14 +261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6948,
+							"line": 6955,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2297,
+					"id": 2298,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -289,14 +289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7440,
+							"line": 7447,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2250,
+					"id": 2251,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -317,14 +317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6936,
+							"line": 6943,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2249,
+					"id": 2250,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -345,14 +345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6924,
+							"line": 6931,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2296,
+					"id": 2297,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -374,14 +374,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7429,
+							"line": 7436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2263,
+					"id": 2264,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -402,14 +402,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7070,
+							"line": 7077,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2275,
+					"id": 2276,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -430,14 +430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7201,
+							"line": 7208,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2266,
+					"id": 2267,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -458,14 +458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7104,
+							"line": 7111,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2271,
+					"id": 2272,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -486,14 +486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7159,
+							"line": 7166,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2265,
+					"id": 2266,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -514,14 +514,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7093,
+							"line": 7100,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2268,
+					"id": 2269,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -542,14 +542,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7127,
+							"line": 7134,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2276,
+					"id": 2277,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -570,14 +570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7211,
+							"line": 7218,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2272,
+					"id": 2273,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -598,14 +598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7169,
+							"line": 7176,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2269,
+					"id": 2270,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -626,14 +626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7138,
+							"line": 7145,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2274,
+					"id": 2275,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -654,14 +654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7191,
+							"line": 7198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2270,
+					"id": 2271,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -682,14 +682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7148,
+							"line": 7155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2267,
+					"id": 2268,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -710,14 +710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7115,
+							"line": 7122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2273,
+					"id": 2274,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -738,14 +738,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7179,
+							"line": 7186,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2264,
+					"id": 2265,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -766,14 +766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7081,
+							"line": 7088,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2310,
+					"id": 2311,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -794,14 +794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7585,
+							"line": 7592,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2195,
+					"id": 2196,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -818,14 +818,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6492,
+							"line": 6499,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2194,
+					"id": 2195,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -846,14 +846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6483,
+							"line": 6490,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2193,
+					"id": 2194,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -874,14 +874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6471,
+							"line": 6478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2318,
+					"id": 2319,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -902,14 +902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7673,
+							"line": 7680,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2192,
+					"id": 2193,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -926,14 +926,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6460,
+							"line": 6467,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2242,
+					"id": 2243,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -941,14 +941,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6873,
+							"line": 6880,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2185,
+					"id": 2186,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -965,14 +965,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6397,
+							"line": 6404,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2241,
+					"id": 2242,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -989,14 +989,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6872,
+							"line": 6879,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2319,
+					"id": 2320,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1017,14 +1017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7683,
+							"line": 7690,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2333,
+					"id": 2334,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1045,14 +1045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7843,
+							"line": 7850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2294,
+					"id": 2295,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1073,14 +1073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7404,
+							"line": 7411,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2254,
+					"id": 2255,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1101,14 +1101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6978,
+							"line": 6985,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2259,
+					"id": 2260,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1129,14 +1129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7028,
+							"line": 7035,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2311,
+					"id": 2312,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1157,14 +1157,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7597,
+							"line": 7604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2316,
+					"id": 2317,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1185,14 +1185,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7654,
+							"line": 7661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2307,
+					"id": 2308,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1213,14 +1213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7554,
+							"line": 7561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2309,
+					"id": 2310,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1241,14 +1241,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7573,
+							"line": 7580,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2207,
+					"id": 2208,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1265,14 +1265,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6580,
+							"line": 6587,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2210,
+					"id": 2211,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1289,14 +1289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6613,
+							"line": 6620,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2209,
+					"id": 2210,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1314,14 +1314,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6603,
+							"line": 6610,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2208,
+					"id": 2209,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1338,14 +1338,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6590,
+							"line": 6597,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2211,
+					"id": 2212,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1362,14 +1362,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6623,
+							"line": 6630,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2212,
+					"id": 2213,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1390,14 +1390,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6633,
+							"line": 6640,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2214,
+					"id": 2215,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1418,14 +1418,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6657,
+							"line": 6664,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2213,
+					"id": 2214,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1446,14 +1446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6643,
+							"line": 6650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2216,
+					"id": 2217,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1474,14 +1474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6677,
+							"line": 6684,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2215,
+					"id": 2216,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1502,14 +1502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6667,
+							"line": 6674,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2246,
+					"id": 2247,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1526,14 +1526,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6889,
+							"line": 6896,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2240,
+					"id": 2241,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1550,14 +1550,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6862,
+							"line": 6869,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2239,
+					"id": 2240,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1574,14 +1574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6853,
+							"line": 6860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2224,
+					"id": 2225,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1598,14 +1598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6753,
+							"line": 6760,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2184,
+					"id": 2185,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1622,14 +1622,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6388,
+							"line": 6395,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2253,
+					"id": 2254,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1650,14 +1650,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6967,
+							"line": 6974,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2244,
+					"id": 2245,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1665,14 +1665,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6878,
+							"line": 6885,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2315,
+					"id": 2316,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1693,14 +1693,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7643,
+							"line": 7650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2285,
+					"id": 2286,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1721,14 +1721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7299,
+							"line": 7306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2302,
+					"id": 2303,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1749,14 +1749,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7500,
+							"line": 7507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2221,
+					"id": 2222,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1773,14 +1773,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6721,
+							"line": 6728,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2225,
+					"id": 2226,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1797,14 +1797,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6761,
+							"line": 6768,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2317,
+					"id": 2318,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1825,14 +1825,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7664,
+							"line": 7671,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2282,
+					"id": 2283,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1853,14 +1853,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7265,
+							"line": 7272,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2283,
+					"id": 2284,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1881,14 +1881,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7276,
+							"line": 7283,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2238,
+					"id": 2239,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1905,14 +1905,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6842,
+							"line": 6849,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2218,
+					"id": 2219,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1930,14 +1930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6693,
+							"line": 6700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2219,
+					"id": 2220,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1954,14 +1954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6703,
+							"line": 6710,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2320,
+					"id": 2321,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1982,14 +1982,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7698,
+							"line": 7705,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2347,
+					"id": 2348,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2010,14 +2010,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7988,
+							"line": 7995,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2308,
+					"id": 2309,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2038,14 +2038,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7564,
+							"line": 7571,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2232,
+					"id": 2233,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2062,14 +2062,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6803,
+							"line": 6810,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2326,
+					"id": 2327,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2090,14 +2090,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7764,
+							"line": 7771,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2292,
+					"id": 2293,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2118,14 +2118,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7372,
+							"line": 7379,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2183,
+					"id": 2184,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2142,14 +2142,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6379,
+							"line": 6386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2289,
+					"id": 2290,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2166,14 +2166,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7340,
+							"line": 7347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2258,
+					"id": 2259,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2194,14 +2194,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7018,
+							"line": 7025,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2328,
+					"id": 2329,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2222,14 +2222,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7790,
+							"line": 7797,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2306,
+					"id": 2307,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2250,14 +2250,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7543,
+							"line": 7550,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2280,
+					"id": 2281,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2278,14 +2278,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7245,
+							"line": 7252,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2287,
+					"id": 2288,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2305,14 +2305,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7320,
+							"line": 7327,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2332,
+					"id": 2333,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2333,14 +2333,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7833,
+							"line": 7840,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2331,
+					"id": 2332,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2361,14 +2361,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7823,
+							"line": 7830,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2288,
+					"id": 2289,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2385,14 +2385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7329,
+							"line": 7336,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2299,
+					"id": 2300,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2417,14 +2417,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7464,
+							"line": 7471,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2300,
+					"id": 2301,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2445,14 +2445,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7476,
+							"line": 7483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2330,
+					"id": 2331,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2473,14 +2473,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7813,
+							"line": 7820,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2303,
+					"id": 2304,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2501,14 +2501,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7511,
+							"line": 7518,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2290,
+					"id": 2291,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2533,14 +2533,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7352,
+							"line": 7359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2291,
+					"id": 2292,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2561,14 +2561,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7362,
+							"line": 7369,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2235,
+					"id": 2236,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2585,14 +2585,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6820,
+							"line": 6827,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2324,
+					"id": 2325,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2609,14 +2609,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7742,
+							"line": 7749,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2222,
+					"id": 2223,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2633,14 +2633,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6731,
+							"line": 6738,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2312,
+					"id": 2313,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2661,14 +2661,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7609,
+							"line": 7616,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2327,
+					"id": 2328,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2689,14 +2689,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7777,
+							"line": 7784,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2248,
+					"id": 2249,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2714,14 +2714,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6914,
+							"line": 6921,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2353,
+					"id": 2354,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2742,14 +2742,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8061,
+							"line": 8068,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2226,
+					"id": 2227,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2766,14 +2766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6771,
+							"line": 6778,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2325,
+					"id": 2326,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2794,14 +2794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7754,
+							"line": 7761,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2262,
+					"id": 2263,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2822,14 +2822,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7059,
+							"line": 7066,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2252,
+					"id": 2253,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2850,14 +2850,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6958,
+							"line": 6965,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2298,
+					"id": 2299,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2878,14 +2878,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7451,
+							"line": 7458,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2278,
+					"id": 2279,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2906,14 +2906,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7225,
+							"line": 7232,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2255,
+					"id": 2256,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2937,14 +2937,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6987,
+							"line": 6994,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2247,
+					"id": 2248,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2961,14 +2961,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6898,
+							"line": 6905,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2279,
+					"id": 2280,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2989,14 +2989,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7235,
+							"line": 7242,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2313,
+					"id": 2314,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3017,14 +3017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7621,
+							"line": 7628,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2286,
+					"id": 2287,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3045,14 +3045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7311,
+							"line": 7318,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2179,
+					"id": 2180,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3069,14 +3069,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6348,
+							"line": 6355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2182,
+					"id": 2183,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3093,14 +3093,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6366,
+							"line": 6373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2187,
+					"id": 2188,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3117,14 +3117,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6411,
+							"line": 6418,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2188,
+					"id": 2189,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3141,14 +3141,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6420,
+							"line": 6427,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2348,
+					"id": 2349,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3169,14 +3169,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8000,
+							"line": 8007,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2245,
+					"id": 2246,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3184,14 +3184,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6879,
+							"line": 6886,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2189,
+					"id": 2190,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3208,14 +3208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6429,
+							"line": 6436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2204,
+					"id": 2205,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3226,14 +3226,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6555,
+							"line": 6562,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2284,
+					"id": 2285,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3254,14 +3254,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7286,
+							"line": 7293,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2206,
+					"id": 2207,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3278,14 +3278,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6570,
+							"line": 6577,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2201,
+					"id": 2202,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3302,14 +3302,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6543,
+							"line": 6550,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2356,
+					"id": 2357,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3330,14 +3330,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8094,
+							"line": 8101,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2357,
+					"id": 2358,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3358,14 +3358,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8105,
+							"line": 8112,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2355,
+					"id": 2356,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3386,14 +3386,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8083,
+							"line": 8090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2358,
+					"id": 2359,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3414,14 +3414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8116,
+							"line": 8123,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2354,
+					"id": 2355,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3442,14 +3442,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8072,
+							"line": 8079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2359,
+					"id": 2360,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3470,14 +3470,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8127,
+							"line": 8134,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2344,
+					"id": 2345,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3498,14 +3498,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7954,
+							"line": 7961,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2345,
+					"id": 2346,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3526,14 +3526,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7965,
+							"line": 7972,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2342,
+					"id": 2343,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3554,14 +3554,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7933,
+							"line": 7940,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2340,
+					"id": 2341,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3582,14 +3582,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7913,
+							"line": 7920,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2346,
+					"id": 2347,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3610,14 +3610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7976,
+							"line": 7983,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2341,
+					"id": 2342,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3638,14 +3638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7923,
+							"line": 7930,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2343,
+					"id": 2344,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3666,14 +3666,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7943,
+							"line": 7950,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2314,
+					"id": 2315,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3694,14 +3694,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7632,
+							"line": 7639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2338,
+					"id": 2339,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3722,14 +3722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7893,
+							"line": 7900,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2339,
+					"id": 2340,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3750,14 +3750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7903,
+							"line": 7910,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2336,
+					"id": 2337,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3778,14 +3778,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7873,
+							"line": 7880,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2335,
+					"id": 2336,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3806,14 +3806,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7863,
+							"line": 7870,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2337,
+					"id": 2338,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3834,14 +3834,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7883,
+							"line": 7890,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2323,
+					"id": 2324,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3862,14 +3862,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7731,
+							"line": 7738,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2351,
+					"id": 2352,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3890,14 +3890,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8036,
+							"line": 8043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2350,
+					"id": 2351,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3918,14 +3918,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8024,
+							"line": 8031,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2349,
+					"id": 2350,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3946,14 +3946,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8012,
+							"line": 8019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2352,
+					"id": 2353,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3974,14 +3974,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8050,
+							"line": 8057,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2321,
+					"id": 2322,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4002,14 +4002,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7709,
+							"line": 7716,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2322,
+					"id": 2323,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4030,14 +4030,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7720,
+							"line": 7727,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2237,
+					"id": 2238,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4054,14 +4054,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6834,
+							"line": 6841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2257,
+					"id": 2258,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4082,14 +4082,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7008,
+							"line": 7015,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2256,
+					"id": 2257,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4110,14 +4110,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6997,
+							"line": 7004,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2260,
+					"id": 2261,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4138,14 +4138,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7038,
+							"line": 7045,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2261,
+					"id": 2262,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4166,14 +4166,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7048,
+							"line": 7055,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2293,
+					"id": 2294,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4198,14 +4198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7391,
+							"line": 7398,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2223,
+					"id": 2224,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4222,14 +4222,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6743,
+							"line": 6750,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2334,
+					"id": 2335,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4250,14 +4250,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7853,
+							"line": 7860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2329,
+					"id": 2330,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4278,14 +4278,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7802,
+							"line": 7809,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2305,
+					"id": 2306,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4306,14 +4306,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7533,
+							"line": 7540,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2220,
+					"id": 2221,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4330,14 +4330,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6712,
+							"line": 6719,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2295,
+					"id": 2296,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4358,14 +4358,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7415,
+							"line": 7422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2304,
+					"id": 2305,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4386,7 +4386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7522,
+							"line": 7529,
 							"character": 4
 						}
 					],
@@ -4398,176 +4398,176 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2301,
-						2198,
-						2191,
-						2190,
-						2196,
-						2197,
-						2199,
-						2281,
-						2251,
-						2297,
-						2250,
-						2249,
-						2296,
-						2263,
-						2275,
-						2266,
-						2271,
-						2265,
-						2268,
-						2276,
-						2272,
-						2269,
-						2274,
-						2270,
-						2267,
-						2273,
-						2264,
-						2310,
-						2195,
-						2194,
-						2193,
-						2318,
-						2192,
-						2242,
-						2185,
-						2241,
-						2319,
-						2333,
-						2294,
-						2254,
-						2259,
-						2311,
-						2316,
-						2307,
-						2309,
-						2207,
-						2210,
-						2209,
-						2208,
-						2211,
-						2212,
-						2214,
-						2213,
-						2216,
-						2215,
-						2246,
-						2240,
-						2239,
-						2224,
-						2184,
-						2253,
-						2244,
-						2315,
-						2285,
 						2302,
-						2221,
-						2225,
-						2317,
+						2199,
+						2192,
+						2191,
+						2197,
+						2198,
+						2200,
 						2282,
-						2283,
-						2238,
-						2218,
-						2219,
-						2320,
-						2347,
-						2308,
-						2232,
-						2326,
-						2292,
-						2183,
-						2289,
-						2258,
-						2328,
-						2306,
-						2280,
-						2287,
-						2332,
-						2331,
-						2288,
-						2299,
-						2300,
-						2330,
-						2303,
-						2290,
-						2291,
-						2235,
-						2324,
-						2222,
-						2312,
-						2327,
-						2248,
-						2353,
-						2226,
-						2325,
-						2262,
 						2252,
 						2298,
-						2278,
+						2251,
+						2250,
+						2297,
+						2264,
+						2276,
+						2267,
+						2272,
+						2266,
+						2269,
+						2277,
+						2273,
+						2270,
+						2275,
+						2271,
+						2268,
+						2274,
+						2265,
+						2311,
+						2196,
+						2195,
+						2194,
+						2319,
+						2193,
+						2243,
+						2186,
+						2242,
+						2320,
+						2334,
+						2295,
 						2255,
+						2260,
+						2312,
+						2317,
+						2308,
+						2310,
+						2208,
+						2211,
+						2210,
+						2209,
+						2212,
+						2213,
+						2215,
+						2214,
+						2217,
+						2216,
 						2247,
-						2279,
-						2313,
-						2286,
-						2179,
-						2182,
-						2187,
-						2188,
-						2348,
+						2241,
+						2240,
+						2225,
+						2185,
+						2254,
 						2245,
-						2189,
-						2204,
+						2316,
+						2286,
+						2303,
+						2222,
+						2226,
+						2318,
+						2283,
 						2284,
-						2206,
-						2201,
-						2356,
-						2357,
-						2355,
-						2358,
+						2239,
+						2219,
+						2220,
+						2321,
+						2348,
+						2309,
+						2233,
+						2327,
+						2293,
+						2184,
+						2290,
+						2259,
+						2329,
+						2307,
+						2281,
+						2288,
+						2333,
+						2332,
+						2289,
+						2300,
+						2301,
+						2331,
+						2304,
+						2291,
+						2292,
+						2236,
+						2325,
+						2223,
+						2313,
+						2328,
+						2249,
 						2354,
-						2359,
-						2344,
-						2345,
-						2342,
-						2340,
-						2346,
-						2341,
-						2343,
+						2227,
+						2326,
+						2263,
+						2253,
+						2299,
+						2279,
+						2256,
+						2248,
+						2280,
 						2314,
-						2338,
+						2287,
+						2180,
+						2183,
+						2188,
+						2189,
+						2349,
+						2246,
+						2190,
+						2205,
+						2285,
+						2207,
+						2202,
+						2357,
+						2358,
+						2356,
+						2359,
+						2355,
+						2360,
+						2345,
+						2346,
+						2343,
+						2341,
+						2347,
+						2342,
+						2344,
+						2315,
 						2339,
-						2336,
-						2335,
+						2340,
 						2337,
-						2323,
+						2336,
+						2338,
+						2324,
+						2352,
 						2351,
 						2350,
-						2349,
-						2352,
-						2321,
+						2353,
 						2322,
-						2237,
+						2323,
+						2238,
+						2258,
 						2257,
-						2256,
-						2260,
 						2261,
-						2293,
-						2223,
-						2334,
-						2329,
-						2305,
-						2220,
-						2295,
-						2304
+						2262,
+						2294,
+						2224,
+						2335,
+						2330,
+						2306,
+						2221,
+						2296,
+						2305
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6339,
+					"line": 6346,
 					"character": 12
 				}
 			]
@@ -4952,7 +4952,7 @@
 			]
 		},
 		{
-			"id": 1934,
+			"id": 1935,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4968,7 +4968,7 @@
 			},
 			"children": [
 				{
-					"id": 1945,
+					"id": 1946,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4987,7 +4987,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1936,
+					"id": 1937,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5016,7 +5016,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1935,
+					"id": 1936,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5040,7 +5040,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1941,
+					"id": 1942,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5058,7 +5058,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1939,
+					"id": 1940,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5091,7 +5091,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1943,
+					"id": 1944,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5115,7 +5115,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1944,
+					"id": 1945,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5148,13 +5148,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1945,
+						1946,
+						1937,
 						1936,
-						1935,
-						1941,
-						1939,
-						1943,
-						1944
+						1942,
+						1940,
+						1944,
+						1945
 					]
 				}
 			],
@@ -5167,7 +5167,7 @@
 			]
 		},
 		{
-			"id": 3188,
+			"id": 3202,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5183,7 +5183,7 @@
 			},
 			"children": [
 				{
-					"id": 3190,
+					"id": 3204,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5194,14 +5194,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8829,
+							"line": 8839,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3189,
+					"id": 3203,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5212,7 +5212,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8827,
+							"line": 8837,
 							"character": 4
 						}
 					],
@@ -5224,21 +5224,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3190,
-						3189
+						3204,
+						3203
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8825,
+					"line": 8835,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3191,
+			"id": 3205,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5254,7 +5254,7 @@
 			},
 			"children": [
 				{
-					"id": 3193,
+					"id": 3207,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5265,14 +5265,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8840,
+							"line": 8850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3194,
+					"id": 3208,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5283,14 +5283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8842,
+							"line": 8852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3192,
+					"id": 3206,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5301,7 +5301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8838,
+							"line": 8848,
 							"character": 4
 						}
 					],
@@ -5313,22 +5313,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3193,
-						3194,
-						3192
+						3207,
+						3208,
+						3206
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8836,
+					"line": 8846,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3195,
+			"id": 3209,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5344,7 +5344,7 @@
 			},
 			"children": [
 				{
-					"id": 3198,
+					"id": 3212,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5355,14 +5355,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8794,
+							"line": 8804,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3199,
+					"id": 3213,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5373,14 +5373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8796,
+							"line": 8806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3201,
+					"id": 3215,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5391,14 +5391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8800,
+							"line": 8810,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3206,
+					"id": 3220,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5409,14 +5409,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8810,
+							"line": 8820,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3202,
+					"id": 3216,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5427,14 +5427,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8802,
+							"line": 8812,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3204,
+					"id": 3218,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5445,14 +5445,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8806,
+							"line": 8816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3196,
+					"id": 3210,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5463,14 +5463,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8790,
+							"line": 8800,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3208,
+					"id": 3222,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5481,14 +5481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8814,
+							"line": 8824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3197,
+					"id": 3211,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5499,14 +5499,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8792,
+							"line": 8802,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3210,
+					"id": 3224,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5517,14 +5517,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8818,
+							"line": 8828,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3209,
+					"id": 3223,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5535,14 +5535,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8816,
+							"line": 8826,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3203,
+					"id": 3217,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5553,14 +5553,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8804,
+							"line": 8814,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3205,
+					"id": 3219,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5571,14 +5571,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8808,
+							"line": 8818,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3207,
+					"id": 3221,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5589,14 +5589,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8812,
+							"line": 8822,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3200,
+					"id": 3214,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5607,7 +5607,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8798,
+							"line": 8808,
 							"character": 4
 						}
 					],
@@ -5619,34 +5619,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3198,
-						3199,
-						3201,
-						3206,
-						3202,
-						3204,
-						3196,
-						3208,
-						3197,
+						3212,
+						3213,
+						3215,
+						3220,
+						3216,
+						3218,
 						3210,
-						3209,
-						3203,
-						3205,
-						3207,
-						3200
+						3222,
+						3211,
+						3224,
+						3223,
+						3217,
+						3219,
+						3221,
+						3214
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8788,
+					"line": 8798,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2360,
+			"id": 2361,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5656,7 +5656,7 @@
 			},
 			"children": [
 				{
-					"id": 2363,
+					"id": 2364,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5664,14 +5664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8147,
+							"line": 8154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2361,
+					"id": 2362,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5679,14 +5679,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8145,
+							"line": 8152,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2362,
+					"id": 2363,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5694,7 +5694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8146,
+							"line": 8153,
 							"character": 4
 						}
 					],
@@ -5706,22 +5706,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2363,
-						2361,
-						2362
+						2364,
+						2362,
+						2363
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8144,
+					"line": 8151,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2168,
+			"id": 2169,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5745,7 +5745,7 @@
 			},
 			"children": [
 				{
-					"id": 2171,
+					"id": 2172,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5756,14 +5756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8592,
+							"line": 8602,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2170,
+					"id": 2171,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5774,14 +5774,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8588,
+							"line": 8598,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2173,
+					"id": 2174,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5792,14 +5792,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8601,
+							"line": 8611,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2169,
+					"id": 2170,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5810,14 +5810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8584,
+							"line": 8594,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2172,
+					"id": 2173,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5828,7 +5828,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8596,
+							"line": 8606,
 							"character": 4
 						}
 					],
@@ -5840,24 +5840,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2172,
 						2171,
+						2174,
 						2170,
-						2173,
-						2169,
-						2172
+						2173
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8580,
+					"line": 8590,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3143,
+			"id": 3156,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5867,7 +5867,7 @@
 			},
 			"children": [
 				{
-					"id": 3146,
+					"id": 3159,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5878,14 +5878,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8284,
+							"line": 8291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3144,
+					"id": 3157,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5896,14 +5896,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8257,
+							"line": 8264,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3147,
+					"id": 3160,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5914,14 +5914,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8295,
+							"line": 8302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3145,
+					"id": 3158,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5932,7 +5932,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8271,
+							"line": 8278,
 							"character": 4
 						}
 					],
@@ -5944,23 +5944,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3146,
-						3144,
-						3147,
-						3145
+						3159,
+						3157,
+						3160,
+						3158
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8247,
+					"line": 8254,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3139,
+			"id": 3152,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5970,7 +5970,7 @@
 			},
 			"children": [
 				{
-					"id": 3142,
+					"id": 3155,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5981,14 +5981,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8238,
+							"line": 8245,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3141,
+					"id": 3154,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5999,14 +5999,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8230,
+							"line": 8237,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3140,
+					"id": 3153,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6017,7 +6017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8225,
+							"line": 8232,
 							"character": 4
 						}
 					],
@@ -6029,22 +6029,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3142,
-						3141,
-						3140
+						3155,
+						3154,
+						3153
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8220,
+					"line": 8227,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3211,
+			"id": 3225,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6060,7 +6060,7 @@
 			},
 			"children": [
 				{
-					"id": 3216,
+					"id": 3230,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6071,14 +6071,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8779,
+							"line": 8789,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3212,
+					"id": 3226,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6089,14 +6089,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8771,
+							"line": 8781,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3214,
+					"id": 3228,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6107,14 +6107,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8775,
+							"line": 8785,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3213,
+					"id": 3227,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6125,14 +6125,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8773,
+							"line": 8783,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3215,
+					"id": 3229,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6143,14 +6143,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8777,
+							"line": 8787,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3217,
+					"id": 3231,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6161,7 +6161,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8781,
+							"line": 8791,
 							"character": 4
 						}
 					],
@@ -6173,25 +6173,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3216,
-						3212,
-						3214,
-						3213,
-						3215,
-						3217
+						3230,
+						3226,
+						3228,
+						3227,
+						3229,
+						3231
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8769,
+					"line": 8779,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3135,
+			"id": 3148,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6201,7 +6201,7 @@
 			},
 			"children": [
 				{
-					"id": 3137,
+					"id": 3150,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6212,14 +6212,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 80,
+							"line": 84,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3136,
+					"id": 3149,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6230,14 +6230,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 76,
+							"line": 80,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3138,
+					"id": 3151,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6248,7 +6248,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 84,
+							"line": 88,
 							"character": 4
 						}
 					],
@@ -6260,22 +6260,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3137,
-						3136,
-						3138
+						3150,
+						3149,
+						3151
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 72,
+					"line": 76,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2174,
+			"id": 2175,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6285,7 +6285,7 @@
 			},
 			"children": [
 				{
-					"id": 2176,
+					"id": 2177,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6296,14 +6296,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6130,
+							"line": 6137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2177,
+					"id": 2178,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6314,14 +6314,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6134,
+							"line": 6141,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2175,
+					"id": 2176,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6332,7 +6332,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6126,
+							"line": 6133,
 							"character": 4
 						}
 					],
@@ -6344,22 +6344,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2176,
 						2177,
-						2175
+						2178,
+						2176
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6122,
+					"line": 6129,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3152,
+			"id": 3165,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6383,7 +6383,7 @@
 			},
 			"children": [
 				{
-					"id": 3155,
+					"id": 3168,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6394,14 +6394,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8461,
+							"line": 8468,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3156,
+					"id": 3169,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6412,14 +6412,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8464,
+							"line": 8471,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3159,
+					"id": 3172,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6430,14 +6430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8473,
+							"line": 8480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3168,
+					"id": 3181,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6448,14 +6448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8500,
+							"line": 8507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3162,
+					"id": 3175,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6466,14 +6466,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8482,
+							"line": 8489,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3166,
+					"id": 3179,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6484,14 +6484,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8494,
+							"line": 8501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3157,
+					"id": 3170,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6502,14 +6502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8467,
+							"line": 8474,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3165,
+					"id": 3178,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6520,14 +6520,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8491,
+							"line": 8498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3154,
+					"id": 3167,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6538,14 +6538,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8458,
+							"line": 8465,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3160,
+					"id": 3173,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6556,14 +6556,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8476,
+							"line": 8483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3158,
+					"id": 3171,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6574,14 +6574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8470,
+							"line": 8477,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3163,
+					"id": 3176,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6592,14 +6592,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8485,
+							"line": 8492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3161,
+					"id": 3174,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6610,14 +6610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8479,
+							"line": 8486,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3167,
+					"id": 3180,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6628,14 +6628,32 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8497,
+							"line": 8504,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3164,
+					"id": 3182,
+					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "UpdateParameters payload is invalid - malformed applicability"
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8510,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
+				},
+				{
+					"id": 3177,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6646,14 +6664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8488,
+							"line": 8495,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3153,
+					"id": 3166,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6664,7 +6682,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8455,
+							"line": 8462,
 							"character": 4
 						}
 					],
@@ -6676,35 +6694,36 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3155,
-						3156,
-						3159,
 						3168,
-						3162,
-						3166,
-						3157,
-						3165,
-						3154,
-						3160,
-						3158,
-						3163,
-						3161,
+						3169,
+						3172,
+						3181,
+						3175,
+						3179,
+						3170,
+						3178,
 						3167,
-						3164,
-						3153
+						3173,
+						3171,
+						3176,
+						3174,
+						3180,
+						3182,
+						3177,
+						3166
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8453,
+					"line": 8460,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1966,
+			"id": 1967,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6729,7 +6748,7 @@
 			},
 			"children": [
 				{
-					"id": 2003,
+					"id": 2004,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6750,14 +6769,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2885,
+							"line": 2892,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 1994,
+					"id": 1995,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6778,14 +6797,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2748,
+							"line": 2755,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 1974,
+					"id": 1975,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6810,14 +6829,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2496,
+							"line": 2503,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2056,
+					"id": 2057,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6838,14 +6857,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3535,
+							"line": 3542,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2020,
+					"id": 2021,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6866,14 +6885,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3098,
+							"line": 3105,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 1979,
+					"id": 1980,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6898,14 +6917,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2606,
+							"line": 2613,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2016,
+					"id": 2017,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6926,14 +6945,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3066,
+							"line": 3073,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2002,
+					"id": 2003,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6954,14 +6973,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2874,
+							"line": 2881,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2066,
+					"id": 2067,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6983,14 +7002,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3701,
+							"line": 3708,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2045,
+					"id": 2046,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7023,14 +7042,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3347,
+							"line": 3354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 1980,
+					"id": 1981,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7051,14 +7070,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2619,
+							"line": 2626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 1968,
+					"id": 1969,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7083,14 +7102,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2398,
+							"line": 2405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2027,
+					"id": 2028,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7111,14 +7130,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3174,
+							"line": 3181,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2043,
+					"id": 2044,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7155,14 +7174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3333,
+							"line": 3340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2014,
+					"id": 2015,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7183,14 +7202,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3044,
+							"line": 3051,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2029,
+					"id": 2030,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7211,14 +7230,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3194,
+							"line": 3201,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2009,
+					"id": 2010,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7239,14 +7258,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2977,
+							"line": 2984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2035,
+					"id": 2036,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7263,14 +7282,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3245,
+							"line": 3252,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2050,
+					"id": 2051,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7288,14 +7307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3485,
+							"line": 3492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2051,
+					"id": 2052,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7312,14 +7331,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3490,
+							"line": 3497,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2044,
+					"id": 2045,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7336,14 +7355,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3338,
+							"line": 3345,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2030,
+					"id": 2031,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7364,14 +7383,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3205,
+							"line": 3212,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 1975,
+					"id": 1976,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7400,14 +7419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2513,
+							"line": 2520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 1970,
+					"id": 1971,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7436,14 +7455,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2426,
+							"line": 2433,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2057,
+					"id": 2058,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7464,14 +7483,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3546,
+							"line": 3553,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 1973,
+					"id": 1974,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7496,14 +7515,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2484,
+							"line": 2491,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2025,
+					"id": 2026,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7524,14 +7543,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3156,
+							"line": 3163,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2041,
+					"id": 2042,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7560,14 +7579,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3305,
+							"line": 3312,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2042,
+					"id": 2043,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7592,14 +7611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3312,
+							"line": 3319,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 1992,
+					"id": 1993,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7620,14 +7639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2715,
+							"line": 2722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 1991,
+					"id": 1992,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7648,14 +7667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2704,
+							"line": 2711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 1996,
+					"id": 1997,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7677,14 +7696,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2783,
+							"line": 2790,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 1999,
+					"id": 2000,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7705,14 +7724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2831,
+							"line": 2838,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 1998,
+					"id": 1999,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7733,14 +7752,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2815,
+							"line": 2822,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 1997,
+					"id": 1998,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7761,14 +7780,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2799,
+							"line": 2806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2000,
+					"id": 2001,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7789,14 +7808,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2847,
+							"line": 2854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2001,
+					"id": 2002,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7817,14 +7836,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2858,
+							"line": 2865,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2008,
+					"id": 2009,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7845,14 +7864,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2966,
+							"line": 2973,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2007,
+					"id": 2008,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7873,14 +7892,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2954,
+							"line": 2961,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 1972,
+					"id": 1973,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7917,14 +7936,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2472,
+							"line": 2479,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2022,
+					"id": 2023,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7945,14 +7964,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3120,
+							"line": 3127,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2011,
+					"id": 2012,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7973,14 +7992,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3000,
+							"line": 3007,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2071,
+					"id": 2072,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8001,14 +8020,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3762,
+							"line": 3769,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 1978,
+					"id": 1979,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8038,14 +8057,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2596,
+							"line": 2603,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2028,
+					"id": 2029,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8066,14 +8085,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3184,
+							"line": 3191,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2012,
+					"id": 2013,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8094,14 +8113,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3017,
+							"line": 3024,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2033,
+					"id": 2034,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8122,14 +8141,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3235,
+							"line": 3242,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 1986,
+					"id": 1987,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8150,14 +8169,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2661,
+							"line": 2668,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 1967,
+					"id": 1968,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8178,14 +8197,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2386,
+							"line": 2393,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2060,
+					"id": 2061,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8206,14 +8225,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3579,
+							"line": 3586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2059,
+					"id": 2060,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8234,14 +8253,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3568,
+							"line": 3575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2019,
+					"id": 2020,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8262,14 +8281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3087,
+							"line": 3094,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 1993,
+					"id": 1994,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8294,14 +8313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2737,
+							"line": 2744,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 1969,
+					"id": 1970,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8326,14 +8345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2412,
+							"line": 2419,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2023,
+					"id": 2024,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8354,14 +8373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3131,
+							"line": 3138,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 1989,
+					"id": 1990,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8382,14 +8401,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2687,
+							"line": 2694,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2047,
+					"id": 2048,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8420,14 +8439,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3418,
+							"line": 3425,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2065,
+					"id": 2066,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8448,14 +8467,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3635,
+							"line": 3642,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2048,
+					"id": 2049,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8472,14 +8491,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3429,
+							"line": 3436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2004,
+					"id": 2005,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8500,14 +8519,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2906,
+							"line": 2913,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2024,
+					"id": 2025,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8532,14 +8551,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3146,
+							"line": 3153,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2055,
+					"id": 2056,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8560,14 +8579,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3524,
+							"line": 3531,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 1971,
+					"id": 1972,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8588,14 +8607,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2435,
+							"line": 2442,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2081,
+					"id": 2082,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8616,14 +8635,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3904,
+							"line": 3911,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2046,
+					"id": 2047,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8640,14 +8659,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3352,
+							"line": 3359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2040,
+					"id": 2041,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8680,14 +8699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3296,
+							"line": 3303,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2061,
+					"id": 2062,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8708,14 +8727,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3590,
+							"line": 3597,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 1987,
+					"id": 1988,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8736,14 +8755,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2671,
+							"line": 2678,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 1995,
+					"id": 1996,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8764,14 +8783,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2767,
+							"line": 2774,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2013,
+					"id": 2014,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8792,14 +8811,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3028,
+							"line": 3035,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2038,
+					"id": 2039,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8836,14 +8855,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3278,
+							"line": 3285,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2039,
+					"id": 2040,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8876,14 +8895,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3287,
+							"line": 3294,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2021,
+					"id": 2022,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8904,14 +8923,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3109,
+							"line": 3116,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2026,
+					"id": 2027,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8932,14 +8951,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3165,
+							"line": 3172,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2073,
+					"id": 2074,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8960,14 +8979,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3801,
+							"line": 3808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2006,
+					"id": 2007,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8988,14 +9007,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2942,
+							"line": 2949,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2015,
+					"id": 2016,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9016,14 +9035,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3055,
+							"line": 3062,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2005,
+					"id": 2006,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9044,14 +9063,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2924,
+							"line": 2931,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2068,
+					"id": 2069,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9072,14 +9091,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3725,
+							"line": 3732,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2067,
+					"id": 2068,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9100,14 +9119,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3713,
+							"line": 3720,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2069,
+					"id": 2070,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9128,14 +9147,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3737,
+							"line": 3744,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2054,
+					"id": 2055,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9156,14 +9175,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3513,
+							"line": 3520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2062,
+					"id": 2063,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9184,14 +9203,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3601,
+							"line": 3608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2063,
+					"id": 2064,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9212,14 +9231,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3612,
+							"line": 3619,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2058,
+					"id": 2059,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9240,14 +9259,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3557,
+							"line": 3564,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2077,
+					"id": 2078,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9268,14 +9287,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3853,
+							"line": 3860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2078,
+					"id": 2079,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9296,14 +9315,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3866,
+							"line": 3873,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2080,
+					"id": 2081,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9324,14 +9343,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3890,
+							"line": 3897,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2079,
+					"id": 2080,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9352,14 +9371,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3878,
+							"line": 3885,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2074,
+					"id": 2075,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9380,14 +9399,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3814,
+							"line": 3821,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2075,
+					"id": 2076,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9408,14 +9427,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3827,
+							"line": 3834,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2076,
+					"id": 2077,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9436,14 +9455,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3840,
+							"line": 3847,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2072,
+					"id": 2073,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9469,14 +9488,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3786,
+							"line": 3793,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2049,
+					"id": 2050,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9498,14 +9517,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3472,
+							"line": 3479,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2034,
+					"id": 2035,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9522,14 +9541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3240,
+							"line": 3247,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2036,
+					"id": 2037,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9566,14 +9585,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3257,
+							"line": 3264,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2037,
+					"id": 2038,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9606,14 +9625,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3267,
+							"line": 3274,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2010,
+					"id": 2011,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9634,14 +9653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2988,
+							"line": 2995,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 1977,
+					"id": 1978,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9670,14 +9689,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2544,
+							"line": 2551,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 1976,
+					"id": 1977,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9702,14 +9721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2525,
+							"line": 2532,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2031,
+					"id": 2032,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9730,7 +9749,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3216,
+							"line": 3223,
 							"character": 4
 						}
 					],
@@ -9742,120 +9761,120 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2003,
-						1994,
-						1974,
-						2056,
-						2020,
-						1979,
-						2016,
-						2002,
-						2066,
-						2045,
-						1980,
-						1968,
-						2027,
-						2043,
-						2014,
-						2029,
-						2009,
-						2035,
-						2050,
-						2051,
-						2044,
-						2030,
+						2004,
+						1995,
 						1975,
-						1970,
 						2057,
-						1973,
-						2025,
-						2041,
+						2021,
+						1980,
+						2017,
+						2003,
+						2067,
+						2046,
+						1981,
+						1969,
+						2028,
+						2044,
+						2015,
+						2030,
+						2010,
+						2036,
+						2051,
+						2052,
+						2045,
+						2031,
+						1976,
+						1971,
+						2058,
+						1974,
+						2026,
 						2042,
+						2043,
+						1993,
 						1992,
-						1991,
-						1996,
-						1999,
-						1998,
 						1997,
 						2000,
+						1999,
+						1998,
 						2001,
+						2002,
+						2009,
 						2008,
-						2007,
-						1972,
-						2022,
-						2011,
-						2071,
-						1978,
-						2028,
-						2012,
-						2033,
-						1986,
-						1967,
-						2060,
-						2059,
-						2019,
-						1993,
-						1969,
+						1973,
 						2023,
-						1989,
-						2047,
-						2065,
-						2048,
-						2004,
-						2024,
-						2055,
-						1971,
-						2081,
-						2046,
-						2040,
-						2061,
-						1987,
-						1995,
+						2012,
+						2072,
+						1979,
+						2029,
 						2013,
-						2038,
-						2039,
-						2021,
-						2026,
-						2073,
-						2006,
-						2015,
+						2034,
+						1987,
+						1968,
+						2061,
+						2060,
+						2020,
+						1994,
+						1970,
+						2024,
+						1990,
+						2048,
+						2066,
+						2049,
 						2005,
-						2068,
-						2067,
-						2069,
-						2054,
+						2025,
+						2056,
+						1972,
+						2082,
+						2047,
+						2041,
 						2062,
-						2063,
-						2058,
-						2077,
-						2078,
-						2080,
-						2079,
+						1988,
+						1996,
+						2014,
+						2039,
+						2040,
+						2022,
+						2027,
 						2074,
+						2007,
+						2016,
+						2006,
+						2069,
+						2068,
+						2070,
+						2055,
+						2063,
+						2064,
+						2059,
+						2078,
+						2079,
+						2081,
+						2080,
 						2075,
 						2076,
-						2072,
-						2049,
-						2034,
-						2036,
+						2077,
+						2073,
+						2050,
+						2035,
 						2037,
-						2010,
+						2038,
+						2011,
+						1978,
 						1977,
-						1976,
-						2031
+						2032
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2373,
+					"line": 2380,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3175,
+			"id": 3189,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9880,7 +9899,7 @@
 			},
 			"children": [
 				{
-					"id": 3176,
+					"id": 3190,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9891,14 +9910,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8415,
+							"line": 8422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3178,
+					"id": 3192,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9909,14 +9928,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8419,
+							"line": 8426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3177,
+					"id": 3191,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9927,7 +9946,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8417,
+							"line": 8424,
 							"character": 4
 						}
 					],
@@ -9939,22 +9958,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3176,
-						3178,
-						3177
+						3190,
+						3192,
+						3191
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8413,
+					"line": 8420,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2768,
+			"id": 2769,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9964,7 +9983,7 @@
 			},
 			"children": [
 				{
-					"id": 2772,
+					"id": 2773,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9988,7 +10007,31 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2776,
+					"id": 2780,
+					"name": "Collections",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The *Collections* menu option in\nthe *Insights* left navigation panel.\nShown when collections are enabled on the cluster.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 253,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"collections\""
+				},
+				{
+					"id": 2777,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10012,7 +10055,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2778,
+					"id": 2779,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10036,7 +10079,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2770,
+					"id": 2771,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10060,7 +10103,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2775,
+					"id": 2776,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10084,7 +10127,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2771,
+					"id": 2772,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10108,7 +10151,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2773,
+					"id": 2774,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10132,7 +10175,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2769,
+					"id": 2770,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10156,7 +10199,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2774,
+					"id": 2775,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10180,7 +10223,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2777,
+					"id": 2778,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10209,16 +10252,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2772,
+						2773,
+						2780,
+						2777,
+						2779,
+						2771,
 						2776,
-						2778,
+						2772,
+						2774,
 						2770,
 						2775,
-						2771,
-						2773,
-						2769,
-						2774,
-						2777
+						2778
 					]
 				}
 			],
@@ -10231,7 +10275,7 @@
 			]
 		},
 		{
-			"id": 3080,
+			"id": 3093,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10247,7 +10291,7 @@
 			},
 			"children": [
 				{
-					"id": 3083,
+					"id": 3096,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10264,14 +10308,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 128,
+							"line": 132,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3081,
+					"id": 3094,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10282,14 +10326,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 115,
+							"line": 119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3082,
+					"id": 3095,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10300,7 +10344,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 120,
+							"line": 124,
 							"character": 4
 						}
 					],
@@ -10312,29 +10356,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3083,
-						3081,
-						3082
+						3096,
+						3094,
+						3095
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 110,
+					"line": 114,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3074,
+			"id": 3087,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3076,
+					"id": 3089,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10342,14 +10386,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 89,
+							"line": 93,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3077,
+					"id": 3090,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10357,14 +10401,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 90,
+							"line": 94,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3075,
+					"id": 3088,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10372,7 +10416,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 88,
+							"line": 92,
 							"character": 4
 						}
 					],
@@ -10384,22 +10428,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3076,
-						3077,
-						3075
+						3089,
+						3090,
+						3088
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 87,
+					"line": 91,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2779,
+			"id": 2781,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10416,7 +10460,7 @@
 			},
 			"children": [
 				{
-					"id": 2782,
+					"id": 2784,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10427,14 +10471,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2245,
+							"line": 2252,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2785,
+					"id": 2787,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10445,14 +10489,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2257,
+							"line": 2264,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2783,
+					"id": 2785,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10463,14 +10507,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2249,
+							"line": 2256,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2780,
+					"id": 2782,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10481,14 +10525,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2237,
+							"line": 2244,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2784,
+					"id": 2786,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10499,14 +10543,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2253,
+							"line": 2260,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2781,
+					"id": 2783,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10517,7 +10561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2241,
+							"line": 2248,
 							"character": 4
 						}
 					],
@@ -10529,25 +10573,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2782,
-						2785,
-						2783,
-						2780,
 						2784,
-						2781
+						2787,
+						2785,
+						2782,
+						2786,
+						2783
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2233,
+					"line": 2240,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2082,
+			"id": 2083,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10580,7 +10624,7 @@
 			},
 			"children": [
 				{
-					"id": 2105,
+					"id": 2106,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10601,14 +10645,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4570,
+							"line": 4577,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2093,
+					"id": 2094,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10638,14 +10682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4268,
+							"line": 4275,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2150,
+					"id": 2151,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10671,14 +10715,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5914,
+							"line": 5921,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2154,
+					"id": 2155,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10704,14 +10748,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5956,
+							"line": 5963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2134,
+					"id": 2135,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10732,14 +10776,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5570,
+							"line": 5577,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2157,
+					"id": 2158,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10765,14 +10809,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5994,
+							"line": 6001,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2166,
+					"id": 2167,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10793,14 +10837,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6103,
+							"line": 6110,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2112,
+					"id": 2113,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10842,14 +10886,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4803,
+							"line": 4810,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2109,
+					"id": 2110,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10887,14 +10931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4678,
+							"line": 4685,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2151,
+					"id": 2152,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10915,14 +10959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5923,
+							"line": 5930,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2116,
+					"id": 2117,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10956,14 +11000,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4956,
+							"line": 4963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2153,
+					"id": 2154,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10984,14 +11028,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5941,
+							"line": 5948,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2159,
+					"id": 2160,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11012,14 +11056,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6014,
+							"line": 6021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2118,
+					"id": 2119,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11049,14 +11093,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5018,
+							"line": 5025,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2120,
+					"id": 2121,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11090,14 +11134,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5088,
+							"line": 5095,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2103,
+					"id": 2104,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11135,14 +11179,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4548,
+							"line": 4555,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2119,
+					"id": 2120,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11167,14 +11211,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5049,
+							"line": 5056,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2121,
+					"id": 2122,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11208,14 +11252,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5127,
+							"line": 5134,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2104,
+					"id": 2105,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11236,14 +11280,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4560,
+							"line": 4567,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2084,
+					"id": 2085,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11281,14 +11325,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4079,
+							"line": 4086,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2111,
+					"id": 2112,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11327,14 +11371,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4758,
+							"line": 4765,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2148,
+					"id": 2149,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11364,14 +11408,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5888,
+							"line": 5895,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2101,
+					"id": 2102,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11400,14 +11444,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4494,
+							"line": 4501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2108,
+					"id": 2109,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11437,14 +11481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4647,
+							"line": 4654,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2100,
+					"id": 2101,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11473,14 +11517,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4472,
+							"line": 4479,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2133,
+					"id": 2134,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11506,14 +11550,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5560,
+							"line": 5567,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2128,
+					"id": 2129,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11538,14 +11582,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5337,
+							"line": 5344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2087,
+					"id": 2088,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11570,14 +11614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4106,
+							"line": 4113,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2139,
+					"id": 2140,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11603,14 +11647,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5693,
+							"line": 5700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2114,
+					"id": 2115,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11647,14 +11691,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4894,
+							"line": 4901,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2130,
+					"id": 2131,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11679,14 +11723,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5486,
+							"line": 5493,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2164,
+					"id": 2165,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11707,14 +11751,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6083,
+							"line": 6090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2097,
+					"id": 2098,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11739,14 +11783,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4420,
+							"line": 4427,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2106,
+					"id": 2107,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11791,14 +11835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4615,
+							"line": 4622,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2110,
+					"id": 2111,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11840,14 +11884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4713,
+							"line": 4720,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2126,
+					"id": 2127,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11881,14 +11925,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5293,
+							"line": 5300,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2091,
+					"id": 2092,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11915,14 +11959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4222,
+							"line": 4229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2092,
+					"id": 2093,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11956,14 +12000,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4250,
+							"line": 4257,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2165,
+					"id": 2166,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11984,14 +12028,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6093,
+							"line": 6100,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2096,
+					"id": 2097,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12045,14 +12089,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4404,
+							"line": 4411,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2113,
+					"id": 2114,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12094,14 +12138,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4848,
+							"line": 4855,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2149,
+					"id": 2150,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12126,14 +12170,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5903,
+							"line": 5910,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2167,
+					"id": 2168,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12154,14 +12198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6114,
+							"line": 6121,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2107,
+					"id": 2108,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12190,14 +12234,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4629,
+							"line": 4636,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2094,
+					"id": 2095,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12227,14 +12271,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4286,
+							"line": 4293,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2136,
+					"id": 2137,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12259,14 +12303,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5597,
+							"line": 5604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2137,
+					"id": 2138,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12287,14 +12331,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5606,
+							"line": 5613,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2127,
+					"id": 2128,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12319,14 +12363,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5311,
+							"line": 5318,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2152,
+					"id": 2153,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12347,14 +12391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5932,
+							"line": 5939,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2123,
+					"id": 2124,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12388,14 +12432,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5204,
+							"line": 5211,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2144,
+					"id": 2145,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12437,14 +12481,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5822,
+							"line": 5829,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2098,
+					"id": 2099,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12469,14 +12513,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4435,
+							"line": 4442,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2099,
+					"id": 2100,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12501,14 +12545,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4450,
+							"line": 4457,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2083,
+					"id": 2084,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12534,14 +12578,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4010,
+							"line": 4017,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2142,
+					"id": 2143,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12570,14 +12614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5752,
+							"line": 5759,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2162,
+					"id": 2163,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12602,14 +12646,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6060,
+							"line": 6067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2089,
+					"id": 2090,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12639,14 +12683,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4148,
+							"line": 4155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2132,
+					"id": 2133,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12676,14 +12720,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5530,
+							"line": 5537,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2131,
+					"id": 2132,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12713,14 +12757,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5508,
+							"line": 5515,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2088,
+					"id": 2089,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12750,14 +12794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4128,
+							"line": 4135,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2122,
+					"id": 2123,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12786,14 +12830,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5152,
+							"line": 5159,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2115,
+					"id": 2116,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12827,14 +12871,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4927,
+							"line": 4934,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2117,
+					"id": 2118,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12868,14 +12912,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4990,
+							"line": 4997,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2147,
+					"id": 2148,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12905,14 +12949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5872,
+							"line": 5879,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2163,
+					"id": 2164,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12938,14 +12982,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6073,
+							"line": 6080,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2160,
+					"id": 2161,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12967,14 +13011,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6028,
+							"line": 6035,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2125,
+					"id": 2126,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13008,14 +13052,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5263,
+							"line": 5270,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2124,
+					"id": 2125,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13049,14 +13093,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5233,
+							"line": 5240,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2146,
+					"id": 2147,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13082,14 +13126,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5847,
+							"line": 5854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2135,
+					"id": 2136,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13110,14 +13154,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5586,
+							"line": 5593,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2129,
+					"id": 2130,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13163,14 +13207,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5465,
+							"line": 5472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2138,
+					"id": 2139,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13204,14 +13248,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5656,
+							"line": 5663,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2140,
+					"id": 2141,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13236,14 +13280,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5711,
+							"line": 5718,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2141,
+					"id": 2142,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13260,14 +13304,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5719,
+							"line": 5726,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2090,
+					"id": 2091,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13302,14 +13346,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4191,
+							"line": 4198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2102,
+					"id": 2103,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13334,14 +13378,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4509,
+							"line": 4516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2095,
+					"id": 2096,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13362,7 +13406,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4302,
+							"line": 4309,
 							"character": 4
 						}
 					],
@@ -13374,96 +13418,96 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2105,
-						2093,
-						2150,
-						2154,
-						2134,
-						2157,
-						2166,
-						2112,
-						2109,
+						2106,
+						2094,
 						2151,
-						2116,
-						2153,
-						2159,
-						2118,
-						2120,
-						2103,
+						2155,
+						2135,
+						2158,
+						2167,
+						2113,
+						2110,
+						2152,
+						2117,
+						2154,
+						2160,
 						2119,
 						2121,
 						2104,
-						2084,
-						2111,
-						2148,
-						2101,
-						2108,
-						2100,
-						2133,
-						2128,
-						2087,
-						2139,
-						2114,
-						2130,
-						2164,
-						2097,
-						2106,
-						2110,
-						2126,
-						2091,
-						2092,
-						2165,
-						2096,
-						2113,
-						2149,
-						2167,
-						2107,
-						2094,
-						2136,
-						2137,
-						2127,
-						2152,
-						2123,
-						2144,
-						2098,
-						2099,
-						2083,
-						2142,
-						2162,
-						2089,
-						2132,
-						2131,
-						2088,
+						2120,
 						2122,
-						2115,
-						2117,
-						2147,
-						2163,
-						2160,
-						2125,
-						2124,
-						2146,
-						2135,
-						2129,
-						2138,
-						2140,
-						2141,
-						2090,
+						2105,
+						2085,
+						2112,
+						2149,
 						2102,
-						2095
+						2109,
+						2101,
+						2134,
+						2129,
+						2088,
+						2140,
+						2115,
+						2131,
+						2165,
+						2098,
+						2107,
+						2111,
+						2127,
+						2092,
+						2093,
+						2166,
+						2097,
+						2114,
+						2150,
+						2168,
+						2108,
+						2095,
+						2137,
+						2138,
+						2128,
+						2153,
+						2124,
+						2145,
+						2099,
+						2100,
+						2084,
+						2143,
+						2163,
+						2090,
+						2133,
+						2132,
+						2089,
+						2123,
+						2116,
+						2118,
+						2148,
+						2164,
+						2161,
+						2126,
+						2125,
+						2147,
+						2136,
+						2130,
+						2139,
+						2141,
+						2142,
+						2091,
+						2103,
+						2096
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 3980,
+					"line": 3987,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3148,
+			"id": 3161,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13473,7 +13517,7 @@
 			},
 			"children": [
 				{
-					"id": 3150,
+					"id": 3163,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13484,14 +13528,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8634,
+							"line": 8644,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3149,
+					"id": 3162,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13502,14 +13546,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8630,
+							"line": 8640,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3151,
+					"id": 3164,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13520,7 +13564,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8638,
+							"line": 8648,
 							"character": 4
 						}
 					],
@@ -13532,22 +13576,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3150,
-						3149,
-						3151
+						3163,
+						3162,
+						3164
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8626,
+					"line": 8636,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3183,
+			"id": 3197,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13563,7 +13607,7 @@
 			},
 			"children": [
 				{
-					"id": 3185,
+					"id": 3199,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13574,14 +13618,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8904,
+							"line": 8914,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3186,
+					"id": 3200,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13592,14 +13636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8906,
+							"line": 8916,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3187,
+					"id": 3201,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13610,14 +13654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8908,
+							"line": 8918,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3184,
+					"id": 3198,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13628,7 +13672,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8902,
+							"line": 8912,
 							"character": 4
 						}
 					],
@@ -13640,23 +13684,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3185,
-						3186,
-						3187,
-						3184
+						3199,
+						3200,
+						3201,
+						3198
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8900,
+					"line": 8910,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3084,
+			"id": 3097,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13672,7 +13716,7 @@
 			},
 			"children": [
 				{
-					"id": 3085,
+					"id": 3098,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13683,14 +13727,14 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 140,
+							"line": 144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3086,
+					"id": 3099,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13701,7 +13745,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 144,
+							"line": 148,
 							"character": 4
 						}
 					],
@@ -13713,21 +13757,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3085,
-						3086
+						3098,
+						3099
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 135,
+					"line": 139,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3127,
+			"id": 3140,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13743,7 +13787,7 @@
 			},
 			"children": [
 				{
-					"id": 3131,
+					"id": 3144,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13754,14 +13798,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2283,
+							"line": 2290,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3132,
+					"id": 3145,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13772,14 +13816,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2287,
+							"line": 2294,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3128,
+					"id": 3141,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13790,14 +13834,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2270,
+							"line": 2277,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3129,
+					"id": 3142,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13814,14 +13858,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2275,
+							"line": 2282,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3133,
+					"id": 3146,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13832,14 +13876,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2291,
+							"line": 2298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3130,
+					"id": 3143,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13850,14 +13894,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2279,
+							"line": 2286,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3134,
+					"id": 3147,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13868,7 +13912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2295,
+							"line": 2302,
 							"character": 4
 						}
 					],
@@ -13880,26 +13924,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3131,
-						3132,
-						3128,
-						3129,
-						3133,
-						3130,
-						3134
+						3144,
+						3145,
+						3141,
+						3142,
+						3146,
+						3143,
+						3147
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2266,
+					"line": 2273,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3051,
+			"id": 3064,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13909,7 +13953,7 @@
 			},
 			"children": [
 				{
-					"id": 3056,
+					"id": 3069,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13930,14 +13974,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8369,
+							"line": 8376,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3053,
+					"id": 3066,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13958,14 +14002,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8330,
+							"line": 8337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3055,
+					"id": 3068,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13986,14 +14030,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8355,
+							"line": 8362,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3052,
+					"id": 3065,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14014,14 +14058,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8318,
+							"line": 8325,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3057,
+					"id": 3070,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14042,14 +14086,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8381,
+							"line": 8388,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3054,
+					"id": 3067,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14070,7 +14114,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8342,
+							"line": 8349,
 							"character": 4
 						}
 					],
@@ -14082,19 +14126,19 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3056,
-						3053,
-						3055,
-						3052,
-						3057,
-						3054
+						3069,
+						3066,
+						3068,
+						3065,
+						3070,
+						3067
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8305,
+					"line": 8312,
 					"character": 12
 				}
 			]
@@ -14126,6 +14170,24 @@
 						}
 					],
 					"defaultValue": "\"answers\""
+				},
+				{
+					"id": 1934,
+					"name": "Collections",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Collections listing page"
+					},
+					"sources": [
+						{
+							"fileName": "embed/app.ts",
+							"line": 69,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"collections\""
 				},
 				{
 					"id": 1931,
@@ -14242,6 +14304,7 @@
 					"kind": 16,
 					"children": [
 						1928,
+						1934,
 						1931,
 						1926,
 						1929,
@@ -14260,14 +14323,14 @@
 			]
 		},
 		{
-			"id": 2757,
+			"id": 2758,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2758,
+					"id": 2759,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14275,14 +14338,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8134,
+							"line": 8141,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2760,
+					"id": 2761,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14290,14 +14353,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8136,
+							"line": 8143,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2759,
+					"id": 2760,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14305,14 +14368,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8135,
+							"line": 8142,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2761,
+					"id": 2762,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14320,7 +14383,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8137,
+							"line": 8144,
 							"character": 4
 						}
 					],
@@ -14332,23 +14395,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2758,
-						2760,
 						2759,
-						2761
+						2761,
+						2760,
+						2762
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8133,
+					"line": 8140,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3078,
+			"id": 3091,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14364,7 +14427,7 @@
 			},
 			"children": [
 				{
-					"id": 3079,
+					"id": 3092,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14375,7 +14438,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 103,
+							"line": 107,
 							"character": 4
 						}
 					],
@@ -14387,20 +14450,20 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3079
+						3092
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 97,
+					"line": 101,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1950,
+			"id": 1951,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14410,7 +14473,7 @@
 			},
 			"children": [
 				{
-					"id": 1958,
+					"id": 1959,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14421,14 +14484,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2193,
+							"line": 2200,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 1963,
+					"id": 1964,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14439,14 +14502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2213,
+							"line": 2220,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 1962,
+					"id": 1963,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14457,14 +14520,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2209,
+							"line": 2216,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 1960,
+					"id": 1961,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14475,14 +14538,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2201,
+							"line": 2208,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 1961,
+					"id": 1962,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14493,14 +14556,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2205,
+							"line": 2212,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 1957,
+					"id": 1958,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14511,14 +14574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2189,
+							"line": 2196,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 1959,
+					"id": 1960,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14529,14 +14592,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2197,
+							"line": 2204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 1951,
+					"id": 1952,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14547,14 +14610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2165,
+							"line": 2172,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 1956,
+					"id": 1957,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14565,14 +14628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2185,
+							"line": 2192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 1955,
+					"id": 1956,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14583,14 +14646,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2181,
+							"line": 2188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 1964,
+					"id": 1965,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14601,14 +14664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2217,
+							"line": 2224,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 1954,
+					"id": 1955,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14619,14 +14682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2177,
+							"line": 2184,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 1953,
+					"id": 1954,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14637,14 +14700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2173,
+							"line": 2180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 1952,
+					"id": 1953,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14655,14 +14718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2169,
+							"line": 2176,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 1965,
+					"id": 1966,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14673,7 +14736,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2221,
+							"line": 2228,
 							"character": 4
 						}
 					],
@@ -14685,34 +14748,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1958,
-						1963,
-						1962,
-						1960,
-						1961,
-						1957,
 						1959,
-						1951,
-						1956,
-						1955,
 						1964,
+						1963,
+						1961,
+						1962,
+						1958,
+						1960,
+						1952,
+						1957,
+						1956,
+						1965,
+						1955,
 						1954,
 						1953,
-						1952,
-						1965
+						1966
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2161,
+					"line": 2168,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3222,
+			"id": 3236,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14728,7 +14791,7 @@
 			},
 			"children": [
 				{
-					"id": 3224,
+					"id": 3238,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14739,14 +14802,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8932,
+							"line": 8942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3223,
+					"id": 3237,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14757,7 +14820,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8930,
+							"line": 8940,
 							"character": 4
 						}
 					],
@@ -14769,21 +14832,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3224,
-						3223
+						3238,
+						3237
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8928,
+					"line": 8938,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3218,
+			"id": 3232,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14799,7 +14862,7 @@
 			},
 			"children": [
 				{
-					"id": 3219,
+					"id": 3233,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14810,14 +14873,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8917,
+							"line": 8927,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3220,
+					"id": 3234,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14828,14 +14891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8919,
+							"line": 8929,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3221,
+					"id": 3235,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14846,7 +14909,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8921,
+							"line": 8931,
 							"character": 4
 						}
 					],
@@ -14858,29 +14921,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3219,
-						3220,
-						3221
+						3233,
+						3234,
+						3235
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8915,
+					"line": 8925,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3110,
+			"id": 3123,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3119,
+					"id": 3132,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14895,7 +14958,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3115,
+					"id": 3128,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14910,7 +14973,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3120,
+					"id": 3133,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14925,7 +14988,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3114,
+					"id": 3127,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14940,7 +15003,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3113,
+					"id": 3126,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14955,7 +15018,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3126,
+					"id": 3139,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14970,7 +15033,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3121,
+					"id": 3134,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14985,7 +15048,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3122,
+					"id": 3135,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15000,7 +15063,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3116,
+					"id": 3129,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15015,7 +15078,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3123,
+					"id": 3136,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15030,7 +15093,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3124,
+					"id": 3137,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15045,7 +15108,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3125,
+					"id": 3138,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15060,7 +15123,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3117,
+					"id": 3130,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15075,7 +15138,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3111,
+					"id": 3124,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15090,7 +15153,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3112,
+					"id": 3125,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15105,7 +15168,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3118,
+					"id": 3131,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15125,22 +15188,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3119,
-						3115,
-						3120,
-						3114,
-						3113,
+						3132,
+						3128,
+						3133,
+						3127,
 						3126,
-						3121,
-						3122,
-						3116,
-						3123,
+						3139,
+						3134,
+						3135,
+						3129,
+						3136,
+						3137,
+						3138,
+						3130,
 						3124,
 						3125,
-						3117,
-						3111,
-						3112,
-						3118
+						3131
 					]
 				}
 			],
@@ -15260,7 +15323,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3087,
+											"id": 3100,
 											"name": "VizPoint"
 										}
 									}
@@ -15487,7 +15550,7 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1950,
+										"id": 1951,
 										"name": "RuntimeFilterOp"
 									}
 								},
@@ -16492,7 +16555,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 906,
+							"line": 910,
 							"character": 4
 						}
 					],
@@ -16512,7 +16575,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2786,
+										"id": 2788,
 										"name": "DOMSelector"
 									}
 								},
@@ -16524,7 +16587,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2648,
+										"id": 2649,
 										"name": "AppViewConfig"
 									}
 								}
@@ -16556,7 +16619,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1402,
+							"line": 1408,
 							"character": 11
 						}
 					],
@@ -16730,7 +16793,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1271,
+							"line": 1275,
 							"character": 11
 						}
 					],
@@ -17080,7 +17143,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1376,
+							"line": 1382,
 							"character": 11
 						}
 					],
@@ -17190,7 +17253,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17205,7 +17268,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -17272,7 +17335,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -17284,7 +17347,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -17296,7 +17359,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17456,7 +17519,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1458,
+							"line": 1464,
 							"character": 17
 						}
 					],
@@ -17586,12 +17649,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -17704,7 +17767,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -17723,7 +17786,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -17855,7 +17918,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -17962,7 +18025,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 897,
+					"line": 901,
 					"character": 13
 				}
 			],
@@ -19147,7 +19210,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -19162,7 +19225,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -19231,7 +19294,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -19246,7 +19309,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -19261,7 +19324,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -19571,12 +19634,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -19693,7 +19756,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -19712,7 +19775,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -19846,7 +19909,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -20014,7 +20077,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2786,
+										"id": 2788,
 										"name": "DOMSelector"
 									}
 								},
@@ -20026,7 +20089,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2530,
+										"id": 2531,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -20696,7 +20759,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20711,7 +20774,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -20778,7 +20841,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -20790,7 +20853,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -20802,7 +20865,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21092,12 +21155,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -21200,7 +21263,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -21219,7 +21282,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -21348,7 +21411,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -21526,7 +21589,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2479,
+										"id": 2480,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -22082,7 +22145,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -22097,7 +22160,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -22164,7 +22227,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -22179,7 +22242,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -22194,7 +22257,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -22497,12 +22560,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -22615,7 +22678,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -22634,7 +22697,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -22766,7 +22829,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22927,7 +22990,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2786,
+										"id": 2788,
 										"name": "DOMSelector"
 									}
 								},
@@ -22939,7 +23002,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2415,
+										"id": 2416,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -23527,7 +23590,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23542,7 +23605,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -23609,7 +23672,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23624,7 +23687,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -23639,7 +23702,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23942,12 +24005,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -24060,7 +24123,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -24079,7 +24142,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -24211,7 +24274,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -25450,7 +25513,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -25465,7 +25528,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								}
@@ -25532,7 +25595,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1966,
+										"id": 1967,
 										"name": "EmbedEvent"
 									}
 								},
@@ -25547,7 +25610,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2790,
+										"id": 2792,
 										"name": "MessageCallback"
 									}
 								},
@@ -25562,7 +25625,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2787,
+										"id": 2789,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -25862,12 +25925,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2178,
+												"id": 2179,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2082,
+												"id": 2083,
 												"name": "HostEvent"
 											}
 										]
@@ -25980,7 +26043,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2082,
+										"id": 2083,
 										"name": "HostEvent"
 									}
 								},
@@ -25999,7 +26062,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2168,
+										"id": 2169,
 										"name": "ContextType"
 									}
 								}
@@ -26131,7 +26194,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3110,
+										"id": 3123,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -26255,7 +26318,7 @@
 			]
 		},
 		{
-			"id": 2648,
+			"id": 2649,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26271,7 +26334,7 @@
 			},
 			"children": [
 				{
-					"id": 2700,
+					"id": 2701,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26295,27 +26358,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2701,
+							"id": 2702,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2702,
+								"id": 2703,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2703,
+										"id": 2704,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -26351,7 +26414,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2733,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26379,7 +26442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1756,
+							"line": 1763,
 							"character": 4
 						}
 					],
@@ -26393,7 +26456,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2669,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26420,7 +26483,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 519,
+							"line": 523,
 							"character": 4
 						}
 					],
@@ -26430,7 +26493,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2730,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26454,13 +26517,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1721,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2360,
+						"id": 2361,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -26469,7 +26532,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2751,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26493,7 +26556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1994,
+							"line": 2001,
 							"character": 4
 						}
 					],
@@ -26507,7 +26570,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2721,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26539,7 +26602,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -26556,7 +26619,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2705,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26579,13 +26642,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -26594,7 +26657,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2670,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26622,18 +26685,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 540,
+							"line": 544,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3135,
+						"id": 3148,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2734,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26661,7 +26724,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1772,
+							"line": 1779,
 							"character": 4
 						}
 					],
@@ -26675,7 +26738,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2652,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26703,7 +26766,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 227,
+							"line": 231,
 							"character": 4
 						}
 					],
@@ -26713,7 +26776,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2714,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26737,7 +26800,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -26751,7 +26814,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2697,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26775,7 +26838,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -26789,7 +26852,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2696,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26813,7 +26876,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -26821,7 +26884,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -26831,7 +26894,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2668,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26858,7 +26921,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 512,
+							"line": 516,
 							"character": 4
 						}
 					],
@@ -26868,7 +26931,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2709,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26895,7 +26958,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -26909,7 +26972,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2745,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26937,7 +27000,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1890,
+							"line": 1897,
 							"character": 4
 						}
 					],
@@ -26951,7 +27014,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2750,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26979,7 +27042,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1978,
+							"line": 1985,
 							"character": 4
 						}
 					],
@@ -26993,7 +27056,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2735,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27021,7 +27084,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1788,
+							"line": 1795,
 							"character": 4
 						}
 					],
@@ -27035,7 +27098,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2689,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27059,7 +27122,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 860,
+							"line": 864,
 							"character": 4
 						}
 					],
@@ -27069,7 +27132,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2717,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27093,7 +27156,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -27107,7 +27170,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2690,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27130,7 +27193,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 873,
+							"line": 877,
 							"character": 4
 						}
 					],
@@ -27140,7 +27203,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2683,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27168,7 +27231,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 745,
+							"line": 749,
 							"character": 4
 						}
 					],
@@ -27178,7 +27241,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2653,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27206,7 +27269,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 243,
+							"line": 247,
 							"character": 4
 						}
 					],
@@ -27216,7 +27279,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2665,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27244,7 +27307,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 453,
+							"line": 457,
 							"character": 4
 						}
 					],
@@ -27254,7 +27317,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2687,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27278,7 +27341,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 827,
+							"line": 831,
 							"character": 4
 						}
 					],
@@ -27288,7 +27351,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2711,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27312,7 +27375,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -27326,7 +27389,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2731,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27350,7 +27413,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1727,
+							"line": 1734,
 							"character": 4
 						}
 					],
@@ -27364,7 +27427,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2732,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27388,7 +27451,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1740,
+							"line": 1747,
 							"character": 4
 						}
 					],
@@ -27402,7 +27465,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2713,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27425,7 +27488,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -27439,7 +27502,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2693,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27463,13 +27526,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -27478,7 +27541,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2666,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27502,7 +27565,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 476,
+							"line": 480,
 							"character": 4
 						}
 					],
@@ -27512,7 +27575,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2698,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27540,7 +27603,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -27548,7 +27611,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -27558,7 +27621,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2740,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27582,7 +27645,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1650,
+							"line": 1657,
 							"character": 4
 						}
 					],
@@ -27590,7 +27653,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2768,
+							"id": 2769,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -27600,7 +27663,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2738,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27624,7 +27687,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1608,
+							"line": 1615,
 							"character": 4
 						}
 					],
@@ -27632,7 +27695,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2779,
+							"id": 2781,
 							"name": "HomepageModule"
 						}
 					},
@@ -27642,7 +27705,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2737,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27666,7 +27729,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1587,
+							"line": 1594,
 							"character": 4
 						}
 					],
@@ -27674,7 +27737,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3127,
+							"id": 3140,
 							"name": "ListPageColumns"
 						}
 					},
@@ -27684,7 +27747,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2657,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27712,7 +27775,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 320,
+							"line": 324,
 							"character": 4
 						}
 					],
@@ -27722,7 +27785,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2654,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27750,7 +27813,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 259,
+							"line": 263,
 							"character": 4
 						}
 					],
@@ -27760,7 +27823,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2651,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27788,7 +27851,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 209,
+							"line": 213,
 							"character": 4
 						}
 					],
@@ -27798,7 +27861,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2748,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27826,7 +27889,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1945,
+							"line": 1952,
 							"character": 4
 						}
 					],
@@ -27840,7 +27903,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2741,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27868,7 +27931,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1826,
+							"line": 1833,
 							"character": 4
 						}
 					],
@@ -27882,7 +27945,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2656,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27910,7 +27973,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 298,
+							"line": 302,
 							"character": 4
 						}
 					],
@@ -27920,7 +27983,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2655,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27948,7 +28011,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 279,
+							"line": 283,
 							"character": 4
 						}
 					],
@@ -27958,7 +28021,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2663,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27982,7 +28045,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 429,
+							"line": 433,
 							"character": 4
 						}
 					],
@@ -27995,7 +28058,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2658,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28023,7 +28086,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 338,
+							"line": 342,
 							"character": 4
 						}
 					],
@@ -28033,7 +28096,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2662,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28057,7 +28120,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 412,
+							"line": 416,
 							"character": 4
 						}
 					],
@@ -28067,7 +28130,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2671,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28087,18 +28150,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 547,
+							"line": 551,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3074,
+						"id": 3087,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2706,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28122,7 +28185,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -28136,7 +28199,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2727,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28159,7 +28222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -28173,7 +28236,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2726,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28196,7 +28259,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -28213,7 +28276,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2752,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28237,7 +28300,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2012,
+							"line": 2019,
 							"character": 4
 						}
 					],
@@ -28251,7 +28314,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2676,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28275,7 +28338,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 633,
+							"line": 637,
 							"character": 4
 						}
 					],
@@ -28285,7 +28348,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2754,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28309,7 +28372,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2044,
+							"line": 2051,
 							"character": 4
 						}
 					],
@@ -28323,7 +28386,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2678,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28347,7 +28410,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 667,
+							"line": 671,
 							"character": 4
 						}
 					],
@@ -28357,7 +28420,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2753,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28381,7 +28444,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2027,
+							"line": 2034,
 							"character": 4
 						}
 					],
@@ -28395,7 +28458,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2746,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28423,7 +28486,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1907,
+							"line": 1914,
 							"character": 4
 						}
 					],
@@ -28437,7 +28500,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2744,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28461,7 +28524,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1873,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -28475,7 +28538,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2756,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28503,7 +28566,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2076,
+							"line": 2083,
 							"character": 4
 						}
 					],
@@ -28517,7 +28580,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2674,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28544,7 +28607,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 596,
+							"line": 600,
 							"character": 4
 						}
 					],
@@ -28554,7 +28617,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2677,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28578,7 +28641,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 650,
+							"line": 654,
 							"character": 4
 						}
 					],
@@ -28588,7 +28651,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2725,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28608,7 +28671,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -28622,7 +28685,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2675,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28646,7 +28709,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 614,
+							"line": 618,
 							"character": 4
 						}
 					],
@@ -28656,7 +28719,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2736,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28680,7 +28743,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1804,
+							"line": 1811,
 							"character": 4
 						}
 					],
@@ -28694,7 +28757,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2672,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28722,7 +28785,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 562,
+							"line": 566,
 							"character": 4
 						}
 					],
@@ -28732,7 +28795,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2679,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28759,7 +28822,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 684,
+							"line": 688,
 							"character": 4
 						}
 					],
@@ -28769,7 +28832,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2681,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28793,7 +28856,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 719,
+							"line": 723,
 							"character": 4
 						}
 					],
@@ -28803,7 +28866,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2716,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28827,7 +28890,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -28841,7 +28904,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2700,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28865,7 +28928,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -28879,7 +28942,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2688,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28906,7 +28969,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 844,
+							"line": 848,
 							"character": 4
 						}
 					],
@@ -28916,7 +28979,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2667,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28943,7 +29006,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 492,
+							"line": 496,
 							"character": 4
 						}
 					],
@@ -28953,7 +29016,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2757,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28981,7 +29044,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2092,
+							"line": 2099,
 							"character": 4
 						}
 					],
@@ -28995,7 +29058,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2673,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29023,7 +29086,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 578,
+							"line": 582,
 							"character": 4
 						}
 					],
@@ -29033,7 +29096,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2715,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29057,7 +29120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -29071,7 +29134,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2660,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29095,7 +29158,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 376,
+							"line": 380,
 							"character": 4
 						}
 					],
@@ -29106,7 +29169,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2659,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29130,7 +29193,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 358,
+							"line": 362,
 							"character": 4
 						}
 					],
@@ -29140,7 +29203,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2710,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29164,7 +29227,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -29187,7 +29250,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2708,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29211,7 +29274,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -29225,7 +29288,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2718,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29249,7 +29312,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1294,
+							"line": 1301,
 							"character": 4
 						}
 					],
@@ -29263,7 +29326,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2722,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29290,7 +29353,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -29304,7 +29367,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2739,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29328,7 +29391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1636,
 							"character": 4
 						}
 					],
@@ -29336,7 +29399,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2779,
+							"id": 2781,
 							"name": "HomepageModule"
 						}
 					},
@@ -29346,7 +29409,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2728,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29370,7 +29433,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1678,
+							"line": 1685,
 							"character": 4
 						}
 					],
@@ -29378,7 +29441,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -29388,7 +29451,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2729,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29412,7 +29475,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1699,
+							"line": 1706,
 							"character": 4
 						}
 					],
@@ -29420,7 +29483,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -29430,7 +29493,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2723,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29457,7 +29520,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -29471,7 +29534,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2720,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29494,7 +29557,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -29508,7 +29571,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2743,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29536,7 +29599,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1858,
+							"line": 1865,
 							"character": 4
 						}
 					],
@@ -29550,7 +29613,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2749,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29578,7 +29641,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1962,
+							"line": 1969,
 							"character": 4
 						}
 					],
@@ -29592,7 +29655,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2742,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29620,7 +29683,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1842,
+							"line": 1849,
 							"character": 4
 						}
 					],
@@ -29634,7 +29697,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2747,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29662,7 +29725,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1924,
+							"line": 1931,
 							"character": 4
 						}
 					],
@@ -29676,7 +29739,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2755,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29704,7 +29767,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2060,
+							"line": 2067,
 							"character": 4
 						}
 					],
@@ -29718,7 +29781,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2650,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29746,7 +29809,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 187,
+							"line": 191,
 							"character": 4
 						}
 					],
@@ -29756,7 +29819,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2685,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29780,7 +29843,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 783,
+							"line": 787,
 							"character": 4
 						}
 					],
@@ -29791,7 +29854,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2684,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29815,7 +29878,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 765,
+							"line": 769,
 							"character": 4
 						}
 					],
@@ -29826,7 +29889,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2686,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29850,18 +29913,18 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 818,
+							"line": 822,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2627,
+						"id": 2628,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2661,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29885,7 +29948,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 392,
+							"line": 396,
 							"character": 4
 						}
 					],
@@ -29895,7 +29958,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2682,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29923,7 +29986,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 735,
+							"line": 739,
 							"character": 4
 						}
 					],
@@ -29933,7 +29996,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2724,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29960,7 +30023,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -29974,7 +30037,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2699,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30002,7 +30065,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -30010,7 +30073,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -30020,7 +30083,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2691,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30039,13 +30102,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 879,
+							"line": 883,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3180,
+						"id": 3194,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -30055,110 +30118,110 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2700,
-						2732,
-						2668,
-						2729,
-						2750,
-						2720,
-						2704,
-						2669,
+						2701,
 						2733,
-						2651,
-						2713,
-						2696,
-						2695,
-						2667,
-						2708,
-						2744,
-						2749,
-						2734,
-						2688,
-						2716,
-						2689,
-						2682,
-						2652,
-						2664,
-						2686,
-						2710,
+						2669,
 						2730,
-						2731,
-						2712,
-						2692,
-						2665,
-						2697,
-						2739,
-						2737,
-						2736,
-						2656,
-						2653,
-						2650,
-						2747,
-						2740,
-						2655,
-						2654,
-						2662,
-						2657,
-						2661,
-						2670,
-						2705,
-						2726,
-						2725,
 						2751,
-						2675,
-						2753,
-						2677,
-						2752,
-						2745,
-						2743,
-						2755,
-						2673,
-						2676,
-						2724,
-						2674,
-						2735,
-						2671,
-						2678,
-						2680,
-						2715,
-						2699,
-						2687,
-						2666,
-						2756,
-						2672,
-						2714,
-						2659,
-						2658,
-						2709,
-						2707,
-						2717,
 						2721,
+						2705,
+						2670,
+						2734,
+						2652,
+						2714,
+						2697,
+						2696,
+						2668,
+						2709,
+						2745,
+						2750,
+						2735,
+						2689,
+						2717,
+						2690,
+						2683,
+						2653,
+						2665,
+						2687,
+						2711,
+						2731,
+						2732,
+						2713,
+						2693,
+						2666,
+						2698,
+						2740,
 						2738,
-						2727,
-						2728,
-						2722,
-						2719,
-						2742,
+						2737,
+						2657,
+						2654,
+						2651,
 						2748,
 						2741,
-						2746,
+						2656,
+						2655,
+						2663,
+						2658,
+						2662,
+						2671,
+						2706,
+						2727,
+						2726,
+						2752,
+						2676,
 						2754,
-						2649,
-						2684,
-						2683,
-						2685,
-						2660,
+						2678,
+						2753,
+						2746,
+						2744,
+						2756,
+						2674,
+						2677,
+						2725,
+						2675,
+						2736,
+						2672,
+						2679,
 						2681,
+						2716,
+						2700,
+						2688,
+						2667,
+						2757,
+						2673,
+						2715,
+						2660,
+						2659,
+						2710,
+						2708,
+						2718,
+						2722,
+						2739,
+						2728,
+						2729,
 						2723,
-						2698,
-						2690
+						2720,
+						2743,
+						2749,
+						2742,
+						2747,
+						2755,
+						2650,
+						2685,
+						2684,
+						2686,
+						2661,
+						2682,
+						2724,
+						2699,
+						2691
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 170,
+					"line": 174,
 					"character": 17
 				}
 			],
@@ -30922,7 +30985,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
@@ -31011,7 +31074,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -31052,13 +31115,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -31092,7 +31155,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -31131,7 +31194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -31170,7 +31233,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -31178,7 +31241,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -31216,7 +31279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -31255,7 +31318,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -31294,7 +31357,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -31332,7 +31395,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -31371,13 +31434,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -31415,7 +31478,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -31423,7 +31486,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -31458,7 +31521,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -31496,7 +31559,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -31534,7 +31597,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -31572,7 +31635,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -31611,7 +31674,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -31650,7 +31713,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -31689,7 +31752,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -31728,7 +31791,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -31776,7 +31839,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -31818,7 +31881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -31860,7 +31923,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -31898,7 +31961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -31940,7 +32003,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -31983,7 +32046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -31991,7 +32054,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -32123,7 +32186,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
@@ -32212,7 +32275,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -32253,13 +32316,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -32336,7 +32399,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -32414,7 +32477,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -32453,7 +32516,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -32461,7 +32524,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -32499,7 +32562,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -32538,7 +32601,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -32659,7 +32722,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -32775,7 +32838,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -32814,13 +32877,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -32858,7 +32921,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -32866,7 +32929,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -32979,7 +33042,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -33017,7 +33080,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -33055,7 +33118,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -33093,7 +33156,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -33132,7 +33195,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -33171,7 +33234,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -33210,7 +33273,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -33249,7 +33312,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -33297,7 +33360,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -33339,7 +33402,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -33386,7 +33449,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -33429,7 +33492,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -33495,7 +33558,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -33533,7 +33596,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -33737,7 +33800,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -33780,7 +33843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -33788,7 +33851,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -33891,7 +33954,7 @@
 			]
 		},
 		{
-			"id": 3090,
+			"id": 3103,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33906,7 +33969,7 @@
 			},
 			"children": [
 				{
-					"id": 3091,
+					"id": 3104,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33916,21 +33979,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8178,
+							"line": 8185,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3092,
+							"id": 3105,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3093,
+									"id": 3106,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -33938,18 +34001,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8179,
+											"line": 8186,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3087,
+										"id": 3100,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3094,
+									"id": 3107,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -33957,7 +34020,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8180,
+											"line": 8187,
 											"character": 8
 										}
 									],
@@ -33965,7 +34028,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3087,
+											"id": 3100,
 											"name": "VizPoint"
 										}
 									}
@@ -33976,8 +34039,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3093,
-										3094
+										3106,
+										3107
 									]
 								}
 							]
@@ -33985,7 +34048,7 @@
 					}
 				},
 				{
-					"id": 3095,
+					"id": 3108,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33993,21 +34056,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8182,
+							"line": 8189,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3096,
+							"id": 3109,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3104,
+									"id": 3117,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34015,7 +34078,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8190,
+											"line": 8197,
 											"character": 8
 										}
 									],
@@ -34028,8 +34091,29 @@
 									}
 								},
 								{
-									"id": 3105,
+									"id": 3118,
 									"name": "data",
+									"kind": 1024,
+									"kindString": "Property",
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "types.ts",
+											"line": 8198,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "array",
+										"elementType": {
+											"type": "intrinsic",
+											"name": "any"
+										}
+									}
+								},
+								{
+									"id": 3111,
+									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
 									"flags": {},
@@ -34041,33 +34125,12 @@
 										}
 									],
 									"type": {
-										"type": "array",
-										"elementType": {
-											"type": "intrinsic",
-											"name": "any"
-										}
-									}
-								},
-								{
-									"id": 3098,
-									"name": "id",
-									"kind": 1024,
-									"kindString": "Property",
-									"flags": {},
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 8184,
-											"character": 8
-										}
-									],
-									"type": {
 										"type": "intrinsic",
 										"name": "string"
 									}
 								},
 								{
-									"id": 3097,
+									"id": 3110,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34075,7 +34138,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8183,
+											"line": 8190,
 											"character": 8
 										}
 									],
@@ -34085,7 +34148,7 @@
 									}
 								},
 								{
-									"id": 3099,
+									"id": 3112,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34093,21 +34156,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8185,
+											"line": 8192,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3100,
+											"id": 3113,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3101,
+													"id": 3114,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -34115,21 +34178,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8186,
+															"line": 8193,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3102,
+															"id": 3115,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3103,
+																	"id": 3116,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -34137,7 +34200,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8187,
+																			"line": 8194,
 																			"character": 16
 																		}
 																	],
@@ -34152,7 +34215,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3103
+																		3116
 																	]
 																}
 															]
@@ -34165,7 +34228,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3101
+														3114
 													]
 												}
 											]
@@ -34178,23 +34241,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3104,
-										3105,
-										3098,
-										3097,
-										3099
+										3117,
+										3118,
+										3111,
+										3110,
+										3112
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3106,
+								"id": 3119,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3107,
+										"id": 3120,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34213,7 +34276,7 @@
 					}
 				},
 				{
-					"id": 3108,
+					"id": 3121,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34221,7 +34284,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8194,
+							"line": 8201,
 							"character": 4
 						}
 					],
@@ -34232,7 +34295,7 @@
 					}
 				},
 				{
-					"id": 3109,
+					"id": 3122,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34242,7 +34305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8195,
+							"line": 8202,
 							"character": 4
 						}
 					],
@@ -34257,23 +34320,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3091,
-						3095,
+						3104,
 						3108,
-						3109
+						3121,
+						3122
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8177,
+					"line": 8184,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2825,
+			"id": 2827,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34283,7 +34346,7 @@
 			},
 			"children": [
 				{
-					"id": 2879,
+					"id": 2881,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34306,7 +34369,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2880,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34329,7 +34392,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2850,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34352,7 +34415,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2851,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34375,7 +34438,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2853,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34398,7 +34461,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2852,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34421,7 +34484,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2832,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34444,7 +34507,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2893,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34467,7 +34530,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2894,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34490,7 +34553,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2891,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34513,7 +34576,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2892,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34536,7 +34599,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2855,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34559,7 +34622,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2860,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34582,7 +34645,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2857,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34605,7 +34668,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2859,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34628,7 +34691,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2858,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34651,7 +34714,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2856,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34674,7 +34737,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2865,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34697,7 +34760,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2862,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34720,7 +34783,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2864,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34743,7 +34806,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2863,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34766,7 +34829,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2861,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34789,7 +34852,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2869,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34812,7 +34875,7 @@
 					}
 				},
 				{
-					"id": 2866,
+					"id": 2868,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34835,7 +34898,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2867,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34858,7 +34921,7 @@
 					}
 				},
 				{
-					"id": 2864,
+					"id": 2866,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34881,7 +34944,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2854,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34904,7 +34967,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 2989,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34927,7 +34990,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2984,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34950,7 +35013,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2979,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34973,7 +35036,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2978,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34996,7 +35059,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2981,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35019,7 +35082,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2980,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35042,7 +35105,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2916,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35065,7 +35128,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2919,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35088,7 +35151,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2914,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35111,7 +35174,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2917,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35134,7 +35197,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2918,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35157,7 +35220,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2913,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35180,7 +35243,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2915,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35203,7 +35266,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2886,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35226,7 +35289,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2885,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35249,7 +35312,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2888,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35272,7 +35335,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2887,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35295,7 +35358,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2884,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35318,7 +35381,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2882,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35341,7 +35404,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2883,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35364,7 +35427,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2889,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35387,7 +35450,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2890,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35410,7 +35473,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2901,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35433,7 +35496,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2902,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35456,7 +35519,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2905,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35479,7 +35542,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2903,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35502,7 +35565,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2904,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35525,7 +35588,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2912,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35548,7 +35611,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2911,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35571,7 +35634,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2910,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35594,7 +35657,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2909,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35617,7 +35680,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2977,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35640,7 +35703,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2976,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35663,7 +35726,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2975,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35686,7 +35749,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2983,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35709,7 +35772,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2982,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35732,7 +35795,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2907,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35755,7 +35818,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2906,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35778,7 +35841,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2936,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35801,7 +35864,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2949,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35825,7 +35888,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2948,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35849,7 +35912,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2946,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35873,7 +35936,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2947,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35897,7 +35960,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2954,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35920,7 +35983,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2952,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35943,7 +36006,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2951,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35966,7 +36029,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3038,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35989,7 +36052,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3042,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36012,7 +36075,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3043,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36035,7 +36098,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3039,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36058,7 +36121,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3040,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36081,7 +36144,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3041,
 					"name": "--ts-var-liveboard-edit-toolbar-text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36104,7 +36167,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2937,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36128,7 +36191,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2938,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36152,7 +36215,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2942,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36176,7 +36239,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2930,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36200,7 +36263,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2945,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36224,7 +36287,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2944,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36248,7 +36311,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2935,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36272,7 +36335,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2943,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36296,7 +36359,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2933,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36320,7 +36383,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2934,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36344,7 +36407,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2941,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36368,7 +36431,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2931,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36392,7 +36455,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2932,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36416,7 +36479,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2968,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36439,7 +36502,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2965,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36462,7 +36525,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2966,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36485,7 +36548,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2967,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36508,7 +36571,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2921,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36531,7 +36594,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2974,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36554,7 +36617,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2969,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36577,7 +36640,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2970,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36600,7 +36663,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2973,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36623,7 +36686,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2971,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36646,7 +36709,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2972,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36669,7 +36732,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2922,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36692,7 +36755,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2926,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36715,7 +36778,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2925,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36738,7 +36801,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2920,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36761,7 +36824,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2940,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36784,7 +36847,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2939,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36807,7 +36870,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2953,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36830,7 +36893,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3008,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36853,7 +36916,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3005,
 					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36876,7 +36939,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3007,
 					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36899,7 +36962,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3009,
 					"name": "--ts-var-liveboard-styling-button-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36922,7 +36985,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3010,
 					"name": "--ts-var-liveboard-styling-button-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36945,7 +37008,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3006,
 					"name": "--ts-var-liveboard-styling-button-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36968,7 +37031,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3011,
 					"name": "--ts-var-liveboard-styling-color-palette-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36991,7 +37054,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3004,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37014,7 +37077,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3003,
 					"name": "--ts-var-liveboard-styling-panel-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37037,7 +37100,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2955,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37060,7 +37123,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2956,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37083,7 +37146,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2924,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37106,7 +37169,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2923,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37129,7 +37192,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2927,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37152,7 +37215,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2928,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37175,7 +37238,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2929,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37198,7 +37261,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2957,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37221,7 +37284,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2958,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37244,7 +37307,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2899,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37267,7 +37330,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2896,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37290,7 +37353,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2895,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37313,7 +37376,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2897,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37336,7 +37399,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2900,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37359,7 +37422,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2898,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37382,7 +37445,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2833,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37405,7 +37468,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2834,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37428,7 +37491,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2963,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37451,7 +37514,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2964,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37474,7 +37537,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2959,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37497,7 +37560,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2961,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37520,7 +37583,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2962,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37543,7 +37606,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2960,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37566,7 +37629,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2828,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37589,7 +37652,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2829,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37612,7 +37675,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2830,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37635,7 +37698,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2831,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37658,7 +37721,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 2992,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37681,7 +37744,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 2991,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37704,7 +37767,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 2996,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37727,7 +37790,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 2997,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37750,7 +37813,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3000,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37773,7 +37836,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 2999,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37796,7 +37859,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 2998,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37819,7 +37882,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3001,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37842,7 +37905,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 2994,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37865,7 +37928,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3002,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37888,7 +37951,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 2993,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37911,7 +37974,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 2995,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37934,7 +37997,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2842,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37957,7 +38020,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2846,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37980,7 +38043,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2847,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38003,7 +38066,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2845,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38026,7 +38089,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2841,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38049,7 +38112,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2844,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38072,7 +38135,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2838,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38095,7 +38158,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2839,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38118,7 +38181,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2840,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38141,7 +38204,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2835,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38164,7 +38227,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2836,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38187,7 +38250,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2837,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38210,7 +38273,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2843,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38233,7 +38296,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2908,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38256,7 +38319,260 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 3054,
+					"name": "--ts-var-share-chat-header-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the share chat header's inner title/actions row.\nDefaults to transparent."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1229,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3053,
+					"name": "--ts-var-share-chat-header-container-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background gradient color-stop of the share chat header's outer container\n(sender's pre-share header). Defaults to transparent."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1223,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3057,
+					"name": "--ts-var-share-chat-header-input-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1244,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3058,
+					"name": "--ts-var-share-chat-header-input-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1249,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3056,
+					"name": "--ts-var-share-chat-header-input-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1239,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3055,
+					"name": "--ts-var-share-chat-header-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the title text in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1234,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3050,
+					"name": "--ts-var-shared-conv-header-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the shared conversation header (recipient's read-only view)."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1207,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3051,
+					"name": "--ts-var-shared-conv-header-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the shared conversation header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1212,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3052,
+					"name": "--ts-var-shared-conv-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the title text in the shared conversation header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1217,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3059,
+					"name": "--ts-var-shimmer-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the shimmer loading effect. Also affects the\nsaved chats sidebar's new-chat shimmer, which shares the same style."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1255,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3060,
+					"name": "--ts-var-shimmer-sweep-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the shimmer sweep animation's gradient mid-stop."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1260,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2950,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38279,7 +38595,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 2988,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38302,7 +38618,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2985,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38325,7 +38641,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 2986,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38348,7 +38664,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 2987,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38371,7 +38687,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 2990,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38394,7 +38710,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2848,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38417,7 +38733,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2849,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38440,7 +38756,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3045,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38463,7 +38779,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3017,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38486,7 +38802,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3046,
 					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38509,7 +38825,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3044,
 					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38532,7 +38848,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3013,
 					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38555,7 +38871,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3015,
 					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38578,7 +38894,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3016,
 					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38601,7 +38917,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3014,
 					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38624,7 +38940,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3036,
 					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38647,7 +38963,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3037,
 					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38670,7 +38986,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3022,
 					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38693,7 +39009,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3012,
 					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38716,7 +39032,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3018,
 					"name": "--ts-var-spotterviz-prompt-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38739,7 +39055,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3019,
 					"name": "--ts-var-spotterviz-prompt-card-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38762,7 +39078,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3047,
 					"name": "--ts-var-spotterviz-reference-icon-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38785,7 +39101,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3049,
 					"name": "--ts-var-spotterviz-reference-icon-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38808,7 +39124,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3048,
 					"name": "--ts-var-spotterviz-reference-icon-selected-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38831,7 +39147,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3020,
 					"name": "--ts-var-spotterviz-text-primary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38854,7 +39170,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3021,
 					"name": "--ts-var-spotterviz-text-secondary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38877,7 +39193,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3026,
 					"name": "--ts-var-spotterviz-thinking-completed-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38900,7 +39216,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3028,
 					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38923,7 +39239,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3025,
 					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38946,7 +39262,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3027,
 					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38969,7 +39285,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3031,
 					"name": "--ts-var-spotterviz-tool-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38992,7 +39308,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3029,
 					"name": "--ts-var-spotterviz-tool-call-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39015,7 +39331,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3033,
 					"name": "--ts-var-spotterviz-tool-feedback-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39038,7 +39354,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3034,
 					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39061,7 +39377,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3032,
 					"name": "--ts-var-spotterviz-tool-json-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39084,7 +39400,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3035,
 					"name": "--ts-var-spotterviz-tool-json-input-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39107,7 +39423,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3030,
 					"name": "--ts-var-spotterviz-tool-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39130,7 +39446,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3024,
 					"name": "--ts-var-spotterviz-usermessage-icon-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39153,7 +39469,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3023,
 					"name": "--ts-var-spotterviz-usermessage-icon-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39176,7 +39492,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2878,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39199,7 +39515,7 @@
 					}
 				},
 				{
-					"id": 2874,
+					"id": 2876,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39222,7 +39538,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2877,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39245,7 +39561,7 @@
 					}
 				},
 				{
-					"id": 2871,
+					"id": 2873,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39268,7 +39584,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2874,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39291,7 +39607,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2875,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39314,7 +39630,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2879,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39337,7 +39653,7 @@
 					}
 				},
 				{
-					"id": 2868,
+					"id": 2870,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39360,7 +39676,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2871,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39383,7 +39699,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2872,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39411,228 +39727,239 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2879,
-						2878,
-						2848,
-						2849,
-						2851,
+						2881,
+						2880,
 						2850,
-						2830,
+						2851,
+						2853,
+						2852,
+						2832,
+						2893,
+						2894,
 						2891,
 						2892,
-						2889,
-						2890,
-						2853,
-						2858,
 						2855,
-						2857,
-						2856,
-						2854,
-						2863,
 						2860,
-						2862,
-						2861,
+						2857,
 						2859,
+						2858,
+						2856,
+						2865,
+						2862,
+						2864,
+						2863,
+						2861,
+						2869,
+						2868,
 						2867,
 						2866,
-						2865,
-						2864,
-						2852,
-						2987,
-						2982,
-						2977,
-						2976,
+						2854,
+						2989,
+						2984,
 						2979,
 						2978,
-						2914,
-						2917,
-						2912,
-						2915,
-						2916,
-						2911,
-						2913,
-						2884,
-						2883,
-						2886,
-						2885,
-						2882,
-						2880,
-						2881,
-						2887,
-						2888,
-						2899,
-						2900,
-						2903,
-						2901,
-						2902,
-						2910,
-						2909,
-						2908,
-						2907,
-						2975,
-						2974,
-						2973,
 						2981,
 						2980,
+						2916,
+						2919,
+						2914,
+						2917,
+						2918,
+						2913,
+						2915,
+						2886,
+						2885,
+						2888,
+						2887,
+						2884,
+						2882,
+						2883,
+						2889,
+						2890,
+						2901,
+						2902,
 						2905,
+						2903,
 						2904,
-						2934,
-						2947,
-						2946,
-						2944,
-						2945,
-						2952,
-						2950,
+						2912,
+						2911,
+						2910,
+						2909,
+						2977,
+						2976,
+						2975,
+						2983,
+						2982,
+						2907,
+						2906,
+						2936,
 						2949,
-						3036,
+						2948,
+						2946,
+						2947,
+						2954,
+						2952,
+						2951,
+						3038,
+						3042,
+						3043,
+						3039,
 						3040,
 						3041,
-						3037,
-						3038,
-						3039,
-						2935,
-						2936,
-						2940,
-						2928,
-						2943,
+						2937,
+						2938,
 						2942,
+						2930,
+						2945,
+						2944,
+						2935,
+						2943,
 						2933,
+						2934,
 						2941,
 						2931,
 						2932,
-						2939,
-						2929,
-						2930,
-						2966,
-						2963,
-						2964,
-						2965,
-						2919,
-						2972,
-						2967,
 						2968,
-						2971,
+						2965,
+						2966,
+						2967,
+						2921,
+						2974,
 						2969,
 						2970,
+						2973,
+						2971,
+						2972,
+						2922,
+						2926,
+						2925,
 						2920,
-						2924,
-						2923,
-						2918,
-						2938,
-						2937,
-						2951,
-						3006,
-						3003,
+						2940,
+						2939,
+						2953,
+						3008,
 						3005,
 						3007,
-						3008,
-						3004,
 						3009,
-						3002,
-						3001,
-						2953,
-						2954,
-						2922,
-						2921,
-						2925,
-						2926,
-						2927,
+						3010,
+						3006,
+						3011,
+						3004,
+						3003,
 						2955,
 						2956,
-						2897,
-						2894,
-						2893,
-						2895,
-						2898,
-						2896,
-						2831,
-						2832,
-						2961,
-						2962,
+						2924,
+						2923,
+						2927,
+						2928,
+						2929,
 						2957,
-						2959,
-						2960,
 						2958,
-						2826,
-						2827,
-						2828,
-						2829,
-						2990,
-						2989,
-						2994,
-						2995,
-						2998,
-						2997,
-						2996,
-						2999,
-						2992,
-						3000,
-						2991,
-						2993,
-						2840,
-						2844,
-						2845,
-						2843,
-						2839,
-						2842,
-						2836,
-						2837,
-						2838,
+						2899,
+						2896,
+						2895,
+						2897,
+						2900,
+						2898,
 						2833,
 						2834,
-						2835,
-						2841,
-						2906,
-						2948,
-						2986,
-						2983,
-						2984,
-						2985,
-						2988,
+						2963,
+						2964,
+						2959,
+						2961,
+						2962,
+						2960,
+						2828,
+						2829,
+						2830,
+						2831,
+						2992,
+						2991,
+						2996,
+						2997,
+						3000,
+						2999,
+						2998,
+						3001,
+						2994,
+						3002,
+						2993,
+						2995,
+						2842,
 						2846,
 						2847,
-						3043,
-						3015,
-						3044,
-						3042,
-						3011,
-						3013,
-						3014,
-						3012,
-						3034,
-						3035,
-						3020,
-						3010,
-						3016,
-						3017,
+						2845,
+						2841,
+						2844,
+						2838,
+						2839,
+						2840,
+						2835,
+						2836,
+						2837,
+						2843,
+						2908,
+						3054,
+						3053,
+						3057,
+						3058,
+						3056,
+						3055,
+						3050,
+						3051,
+						3052,
+						3059,
+						3060,
+						2950,
+						2988,
+						2985,
+						2986,
+						2987,
+						2990,
+						2848,
+						2849,
 						3045,
-						3047,
+						3017,
 						3046,
+						3044,
+						3013,
+						3015,
+						3016,
+						3014,
+						3036,
+						3037,
+						3022,
+						3012,
 						3018,
 						3019,
-						3024,
+						3047,
+						3049,
+						3048,
+						3020,
+						3021,
 						3026,
-						3023,
+						3028,
 						3025,
-						3029,
 						3027,
 						3031,
-						3032,
-						3030,
+						3029,
 						3033,
-						3028,
-						3022,
-						3021,
+						3034,
+						3032,
+						3035,
+						3030,
+						3024,
+						3023,
+						2878,
 						2876,
+						2877,
+						2873,
 						2874,
 						2875,
+						2879,
+						2870,
 						2871,
-						2872,
-						2873,
-						2877,
-						2868,
-						2869,
-						2870
+						2872
 					]
 				}
 			],
@@ -39645,7 +39972,7 @@
 			]
 		},
 		{
-			"id": 2813,
+			"id": 2815,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39655,7 +39982,7 @@
 			},
 			"children": [
 				{
-					"id": 2815,
+					"id": 2817,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39665,18 +39992,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 298,
+							"line": 305,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2816,
+						"id": 2818,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2816,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39686,7 +40013,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 297,
+							"line": 304,
 							"character": 4
 						}
 					],
@@ -39701,21 +40028,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2815,
-						2814
+						2817,
+						2816
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 296,
+					"line": 303,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2803,
+			"id": 2805,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39731,7 +40058,7 @@
 			},
 			"children": [
 				{
-					"id": 2805,
+					"id": 2807,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39741,21 +40068,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 334,
+							"line": 341,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2806,
+							"id": 2808,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2808,
+									"id": 2810,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39765,7 +40092,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 339,
+											"line": 346,
 											"character": 8
 										}
 									],
@@ -39785,7 +40112,7 @@
 									}
 								},
 								{
-									"id": 2809,
+									"id": 2811,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39795,7 +40122,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 340,
+											"line": 347,
 											"character": 8
 										}
 									],
@@ -39805,7 +40132,7 @@
 									}
 								},
 								{
-									"id": 2807,
+									"id": 2809,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39823,7 +40150,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 338,
+											"line": 345,
 											"character": 8
 										}
 									],
@@ -39848,21 +40175,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2808,
-										2809,
-										2807
+										2810,
+										2811,
+										2809
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2810,
+								"id": 2812,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2811,
+										"id": 2813,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -39881,7 +40208,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2814,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39891,7 +40218,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 343,
+							"line": 350,
 							"character": 4
 						}
 					],
@@ -39901,7 +40228,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2806,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39911,13 +40238,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 333,
+							"line": 340,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2813,
+						"id": 2815,
 						"name": "CustomStyles"
 					}
 				}
@@ -39927,22 +40254,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2805,
-						2812,
-						2804
+						2807,
+						2814,
+						2806
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 332,
+					"line": 339,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2364,
+			"id": 2365,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39958,7 +40285,7 @@
 			},
 			"children": [
 				{
-					"id": 2405,
+					"id": 2406,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39981,27 +40308,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 651,
+							"line": 658,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2406,
+							"id": 2407,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2407,
+								"id": 2408,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2408,
+										"id": 2409,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -40033,7 +40360,7 @@
 					}
 				},
 				{
-					"id": 2367,
+					"id": 2368,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40046,7 +40373,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 369,
+							"line": 376,
 							"character": 4
 						}
 					],
@@ -40056,7 +40383,7 @@
 					}
 				},
 				{
-					"id": 2387,
+					"id": 2388,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40079,7 +40406,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 527,
+							"line": 534,
 							"character": 4
 						}
 					],
@@ -40098,7 +40425,7 @@
 					}
 				},
 				{
-					"id": 2389,
+					"id": 2390,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40117,7 +40444,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 540,
+							"line": 547,
 							"character": 4
 						}
 					],
@@ -40127,7 +40454,7 @@
 					}
 				},
 				{
-					"id": 2366,
+					"id": 2367,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40138,18 +40465,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 361,
+							"line": 368,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1934,
+						"id": 1935,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2379,
+					"id": 2380,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40168,7 +40495,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 460,
+							"line": 467,
 							"character": 4
 						}
 					],
@@ -40178,7 +40505,7 @@
 					}
 				},
 				{
-					"id": 2390,
+					"id": 2391,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40201,7 +40528,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 547,
+							"line": 554,
 							"character": 4
 						}
 					],
@@ -40211,7 +40538,7 @@
 					}
 				},
 				{
-					"id": 2382,
+					"id": 2383,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40230,7 +40557,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 482,
+							"line": 489,
 							"character": 4
 						}
 					],
@@ -40240,7 +40567,7 @@
 					}
 				},
 				{
-					"id": 2414,
+					"id": 2415,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40263,7 +40590,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 859,
+							"line": 866,
 							"character": 4
 						}
 					],
@@ -40273,7 +40600,7 @@
 					}
 				},
 				{
-					"id": 2402,
+					"id": 2403,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40292,7 +40619,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 610,
+							"line": 617,
 							"character": 4
 						}
 					],
@@ -40302,7 +40629,7 @@
 					}
 				},
 				{
-					"id": 2412,
+					"id": 2413,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40333,7 +40660,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 846,
+							"line": 853,
 							"character": 4
 						}
 					],
@@ -40346,7 +40673,7 @@
 					}
 				},
 				{
-					"id": 2409,
+					"id": 2410,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40369,7 +40696,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 667,
+							"line": 674,
 							"character": 4
 						}
 					],
@@ -40389,7 +40716,7 @@
 					}
 				},
 				{
-					"id": 2386,
+					"id": 2387,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40408,18 +40735,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 512,
+							"line": 519,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2400,
+					"id": 2401,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40438,7 +40765,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 600,
+							"line": 607,
 							"character": 4
 						}
 					],
@@ -40448,7 +40775,7 @@
 					}
 				},
 				{
-					"id": 2384,
+					"id": 2385,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40468,7 +40795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 502,
+							"line": 509,
 							"character": 4
 						}
 					],
@@ -40478,7 +40805,7 @@
 					}
 				},
 				{
-					"id": 2411,
+					"id": 2412,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40505,7 +40832,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 684,
+							"line": 691,
 							"character": 4
 						}
 					],
@@ -40515,7 +40842,7 @@
 					}
 				},
 				{
-					"id": 2404,
+					"id": 2405,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40534,7 +40861,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 631,
+							"line": 638,
 							"character": 4
 						}
 					],
@@ -40544,7 +40871,7 @@
 					}
 				},
 				{
-					"id": 2380,
+					"id": 2381,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40567,7 +40894,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 470,
+							"line": 477,
 							"character": 4
 						}
 					],
@@ -40577,7 +40904,7 @@
 					}
 				},
 				{
-					"id": 2410,
+					"id": 2411,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40587,7 +40914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 669,
+							"line": 676,
 							"character": 4
 						}
 					],
@@ -40597,7 +40924,7 @@
 					}
 				},
 				{
-					"id": 2378,
+					"id": 2379,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40616,7 +40943,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 453,
+							"line": 460,
 							"character": 4
 						}
 					],
@@ -40626,7 +40953,7 @@
 					}
 				},
 				{
-					"id": 2373,
+					"id": 2374,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40650,7 +40977,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 414,
+							"line": 421,
 							"character": 4
 						}
 					],
@@ -40660,7 +40987,7 @@
 					}
 				},
 				{
-					"id": 2398,
+					"id": 2399,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40687,18 +41014,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 589,
+							"line": 596,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3051,
+						"id": 3064,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2381,
+					"id": 2382,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40717,7 +41044,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 476,
+							"line": 483,
 							"character": 4
 						}
 					],
@@ -40727,7 +41054,7 @@
 					}
 				},
 				{
-					"id": 2372,
+					"id": 2373,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40750,7 +41077,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 403,
+							"line": 410,
 							"character": 4
 						}
 					],
@@ -40760,7 +41087,7 @@
 					}
 				},
 				{
-					"id": 2401,
+					"id": 2402,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40779,7 +41106,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 605,
+							"line": 612,
 							"character": 4
 						}
 					],
@@ -40789,7 +41116,7 @@
 					}
 				},
 				{
-					"id": 2371,
+					"id": 2372,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40803,7 +41130,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 394,
+							"line": 401,
 							"character": 4
 						}
 					],
@@ -40813,7 +41140,7 @@
 					}
 				},
 				{
-					"id": 2396,
+					"id": 2397,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40832,7 +41159,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 564,
+							"line": 571,
 							"character": 4
 						}
 					],
@@ -40842,7 +41169,7 @@
 					}
 				},
 				{
-					"id": 2383,
+					"id": 2384,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40865,7 +41192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 491,
+							"line": 498,
 							"character": 4
 						}
 					],
@@ -40875,7 +41202,7 @@
 					}
 				},
 				{
-					"id": 2374,
+					"id": 2375,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40895,7 +41222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 424,
+							"line": 431,
 							"character": 4
 						}
 					],
@@ -40905,7 +41232,7 @@
 					}
 				},
 				{
-					"id": 2376,
+					"id": 2377,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40924,7 +41251,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 435,
+							"line": 442,
 							"character": 4
 						}
 					],
@@ -40934,7 +41261,7 @@
 					}
 				},
 				{
-					"id": 2397,
+					"id": 2398,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40953,7 +41280,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 570,
+							"line": 577,
 							"character": 4
 						}
 					],
@@ -40963,7 +41290,7 @@
 					}
 				},
 				{
-					"id": 2377,
+					"id": 2378,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40982,7 +41309,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 445,
+							"line": 452,
 							"character": 4
 						}
 					],
@@ -40992,7 +41319,7 @@
 					}
 				},
 				{
-					"id": 2385,
+					"id": 2386,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41011,7 +41338,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 507,
+							"line": 514,
 							"character": 4
 						}
 					],
@@ -41021,7 +41348,7 @@
 					}
 				},
 				{
-					"id": 2365,
+					"id": 2366,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41032,7 +41359,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 357,
+							"line": 364,
 							"character": 4
 						}
 					],
@@ -41042,7 +41369,7 @@
 					}
 				},
 				{
-					"id": 2388,
+					"id": 2389,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41055,7 +41382,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 534,
+							"line": 541,
 							"character": 4
 						}
 					],
@@ -41065,7 +41392,7 @@
 					}
 				},
 				{
-					"id": 2370,
+					"id": 2371,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41078,7 +41405,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 386,
+							"line": 393,
 							"character": 4
 						}
 					],
@@ -41088,7 +41415,7 @@
 					}
 				},
 				{
-					"id": 2413,
+					"id": 2414,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41111,7 +41438,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 853,
+							"line": 860,
 							"character": 4
 						}
 					],
@@ -41121,7 +41448,7 @@
 					}
 				},
 				{
-					"id": 2368,
+					"id": 2369,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -41131,13 +41458,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 381,
+							"line": 388,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 2369,
+							"id": 2370,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -41165,63 +41492,63 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2405,
-						2367,
-						2387,
-						2389,
-						2366,
-						2379,
-						2390,
-						2382,
-						2414,
-						2402,
-						2412,
-						2409,
-						2386,
-						2400,
-						2384,
-						2411,
-						2404,
-						2380,
-						2410,
-						2378,
-						2373,
-						2398,
-						2381,
-						2372,
-						2401,
-						2371,
-						2396,
-						2383,
-						2374,
-						2376,
-						2397,
-						2377,
-						2385,
-						2365,
+						2406,
+						2368,
 						2388,
-						2370,
-						2413
+						2390,
+						2367,
+						2380,
+						2391,
+						2383,
+						2415,
+						2403,
+						2413,
+						2410,
+						2387,
+						2401,
+						2385,
+						2412,
+						2405,
+						2381,
+						2411,
+						2379,
+						2374,
+						2399,
+						2382,
+						2373,
+						2402,
+						2372,
+						2397,
+						2384,
+						2375,
+						2377,
+						2398,
+						2378,
+						2386,
+						2366,
+						2389,
+						2371,
+						2414
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2368
+						2369
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 353,
+					"line": 360,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3169,
+			"id": 3183,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41250,7 +41577,7 @@
 			},
 			"children": [
 				{
-					"id": 3172,
+					"id": 3186,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41261,18 +41588,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8559,
+							"line": 8569,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3152,
+						"id": 3165,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3170,
+					"id": 3184,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41283,18 +41610,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8555,
+							"line": 8565,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3175,
+						"id": 3189,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3171,
+					"id": 3185,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41305,7 +41632,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8557,
+							"line": 8567,
 							"character": 4
 						}
 					],
@@ -41332,21 +41659,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3172,
-						3170,
-						3171
+						3186,
+						3184,
+						3185
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8553,
+					"line": 8563,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3173,
+				"id": 3187,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -41356,7 +41683,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3174,
+						"id": 3188,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -41373,7 +41700,7 @@
 			}
 		},
 		{
-			"id": 2762,
+			"id": 2763,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41389,7 +41716,7 @@
 			},
 			"children": [
 				{
-					"id": 2764,
+					"id": 2765,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41402,7 +41729,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 877,
+							"line": 884,
 							"character": 4
 						}
 					],
@@ -41421,7 +41748,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2766,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41434,7 +41761,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 883,
+							"line": 890,
 							"character": 4
 						}
 					],
@@ -41457,7 +41784,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2764,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41470,7 +41797,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 873,
+							"line": 880,
 							"character": 4
 						}
 					],
@@ -41494,21 +41821,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2764,
 						2765,
-						2763
+						2766,
+						2764
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 869,
+					"line": 876,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 2766,
+				"id": 2767,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -41518,7 +41845,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2767,
+						"id": 2768,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -41552,7 +41879,7 @@
 			}
 		},
 		{
-			"id": 2530,
+			"id": 2531,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41568,7 +41895,7 @@
 			},
 			"children": [
 				{
-					"id": 2542,
+					"id": 2543,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41602,7 +41929,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2575,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41626,27 +41953,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2575,
+							"id": 2576,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2576,
+								"id": 2577,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2577,
+										"id": 2578,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -41682,7 +42009,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2607,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41710,7 +42037,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1756,
+							"line": 1763,
 							"character": 4
 						}
 					],
@@ -41724,7 +42051,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2604,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41748,13 +42075,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1721,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2360,
+						"id": 2361,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -41763,7 +42090,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2621,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41787,7 +42114,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1994,
+							"line": 2001,
 							"character": 4
 						}
 					],
@@ -41801,7 +42128,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2595,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41833,7 +42160,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -41850,7 +42177,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2579,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41873,13 +42200,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -41888,7 +42215,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2608,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41916,7 +42243,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1772,
+							"line": 1779,
 							"character": 4
 						}
 					],
@@ -41930,7 +42257,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2533,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41972,7 +42299,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2588,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41996,7 +42323,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -42010,7 +42337,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2571,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42034,7 +42361,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -42048,7 +42375,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2570,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42072,7 +42399,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -42080,7 +42407,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -42090,7 +42417,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2583,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42117,7 +42444,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -42131,7 +42458,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2615,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42159,7 +42486,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1890,
+							"line": 1897,
 							"character": 4
 						}
 					],
@@ -42173,7 +42500,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2620,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42201,7 +42528,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1978,
+							"line": 1985,
 							"character": 4
 						}
 					],
@@ -42215,7 +42542,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2609,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42243,7 +42570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1788,
+							"line": 1795,
 							"character": 4
 						}
 					],
@@ -42257,7 +42584,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2591,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42281,7 +42608,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -42295,7 +42622,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2565,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42328,7 +42655,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2558,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42358,7 +42685,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2562,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42392,7 +42719,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2585,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42416,7 +42743,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -42430,7 +42757,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2535,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42467,7 +42794,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2605,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42491,7 +42818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1727,
+							"line": 1734,
 							"character": 4
 						}
 					],
@@ -42505,7 +42832,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2606,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42529,7 +42856,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1740,
+							"line": 1747,
 							"character": 4
 						}
 					],
@@ -42543,7 +42870,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2587,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42566,7 +42893,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -42580,7 +42907,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2567,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42604,13 +42931,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -42619,7 +42946,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2532,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42653,7 +42980,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2572,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42681,7 +43008,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -42689,7 +43016,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -42699,7 +43026,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2550,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42736,7 +43063,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2618,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42764,7 +43091,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1945,
+							"line": 1952,
 							"character": 4
 						}
 					],
@@ -42778,7 +43105,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2611,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42806,7 +43133,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1826,
+							"line": 1833,
 							"character": 4
 						}
 					],
@@ -42820,7 +43147,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2545,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42854,7 +43181,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2580,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42878,7 +43205,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -42892,7 +43219,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2601,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42915,7 +43242,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -42929,7 +43256,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2600,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42952,7 +43279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -42969,7 +43296,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2622,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42993,7 +43320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2012,
+							"line": 2019,
 							"character": 4
 						}
 					],
@@ -43007,7 +43334,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2554,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43041,7 +43368,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2624,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43065,7 +43392,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2044,
+							"line": 2051,
 							"character": 4
 						}
 					],
@@ -43079,7 +43406,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2556,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43113,7 +43440,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2623,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43137,7 +43464,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2027,
+							"line": 2034,
 							"character": 4
 						}
 					],
@@ -43151,7 +43478,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2616,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43179,7 +43506,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1907,
+							"line": 1914,
 							"character": 4
 						}
 					],
@@ -43193,7 +43520,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2614,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43217,7 +43544,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1873,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -43231,7 +43558,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2626,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43259,7 +43586,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2076,
+							"line": 2083,
 							"character": 4
 						}
 					],
@@ -43273,7 +43600,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2552,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43310,7 +43637,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2555,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43344,7 +43671,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2599,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43364,7 +43691,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -43378,7 +43705,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2553,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43412,7 +43739,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2610,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43436,7 +43763,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1804,
+							"line": 1811,
 							"character": 4
 						}
 					],
@@ -43450,7 +43777,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2557,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43487,7 +43814,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2559,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43521,7 +43848,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2590,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43545,7 +43872,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -43559,7 +43886,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2536,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43593,7 +43920,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2542,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43627,7 +43954,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2574,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43651,7 +43978,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -43665,7 +43992,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2534,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43702,7 +44029,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2627,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43730,7 +44057,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2092,
+							"line": 2099,
 							"character": 4
 						}
 					],
@@ -43744,7 +44071,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2589,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43768,7 +44095,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -43782,7 +44109,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2544,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43816,7 +44143,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2584,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43840,7 +44167,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -43863,7 +44190,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2582,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43887,7 +44214,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -43901,7 +44228,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2539,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43935,7 +44262,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2592,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43959,7 +44286,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1294,
+							"line": 1301,
 							"character": 4
 						}
 					],
@@ -43973,7 +44300,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2596,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44000,7 +44327,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -44014,7 +44341,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2602,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44038,7 +44365,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1678,
+							"line": 1685,
 							"character": 4
 						}
 					],
@@ -44046,7 +44373,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -44056,7 +44383,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2603,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44080,7 +44407,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1699,
+							"line": 1706,
 							"character": 4
 						}
 					],
@@ -44088,7 +44415,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -44098,7 +44425,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2597,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44125,7 +44452,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -44139,7 +44466,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2594,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44162,7 +44489,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -44176,7 +44503,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2613,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44204,7 +44531,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1858,
+							"line": 1865,
 							"character": 4
 						}
 					],
@@ -44218,7 +44545,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2619,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44246,7 +44573,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1962,
+							"line": 1969,
 							"character": 4
 						}
 					],
@@ -44260,7 +44587,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2612,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44288,7 +44615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1842,
+							"line": 1849,
 							"character": 4
 						}
 					],
@@ -44302,7 +44629,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2617,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44330,7 +44657,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1924,
+							"line": 1931,
 							"character": 4
 						}
 					],
@@ -44344,7 +44671,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2625,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44372,7 +44699,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2060,
+							"line": 2067,
 							"character": 4
 						}
 					],
@@ -44386,7 +44713,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2546,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44420,7 +44747,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2560,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44453,7 +44780,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2563,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44488,7 +44815,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2564,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44518,12 +44845,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2627,
+						"id": 2628,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2561,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44561,7 +44888,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2598,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44588,7 +44915,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -44602,7 +44929,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2573,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44630,7 +44957,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -44638,7 +44965,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -44648,7 +44975,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2551,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44685,7 +45012,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2540,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44722,7 +45049,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2538,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44761,88 +45088,88 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2542,
-						2574,
-						2606,
-						2603,
-						2620,
-						2594,
-						2578,
-						2607,
-						2532,
-						2587,
-						2570,
-						2569,
-						2582,
-						2614,
-						2619,
-						2608,
-						2590,
-						2564,
-						2557,
-						2561,
-						2584,
-						2534,
-						2604,
-						2605,
-						2586,
-						2566,
-						2531,
-						2571,
-						2549,
-						2617,
-						2610,
-						2544,
-						2579,
-						2600,
-						2599,
-						2621,
-						2553,
-						2623,
-						2555,
-						2622,
-						2615,
-						2613,
-						2625,
-						2551,
-						2554,
-						2598,
-						2552,
-						2609,
-						2556,
-						2558,
-						2589,
-						2535,
-						2541,
-						2573,
-						2533,
-						2626,
-						2588,
 						2543,
-						2583,
-						2581,
-						2538,
-						2591,
+						2575,
+						2607,
+						2604,
+						2621,
 						2595,
-						2601,
-						2602,
-						2596,
-						2593,
-						2612,
-						2618,
-						2611,
-						2616,
-						2624,
-						2545,
-						2559,
+						2579,
+						2608,
+						2533,
+						2588,
+						2571,
+						2570,
+						2583,
+						2615,
+						2620,
+						2609,
+						2591,
+						2565,
+						2558,
 						2562,
-						2563,
-						2560,
-						2597,
+						2585,
+						2535,
+						2605,
+						2606,
+						2587,
+						2567,
+						2532,
 						2572,
 						2550,
+						2618,
+						2611,
+						2545,
+						2580,
+						2601,
+						2600,
+						2622,
+						2554,
+						2624,
+						2556,
+						2623,
+						2616,
+						2614,
+						2626,
+						2552,
+						2555,
+						2599,
+						2553,
+						2610,
+						2557,
+						2559,
+						2590,
+						2536,
+						2542,
+						2574,
+						2534,
+						2627,
+						2589,
+						2544,
+						2584,
+						2582,
 						2539,
-						2537
+						2592,
+						2596,
+						2602,
+						2603,
+						2597,
+						2594,
+						2613,
+						2619,
+						2612,
+						2617,
+						2625,
+						2546,
+						2560,
+						2563,
+						2564,
+						2561,
+						2598,
+						2573,
+						2551,
+						2540,
+						2538
 					]
 				}
 			],
@@ -44869,7 +45196,7 @@
 			]
 		},
 		{
-			"id": 1946,
+			"id": 1947,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44879,7 +45206,7 @@
 			},
 			"children": [
 				{
-					"id": 1947,
+					"id": 1948,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44890,7 +45217,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2306,
+							"line": 2313,
 							"character": 4
 						}
 					],
@@ -44900,7 +45227,7 @@
 					}
 				},
 				{
-					"id": 1948,
+					"id": 1949,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44911,18 +45238,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2310,
+							"line": 2317,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1950,
+						"id": 1951,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 1949,
+					"id": 1950,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44933,7 +45260,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2316,
+							"line": 2323,
 							"character": 4
 						}
 					],
@@ -44968,22 +45295,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1947,
 						1948,
-						1949
+						1949,
+						1950
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2302,
+					"line": 2309,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3048,
+			"id": 3061,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44993,7 +45320,7 @@
 			},
 			"children": [
 				{
-					"id": 3049,
+					"id": 3062,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45004,7 +45331,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2326,
+							"line": 2333,
 							"character": 4
 						}
 					],
@@ -45014,7 +45341,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3063,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45025,7 +45352,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2330,
+							"line": 2337,
 							"character": 4
 						}
 					],
@@ -45053,21 +45380,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3049,
-						3050
+						3062,
+						3063
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2322,
+					"line": 2329,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2479,
+			"id": 2480,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -45082,7 +45409,7 @@
 			},
 			"children": [
 				{
-					"id": 2494,
+					"id": 2495,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45106,27 +45433,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2495,
+							"id": 2496,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2496,
+								"id": 2497,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2497,
+										"id": 2498,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -45162,7 +45489,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2527,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45190,7 +45517,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1756,
+							"line": 1763,
 							"character": 4
 						}
 					],
@@ -45204,7 +45531,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2524,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45228,13 +45555,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1721,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2360,
+						"id": 2361,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -45243,7 +45570,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2515,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45275,7 +45602,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -45292,7 +45619,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2499,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45315,13 +45642,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -45330,7 +45657,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2528,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45358,7 +45685,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1772,
+							"line": 1779,
 							"character": 4
 						}
 					],
@@ -45372,7 +45699,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2482,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45406,7 +45733,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2481,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45447,7 +45774,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2508,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45471,7 +45798,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -45485,7 +45812,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2491,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45509,7 +45836,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -45523,7 +45850,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2490,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45547,7 +45874,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -45555,7 +45882,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -45565,7 +45892,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2503,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45592,7 +45919,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -45606,7 +45933,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2529,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45634,7 +45961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1788,
+							"line": 1795,
 							"character": 4
 						}
 					],
@@ -45648,7 +45975,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2511,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45672,7 +45999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -45686,7 +46013,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2505,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45710,7 +46037,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -45724,7 +46051,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2525,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45748,7 +46075,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1727,
+							"line": 1734,
 							"character": 4
 						}
 					],
@@ -45762,7 +46089,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2526,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45786,7 +46113,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1740,
+							"line": 1747,
 							"character": 4
 						}
 					],
@@ -45800,7 +46127,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2485,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45834,7 +46161,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2507,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45857,7 +46184,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -45871,7 +46198,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2487,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45895,13 +46222,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45910,7 +46237,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2492,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45938,7 +46265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -45946,7 +46273,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -45956,7 +46283,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2500,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45980,7 +46307,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -45994,7 +46321,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2521,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46017,7 +46344,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -46031,7 +46358,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2520,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46054,7 +46381,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -46071,7 +46398,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2519,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46091,7 +46418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -46105,7 +46432,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2530,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46129,7 +46456,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1804,
+							"line": 1811,
 							"character": 4
 						}
 					],
@@ -46143,7 +46470,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2510,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46167,7 +46494,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -46181,7 +46508,7 @@
 					}
 				},
 				{
-					"id": 2493,
+					"id": 2494,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46205,7 +46532,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -46219,7 +46546,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2509,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46243,7 +46570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -46257,7 +46584,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2504,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46281,7 +46608,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -46304,7 +46631,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2502,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46328,7 +46655,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -46342,7 +46669,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2512,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46366,7 +46693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1294,
+							"line": 1301,
 							"character": 4
 						}
 					],
@@ -46380,7 +46707,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2516,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46407,7 +46734,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -46421,7 +46748,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2522,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46445,7 +46772,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1678,
+							"line": 1685,
 							"character": 4
 						}
 					],
@@ -46453,7 +46780,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46463,7 +46790,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2523,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46487,7 +46814,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1699,
+							"line": 1706,
 							"character": 4
 						}
 					],
@@ -46495,7 +46822,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46505,7 +46832,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2484,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46539,7 +46866,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2517,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46566,7 +46893,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -46580,7 +46907,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2514,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46603,7 +46930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -46617,7 +46944,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2518,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46644,7 +46971,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -46658,7 +46985,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2483,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46692,7 +47019,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2493,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46720,7 +47047,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -46728,7 +47055,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -46743,47 +47070,47 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2494,
-						2526,
-						2523,
-						2514,
-						2498,
+						2495,
 						2527,
-						2481,
-						2480,
-						2507,
-						2490,
-						2489,
-						2502,
-						2528,
-						2510,
-						2504,
 						2524,
-						2525,
-						2484,
-						2506,
-						2486,
-						2491,
+						2515,
 						2499,
+						2528,
+						2482,
+						2481,
+						2508,
+						2491,
+						2490,
+						2503,
+						2529,
+						2511,
+						2505,
+						2525,
+						2526,
+						2485,
+						2507,
+						2487,
+						2492,
+						2500,
+						2521,
 						2520,
 						2519,
-						2518,
-						2529,
+						2530,
+						2510,
+						2494,
 						2509,
-						2493,
-						2508,
-						2503,
-						2501,
-						2511,
-						2515,
-						2521,
-						2522,
-						2483,
+						2504,
+						2502,
+						2512,
 						2516,
-						2513,
+						2522,
+						2523,
+						2484,
 						2517,
-						2482,
-						2492
+						2514,
+						2518,
+						2483,
+						2493
 					]
 				}
 			],
@@ -46806,7 +47133,7 @@
 			]
 		},
 		{
-			"id": 2415,
+			"id": 2416,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -46822,7 +47149,7 @@
 			},
 			"children": [
 				{
-					"id": 2453,
+					"id": 2454,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46846,27 +47173,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2454,
+							"id": 2455,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2455,
+								"id": 2456,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2456,
+										"id": 2457,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -46902,7 +47229,7 @@
 					}
 				},
 				{
-					"id": 2427,
+					"id": 2428,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46936,7 +47263,7 @@
 					}
 				},
 				{
-					"id": 2417,
+					"id": 2418,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46970,7 +47297,7 @@
 					}
 				},
 				{
-					"id": 2416,
+					"id": 2417,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47004,7 +47331,7 @@
 					}
 				},
 				{
-					"id": 2440,
+					"id": 2441,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47032,7 +47359,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1756,
+							"line": 1763,
 							"character": 4
 						}
 					],
@@ -47046,7 +47373,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2431,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47083,7 +47410,7 @@
 					}
 				},
 				{
-					"id": 2437,
+					"id": 2438,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47107,13 +47434,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1721,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2360,
+						"id": 2361,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47122,7 +47449,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2473,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47154,7 +47481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -47171,7 +47498,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2458,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47194,13 +47521,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47209,7 +47536,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2432,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47247,7 +47574,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2442,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47275,7 +47602,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1772,
+							"line": 1779,
 							"character": 4
 						}
 					],
@@ -47289,7 +47616,7 @@
 					}
 				},
 				{
-					"id": 2423,
+					"id": 2424,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47323,7 +47650,7 @@
 					}
 				},
 				{
-					"id": 2422,
+					"id": 2423,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47359,7 +47686,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2467,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47383,7 +47710,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -47397,7 +47724,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2450,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47421,7 +47748,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -47435,7 +47762,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2449,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47459,7 +47786,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -47467,7 +47794,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -47477,7 +47804,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2462,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47504,7 +47831,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -47518,7 +47845,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2443,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47546,7 +47873,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1788,
+							"line": 1795,
 							"character": 4
 						}
 					],
@@ -47560,7 +47887,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2470,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47584,7 +47911,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -47598,7 +47925,7 @@
 					}
 				},
 				{
-					"id": 2420,
+					"id": 2421,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47632,7 +47959,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2464,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47656,7 +47983,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -47670,7 +47997,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2439,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47694,7 +48021,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1727,
+							"line": 1734,
 							"character": 4
 						}
 					],
@@ -47708,7 +48035,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2440,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47732,7 +48059,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1740,
+							"line": 1747,
 							"character": 4
 						}
 					],
@@ -47746,7 +48073,7 @@
 					}
 				},
 				{
-					"id": 2426,
+					"id": 2427,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47780,7 +48107,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2466,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47803,7 +48130,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -47817,7 +48144,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2433,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47855,7 +48182,7 @@
 					}
 				},
 				{
-					"id": 2421,
+					"id": 2422,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47889,7 +48216,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2446,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47913,13 +48240,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -47928,7 +48255,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2451,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47956,7 +48283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -47964,7 +48291,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -47974,7 +48301,7 @@
 					}
 				},
 				{
-					"id": 2418,
+					"id": 2419,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48008,7 +48335,7 @@
 					}
 				},
 				{
-					"id": 2419,
+					"id": 2420,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48042,7 +48369,7 @@
 					}
 				},
 				{
-					"id": 2428,
+					"id": 2429,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48076,7 +48403,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2459,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48100,7 +48427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -48114,7 +48441,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2479,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48137,7 +48464,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -48151,7 +48478,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2478,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48174,7 +48501,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -48191,7 +48518,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2477,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48211,7 +48538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -48225,7 +48552,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2444,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48249,7 +48576,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1804,
+							"line": 1811,
 							"character": 4
 						}
 					],
@@ -48263,7 +48590,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2469,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48287,7 +48614,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -48301,7 +48628,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2453,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48325,7 +48652,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -48339,7 +48666,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2434,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48377,7 +48704,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2468,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48401,7 +48728,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -48415,7 +48742,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2463,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48439,7 +48766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -48462,7 +48789,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2461,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48486,7 +48813,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -48500,7 +48827,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2474,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48527,7 +48854,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -48541,7 +48868,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2436,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48565,7 +48892,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1678,
+							"line": 1685,
 							"character": 4
 						}
 					],
@@ -48573,7 +48900,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -48583,7 +48910,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2437,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48607,7 +48934,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1699,
+							"line": 1706,
 							"character": 4
 						}
 					],
@@ -48615,7 +48942,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -48625,7 +48952,7 @@
 					}
 				},
 				{
-					"id": 2425,
+					"id": 2426,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48655,7 +48982,7 @@
 					}
 				},
 				{
-					"id": 2424,
+					"id": 2425,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48684,7 +49011,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2475,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48711,7 +49038,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -48725,7 +49052,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2472,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48748,7 +49075,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -48762,7 +49089,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2476,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48789,7 +49116,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -48803,7 +49130,7 @@
 					}
 				},
 				{
-					"id": 2429,
+					"id": 2430,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48833,7 +49160,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2452,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48861,7 +49188,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -48869,7 +49196,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -48879,7 +49206,7 @@
 					}
 				},
 				{
-					"id": 2434,
+					"id": 2435,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48904,7 +49231,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3180,
+						"id": 3194,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -48914,60 +49241,60 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2453,
-						2427,
-						2417,
-						2416,
-						2440,
-						2430,
-						2437,
-						2472,
-						2457,
-						2431,
-						2441,
-						2423,
-						2422,
-						2466,
-						2449,
-						2448,
-						2461,
-						2442,
-						2469,
-						2420,
-						2463,
-						2438,
-						2439,
-						2426,
-						2465,
-						2432,
-						2421,
-						2445,
-						2450,
-						2418,
-						2419,
+						2454,
 						2428,
+						2418,
+						2417,
+						2441,
+						2431,
+						2438,
+						2473,
 						2458,
+						2432,
+						2442,
+						2424,
+						2423,
+						2467,
+						2450,
+						2449,
+						2462,
+						2443,
+						2470,
+						2421,
+						2464,
+						2439,
+						2440,
+						2427,
+						2466,
+						2433,
+						2422,
+						2446,
+						2451,
+						2419,
+						2420,
+						2429,
+						2459,
+						2479,
 						2478,
 						2477,
-						2476,
-						2443,
+						2444,
+						2469,
+						2453,
+						2434,
 						2468,
-						2452,
-						2433,
-						2467,
-						2462,
-						2460,
-						2473,
-						2435,
-						2436,
-						2425,
-						2424,
+						2463,
+						2461,
 						2474,
-						2471,
+						2436,
+						2437,
+						2426,
+						2425,
 						2475,
-						2429,
-						2451,
-						2434
+						2472,
+						2476,
+						2430,
+						2452,
+						2435
 					]
 				}
 			],
@@ -49175,7 +49502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
@@ -49263,7 +49590,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -49303,13 +49630,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49342,7 +49669,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -49380,7 +49707,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -49418,7 +49745,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -49426,7 +49753,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -49463,7 +49790,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -49501,7 +49828,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -49539,7 +49866,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -49576,7 +49903,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -49614,13 +49941,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -49657,7 +49984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -49665,7 +49992,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -49699,7 +50026,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -49736,7 +50063,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -49773,7 +50100,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -49810,7 +50137,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -49848,7 +50175,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -49886,7 +50213,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -49924,7 +50251,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -49962,7 +50289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -50009,7 +50336,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -50050,7 +50377,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -50091,7 +50418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -50128,7 +50455,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -50169,7 +50496,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -50211,7 +50538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -50219,7 +50546,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -50549,7 +50876,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1041,
+							"line": 1048,
 							"character": 4
 						}
 					],
@@ -50637,7 +50964,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1493,
+							"line": 1500,
 							"character": 4
 						}
 					],
@@ -50677,13 +51004,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1048,
+							"line": 1055,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2803,
+						"id": 2805,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -50754,7 +51081,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1203,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -50826,7 +51153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 961,
+							"line": 968,
 							"character": 4
 						}
 					],
@@ -50864,7 +51191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 945,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -50872,7 +51199,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -50909,7 +51236,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1112,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -50947,7 +51274,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1278,
+							"line": 1285,
 							"character": 4
 						}
 					],
@@ -51057,7 +51384,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1168,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -51162,7 +51489,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -51200,13 +51527,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 917,
+							"line": 924,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2762,
+						"id": 2763,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -51243,7 +51570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 981,
+							"line": 988,
 							"character": 4
 						}
 					],
@@ -51251,7 +51578,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -51353,7 +51680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1064,
+							"line": 1071,
 							"character": 4
 						}
 					],
@@ -51390,7 +51717,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8692,
 							"character": 4
 						}
 					],
@@ -51427,7 +51754,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8665,
+							"line": 8675,
 							"character": 4
 						}
 					],
@@ -51464,7 +51791,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8659,
 							"character": 4
 						}
 					],
@@ -51502,7 +51829,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1247,
+							"line": 1254,
 							"character": 4
 						}
 					],
@@ -51540,7 +51867,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1017,
+							"line": 1024,
 							"character": 4
 						}
 					],
@@ -51578,7 +51905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1222,
+							"line": 1229,
 							"character": 4
 						}
 					],
@@ -51616,7 +51943,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1151,
+							"line": 1158,
 							"character": 4
 						}
 					],
@@ -51663,7 +51990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1091,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -51704,7 +52031,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1507,
+							"line": 1514,
 							"character": 4
 						}
 					],
@@ -51750,7 +52077,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1946,
+							"id": 1947,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -51788,7 +52115,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3048,
+							"id": 3061,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -51844,7 +52171,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1520,
+							"line": 1527,
 							"character": 4
 						}
 					],
@@ -51881,7 +52208,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1314,
+							"line": 1321,
 							"character": 4
 						}
 					],
@@ -52064,7 +52391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1534,
+							"line": 1541,
 							"character": 4
 						}
 					],
@@ -52106,7 +52433,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1002,
+							"line": 1009,
 							"character": 4
 						}
 					],
@@ -52114,7 +52441,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2178,
+							"id": 2179,
 							"name": "Action"
 						}
 					},
@@ -52674,7 +53001,7 @@
 			]
 		},
 		{
-			"id": 2627,
+			"id": 2628,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52698,7 +53025,7 @@
 			},
 			"children": [
 				{
-					"id": 2629,
+					"id": 2630,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52731,7 +53058,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2629,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52764,7 +53091,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2632,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52791,13 +53118,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2641,
+							"id": 2642,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2633,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52826,7 +53153,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2631,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52859,7 +53186,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2634,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52888,7 +53215,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2639,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52921,7 +53248,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2641,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52950,7 +53277,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2640,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52979,7 +53306,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2637,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53012,7 +53339,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2635,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53041,7 +53368,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2636,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53068,13 +53395,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2645,
+							"id": 2646,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2638,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53112,19 +53439,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2629,
-						2628,
-						2631,
-						2632,
 						2630,
+						2629,
+						2632,
 						2633,
-						2638,
-						2640,
-						2639,
-						2636,
+						2631,
 						2634,
+						2639,
+						2641,
+						2640,
+						2637,
 						2635,
-						2637
+						2636,
+						2638
 					]
 				}
 			],
@@ -53137,7 +53464,7 @@
 			]
 		},
 		{
-			"id": 2645,
+			"id": 2646,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53157,7 +53484,7 @@
 			},
 			"children": [
 				{
-					"id": 2646,
+					"id": 2647,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53178,7 +53505,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2648,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53204,8 +53531,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2646,
-						2647
+						2647,
+						2648
 					]
 				}
 			],
@@ -53218,7 +53545,7 @@
 			]
 		},
 		{
-			"id": 2641,
+			"id": 2642,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53238,7 +53565,7 @@
 			},
 			"children": [
 				{
-					"id": 2643,
+					"id": 2644,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53259,7 +53586,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2645,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53280,7 +53607,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2643,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53306,9 +53633,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2643,
 						2644,
-						2642
+						2645,
+						2643
 					]
 				}
 			],
@@ -53383,7 +53710,7 @@
 			]
 		},
 		{
-			"id": 3180,
+			"id": 3194,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53403,7 +53730,7 @@
 			},
 			"children": [
 				{
-					"id": 3181,
+					"id": 3195,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53416,7 +53743,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9185,
 							"character": 4
 						}
 					],
@@ -53426,7 +53753,7 @@
 					}
 				},
 				{
-					"id": 3182,
+					"id": 3196,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53439,7 +53766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9177,
+							"line": 9187,
 							"character": 4
 						}
 					],
@@ -53454,28 +53781,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3181,
-						3182
+						3195,
+						3196
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9173,
+					"line": 9183,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3087,
+			"id": 3100,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3088,
+					"id": 3101,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53483,7 +53810,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8170,
+							"line": 8177,
 							"character": 4
 						}
 					],
@@ -53496,7 +53823,7 @@
 					}
 				},
 				{
-					"id": 3089,
+					"id": 3102,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53504,7 +53831,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8171,
+							"line": 8178,
 							"character": 4
 						}
 					],
@@ -53522,21 +53849,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3088,
-						3089
+						3101,
+						3102
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8169,
+					"line": 8176,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2816,
+			"id": 2818,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53546,7 +53873,7 @@
 			},
 			"children": [
 				{
-					"id": 2818,
+					"id": 2820,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53569,27 +53896,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 287,
+							"line": 294,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2819,
+							"id": 2821,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2820,
+								"id": 2822,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2821,
+										"id": 2823,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -53602,7 +53929,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2822,
+										"id": 2824,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -53610,19 +53937,19 @@
 										"sources": [
 											{
 												"fileName": "types.ts",
-												"line": 288,
+												"line": 295,
 												"character": 28
 											}
 										],
 										"indexSignature": {
-											"id": 2823,
+											"id": 2825,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2824,
+													"id": 2826,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -53644,7 +53971,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2819,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53657,13 +53984,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 261,
+							"line": 268,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2825,
+						"id": 2827,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -53673,15 +54000,15 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2818,
-						2817
+						2820,
+						2819
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 254,
+					"line": 261,
 					"character": 17
 				}
 			]
@@ -53979,7 +54306,7 @@
 			]
 		},
 		{
-			"id": 3179,
+			"id": 3193,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -53991,7 +54318,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1551,
+					"line": 1558,
 					"character": 12
 				}
 			],
@@ -54036,7 +54363,7 @@
 			}
 		},
 		{
-			"id": 2786,
+			"id": 2788,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -54044,7 +54371,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 248,
+					"line": 255,
 					"character": 12
 				}
 			],
@@ -54063,7 +54390,7 @@
 			}
 		},
 		{
-			"id": 2790,
+			"id": 2792,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -54071,14 +54398,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2129,
+					"line": 2136,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2791,
+					"id": 2793,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -54095,13 +54422,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2129,
+							"line": 2136,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2792,
+							"id": 2794,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -54111,19 +54438,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2793,
+									"id": 2795,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2798,
+										"id": 2800,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2794,
+									"id": 2796,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -54133,7 +54460,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2795,
+											"id": 2797,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -54141,13 +54468,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2136,
+													"line": 2143,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2796,
+													"id": 2798,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -54157,7 +54484,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2797,
+															"id": 2799,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -54188,7 +54515,7 @@
 			}
 		},
 		{
-			"id": 2787,
+			"id": 2789,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -54205,21 +54532,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2118,
+					"line": 2125,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2788,
+					"id": 2790,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2789,
+							"id": 2791,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54232,7 +54559,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2123,
+									"line": 2130,
 									"character": 4
 								}
 							],
@@ -54247,14 +54574,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2789
+								2791
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2118,
+							"line": 2125,
 							"character": 29
 						}
 					]
@@ -54262,7 +54589,7 @@
 			}
 		},
 		{
-			"id": 2798,
+			"id": 2800,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -54279,21 +54606,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2105,
+					"line": 2112,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2799,
+					"id": 2801,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2801,
+							"id": 2803,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54301,7 +54628,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2109,
+									"line": 2116,
 									"character": 4
 								}
 							],
@@ -54311,7 +54638,7 @@
 							}
 						},
 						{
-							"id": 2802,
+							"id": 2804,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54321,7 +54648,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2111,
+									"line": 2118,
 									"character": 4
 								}
 							],
@@ -54331,7 +54658,7 @@
 							}
 						},
 						{
-							"id": 2800,
+							"id": 2802,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54339,7 +54666,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2107,
+									"line": 2114,
 									"character": 4
 								}
 							],
@@ -54354,16 +54681,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2801,
-								2802,
-								2800
+								2803,
+								2804,
+								2802
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2105,
+							"line": 2112,
 							"character": 29
 						}
 					]
@@ -54770,7 +55097,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2364,
+						"id": 2365,
 						"name": "EmbedConfig"
 					}
 				}
@@ -54870,7 +55197,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2364,
+								"id": 2365,
 								"name": "EmbedConfig"
 							}
 						}
@@ -55017,7 +55344,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2757,
+									"id": 2758,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -55145,7 +55472,7 @@
 			]
 		},
 		{
-			"id": 3225,
+			"id": 3239,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -55161,7 +55488,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3226,
+					"id": 3240,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -55191,7 +55518,7 @@
 			]
 		},
 		{
-			"id": 3227,
+			"id": 3241,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -55205,7 +55532,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3228,
+					"id": 3242,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -55227,7 +55554,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3229,
+							"id": 3243,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55237,7 +55564,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3179,
+								"id": 3193,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -55415,7 +55742,7 @@
 			]
 		},
 		{
-			"id": 3058,
+			"id": 3071,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -55429,7 +55756,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3059,
+					"id": 3072,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -55439,7 +55766,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3060,
+							"id": 3073,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55451,7 +55778,7 @@
 							}
 						},
 						{
-							"id": 3061,
+							"id": 3074,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55462,7 +55789,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3062,
+									"id": 3075,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -55485,41 +55812,41 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2178,
+				2179,
 				1783,
 				1768,
 				1775,
-				1934,
-				3188,
-				3191,
-				3195,
-				2360,
-				2168,
-				3143,
-				3139,
-				3211,
-				3135,
-				2174,
+				1935,
+				3202,
+				3205,
+				3209,
+				2361,
+				2169,
+				3156,
 				3152,
-				1966,
-				3175,
-				2768,
-				3080,
-				3074,
-				2779,
-				2082,
+				3225,
 				3148,
-				3183,
-				3084,
-				3127,
-				3051,
+				2175,
+				3165,
+				1967,
+				3189,
+				2769,
+				3093,
+				3087,
+				2781,
+				2083,
+				3161,
+				3197,
+				3097,
+				3140,
+				3064,
 				1925,
-				2757,
-				3078,
-				1950,
-				3222,
-				3218,
-				3110
+				2758,
+				3091,
+				1951,
+				3236,
+				3232,
+				3123
 			]
 		},
 		{
@@ -55541,34 +55868,34 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2648,
+				2649,
 				1785,
 				1204,
 				1530,
-				3090,
-				2825,
-				2813,
-				2803,
-				2364,
-				3169,
-				2762,
-				2530,
-				1946,
-				3048,
-				2479,
-				2415,
+				3103,
+				2827,
+				2815,
+				2805,
+				2365,
+				3183,
+				2763,
+				2531,
+				1947,
+				3061,
+				2480,
+				2416,
 				1915,
 				1167,
 				1510,
 				1458,
 				1516,
-				2627,
-				2645,
-				2641,
+				2628,
+				2646,
+				2642,
 				1922,
-				3180,
-				3087,
-				2816,
+				3194,
+				3100,
+				2818,
 				21,
 				28
 			]
@@ -55577,11 +55904,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3179,
-				2786,
-				2790,
-				2787,
-				2798
+				3193,
+				2788,
+				2792,
+				2789,
+				2800
 			]
 		},
 		{
@@ -55598,10 +55925,10 @@
 				4,
 				7,
 				25,
-				3225,
-				3227,
+				3239,
+				3241,
 				40,
-				3058
+				3071
 			]
 		}
 	],

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -49,7 +49,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7459,
+							"line": 7487,
 							"character": 4
 						}
 					],
@@ -77,7 +77,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6492,
+							"line": 6520,
 							"character": 4
 						}
 					],
@@ -105,7 +105,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6421,
+							"line": 6449,
 							"character": 4
 						}
 					],
@@ -129,7 +129,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6410,
+							"line": 6438,
 							"character": 4
 						}
 					],
@@ -153,7 +153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6473,
+							"line": 6501,
 							"character": 4
 						}
 					],
@@ -177,7 +177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6482,
+							"line": 6510,
 							"character": 4
 						}
 					],
@@ -205,7 +205,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6502,
+							"line": 6530,
 							"character": 4
 						}
 					],
@@ -233,7 +233,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7227,
+							"line": 7255,
 							"character": 4
 						}
 					],
@@ -261,7 +261,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6920,
+							"line": 6948,
 							"character": 4
 						}
 					],
@@ -289,7 +289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7412,
+							"line": 7440,
 							"character": 4
 						}
 					],
@@ -317,7 +317,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6908,
+							"line": 6936,
 							"character": 4
 						}
 					],
@@ -345,7 +345,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6896,
+							"line": 6924,
 							"character": 4
 						}
 					],
@@ -374,7 +374,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7401,
+							"line": 7429,
 							"character": 4
 						}
 					],
@@ -402,7 +402,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7042,
+							"line": 7070,
 							"character": 4
 						}
 					],
@@ -430,7 +430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7173,
+							"line": 7201,
 							"character": 4
 						}
 					],
@@ -458,7 +458,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7076,
+							"line": 7104,
 							"character": 4
 						}
 					],
@@ -486,7 +486,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7131,
+							"line": 7159,
 							"character": 4
 						}
 					],
@@ -514,7 +514,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7065,
+							"line": 7093,
 							"character": 4
 						}
 					],
@@ -542,7 +542,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7099,
+							"line": 7127,
 							"character": 4
 						}
 					],
@@ -570,7 +570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7183,
+							"line": 7211,
 							"character": 4
 						}
 					],
@@ -598,7 +598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7141,
+							"line": 7169,
 							"character": 4
 						}
 					],
@@ -626,7 +626,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7110,
+							"line": 7138,
 							"character": 4
 						}
 					],
@@ -654,7 +654,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7163,
+							"line": 7191,
 							"character": 4
 						}
 					],
@@ -682,7 +682,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7120,
+							"line": 7148,
 							"character": 4
 						}
 					],
@@ -710,7 +710,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7087,
+							"line": 7115,
 							"character": 4
 						}
 					],
@@ -738,7 +738,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7151,
+							"line": 7179,
 							"character": 4
 						}
 					],
@@ -766,7 +766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7053,
+							"line": 7081,
 							"character": 4
 						}
 					],
@@ -794,7 +794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7557,
+							"line": 7585,
 							"character": 4
 						}
 					],
@@ -818,7 +818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6464,
+							"line": 6492,
 							"character": 4
 						}
 					],
@@ -846,7 +846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6455,
+							"line": 6483,
 							"character": 4
 						}
 					],
@@ -874,7 +874,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6443,
+							"line": 6471,
 							"character": 4
 						}
 					],
@@ -902,7 +902,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7645,
+							"line": 7673,
 							"character": 4
 						}
 					],
@@ -926,7 +926,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6432,
+							"line": 6460,
 							"character": 4
 						}
 					],
@@ -941,7 +941,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6845,
+							"line": 6873,
 							"character": 4
 						}
 					],
@@ -965,7 +965,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6369,
+							"line": 6397,
 							"character": 4
 						}
 					],
@@ -989,7 +989,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6844,
+							"line": 6872,
 							"character": 4
 						}
 					],
@@ -1017,7 +1017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7655,
+							"line": 7683,
 							"character": 4
 						}
 					],
@@ -1045,7 +1045,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7815,
+							"line": 7843,
 							"character": 4
 						}
 					],
@@ -1073,7 +1073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7376,
+							"line": 7404,
 							"character": 4
 						}
 					],
@@ -1101,7 +1101,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6950,
+							"line": 6978,
 							"character": 4
 						}
 					],
@@ -1129,7 +1129,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7000,
+							"line": 7028,
 							"character": 4
 						}
 					],
@@ -1157,7 +1157,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7569,
+							"line": 7597,
 							"character": 4
 						}
 					],
@@ -1185,7 +1185,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7626,
+							"line": 7654,
 							"character": 4
 						}
 					],
@@ -1213,7 +1213,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7526,
+							"line": 7554,
 							"character": 4
 						}
 					],
@@ -1241,7 +1241,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7545,
+							"line": 7573,
 							"character": 4
 						}
 					],
@@ -1265,7 +1265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6552,
+							"line": 6580,
 							"character": 4
 						}
 					],
@@ -1289,7 +1289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6585,
+							"line": 6613,
 							"character": 4
 						}
 					],
@@ -1314,7 +1314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6575,
+							"line": 6603,
 							"character": 4
 						}
 					],
@@ -1338,7 +1338,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6562,
+							"line": 6590,
 							"character": 4
 						}
 					],
@@ -1362,7 +1362,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6595,
+							"line": 6623,
 							"character": 4
 						}
 					],
@@ -1390,7 +1390,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6605,
+							"line": 6633,
 							"character": 4
 						}
 					],
@@ -1418,7 +1418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6629,
+							"line": 6657,
 							"character": 4
 						}
 					],
@@ -1446,7 +1446,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6615,
+							"line": 6643,
 							"character": 4
 						}
 					],
@@ -1474,7 +1474,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6649,
+							"line": 6677,
 							"character": 4
 						}
 					],
@@ -1502,7 +1502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6639,
+							"line": 6667,
 							"character": 4
 						}
 					],
@@ -1526,7 +1526,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6861,
+							"line": 6889,
 							"character": 4
 						}
 					],
@@ -1550,7 +1550,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6834,
+							"line": 6862,
 							"character": 4
 						}
 					],
@@ -1574,7 +1574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6825,
+							"line": 6853,
 							"character": 4
 						}
 					],
@@ -1598,7 +1598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6725,
+							"line": 6753,
 							"character": 4
 						}
 					],
@@ -1622,7 +1622,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6360,
+							"line": 6388,
 							"character": 4
 						}
 					],
@@ -1650,7 +1650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6939,
+							"line": 6967,
 							"character": 4
 						}
 					],
@@ -1665,7 +1665,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6850,
+							"line": 6878,
 							"character": 4
 						}
 					],
@@ -1693,7 +1693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7615,
+							"line": 7643,
 							"character": 4
 						}
 					],
@@ -1721,7 +1721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7271,
+							"line": 7299,
 							"character": 4
 						}
 					],
@@ -1749,7 +1749,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7472,
+							"line": 7500,
 							"character": 4
 						}
 					],
@@ -1773,7 +1773,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6693,
+							"line": 6721,
 							"character": 4
 						}
 					],
@@ -1797,7 +1797,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6733,
+							"line": 6761,
 							"character": 4
 						}
 					],
@@ -1825,7 +1825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7636,
+							"line": 7664,
 							"character": 4
 						}
 					],
@@ -1853,7 +1853,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7237,
+							"line": 7265,
 							"character": 4
 						}
 					],
@@ -1881,7 +1881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7248,
+							"line": 7276,
 							"character": 4
 						}
 					],
@@ -1905,7 +1905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6814,
+							"line": 6842,
 							"character": 4
 						}
 					],
@@ -1930,7 +1930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6665,
+							"line": 6693,
 							"character": 4
 						}
 					],
@@ -1954,7 +1954,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6675,
+							"line": 6703,
 							"character": 4
 						}
 					],
@@ -1982,7 +1982,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7670,
+							"line": 7698,
 							"character": 4
 						}
 					],
@@ -2010,7 +2010,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7960,
+							"line": 7988,
 							"character": 4
 						}
 					],
@@ -2038,7 +2038,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7536,
+							"line": 7564,
 							"character": 4
 						}
 					],
@@ -2062,7 +2062,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6775,
+							"line": 6803,
 							"character": 4
 						}
 					],
@@ -2090,7 +2090,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7736,
+							"line": 7764,
 							"character": 4
 						}
 					],
@@ -2118,7 +2118,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7344,
+							"line": 7372,
 							"character": 4
 						}
 					],
@@ -2142,7 +2142,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6351,
+							"line": 6379,
 							"character": 4
 						}
 					],
@@ -2166,7 +2166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7312,
+							"line": 7340,
 							"character": 4
 						}
 					],
@@ -2194,7 +2194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6990,
+							"line": 7018,
 							"character": 4
 						}
 					],
@@ -2222,7 +2222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7762,
+							"line": 7790,
 							"character": 4
 						}
 					],
@@ -2250,7 +2250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7515,
+							"line": 7543,
 							"character": 4
 						}
 					],
@@ -2278,7 +2278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7217,
+							"line": 7245,
 							"character": 4
 						}
 					],
@@ -2305,7 +2305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7292,
+							"line": 7320,
 							"character": 4
 						}
 					],
@@ -2333,7 +2333,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7805,
+							"line": 7833,
 							"character": 4
 						}
 					],
@@ -2361,7 +2361,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7795,
+							"line": 7823,
 							"character": 4
 						}
 					],
@@ -2385,7 +2385,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7301,
+							"line": 7329,
 							"character": 4
 						}
 					],
@@ -2417,7 +2417,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7436,
+							"line": 7464,
 							"character": 4
 						}
 					],
@@ -2445,7 +2445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7448,
+							"line": 7476,
 							"character": 4
 						}
 					],
@@ -2473,7 +2473,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7785,
+							"line": 7813,
 							"character": 4
 						}
 					],
@@ -2501,7 +2501,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7483,
+							"line": 7511,
 							"character": 4
 						}
 					],
@@ -2533,7 +2533,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7324,
+							"line": 7352,
 							"character": 4
 						}
 					],
@@ -2561,7 +2561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7334,
+							"line": 7362,
 							"character": 4
 						}
 					],
@@ -2585,7 +2585,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6792,
+							"line": 6820,
 							"character": 4
 						}
 					],
@@ -2609,7 +2609,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7714,
+							"line": 7742,
 							"character": 4
 						}
 					],
@@ -2633,7 +2633,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6703,
+							"line": 6731,
 							"character": 4
 						}
 					],
@@ -2661,7 +2661,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7581,
+							"line": 7609,
 							"character": 4
 						}
 					],
@@ -2689,7 +2689,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7749,
+							"line": 7777,
 							"character": 4
 						}
 					],
@@ -2714,7 +2714,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6886,
+							"line": 6914,
 							"character": 4
 						}
 					],
@@ -2742,7 +2742,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8033,
+							"line": 8061,
 							"character": 4
 						}
 					],
@@ -2766,7 +2766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6743,
+							"line": 6771,
 							"character": 4
 						}
 					],
@@ -2794,7 +2794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7726,
+							"line": 7754,
 							"character": 4
 						}
 					],
@@ -2822,7 +2822,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7031,
+							"line": 7059,
 							"character": 4
 						}
 					],
@@ -2850,7 +2850,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6930,
+							"line": 6958,
 							"character": 4
 						}
 					],
@@ -2878,7 +2878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7423,
+							"line": 7451,
 							"character": 4
 						}
 					],
@@ -2906,7 +2906,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7197,
+							"line": 7225,
 							"character": 4
 						}
 					],
@@ -2937,7 +2937,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6959,
+							"line": 6987,
 							"character": 4
 						}
 					],
@@ -2961,7 +2961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6870,
+							"line": 6898,
 							"character": 4
 						}
 					],
@@ -2989,7 +2989,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7207,
+							"line": 7235,
 							"character": 4
 						}
 					],
@@ -3017,7 +3017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7593,
+							"line": 7621,
 							"character": 4
 						}
 					],
@@ -3045,7 +3045,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7283,
+							"line": 7311,
 							"character": 4
 						}
 					],
@@ -3069,7 +3069,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6320,
+							"line": 6348,
 							"character": 4
 						}
 					],
@@ -3093,7 +3093,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6338,
+							"line": 6366,
 							"character": 4
 						}
 					],
@@ -3117,7 +3117,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6383,
+							"line": 6411,
 							"character": 4
 						}
 					],
@@ -3141,7 +3141,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6392,
+							"line": 6420,
 							"character": 4
 						}
 					],
@@ -3169,7 +3169,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7972,
+							"line": 8000,
 							"character": 4
 						}
 					],
@@ -3184,7 +3184,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6851,
+							"line": 6879,
 							"character": 4
 						}
 					],
@@ -3208,7 +3208,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6401,
+							"line": 6429,
 							"character": 4
 						}
 					],
@@ -3226,7 +3226,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6527,
+							"line": 6555,
 							"character": 4
 						}
 					],
@@ -3254,7 +3254,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7258,
+							"line": 7286,
 							"character": 4
 						}
 					],
@@ -3278,7 +3278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6542,
+							"line": 6570,
 							"character": 4
 						}
 					],
@@ -3302,7 +3302,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6515,
+							"line": 6543,
 							"character": 4
 						}
 					],
@@ -3330,7 +3330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8066,
+							"line": 8094,
 							"character": 4
 						}
 					],
@@ -3358,7 +3358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8077,
+							"line": 8105,
 							"character": 4
 						}
 					],
@@ -3386,7 +3386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8055,
+							"line": 8083,
 							"character": 4
 						}
 					],
@@ -3414,7 +3414,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8088,
+							"line": 8116,
 							"character": 4
 						}
 					],
@@ -3442,7 +3442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8044,
+							"line": 8072,
 							"character": 4
 						}
 					],
@@ -3470,7 +3470,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8099,
+							"line": 8127,
 							"character": 4
 						}
 					],
@@ -3498,7 +3498,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7926,
+							"line": 7954,
 							"character": 4
 						}
 					],
@@ -3526,7 +3526,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7937,
+							"line": 7965,
 							"character": 4
 						}
 					],
@@ -3554,7 +3554,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7905,
+							"line": 7933,
 							"character": 4
 						}
 					],
@@ -3582,7 +3582,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7885,
+							"line": 7913,
 							"character": 4
 						}
 					],
@@ -3610,7 +3610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7948,
+							"line": 7976,
 							"character": 4
 						}
 					],
@@ -3638,7 +3638,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7895,
+							"line": 7923,
 							"character": 4
 						}
 					],
@@ -3666,7 +3666,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7915,
+							"line": 7943,
 							"character": 4
 						}
 					],
@@ -3694,7 +3694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7604,
+							"line": 7632,
 							"character": 4
 						}
 					],
@@ -3722,7 +3722,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7865,
+							"line": 7893,
 							"character": 4
 						}
 					],
@@ -3750,7 +3750,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7875,
+							"line": 7903,
 							"character": 4
 						}
 					],
@@ -3778,7 +3778,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7845,
+							"line": 7873,
 							"character": 4
 						}
 					],
@@ -3806,7 +3806,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7835,
+							"line": 7863,
 							"character": 4
 						}
 					],
@@ -3834,7 +3834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7855,
+							"line": 7883,
 							"character": 4
 						}
 					],
@@ -3862,7 +3862,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7703,
+							"line": 7731,
 							"character": 4
 						}
 					],
@@ -3890,7 +3890,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8008,
+							"line": 8036,
 							"character": 4
 						}
 					],
@@ -3918,7 +3918,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7996,
+							"line": 8024,
 							"character": 4
 						}
 					],
@@ -3946,7 +3946,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7984,
+							"line": 8012,
 							"character": 4
 						}
 					],
@@ -3974,7 +3974,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8022,
+							"line": 8050,
 							"character": 4
 						}
 					],
@@ -4002,7 +4002,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7681,
+							"line": 7709,
 							"character": 4
 						}
 					],
@@ -4030,7 +4030,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7692,
+							"line": 7720,
 							"character": 4
 						}
 					],
@@ -4054,7 +4054,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6806,
+							"line": 6834,
 							"character": 4
 						}
 					],
@@ -4082,7 +4082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6980,
+							"line": 7008,
 							"character": 4
 						}
 					],
@@ -4110,7 +4110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6969,
+							"line": 6997,
 							"character": 4
 						}
 					],
@@ -4138,7 +4138,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7010,
+							"line": 7038,
 							"character": 4
 						}
 					],
@@ -4166,7 +4166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7020,
+							"line": 7048,
 							"character": 4
 						}
 					],
@@ -4198,7 +4198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7363,
+							"line": 7391,
 							"character": 4
 						}
 					],
@@ -4222,7 +4222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6715,
+							"line": 6743,
 							"character": 4
 						}
 					],
@@ -4250,7 +4250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7825,
+							"line": 7853,
 							"character": 4
 						}
 					],
@@ -4278,7 +4278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7774,
+							"line": 7802,
 							"character": 4
 						}
 					],
@@ -4306,7 +4306,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7505,
+							"line": 7533,
 							"character": 4
 						}
 					],
@@ -4330,7 +4330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6684,
+							"line": 6712,
 							"character": 4
 						}
 					],
@@ -4358,7 +4358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7387,
+							"line": 7415,
 							"character": 4
 						}
 					],
@@ -4386,7 +4386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7494,
+							"line": 7522,
 							"character": 4
 						}
 					],
@@ -4567,7 +4567,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6311,
+					"line": 6339,
 					"character": 12
 				}
 			]
@@ -5194,7 +5194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8801,
+							"line": 8829,
 							"character": 4
 						}
 					],
@@ -5212,7 +5212,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8799,
+							"line": 8827,
 							"character": 4
 						}
 					],
@@ -5232,7 +5232,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8797,
+					"line": 8825,
 					"character": 12
 				}
 			]
@@ -5265,7 +5265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8812,
+							"line": 8840,
 							"character": 4
 						}
 					],
@@ -5283,7 +5283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8814,
+							"line": 8842,
 							"character": 4
 						}
 					],
@@ -5301,7 +5301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8810,
+							"line": 8838,
 							"character": 4
 						}
 					],
@@ -5322,7 +5322,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8808,
+					"line": 8836,
 					"character": 12
 				}
 			]
@@ -5355,7 +5355,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8766,
+							"line": 8794,
 							"character": 4
 						}
 					],
@@ -5373,7 +5373,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8768,
+							"line": 8796,
 							"character": 4
 						}
 					],
@@ -5391,7 +5391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8772,
+							"line": 8800,
 							"character": 4
 						}
 					],
@@ -5409,7 +5409,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8782,
+							"line": 8810,
 							"character": 4
 						}
 					],
@@ -5427,7 +5427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8774,
+							"line": 8802,
 							"character": 4
 						}
 					],
@@ -5445,7 +5445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8778,
+							"line": 8806,
 							"character": 4
 						}
 					],
@@ -5463,7 +5463,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8762,
+							"line": 8790,
 							"character": 4
 						}
 					],
@@ -5481,7 +5481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8786,
+							"line": 8814,
 							"character": 4
 						}
 					],
@@ -5499,7 +5499,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8764,
+							"line": 8792,
 							"character": 4
 						}
 					],
@@ -5517,7 +5517,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8790,
+							"line": 8818,
 							"character": 4
 						}
 					],
@@ -5535,7 +5535,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8788,
+							"line": 8816,
 							"character": 4
 						}
 					],
@@ -5553,7 +5553,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8776,
+							"line": 8804,
 							"character": 4
 						}
 					],
@@ -5571,7 +5571,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8780,
+							"line": 8808,
 							"character": 4
 						}
 					],
@@ -5589,7 +5589,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8784,
+							"line": 8812,
 							"character": 4
 						}
 					],
@@ -5607,7 +5607,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8770,
+							"line": 8798,
 							"character": 4
 						}
 					],
@@ -5640,7 +5640,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8760,
+					"line": 8788,
 					"character": 12
 				}
 			]
@@ -5664,7 +5664,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8119,
+							"line": 8147,
 							"character": 4
 						}
 					],
@@ -5679,7 +5679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8117,
+							"line": 8145,
 							"character": 4
 						}
 					],
@@ -5694,7 +5694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8118,
+							"line": 8146,
 							"character": 4
 						}
 					],
@@ -5715,7 +5715,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8116,
+					"line": 8144,
 					"character": 12
 				}
 			]
@@ -5756,7 +5756,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8564,
+							"line": 8592,
 							"character": 4
 						}
 					],
@@ -5774,7 +5774,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8560,
+							"line": 8588,
 							"character": 4
 						}
 					],
@@ -5792,7 +5792,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8573,
+							"line": 8601,
 							"character": 4
 						}
 					],
@@ -5810,7 +5810,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8556,
+							"line": 8584,
 							"character": 4
 						}
 					],
@@ -5828,7 +5828,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8568,
+							"line": 8596,
 							"character": 4
 						}
 					],
@@ -5851,7 +5851,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8552,
+					"line": 8580,
 					"character": 12
 				}
 			]
@@ -5878,7 +5878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8256,
+							"line": 8284,
 							"character": 4
 						}
 					],
@@ -5896,7 +5896,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8229,
+							"line": 8257,
 							"character": 4
 						}
 					],
@@ -5914,7 +5914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8267,
+							"line": 8295,
 							"character": 4
 						}
 					],
@@ -5932,7 +5932,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8243,
+							"line": 8271,
 							"character": 4
 						}
 					],
@@ -5954,7 +5954,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8219,
+					"line": 8247,
 					"character": 12
 				}
 			]
@@ -5981,7 +5981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8210,
+							"line": 8238,
 							"character": 4
 						}
 					],
@@ -5999,7 +5999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8202,
+							"line": 8230,
 							"character": 4
 						}
 					],
@@ -6017,7 +6017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8197,
+							"line": 8225,
 							"character": 4
 						}
 					],
@@ -6038,7 +6038,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8192,
+					"line": 8220,
 					"character": 12
 				}
 			]
@@ -6071,7 +6071,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8751,
+							"line": 8779,
 							"character": 4
 						}
 					],
@@ -6089,7 +6089,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8743,
+							"line": 8771,
 							"character": 4
 						}
 					],
@@ -6107,7 +6107,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8747,
+							"line": 8775,
 							"character": 4
 						}
 					],
@@ -6125,7 +6125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8745,
+							"line": 8773,
 							"character": 4
 						}
 					],
@@ -6143,7 +6143,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8749,
+							"line": 8777,
 							"character": 4
 						}
 					],
@@ -6161,7 +6161,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8753,
+							"line": 8781,
 							"character": 4
 						}
 					],
@@ -6185,7 +6185,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8741,
+					"line": 8769,
 					"character": 12
 				}
 			]
@@ -6296,7 +6296,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6102,
+							"line": 6130,
 							"character": 4
 						}
 					],
@@ -6314,7 +6314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6106,
+							"line": 6134,
 							"character": 4
 						}
 					],
@@ -6332,7 +6332,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6098,
+							"line": 6126,
 							"character": 4
 						}
 					],
@@ -6353,7 +6353,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6094,
+					"line": 6122,
 					"character": 12
 				}
 			]
@@ -6394,7 +6394,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8433,
+							"line": 8461,
 							"character": 4
 						}
 					],
@@ -6412,7 +6412,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8436,
+							"line": 8464,
 							"character": 4
 						}
 					],
@@ -6430,7 +6430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8445,
+							"line": 8473,
 							"character": 4
 						}
 					],
@@ -6448,7 +6448,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8472,
+							"line": 8500,
 							"character": 4
 						}
 					],
@@ -6466,7 +6466,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8454,
+							"line": 8482,
 							"character": 4
 						}
 					],
@@ -6484,7 +6484,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8466,
+							"line": 8494,
 							"character": 4
 						}
 					],
@@ -6502,7 +6502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8439,
+							"line": 8467,
 							"character": 4
 						}
 					],
@@ -6520,7 +6520,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8463,
+							"line": 8491,
 							"character": 4
 						}
 					],
@@ -6538,7 +6538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8430,
+							"line": 8458,
 							"character": 4
 						}
 					],
@@ -6556,7 +6556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8448,
+							"line": 8476,
 							"character": 4
 						}
 					],
@@ -6574,7 +6574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8442,
+							"line": 8470,
 							"character": 4
 						}
 					],
@@ -6592,7 +6592,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8457,
+							"line": 8485,
 							"character": 4
 						}
 					],
@@ -6610,7 +6610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8451,
+							"line": 8479,
 							"character": 4
 						}
 					],
@@ -6628,7 +6628,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8469,
+							"line": 8497,
 							"character": 4
 						}
 					],
@@ -6646,7 +6646,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8460,
+							"line": 8488,
 							"character": 4
 						}
 					],
@@ -6664,7 +6664,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8427,
+							"line": 8455,
 							"character": 4
 						}
 					],
@@ -6698,7 +6698,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8425,
+					"line": 8453,
 					"character": 12
 				}
 			]
@@ -9891,7 +9891,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8387,
+							"line": 8415,
 							"character": 4
 						}
 					],
@@ -9909,7 +9909,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8391,
+							"line": 8419,
 							"character": 4
 						}
 					],
@@ -9927,7 +9927,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8389,
+							"line": 8417,
 							"character": 4
 						}
 					],
@@ -9948,7 +9948,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8385,
+					"line": 8413,
 					"character": 12
 				}
 			]
@@ -10671,7 +10671,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5886,
+							"line": 5914,
 							"character": 4
 						}
 					],
@@ -10704,7 +10704,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5928,
+							"line": 5956,
 							"character": 4
 						}
 					],
@@ -10732,7 +10732,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5566,
+							"line": 5570,
 							"character": 4
 						}
 					],
@@ -10765,7 +10765,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5966,
+							"line": 5994,
 							"character": 4
 						}
 					],
@@ -10793,7 +10793,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6075,
+							"line": 6103,
 							"character": 4
 						}
 					],
@@ -10915,7 +10915,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5895,
+							"line": 5923,
 							"character": 4
 						}
 					],
@@ -10984,7 +10984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5913,
+							"line": 5941,
 							"character": 4
 						}
 					],
@@ -11012,7 +11012,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5986,
+							"line": 6014,
 							"character": 4
 						}
 					],
@@ -11364,7 +11364,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5860,
+							"line": 5888,
 							"character": 4
 						}
 					],
@@ -11506,7 +11506,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5556,
+							"line": 5560,
 							"character": 4
 						}
 					],
@@ -11519,7 +11519,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Get details of filters applied on the Liveboard.\nReturns arrays containing Liveboard filter and runtime filter elements.\nEach Liveboard filter may include an `applicability` attribute\n(`{ level, targetId }`) indicating the scope of the filter,\nfor example, a specific Liveboard tab.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
+						"shortText": "Get details of filters applied on the Liveboard.\nReturns arrays containing Liveboard filter and runtime filter elements.\nEach Liveboard filter may include an `applicability` attribute\nindicating the scope of the filter. It contains a `level`\n(`LIVEBOARD`, `TAB`, or `GROUP`) and, when `level` is `TAB` or\n`GROUP`, a `targetId` with the GUID of the target. At `LIVEBOARD`\nlevel there is no `targetId`, since the filter applies to the\nwhole Liveboard.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
 						"tags": [
 							{
 								"tag": "example",
@@ -11538,7 +11538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5334,
+							"line": 5337,
 							"character": 4
 						}
 					],
@@ -11583,7 +11583,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Triggers GetParameters to fetch the runtime Parameters.\nEach parameter may include an `applicability` attribute\n(`{ level, targetId }`) indicating the scope of the parameter,\nfor example, a specific Liveboard tab.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
+						"shortText": "Triggers GetParameters to fetch the runtime Parameters.\nEach parameter may include an `applicability` attribute\nindicating the scope of the parameter. It contains a `level`\n(`LIVEBOARD`, `TAB`, or `GROUP`) and, when `level` is `TAB` or\n`GROUP`, a `targetId` with the GUID of the target. At `LIVEBOARD`\nlevel there is no `targetId`, since the parameter applies to the\nwhole Liveboard.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
 						"tags": [
 							{
 								"tag": "param",
@@ -11603,7 +11603,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5665,
+							"line": 5693,
 							"character": 4
 						}
 					],
@@ -11679,7 +11679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5482,
+							"line": 5486,
 							"character": 4
 						}
 					],
@@ -11707,7 +11707,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6055,
+							"line": 6083,
 							"character": 4
 						}
 					],
@@ -11984,7 +11984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6065,
+							"line": 6093,
 							"character": 4
 						}
 					],
@@ -12126,7 +12126,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5875,
+							"line": 5903,
 							"character": 4
 						}
 					],
@@ -12154,7 +12154,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6086,
+							"line": 6114,
 							"character": 4
 						}
 					],
@@ -12259,7 +12259,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5593,
+							"line": 5597,
 							"character": 4
 						}
 					],
@@ -12287,7 +12287,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5602,
+							"line": 5606,
 							"character": 4
 						}
 					],
@@ -12347,7 +12347,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5904,
+							"line": 5932,
 							"character": 4
 						}
 					],
@@ -12437,7 +12437,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5794,
+							"line": 5822,
 							"character": 4
 						}
 					],
@@ -12570,7 +12570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5724,
+							"line": 5752,
 							"character": 4
 						}
 					],
@@ -12602,7 +12602,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6032,
+							"line": 6060,
 							"character": 4
 						}
 					],
@@ -12676,7 +12676,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5526,
+							"line": 5530,
 							"character": 4
 						}
 					],
@@ -12713,7 +12713,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5504,
+							"line": 5508,
 							"character": 4
 						}
 					],
@@ -12905,7 +12905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5844,
+							"line": 5872,
 							"character": 4
 						}
 					],
@@ -12938,7 +12938,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6045,
+							"line": 6073,
 							"character": 4
 						}
 					],
@@ -12967,7 +12967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6000,
+							"line": 6028,
 							"character": 4
 						}
 					],
@@ -13082,7 +13082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5819,
+							"line": 5847,
 							"character": 4
 						}
 					],
@@ -13110,7 +13110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5582,
+							"line": 5586,
 							"character": 4
 						}
 					],
@@ -13127,7 +13127,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and\nvalues.\n- `filters`: Multiple filter objects with column name, filter operator,\nand values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].\n\n`applicability` - Optional. Scopes the filter to a specific target,\nfor example, a single Liveboard tab. Available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl. Includes the following attributes:\n\n - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.\n - `targetId`: The GUID of the target, for example, the tab GUID.\n   Not required when `level` is `LIVEBOARD`, since the filter applies\n   to the whole Liveboard.",
+								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and\nvalues.\n- `filters`: Multiple filter objects with column name, filter operator,\nand values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].\n\n`applicability` - Optional. Scopes the filter to a specific target,\nfor example, a single Liveboard tab. Available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl. Includes the following attributes:\n\n - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.\n - `targetId`: The GUID of the target, for example, the tab GUID.\n   Required when `level` is `TAB` or `GROUP`. Do not pass it when\n   `level` is `LIVEBOARD`, since the filter applies to the whole\n   Liveboard.",
 								"param": "-"
 							},
 							{
@@ -13163,7 +13163,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5461,
+							"line": 5465,
 							"character": 4
 						}
 					],
@@ -13180,12 +13180,16 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys for each item:\n- `name`: Name of the parameter.\n- `value`: The value to set for the parameter.\n- `isVisibleToUser`: Optional. To control the visibility of the parameter chip.\n",
+								"text": "Includes the following keys for each item:\n- `name`: Name of the parameter.\n- `value`: The value to set for the parameter.\n- `isVisibleToUser`: Optional. To control the visibility of the parameter chip.\n- `applicability`: Optional. Scopes the parameter to a specific target,\nfor example, a single Liveboard tab. Available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl. Includes the following attributes:\n\n   - `level`: The scope of the parameter: `LIVEBOARD`, `TAB`, or `GROUP`.\n   - `targetId`: The GUID of the target, for example, the tab GUID.\n     Required when `level` is `TAB` or `GROUP`. Do not pass it when\n     `level` is `LIVEBOARD`, since the parameter applies to the whole\n     Liveboard.\n",
 								"param": "-"
 							},
 							{
 								"tag": "example",
 								"text": "\n```js\nliveboardEmbed.trigger(HostEvent.UpdateParameters, [{\n  name: \"Integer Range Param\",\n  value: 10,\n  isVisibleToUser: false\n}])\n```"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\n// Scope the parameter to a specific Liveboard tab\nliveboardEmbed.trigger(HostEvent.UpdateParameters, [{\n  name: \"Integer Range Param\",\n  value: 10,\n  applicability: {\n    level: \"TAB\",\n    targetId: \"e0836cad-4fdf-42d4-bd97-567a6b2a6058\"\n  }\n}])\n```"
 							},
 							{
 								"tag": "example",
@@ -13200,7 +13204,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5631,
+							"line": 5656,
 							"character": 4
 						}
 					],
@@ -13232,7 +13236,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5683,
+							"line": 5711,
 							"character": 4
 						}
 					],
@@ -13256,7 +13260,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5691,
+							"line": 5719,
 							"character": 4
 						}
 					],
@@ -13480,7 +13484,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8606,
+							"line": 8634,
 							"character": 4
 						}
 					],
@@ -13498,7 +13502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8602,
+							"line": 8630,
 							"character": 4
 						}
 					],
@@ -13516,7 +13520,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8610,
+							"line": 8638,
 							"character": 4
 						}
 					],
@@ -13537,7 +13541,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8598,
+					"line": 8626,
 					"character": 12
 				}
 			]
@@ -13570,7 +13574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8876,
+							"line": 8904,
 							"character": 4
 						}
 					],
@@ -13588,7 +13592,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8878,
+							"line": 8906,
 							"character": 4
 						}
 					],
@@ -13606,7 +13610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8880,
+							"line": 8908,
 							"character": 4
 						}
 					],
@@ -13624,7 +13628,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8874,
+							"line": 8902,
 							"character": 4
 						}
 					],
@@ -13646,7 +13650,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8872,
+					"line": 8900,
 					"character": 12
 				}
 			]
@@ -13926,7 +13930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8341,
+							"line": 8369,
 							"character": 4
 						}
 					],
@@ -13954,7 +13958,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8302,
+							"line": 8330,
 							"character": 4
 						}
 					],
@@ -13982,7 +13986,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8327,
+							"line": 8355,
 							"character": 4
 						}
 					],
@@ -14010,7 +14014,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8290,
+							"line": 8318,
 							"character": 4
 						}
 					],
@@ -14038,7 +14042,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8353,
+							"line": 8381,
 							"character": 4
 						}
 					],
@@ -14066,7 +14070,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8314,
+							"line": 8342,
 							"character": 4
 						}
 					],
@@ -14090,7 +14094,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8277,
+					"line": 8305,
 					"character": 12
 				}
 			]
@@ -14271,7 +14275,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8106,
+							"line": 8134,
 							"character": 4
 						}
 					],
@@ -14286,7 +14290,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8108,
+							"line": 8136,
 							"character": 4
 						}
 					],
@@ -14301,7 +14305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8107,
+							"line": 8135,
 							"character": 4
 						}
 					],
@@ -14316,7 +14320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8109,
+							"line": 8137,
 							"character": 4
 						}
 					],
@@ -14338,7 +14342,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8105,
+					"line": 8133,
 					"character": 12
 				}
 			]
@@ -14735,7 +14739,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8904,
+							"line": 8932,
 							"character": 4
 						}
 					],
@@ -14753,7 +14757,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8902,
+							"line": 8930,
 							"character": 4
 						}
 					],
@@ -14773,7 +14777,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8900,
+					"line": 8928,
 					"character": 12
 				}
 			]
@@ -14806,7 +14810,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8889,
+							"line": 8917,
 							"character": 4
 						}
 					],
@@ -14824,7 +14828,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8891,
+							"line": 8919,
 							"character": 4
 						}
 					],
@@ -14842,7 +14846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8893,
+							"line": 8921,
 							"character": 4
 						}
 					],
@@ -14863,7 +14867,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8887,
+					"line": 8915,
 					"character": 12
 				}
 			]
@@ -14884,7 +14888,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 48,
+							"line": 56,
 							"character": 2
 						}
 					],
@@ -14899,7 +14903,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 44,
+							"line": 52,
 							"character": 2
 						}
 					],
@@ -14914,7 +14918,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 49,
+							"line": 57,
 							"character": 2
 						}
 					],
@@ -14929,7 +14933,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 43,
+							"line": 51,
 							"character": 2
 						}
 					],
@@ -14944,7 +14948,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 42,
+							"line": 50,
 							"character": 2
 						}
 					],
@@ -14959,7 +14963,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 55,
+							"line": 63,
 							"character": 2
 						}
 					],
@@ -14974,7 +14978,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 50,
+							"line": 58,
 							"character": 2
 						}
 					],
@@ -14989,7 +14993,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 51,
+							"line": 59,
 							"character": 2
 						}
 					],
@@ -15004,7 +15008,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 45,
+							"line": 53,
 							"character": 2
 						}
 					],
@@ -15019,7 +15023,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 52,
+							"line": 60,
 							"character": 2
 						}
 					],
@@ -15034,7 +15038,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 53,
+							"line": 61,
 							"character": 2
 						}
 					],
@@ -15049,7 +15053,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 54,
+							"line": 62,
 							"character": 2
 						}
 					],
@@ -15064,7 +15068,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 46,
+							"line": 54,
 							"character": 2
 						}
 					],
@@ -15079,7 +15083,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 40,
+							"line": 48,
 							"character": 2
 						}
 					],
@@ -15094,7 +15098,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 41,
+							"line": 49,
 							"character": 2
 						}
 					],
@@ -15109,7 +15113,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 47,
+							"line": 55,
 							"character": 2
 						}
 					],
@@ -15143,7 +15147,7 @@
 			"sources": [
 				{
 					"fileName": "embed/hostEventClient/contracts.ts",
-					"line": 39,
+					"line": 47,
 					"character": 12
 				}
 			]
@@ -28155,7 +28159,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -28192,7 +28196,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -28604,7 +28608,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -31492,7 +31496,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -31530,7 +31534,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -31568,7 +31572,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -33013,7 +33017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -33051,7 +33055,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -33089,7 +33093,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -33912,7 +33916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8150,
+							"line": 8178,
 							"character": 4
 						}
 					],
@@ -33934,7 +33938,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8151,
+											"line": 8179,
 											"character": 8
 										}
 									],
@@ -33953,7 +33957,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8152,
+											"line": 8180,
 											"character": 8
 										}
 									],
@@ -33989,7 +33993,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8154,
+							"line": 8182,
 							"character": 4
 						}
 					],
@@ -34011,7 +34015,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8162,
+											"line": 8190,
 											"character": 8
 										}
 									],
@@ -34032,7 +34036,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8163,
+											"line": 8191,
 											"character": 8
 										}
 									],
@@ -34053,7 +34057,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8156,
+											"line": 8184,
 											"character": 8
 										}
 									],
@@ -34071,7 +34075,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8155,
+											"line": 8183,
 											"character": 8
 										}
 									],
@@ -34089,7 +34093,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8157,
+											"line": 8185,
 											"character": 8
 										}
 									],
@@ -34111,7 +34115,7 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8158,
+															"line": 8186,
 															"character": 12
 														}
 													],
@@ -34133,7 +34137,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8159,
+																			"line": 8187,
 																			"character": 16
 																		}
 																	],
@@ -34217,7 +34221,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8166,
+							"line": 8194,
 							"character": 4
 						}
 					],
@@ -34238,7 +34242,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8167,
+							"line": 8195,
 							"character": 4
 						}
 					],
@@ -34263,7 +34267,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8149,
+					"line": 8177,
 					"character": 17
 				}
 			]
@@ -41257,7 +41261,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8531,
+							"line": 8559,
 							"character": 4
 						}
 					],
@@ -41279,7 +41283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8527,
+							"line": 8555,
 							"character": 4
 						}
 					],
@@ -41301,7 +41305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8529,
+							"line": 8557,
 							"character": 4
 						}
 					],
@@ -41337,7 +41341,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8525,
+					"line": 8553,
 					"character": 17
 				}
 			],
@@ -42911,7 +42915,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -42948,7 +42952,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -43360,7 +43364,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -46013,7 +46017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -46050,7 +46054,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -46087,7 +46091,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -48133,7 +48137,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -48170,7 +48174,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -48207,7 +48211,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -49732,7 +49736,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -49769,7 +49773,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -49806,7 +49810,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -51386,7 +51390,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8682,
 							"character": 4
 						}
 					],
@@ -51423,7 +51427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8637,
+							"line": 8665,
 							"character": 4
 						}
 					],
@@ -51460,7 +51464,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8621,
+							"line": 8649,
 							"character": 4
 						}
 					],
@@ -53412,7 +53416,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9147,
+							"line": 9175,
 							"character": 4
 						}
 					],
@@ -53435,7 +53439,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9149,
+							"line": 9177,
 							"character": 4
 						}
 					],
@@ -53458,7 +53462,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9145,
+					"line": 9173,
 					"character": 17
 				}
 			]
@@ -53479,7 +53483,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8142,
+							"line": 8170,
 							"character": 4
 						}
 					],
@@ -53500,7 +53504,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8143,
+							"line": 8171,
 							"character": 4
 						}
 					],
@@ -53526,7 +53530,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8141,
+					"line": 8169,
 					"character": 17
 				}
 			]

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -49,7 +49,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7425,
+							"line": 7459,
 							"character": 4
 						}
 					],
@@ -77,7 +77,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6458,
+							"line": 6492,
 							"character": 4
 						}
 					],
@@ -105,7 +105,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6387,
+							"line": 6421,
 							"character": 4
 						}
 					],
@@ -129,7 +129,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6376,
+							"line": 6410,
 							"character": 4
 						}
 					],
@@ -153,7 +153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6439,
+							"line": 6473,
 							"character": 4
 						}
 					],
@@ -177,7 +177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6448,
+							"line": 6482,
 							"character": 4
 						}
 					],
@@ -205,7 +205,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6468,
+							"line": 6502,
 							"character": 4
 						}
 					],
@@ -233,7 +233,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7193,
+							"line": 7227,
 							"character": 4
 						}
 					],
@@ -261,7 +261,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6886,
+							"line": 6920,
 							"character": 4
 						}
 					],
@@ -289,7 +289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7378,
+							"line": 7412,
 							"character": 4
 						}
 					],
@@ -317,7 +317,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6874,
+							"line": 6908,
 							"character": 4
 						}
 					],
@@ -345,7 +345,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6862,
+							"line": 6896,
 							"character": 4
 						}
 					],
@@ -374,7 +374,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7367,
+							"line": 7401,
 							"character": 4
 						}
 					],
@@ -402,7 +402,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7008,
+							"line": 7042,
 							"character": 4
 						}
 					],
@@ -430,7 +430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7139,
+							"line": 7173,
 							"character": 4
 						}
 					],
@@ -458,7 +458,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7042,
+							"line": 7076,
 							"character": 4
 						}
 					],
@@ -486,7 +486,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7097,
+							"line": 7131,
 							"character": 4
 						}
 					],
@@ -514,7 +514,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7031,
+							"line": 7065,
 							"character": 4
 						}
 					],
@@ -542,7 +542,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7065,
+							"line": 7099,
 							"character": 4
 						}
 					],
@@ -570,7 +570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7149,
+							"line": 7183,
 							"character": 4
 						}
 					],
@@ -598,7 +598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7107,
+							"line": 7141,
 							"character": 4
 						}
 					],
@@ -626,7 +626,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7076,
+							"line": 7110,
 							"character": 4
 						}
 					],
@@ -654,7 +654,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7129,
+							"line": 7163,
 							"character": 4
 						}
 					],
@@ -682,7 +682,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7086,
+							"line": 7120,
 							"character": 4
 						}
 					],
@@ -710,7 +710,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7053,
+							"line": 7087,
 							"character": 4
 						}
 					],
@@ -738,7 +738,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7117,
+							"line": 7151,
 							"character": 4
 						}
 					],
@@ -766,7 +766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7019,
+							"line": 7053,
 							"character": 4
 						}
 					],
@@ -794,7 +794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7523,
+							"line": 7557,
 							"character": 4
 						}
 					],
@@ -818,7 +818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6430,
+							"line": 6464,
 							"character": 4
 						}
 					],
@@ -846,7 +846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6421,
+							"line": 6455,
 							"character": 4
 						}
 					],
@@ -874,7 +874,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6409,
+							"line": 6443,
 							"character": 4
 						}
 					],
@@ -902,7 +902,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7611,
+							"line": 7645,
 							"character": 4
 						}
 					],
@@ -926,7 +926,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6398,
+							"line": 6432,
 							"character": 4
 						}
 					],
@@ -941,7 +941,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6811,
+							"line": 6845,
 							"character": 4
 						}
 					],
@@ -965,7 +965,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6335,
+							"line": 6369,
 							"character": 4
 						}
 					],
@@ -989,7 +989,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6810,
+							"line": 6844,
 							"character": 4
 						}
 					],
@@ -1017,7 +1017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7621,
+							"line": 7655,
 							"character": 4
 						}
 					],
@@ -1045,7 +1045,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7781,
+							"line": 7815,
 							"character": 4
 						}
 					],
@@ -1073,7 +1073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7342,
+							"line": 7376,
 							"character": 4
 						}
 					],
@@ -1101,7 +1101,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6916,
+							"line": 6950,
 							"character": 4
 						}
 					],
@@ -1129,7 +1129,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6966,
+							"line": 7000,
 							"character": 4
 						}
 					],
@@ -1157,7 +1157,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7535,
+							"line": 7569,
 							"character": 4
 						}
 					],
@@ -1185,7 +1185,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7592,
+							"line": 7626,
 							"character": 4
 						}
 					],
@@ -1213,7 +1213,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7492,
+							"line": 7526,
 							"character": 4
 						}
 					],
@@ -1241,7 +1241,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7511,
+							"line": 7545,
 							"character": 4
 						}
 					],
@@ -1265,7 +1265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6518,
+							"line": 6552,
 							"character": 4
 						}
 					],
@@ -1289,7 +1289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6551,
+							"line": 6585,
 							"character": 4
 						}
 					],
@@ -1314,7 +1314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6541,
+							"line": 6575,
 							"character": 4
 						}
 					],
@@ -1338,7 +1338,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6528,
+							"line": 6562,
 							"character": 4
 						}
 					],
@@ -1362,7 +1362,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6561,
+							"line": 6595,
 							"character": 4
 						}
 					],
@@ -1390,7 +1390,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6571,
+							"line": 6605,
 							"character": 4
 						}
 					],
@@ -1418,7 +1418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6595,
+							"line": 6629,
 							"character": 4
 						}
 					],
@@ -1446,7 +1446,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6581,
+							"line": 6615,
 							"character": 4
 						}
 					],
@@ -1474,7 +1474,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6615,
+							"line": 6649,
 							"character": 4
 						}
 					],
@@ -1502,7 +1502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6605,
+							"line": 6639,
 							"character": 4
 						}
 					],
@@ -1526,7 +1526,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6827,
+							"line": 6861,
 							"character": 4
 						}
 					],
@@ -1550,7 +1550,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6800,
+							"line": 6834,
 							"character": 4
 						}
 					],
@@ -1574,7 +1574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6791,
+							"line": 6825,
 							"character": 4
 						}
 					],
@@ -1598,7 +1598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6691,
+							"line": 6725,
 							"character": 4
 						}
 					],
@@ -1622,7 +1622,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6326,
+							"line": 6360,
 							"character": 4
 						}
 					],
@@ -1650,7 +1650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6905,
+							"line": 6939,
 							"character": 4
 						}
 					],
@@ -1665,7 +1665,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6816,
+							"line": 6850,
 							"character": 4
 						}
 					],
@@ -1693,7 +1693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7581,
+							"line": 7615,
 							"character": 4
 						}
 					],
@@ -1721,7 +1721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7237,
+							"line": 7271,
 							"character": 4
 						}
 					],
@@ -1749,7 +1749,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7438,
+							"line": 7472,
 							"character": 4
 						}
 					],
@@ -1773,7 +1773,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6659,
+							"line": 6693,
 							"character": 4
 						}
 					],
@@ -1797,7 +1797,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6699,
+							"line": 6733,
 							"character": 4
 						}
 					],
@@ -1825,7 +1825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7602,
+							"line": 7636,
 							"character": 4
 						}
 					],
@@ -1853,7 +1853,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7203,
+							"line": 7237,
 							"character": 4
 						}
 					],
@@ -1881,7 +1881,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7214,
+							"line": 7248,
 							"character": 4
 						}
 					],
@@ -1905,7 +1905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6780,
+							"line": 6814,
 							"character": 4
 						}
 					],
@@ -1930,7 +1930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6631,
+							"line": 6665,
 							"character": 4
 						}
 					],
@@ -1954,7 +1954,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6641,
+							"line": 6675,
 							"character": 4
 						}
 					],
@@ -1982,7 +1982,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7636,
+							"line": 7670,
 							"character": 4
 						}
 					],
@@ -2010,7 +2010,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7926,
+							"line": 7960,
 							"character": 4
 						}
 					],
@@ -2038,7 +2038,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7502,
+							"line": 7536,
 							"character": 4
 						}
 					],
@@ -2062,7 +2062,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6741,
+							"line": 6775,
 							"character": 4
 						}
 					],
@@ -2090,7 +2090,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7702,
+							"line": 7736,
 							"character": 4
 						}
 					],
@@ -2118,7 +2118,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7310,
+							"line": 7344,
 							"character": 4
 						}
 					],
@@ -2142,7 +2142,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6317,
+							"line": 6351,
 							"character": 4
 						}
 					],
@@ -2166,7 +2166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7278,
+							"line": 7312,
 							"character": 4
 						}
 					],
@@ -2194,7 +2194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6956,
+							"line": 6990,
 							"character": 4
 						}
 					],
@@ -2222,7 +2222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7728,
+							"line": 7762,
 							"character": 4
 						}
 					],
@@ -2250,7 +2250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7481,
+							"line": 7515,
 							"character": 4
 						}
 					],
@@ -2278,7 +2278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7183,
+							"line": 7217,
 							"character": 4
 						}
 					],
@@ -2305,7 +2305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7258,
+							"line": 7292,
 							"character": 4
 						}
 					],
@@ -2333,7 +2333,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7771,
+							"line": 7805,
 							"character": 4
 						}
 					],
@@ -2361,7 +2361,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7761,
+							"line": 7795,
 							"character": 4
 						}
 					],
@@ -2385,7 +2385,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7267,
+							"line": 7301,
 							"character": 4
 						}
 					],
@@ -2417,7 +2417,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7402,
+							"line": 7436,
 							"character": 4
 						}
 					],
@@ -2445,7 +2445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7414,
+							"line": 7448,
 							"character": 4
 						}
 					],
@@ -2473,7 +2473,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7751,
+							"line": 7785,
 							"character": 4
 						}
 					],
@@ -2501,7 +2501,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7449,
+							"line": 7483,
 							"character": 4
 						}
 					],
@@ -2533,7 +2533,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7290,
+							"line": 7324,
 							"character": 4
 						}
 					],
@@ -2561,7 +2561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7300,
+							"line": 7334,
 							"character": 4
 						}
 					],
@@ -2585,7 +2585,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6758,
+							"line": 6792,
 							"character": 4
 						}
 					],
@@ -2609,7 +2609,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7680,
+							"line": 7714,
 							"character": 4
 						}
 					],
@@ -2633,7 +2633,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6669,
+							"line": 6703,
 							"character": 4
 						}
 					],
@@ -2661,7 +2661,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7547,
+							"line": 7581,
 							"character": 4
 						}
 					],
@@ -2689,7 +2689,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7715,
+							"line": 7749,
 							"character": 4
 						}
 					],
@@ -2714,7 +2714,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6852,
+							"line": 6886,
 							"character": 4
 						}
 					],
@@ -2742,7 +2742,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7999,
+							"line": 8033,
 							"character": 4
 						}
 					],
@@ -2766,7 +2766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6709,
+							"line": 6743,
 							"character": 4
 						}
 					],
@@ -2794,7 +2794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7692,
+							"line": 7726,
 							"character": 4
 						}
 					],
@@ -2822,7 +2822,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6997,
+							"line": 7031,
 							"character": 4
 						}
 					],
@@ -2850,7 +2850,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6896,
+							"line": 6930,
 							"character": 4
 						}
 					],
@@ -2878,7 +2878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7389,
+							"line": 7423,
 							"character": 4
 						}
 					],
@@ -2906,7 +2906,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7163,
+							"line": 7197,
 							"character": 4
 						}
 					],
@@ -2937,7 +2937,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6925,
+							"line": 6959,
 							"character": 4
 						}
 					],
@@ -2961,7 +2961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6836,
+							"line": 6870,
 							"character": 4
 						}
 					],
@@ -2989,7 +2989,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7173,
+							"line": 7207,
 							"character": 4
 						}
 					],
@@ -3017,7 +3017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7559,
+							"line": 7593,
 							"character": 4
 						}
 					],
@@ -3045,7 +3045,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7249,
+							"line": 7283,
 							"character": 4
 						}
 					],
@@ -3069,7 +3069,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6286,
+							"line": 6320,
 							"character": 4
 						}
 					],
@@ -3093,7 +3093,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6304,
+							"line": 6338,
 							"character": 4
 						}
 					],
@@ -3117,7 +3117,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6349,
+							"line": 6383,
 							"character": 4
 						}
 					],
@@ -3141,7 +3141,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6358,
+							"line": 6392,
 							"character": 4
 						}
 					],
@@ -3169,7 +3169,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7938,
+							"line": 7972,
 							"character": 4
 						}
 					],
@@ -3184,7 +3184,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6817,
+							"line": 6851,
 							"character": 4
 						}
 					],
@@ -3208,7 +3208,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6367,
+							"line": 6401,
 							"character": 4
 						}
 					],
@@ -3226,7 +3226,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6493,
+							"line": 6527,
 							"character": 4
 						}
 					],
@@ -3254,7 +3254,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7224,
+							"line": 7258,
 							"character": 4
 						}
 					],
@@ -3278,7 +3278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6508,
+							"line": 6542,
 							"character": 4
 						}
 					],
@@ -3302,7 +3302,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6481,
+							"line": 6515,
 							"character": 4
 						}
 					],
@@ -3330,7 +3330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8032,
+							"line": 8066,
 							"character": 4
 						}
 					],
@@ -3358,7 +3358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8043,
+							"line": 8077,
 							"character": 4
 						}
 					],
@@ -3386,7 +3386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8021,
+							"line": 8055,
 							"character": 4
 						}
 					],
@@ -3414,7 +3414,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8054,
+							"line": 8088,
 							"character": 4
 						}
 					],
@@ -3442,7 +3442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8010,
+							"line": 8044,
 							"character": 4
 						}
 					],
@@ -3470,7 +3470,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8065,
+							"line": 8099,
 							"character": 4
 						}
 					],
@@ -3498,7 +3498,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7892,
+							"line": 7926,
 							"character": 4
 						}
 					],
@@ -3526,7 +3526,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7903,
+							"line": 7937,
 							"character": 4
 						}
 					],
@@ -3554,7 +3554,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7871,
+							"line": 7905,
 							"character": 4
 						}
 					],
@@ -3582,7 +3582,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7851,
+							"line": 7885,
 							"character": 4
 						}
 					],
@@ -3610,7 +3610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7914,
+							"line": 7948,
 							"character": 4
 						}
 					],
@@ -3638,7 +3638,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7861,
+							"line": 7895,
 							"character": 4
 						}
 					],
@@ -3666,7 +3666,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7881,
+							"line": 7915,
 							"character": 4
 						}
 					],
@@ -3694,7 +3694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7570,
+							"line": 7604,
 							"character": 4
 						}
 					],
@@ -3722,7 +3722,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7831,
+							"line": 7865,
 							"character": 4
 						}
 					],
@@ -3750,7 +3750,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7841,
+							"line": 7875,
 							"character": 4
 						}
 					],
@@ -3778,7 +3778,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7811,
+							"line": 7845,
 							"character": 4
 						}
 					],
@@ -3806,7 +3806,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7801,
+							"line": 7835,
 							"character": 4
 						}
 					],
@@ -3834,7 +3834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7821,
+							"line": 7855,
 							"character": 4
 						}
 					],
@@ -3862,7 +3862,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7669,
+							"line": 7703,
 							"character": 4
 						}
 					],
@@ -3890,7 +3890,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7974,
+							"line": 8008,
 							"character": 4
 						}
 					],
@@ -3918,7 +3918,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7962,
+							"line": 7996,
 							"character": 4
 						}
 					],
@@ -3946,7 +3946,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7950,
+							"line": 7984,
 							"character": 4
 						}
 					],
@@ -3974,7 +3974,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7988,
+							"line": 8022,
 							"character": 4
 						}
 					],
@@ -4002,7 +4002,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7647,
+							"line": 7681,
 							"character": 4
 						}
 					],
@@ -4030,7 +4030,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7658,
+							"line": 7692,
 							"character": 4
 						}
 					],
@@ -4054,7 +4054,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6772,
+							"line": 6806,
 							"character": 4
 						}
 					],
@@ -4082,7 +4082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6946,
+							"line": 6980,
 							"character": 4
 						}
 					],
@@ -4110,7 +4110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6935,
+							"line": 6969,
 							"character": 4
 						}
 					],
@@ -4138,7 +4138,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6976,
+							"line": 7010,
 							"character": 4
 						}
 					],
@@ -4166,7 +4166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6986,
+							"line": 7020,
 							"character": 4
 						}
 					],
@@ -4198,7 +4198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7329,
+							"line": 7363,
 							"character": 4
 						}
 					],
@@ -4222,7 +4222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6681,
+							"line": 6715,
 							"character": 4
 						}
 					],
@@ -4250,7 +4250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7791,
+							"line": 7825,
 							"character": 4
 						}
 					],
@@ -4278,7 +4278,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7740,
+							"line": 7774,
 							"character": 4
 						}
 					],
@@ -4306,7 +4306,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7471,
+							"line": 7505,
 							"character": 4
 						}
 					],
@@ -4330,7 +4330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6650,
+							"line": 6684,
 							"character": 4
 						}
 					],
@@ -4358,7 +4358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7353,
+							"line": 7387,
 							"character": 4
 						}
 					],
@@ -4386,7 +4386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7460,
+							"line": 7494,
 							"character": 4
 						}
 					],
@@ -4567,7 +4567,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6277,
+					"line": 6311,
 					"character": 12
 				}
 			]
@@ -5194,7 +5194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8767,
+							"line": 8801,
 							"character": 4
 						}
 					],
@@ -5212,7 +5212,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8765,
+							"line": 8799,
 							"character": 4
 						}
 					],
@@ -5232,7 +5232,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8763,
+					"line": 8797,
 					"character": 12
 				}
 			]
@@ -5265,7 +5265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8778,
+							"line": 8812,
 							"character": 4
 						}
 					],
@@ -5283,7 +5283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8780,
+							"line": 8814,
 							"character": 4
 						}
 					],
@@ -5301,7 +5301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8776,
+							"line": 8810,
 							"character": 4
 						}
 					],
@@ -5322,7 +5322,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8774,
+					"line": 8808,
 					"character": 12
 				}
 			]
@@ -5355,7 +5355,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8732,
+							"line": 8766,
 							"character": 4
 						}
 					],
@@ -5373,7 +5373,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8734,
+							"line": 8768,
 							"character": 4
 						}
 					],
@@ -5391,7 +5391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8738,
+							"line": 8772,
 							"character": 4
 						}
 					],
@@ -5409,7 +5409,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8748,
+							"line": 8782,
 							"character": 4
 						}
 					],
@@ -5427,7 +5427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8740,
+							"line": 8774,
 							"character": 4
 						}
 					],
@@ -5445,7 +5445,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8744,
+							"line": 8778,
 							"character": 4
 						}
 					],
@@ -5463,7 +5463,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8728,
+							"line": 8762,
 							"character": 4
 						}
 					],
@@ -5481,7 +5481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8752,
+							"line": 8786,
 							"character": 4
 						}
 					],
@@ -5499,7 +5499,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8730,
+							"line": 8764,
 							"character": 4
 						}
 					],
@@ -5517,7 +5517,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8756,
+							"line": 8790,
 							"character": 4
 						}
 					],
@@ -5535,7 +5535,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8754,
+							"line": 8788,
 							"character": 4
 						}
 					],
@@ -5553,7 +5553,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8742,
+							"line": 8776,
 							"character": 4
 						}
 					],
@@ -5571,7 +5571,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8746,
+							"line": 8780,
 							"character": 4
 						}
 					],
@@ -5589,7 +5589,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8750,
+							"line": 8784,
 							"character": 4
 						}
 					],
@@ -5607,7 +5607,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8736,
+							"line": 8770,
 							"character": 4
 						}
 					],
@@ -5640,7 +5640,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8726,
+					"line": 8760,
 					"character": 12
 				}
 			]
@@ -5664,7 +5664,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8085,
+							"line": 8119,
 							"character": 4
 						}
 					],
@@ -5679,7 +5679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8083,
+							"line": 8117,
 							"character": 4
 						}
 					],
@@ -5694,7 +5694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8084,
+							"line": 8118,
 							"character": 4
 						}
 					],
@@ -5715,7 +5715,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8082,
+					"line": 8116,
 					"character": 12
 				}
 			]
@@ -5756,7 +5756,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8530,
+							"line": 8564,
 							"character": 4
 						}
 					],
@@ -5774,7 +5774,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8526,
+							"line": 8560,
 							"character": 4
 						}
 					],
@@ -5792,7 +5792,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8539,
+							"line": 8573,
 							"character": 4
 						}
 					],
@@ -5810,7 +5810,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8522,
+							"line": 8556,
 							"character": 4
 						}
 					],
@@ -5828,7 +5828,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8534,
+							"line": 8568,
 							"character": 4
 						}
 					],
@@ -5851,7 +5851,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8518,
+					"line": 8552,
 					"character": 12
 				}
 			]
@@ -5878,7 +5878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8222,
+							"line": 8256,
 							"character": 4
 						}
 					],
@@ -5896,7 +5896,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8195,
+							"line": 8229,
 							"character": 4
 						}
 					],
@@ -5914,7 +5914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8233,
+							"line": 8267,
 							"character": 4
 						}
 					],
@@ -5932,7 +5932,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8209,
+							"line": 8243,
 							"character": 4
 						}
 					],
@@ -5954,7 +5954,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8185,
+					"line": 8219,
 					"character": 12
 				}
 			]
@@ -5981,7 +5981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8176,
+							"line": 8210,
 							"character": 4
 						}
 					],
@@ -5999,7 +5999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8168,
+							"line": 8202,
 							"character": 4
 						}
 					],
@@ -6017,7 +6017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8163,
+							"line": 8197,
 							"character": 4
 						}
 					],
@@ -6038,7 +6038,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8158,
+					"line": 8192,
 					"character": 12
 				}
 			]
@@ -6071,7 +6071,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8717,
+							"line": 8751,
 							"character": 4
 						}
 					],
@@ -6089,7 +6089,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8709,
+							"line": 8743,
 							"character": 4
 						}
 					],
@@ -6107,7 +6107,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8713,
+							"line": 8747,
 							"character": 4
 						}
 					],
@@ -6125,7 +6125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8711,
+							"line": 8745,
 							"character": 4
 						}
 					],
@@ -6143,7 +6143,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8715,
+							"line": 8749,
 							"character": 4
 						}
 					],
@@ -6161,7 +6161,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8719,
+							"line": 8753,
 							"character": 4
 						}
 					],
@@ -6185,7 +6185,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8707,
+					"line": 8741,
 					"character": 12
 				}
 			]
@@ -6296,7 +6296,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6068,
+							"line": 6102,
 							"character": 4
 						}
 					],
@@ -6314,7 +6314,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6072,
+							"line": 6106,
 							"character": 4
 						}
 					],
@@ -6332,7 +6332,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6064,
+							"line": 6098,
 							"character": 4
 						}
 					],
@@ -6353,7 +6353,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6060,
+					"line": 6094,
 					"character": 12
 				}
 			]
@@ -6394,7 +6394,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8399,
+							"line": 8433,
 							"character": 4
 						}
 					],
@@ -6412,7 +6412,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8402,
+							"line": 8436,
 							"character": 4
 						}
 					],
@@ -6430,7 +6430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8411,
+							"line": 8445,
 							"character": 4
 						}
 					],
@@ -6448,7 +6448,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8438,
+							"line": 8472,
 							"character": 4
 						}
 					],
@@ -6466,7 +6466,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8420,
+							"line": 8454,
 							"character": 4
 						}
 					],
@@ -6484,7 +6484,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8432,
+							"line": 8466,
 							"character": 4
 						}
 					],
@@ -6502,7 +6502,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8405,
+							"line": 8439,
 							"character": 4
 						}
 					],
@@ -6520,7 +6520,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8429,
+							"line": 8463,
 							"character": 4
 						}
 					],
@@ -6538,7 +6538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8396,
+							"line": 8430,
 							"character": 4
 						}
 					],
@@ -6556,7 +6556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8414,
+							"line": 8448,
 							"character": 4
 						}
 					],
@@ -6574,7 +6574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8408,
+							"line": 8442,
 							"character": 4
 						}
 					],
@@ -6592,7 +6592,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8423,
+							"line": 8457,
 							"character": 4
 						}
 					],
@@ -6610,7 +6610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8417,
+							"line": 8451,
 							"character": 4
 						}
 					],
@@ -6628,7 +6628,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8435,
+							"line": 8469,
 							"character": 4
 						}
 					],
@@ -6646,7 +6646,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8426,
+							"line": 8460,
 							"character": 4
 						}
 					],
@@ -6664,7 +6664,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8393,
+							"line": 8427,
 							"character": 4
 						}
 					],
@@ -6698,7 +6698,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8391,
+					"line": 8425,
 					"character": 12
 				}
 			]
@@ -9891,7 +9891,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8353,
+							"line": 8387,
 							"character": 4
 						}
 					],
@@ -9909,7 +9909,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8357,
+							"line": 8391,
 							"character": 4
 						}
 					],
@@ -9927,7 +9927,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8355,
+							"line": 8389,
 							"character": 4
 						}
 					],
@@ -9948,7 +9948,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8351,
+					"line": 8385,
 					"character": 12
 				}
 			]
@@ -10671,7 +10671,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5852,
+							"line": 5886,
 							"character": 4
 						}
 					],
@@ -10704,7 +10704,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5894,
+							"line": 5928,
 							"character": 4
 						}
 					],
@@ -10732,7 +10732,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5537,
+							"line": 5566,
 							"character": 4
 						}
 					],
@@ -10765,7 +10765,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5932,
+							"line": 5966,
 							"character": 4
 						}
 					],
@@ -10793,7 +10793,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6041,
+							"line": 6075,
 							"character": 4
 						}
 					],
@@ -10915,7 +10915,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5861,
+							"line": 5895,
 							"character": 4
 						}
 					],
@@ -10984,7 +10984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5879,
+							"line": 5913,
 							"character": 4
 						}
 					],
@@ -11012,7 +11012,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5952,
+							"line": 5986,
 							"character": 4
 						}
 					],
@@ -11364,7 +11364,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5826,
+							"line": 5860,
 							"character": 4
 						}
 					],
@@ -11506,7 +11506,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5527,
+							"line": 5556,
 							"character": 4
 						}
 					],
@@ -11519,7 +11519,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Get details of filters applied on the Liveboard.\nReturns arrays containing Liveboard filter and runtime filter elements.",
+						"shortText": "Get details of filters applied on the Liveboard.\nReturns arrays containing Liveboard filter and runtime filter elements.\nEach Liveboard filter may include an `applicability` attribute\n(`{ level, targetId }`) indicating the scope of the filter,\nfor example, a specific Liveboard tab.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
 						"tags": [
 							{
 								"tag": "example",
@@ -11538,7 +11538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5329,
+							"line": 5334,
 							"character": 4
 						}
 					],
@@ -11583,7 +11583,7 @@
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Triggers GetParameters to fetch the runtime Parameters.",
+						"shortText": "Triggers GetParameters to fetch the runtime Parameters.\nEach parameter may include an `applicability` attribute\n(`{ level, targetId }`) indicating the scope of the parameter,\nfor example, a specific Liveboard tab.\nThe `applicability` attribute is available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl.",
 						"tags": [
 							{
 								"tag": "param",
@@ -11603,7 +11603,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5631,
+							"line": 5665,
 							"character": 4
 						}
 					],
@@ -11679,7 +11679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5453,
+							"line": 5482,
 							"character": 4
 						}
 					],
@@ -11707,7 +11707,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6021,
+							"line": 6055,
 							"character": 4
 						}
 					],
@@ -11984,7 +11984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6031,
+							"line": 6065,
 							"character": 4
 						}
 					],
@@ -12126,7 +12126,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5841,
+							"line": 5875,
 							"character": 4
 						}
 					],
@@ -12154,7 +12154,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6052,
+							"line": 6086,
 							"character": 4
 						}
 					],
@@ -12259,7 +12259,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5564,
+							"line": 5593,
 							"character": 4
 						}
 					],
@@ -12287,7 +12287,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5573,
+							"line": 5602,
 							"character": 4
 						}
 					],
@@ -12347,7 +12347,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5870,
+							"line": 5904,
 							"character": 4
 						}
 					],
@@ -12437,7 +12437,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5760,
+							"line": 5794,
 							"character": 4
 						}
 					],
@@ -12570,7 +12570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5690,
+							"line": 5724,
 							"character": 4
 						}
 					],
@@ -12602,7 +12602,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5998,
+							"line": 6032,
 							"character": 4
 						}
 					],
@@ -12676,7 +12676,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5497,
+							"line": 5526,
 							"character": 4
 						}
 					],
@@ -12713,7 +12713,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5475,
+							"line": 5504,
 							"character": 4
 						}
 					],
@@ -12905,7 +12905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5810,
+							"line": 5844,
 							"character": 4
 						}
 					],
@@ -12938,7 +12938,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6011,
+							"line": 6045,
 							"character": 4
 						}
 					],
@@ -12967,7 +12967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5966,
+							"line": 6000,
 							"character": 4
 						}
 					],
@@ -13082,7 +13082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5785,
+							"line": 5819,
 							"character": 4
 						}
 					],
@@ -13110,7 +13110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5553,
+							"line": 5582,
 							"character": 4
 						}
 					],
@@ -13127,7 +13127,7 @@
 						"tags": [
 							{
 								"tag": "param",
-								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and\nvalues.\n- `filters`: Multiple filter objects with column name, filter operator,\nand values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].",
+								"text": "Includes the following keys:\n- `filter`: A single filter object containing column name, filter operator, and\nvalues.\n- `filters`: Multiple filter objects with column name, filter operator,\nand values for each.\n\nEach filter object must include the following attributes:\n\n`column` - Name of the column to filter on.\n\n`oper`  - Filter operator, for example, EQ, IN, CONTAINS.\n For information about the supported filter operators,\n see link:https://developers.thoughtspot.com/docs/runtime-filters#rtOperator[Developer Documentation].\n\n`values` - An array of one or several values. The value definition on the\n data type you choose to filter on. For a complete list of supported data types,\n see\n link:https://developers.thoughtspot.com/docs/runtime-filters#_supported_data_types[Supported\n data types].\n\n`type`  - To update filters for date time, specify the date format type.\nFor more information and examples, see link:https://developers.thoughtspot.com/docs/embed-liveboard#_date_filters[Date filters].\n\n`applicability` - Optional. Scopes the filter to a specific target,\nfor example, a single Liveboard tab. Available from SDK: 1.51.0 |\nThoughtSpot: 26.10.0.cl. Includes the following attributes:\n\n - `level`: The scope of the filter: `LIVEBOARD`, `TAB`, or `GROUP`.\n - `targetId`: The GUID of the target, for example, the tab GUID.\n   Not required when `level` is `LIVEBOARD`, since the filter applies\n   to the whole Liveboard.",
 								"param": "-"
 							},
 							{
@@ -13151,6 +13151,10 @@
 								"text": "\n```js\n// Update filters from liveboard context\nimport { ContextType } from '@thoughtspot/visual-embed-sdk';\nliveboardEmbed.trigger(HostEvent.UpdateFilters, {\n    filter: {\n        column: \"item type\",\n        oper: \"IN\",\n        values: [\"shoes\", \"boots\"]\n    }\n}, ContextType.Liveboard);\n```"
 							},
 							{
+								"tag": "example",
+								"text": "\n```js\n// Scope the filter to a specific Liveboard tab\nliveboardEmbed.trigger(HostEvent.UpdateFilters, {\n    filter: {\n        column: \"item type\",\n        oper: \"IN\",\n        values: [\"bags\", \"shirts\"],\n        applicability: {\n            level: \"TAB\",\n            targetId: \"e0836cad-4fdf-42d4-bd97-567a6b2a6058\"\n        }\n    }\n});\n```"
+							},
+							{
 								"tag": "version",
 								"text": "SDK: 1.23.0 | ThoughtSpot: 9.4.0.cl\n"
 							}
@@ -13159,7 +13163,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5432,
+							"line": 5461,
 							"character": 4
 						}
 					],
@@ -13196,7 +13200,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5602,
+							"line": 5631,
 							"character": 4
 						}
 					],
@@ -13228,7 +13232,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5649,
+							"line": 5683,
 							"character": 4
 						}
 					],
@@ -13252,7 +13256,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5657,
+							"line": 5691,
 							"character": 4
 						}
 					],
@@ -13476,7 +13480,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8572,
+							"line": 8606,
 							"character": 4
 						}
 					],
@@ -13494,7 +13498,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8568,
+							"line": 8602,
 							"character": 4
 						}
 					],
@@ -13512,7 +13516,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8576,
+							"line": 8610,
 							"character": 4
 						}
 					],
@@ -13533,7 +13537,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8564,
+					"line": 8598,
 					"character": 12
 				}
 			]
@@ -13566,7 +13570,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8842,
+							"line": 8876,
 							"character": 4
 						}
 					],
@@ -13584,7 +13588,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8844,
+							"line": 8878,
 							"character": 4
 						}
 					],
@@ -13602,7 +13606,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8846,
+							"line": 8880,
 							"character": 4
 						}
 					],
@@ -13620,7 +13624,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8840,
+							"line": 8874,
 							"character": 4
 						}
 					],
@@ -13642,7 +13646,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8838,
+					"line": 8872,
 					"character": 12
 				}
 			]
@@ -13922,7 +13926,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8307,
+							"line": 8341,
 							"character": 4
 						}
 					],
@@ -13950,7 +13954,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8268,
+							"line": 8302,
 							"character": 4
 						}
 					],
@@ -13978,7 +13982,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8293,
+							"line": 8327,
 							"character": 4
 						}
 					],
@@ -14006,7 +14010,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8256,
+							"line": 8290,
 							"character": 4
 						}
 					],
@@ -14034,7 +14038,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8319,
+							"line": 8353,
 							"character": 4
 						}
 					],
@@ -14062,7 +14066,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8280,
+							"line": 8314,
 							"character": 4
 						}
 					],
@@ -14086,7 +14090,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8243,
+					"line": 8277,
 					"character": 12
 				}
 			]
@@ -14267,7 +14271,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8072,
+							"line": 8106,
 							"character": 4
 						}
 					],
@@ -14282,7 +14286,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8074,
+							"line": 8108,
 							"character": 4
 						}
 					],
@@ -14297,7 +14301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8073,
+							"line": 8107,
 							"character": 4
 						}
 					],
@@ -14312,7 +14316,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8075,
+							"line": 8109,
 							"character": 4
 						}
 					],
@@ -14334,7 +14338,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8071,
+					"line": 8105,
 					"character": 12
 				}
 			]
@@ -14731,7 +14735,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8870,
+							"line": 8904,
 							"character": 4
 						}
 					],
@@ -14749,7 +14753,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8868,
+							"line": 8902,
 							"character": 4
 						}
 					],
@@ -14769,7 +14773,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8866,
+					"line": 8900,
 					"character": 12
 				}
 			]
@@ -14802,7 +14806,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8855,
+							"line": 8889,
 							"character": 4
 						}
 					],
@@ -14820,7 +14824,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8857,
+							"line": 8891,
 							"character": 4
 						}
 					],
@@ -14838,7 +14842,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8859,
+							"line": 8893,
 							"character": 4
 						}
 					],
@@ -14859,7 +14863,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8853,
+					"line": 8887,
 					"character": 12
 				}
 			]
@@ -14880,7 +14884,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 19,
+							"line": 48,
 							"character": 2
 						}
 					],
@@ -14895,7 +14899,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 15,
+							"line": 44,
 							"character": 2
 						}
 					],
@@ -14910,7 +14914,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 20,
+							"line": 49,
 							"character": 2
 						}
 					],
@@ -14925,7 +14929,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 14,
+							"line": 43,
 							"character": 2
 						}
 					],
@@ -14940,7 +14944,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 13,
+							"line": 42,
 							"character": 2
 						}
 					],
@@ -14955,7 +14959,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 26,
+							"line": 55,
 							"character": 2
 						}
 					],
@@ -14970,7 +14974,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 21,
+							"line": 50,
 							"character": 2
 						}
 					],
@@ -14985,7 +14989,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 22,
+							"line": 51,
 							"character": 2
 						}
 					],
@@ -15000,7 +15004,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 16,
+							"line": 45,
 							"character": 2
 						}
 					],
@@ -15015,7 +15019,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 23,
+							"line": 52,
 							"character": 2
 						}
 					],
@@ -15030,7 +15034,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 24,
+							"line": 53,
 							"character": 2
 						}
 					],
@@ -15045,7 +15049,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 25,
+							"line": 54,
 							"character": 2
 						}
 					],
@@ -15060,7 +15064,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 17,
+							"line": 46,
 							"character": 2
 						}
 					],
@@ -15075,7 +15079,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 11,
+							"line": 40,
 							"character": 2
 						}
 					],
@@ -15090,7 +15094,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 12,
+							"line": 41,
 							"character": 2
 						}
 					],
@@ -15105,7 +15109,7 @@
 					"sources": [
 						{
 							"fileName": "embed/hostEventClient/contracts.ts",
-							"line": 18,
+							"line": 47,
 							"character": 2
 						}
 					],
@@ -15139,7 +15143,7 @@
 			"sources": [
 				{
 					"fileName": "embed/hostEventClient/contracts.ts",
-					"line": 10,
+					"line": 39,
 					"character": 12
 				}
 			]
@@ -28151,7 +28155,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -28188,7 +28192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -28600,7 +28604,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -31488,7 +31492,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -31526,7 +31530,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -31564,7 +31568,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -33009,7 +33013,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -33047,7 +33051,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -33085,7 +33089,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -33908,7 +33912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8116,
+							"line": 8150,
 							"character": 4
 						}
 					],
@@ -33930,7 +33934,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8117,
+											"line": 8151,
 											"character": 8
 										}
 									],
@@ -33949,7 +33953,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8118,
+											"line": 8152,
 											"character": 8
 										}
 									],
@@ -33985,7 +33989,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8120,
+							"line": 8154,
 							"character": 4
 						}
 					],
@@ -34007,7 +34011,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8128,
+											"line": 8162,
 											"character": 8
 										}
 									],
@@ -34028,7 +34032,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8129,
+											"line": 8163,
 											"character": 8
 										}
 									],
@@ -34049,7 +34053,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8122,
+											"line": 8156,
 											"character": 8
 										}
 									],
@@ -34067,7 +34071,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8121,
+											"line": 8155,
 											"character": 8
 										}
 									],
@@ -34085,7 +34089,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8123,
+											"line": 8157,
 											"character": 8
 										}
 									],
@@ -34107,7 +34111,7 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8124,
+															"line": 8158,
 															"character": 12
 														}
 													],
@@ -34129,7 +34133,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8125,
+																			"line": 8159,
 																			"character": 16
 																		}
 																	],
@@ -34213,7 +34217,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8132,
+							"line": 8166,
 							"character": 4
 						}
 					],
@@ -34234,7 +34238,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8133,
+							"line": 8167,
 							"character": 4
 						}
 					],
@@ -34259,7 +34263,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8115,
+					"line": 8149,
 					"character": 17
 				}
 			]
@@ -41253,7 +41257,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8497,
+							"line": 8531,
 							"character": 4
 						}
 					],
@@ -41275,7 +41279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8493,
+							"line": 8527,
 							"character": 4
 						}
 					],
@@ -41297,7 +41301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8495,
+							"line": 8529,
 							"character": 4
 						}
 					],
@@ -41333,7 +41337,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8491,
+					"line": 8525,
 					"character": 17
 				}
 			],
@@ -42907,7 +42911,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -42944,7 +42948,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -43356,7 +43360,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -46009,7 +46013,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -46046,7 +46050,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -46083,7 +46087,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -48129,7 +48133,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -48166,7 +48170,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -48203,7 +48207,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -49728,7 +49732,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -49765,7 +49769,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -49802,7 +49806,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -51382,7 +51386,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8620,
+							"line": 8654,
 							"character": 4
 						}
 					],
@@ -51419,7 +51423,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8603,
+							"line": 8637,
 							"character": 4
 						}
 					],
@@ -51456,7 +51460,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8621,
 							"character": 4
 						}
 					],
@@ -53408,7 +53412,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9113,
+							"line": 9147,
 							"character": 4
 						}
 					],
@@ -53431,7 +53435,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9115,
+							"line": 9149,
 							"character": 4
 						}
 					],
@@ -53454,7 +53458,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9111,
+					"line": 9145,
 					"character": 17
 				}
 			]
@@ -53475,7 +53479,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8108,
+							"line": 8142,
 							"character": 4
 						}
 					],
@@ -53496,7 +53500,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8109,
+							"line": 8143,
 							"character": 4
 						}
 					],
@@ -53522,7 +53526,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8107,
+					"line": 8141,
 					"character": 17
 				}
 			]


### PR DESCRIPTION
## Summary

Adds support for an optional applicability field on Liveboard filters and parameters, allowing a filter to be scoped to a specific target:

liveboardEmbed.trigger(HostEvent.UpdateFilters, {
    filter: {
        column: "item type",
        oper: "IN",
        values: ["bags", "shirts"],
        applicability: {
            level: "TAB",
            targetId: "e0836cad-4fdf-42d4-bd97-567a6b2a6058"
        }
    }
});

## Changes

**UpdateFilters** host event
- Filter objects (both filter and filters[]) accept an optional applicability: { level, targetId } (contracts.ts — new Applicability and UpdateFiltersFilter types).
- isValidUpdateFiltersPayload validates applicability when present: level and targetId must both be strings, otherwise the existing UPDATEFILTERS_INVALID_PAYLOAD validation error is thrown. Payloads without applicability are validated exactly as before.

**GetFilters / GetParameters** host events
- Response contracts now type each returned filter/parameter as LiveboardFilter / LiveboardParameter, exposing the optional applicability field returned by the embedded app. Both types keep an open index signature, so all other response fields flow through unchanged.


## Docs
- HostEvent.UpdateFilters, GetFilters, and GetParameters JSDoc updated with the applicability.

## Backward compatibility

- applicability is optional everywhere — existing payloads and consumers are unaffected.
- The GetFilters/GetParameters response type change is compile-time only (previously Record<string, any>[]); no runtime behavior changes.