### PR TITLE
SCAL-321088 SCAL-318580 Add SpotterViz brand name Considerations

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -500,6 +500,16 @@ export interface CustomCssVariables {
     '--ts-var-liveboard-tile-background'?: string;
 
     /**
+     * Font color of the insight tiles in the Liveboard.
+     */
+    '--ts-var-liveboard-insight-tile-font-color'?: string;
+
+    /**
+     * Background color of the insight tiles in the Liveboard.
+     */
+    '--ts-var-liveboard-insight-tile-background'?: string;
+
+    /**
      * Border radius of the tiles in the Liveboard.
      */
     '--ts-var-liveboard-tile-border-radius'?: string;

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -805,6 +805,12 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      *            { label: 'Tip', text: 'try asking about revenue by region' },
      *            { label: 'Tip', text: 'use natural language' },
      *        ],
+     *        // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     *        liveboardBrandName: 'Reports',
+     *        spotterBrandName: 'Analyst',
+     *        insightTileBrandName: 'Insight card',
+     *        insightTileViewPlanLabel: 'View plan',
+     *        insightTileLoaderText: 'Generating insight',
      *    },
      * })
      * ```

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -580,6 +580,12 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      *            { label: 'Tip', text: 'try asking about revenue by region' },
      *            { label: 'Tip', text: 'use natural language' },
      *        ],
+     *        // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     *        liveboardBrandName: 'Reports',
+     *        spotterBrandName: 'Analyst',
+     *        insightTileBrandName: 'Insight card',
+     *        insightTileViewPlanLabel: 'View plan',
+     *        insightTileLoaderText: 'Generating insight',
      *    },
      * })
      * ```

--- a/src/embed/spotter-viz-utils.spec.ts
+++ b/src/embed/spotter-viz-utils.spec.ts
@@ -20,6 +20,23 @@ describe('buildSpotterVizAppInitData', () => {
         expect(result.embedParams?.spotterVizConfig?.brandHeadline).toBe("Hi, there! I'm");
     });
 
+    it('passes liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText through spotterVizConfig', () => {
+        const spotterViz = {
+            brandName: 'MyBrand',
+            liveboardBrandName: 'Reports',
+            spotterBrandName: 'Analyst',
+            insightTileBrandName: 'Insight card',
+            insightTileViewPlanLabel: 'View plan',
+            insightTileLoaderText: 'Generating insight',
+        };
+        const result = buildSpotterVizAppInitData(base, { spotterViz });
+        expect(result.embedParams?.spotterVizConfig?.liveboardBrandName).toBe('Reports');
+        expect(result.embedParams?.spotterVizConfig?.spotterBrandName).toBe('Analyst');
+        expect(result.embedParams?.spotterVizConfig?.insightTileBrandName).toBe('Insight card');
+        expect(result.embedParams?.spotterVizConfig?.insightTileViewPlanLabel).toBe('View plan');
+        expect(result.embedParams?.spotterVizConfig?.insightTileLoaderText).toBe('Generating insight');
+    });
+
     it('preserves existing embedParams when adding spotterVizConfig', () => {
         const existing = { ...base, embedParams: { spotterSidebarConfig: { enablePastConversationsSidebar: true } } };
         const spotterViz = { brandName: 'MyBrand' };

--- a/src/embed/spotter-viz-utils.ts
+++ b/src/embed/spotter-viz-utils.ts
@@ -38,6 +38,12 @@ export interface SpotterVizStarterPrompt {
  *            { label: 'Tip', text: 'try asking about revenue by region' },
  *            { label: 'Tip', text: 'use natural language' },
  *        ],
+ *        // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+ *        liveboardBrandName: 'Reports',
+ *        spotterBrandName: 'Analyst',
+ *        insightTileBrandName: 'Insight card',
+ *        insightTileViewPlanLabel: 'View plan',
+ *        insightTileLoaderText: 'Generating insight',
  *    },
  * })
  * ```
@@ -94,6 +100,34 @@ export interface SpotterVizConfig {
      * @version SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl
      */
     loaderTips?: SpotterVizLoaderTip[];
+    /**
+     * Custom term used to replace "Liveboard" in the agent's responses.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @default ''
+     */
+    liveboardBrandName?: string;
+    /**
+     * Custom term used to replace "Spotter" in the agent's responses.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @default ''
+     */
+    spotterBrandName?: string;
+    /**
+     * Custom term used to replace "Insight tile" in the UI and in the agent's responses.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @default ''
+     */
+    insightTileBrandName?: string;
+    /**
+     * Custom term used to replace "View plan" in the insight tile menu.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     */
+    insightTileViewPlanLabel?: string;
+    /**
+     * Custom loader text shown on the insight tile.
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     */
+    insightTileLoaderText?: string;
 }
 
 /**

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -5167,7 +5167,7 @@
 			]
 		},
 		{
-			"id": 3181,
+			"id": 3188,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5183,7 +5183,7 @@
 			},
 			"children": [
 				{
-					"id": 3183,
+					"id": 3190,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5201,7 +5201,7 @@
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3182,
+					"id": 3189,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5224,8 +5224,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3183,
-						3182
+						3190,
+						3189
 					]
 				}
 			],
@@ -5238,7 +5238,7 @@
 			]
 		},
 		{
-			"id": 3184,
+			"id": 3191,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5254,7 +5254,7 @@
 			},
 			"children": [
 				{
-					"id": 3186,
+					"id": 3193,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5272,7 +5272,7 @@
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3187,
+					"id": 3194,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5290,7 +5290,7 @@
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3185,
+					"id": 3192,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5313,9 +5313,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3186,
-						3187,
-						3185
+						3193,
+						3194,
+						3192
 					]
 				}
 			],
@@ -5328,7 +5328,7 @@
 			]
 		},
 		{
-			"id": 3188,
+			"id": 3195,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5344,7 +5344,7 @@
 			},
 			"children": [
 				{
-					"id": 3191,
+					"id": 3198,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5362,7 +5362,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3192,
+					"id": 3199,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5380,7 +5380,7 @@
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3194,
+					"id": 3201,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5398,7 +5398,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3199,
+					"id": 3206,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5416,7 +5416,7 @@
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3195,
+					"id": 3202,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5434,7 +5434,7 @@
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3197,
+					"id": 3204,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5452,7 +5452,7 @@
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3189,
+					"id": 3196,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5470,7 +5470,7 @@
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3201,
+					"id": 3208,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5488,7 +5488,7 @@
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3190,
+					"id": 3197,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5506,7 +5506,7 @@
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3203,
+					"id": 3210,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5524,7 +5524,7 @@
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3202,
+					"id": 3209,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5542,7 +5542,7 @@
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3196,
+					"id": 3203,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5560,7 +5560,7 @@
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3198,
+					"id": 3205,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5578,7 +5578,7 @@
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3200,
+					"id": 3207,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5596,7 +5596,7 @@
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3193,
+					"id": 3200,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5619,21 +5619,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3191,
-						3192,
-						3194,
-						3199,
-						3195,
-						3197,
-						3189,
-						3201,
-						3190,
-						3203,
-						3202,
-						3196,
 						3198,
-						3200,
-						3193
+						3199,
+						3201,
+						3206,
+						3202,
+						3204,
+						3196,
+						3208,
+						3197,
+						3210,
+						3209,
+						3203,
+						3205,
+						3207,
+						3200
 					]
 				}
 			],
@@ -5857,7 +5857,7 @@
 			]
 		},
 		{
-			"id": 3136,
+			"id": 3143,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5867,7 +5867,7 @@
 			},
 			"children": [
 				{
-					"id": 3139,
+					"id": 3146,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5885,7 +5885,7 @@
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3137,
+					"id": 3144,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5903,7 +5903,7 @@
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3140,
+					"id": 3147,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5921,7 +5921,7 @@
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3138,
+					"id": 3145,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5944,10 +5944,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3139,
-						3137,
-						3140,
-						3138
+						3146,
+						3144,
+						3147,
+						3145
 					]
 				}
 			],
@@ -5960,7 +5960,7 @@
 			]
 		},
 		{
-			"id": 3132,
+			"id": 3139,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5970,7 +5970,7 @@
 			},
 			"children": [
 				{
-					"id": 3135,
+					"id": 3142,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5988,7 +5988,7 @@
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3134,
+					"id": 3141,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6006,7 +6006,7 @@
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3133,
+					"id": 3140,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6029,9 +6029,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3135,
-						3134,
-						3133
+						3142,
+						3141,
+						3140
 					]
 				}
 			],
@@ -6044,7 +6044,7 @@
 			]
 		},
 		{
-			"id": 3204,
+			"id": 3211,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6060,7 +6060,7 @@
 			},
 			"children": [
 				{
-					"id": 3209,
+					"id": 3216,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6078,7 +6078,7 @@
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3205,
+					"id": 3212,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6096,7 +6096,7 @@
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3207,
+					"id": 3214,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6114,7 +6114,7 @@
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3206,
+					"id": 3213,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6132,7 +6132,7 @@
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3208,
+					"id": 3215,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6150,7 +6150,7 @@
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3210,
+					"id": 3217,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6173,12 +6173,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3209,
-						3205,
-						3207,
-						3206,
-						3208,
-						3210
+						3216,
+						3212,
+						3214,
+						3213,
+						3215,
+						3217
 					]
 				}
 			],
@@ -6191,7 +6191,7 @@
 			]
 		},
 		{
-			"id": 3128,
+			"id": 3135,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6201,7 +6201,7 @@
 			},
 			"children": [
 				{
-					"id": 3130,
+					"id": 3137,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6219,7 +6219,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3129,
+					"id": 3136,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6237,7 +6237,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3131,
+					"id": 3138,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6260,9 +6260,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3130,
-						3129,
-						3131
+						3137,
+						3136,
+						3138
 					]
 				}
 			],
@@ -6359,7 +6359,7 @@
 			]
 		},
 		{
-			"id": 3145,
+			"id": 3152,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6383,7 +6383,7 @@
 			},
 			"children": [
 				{
-					"id": 3148,
+					"id": 3155,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6401,7 +6401,7 @@
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3149,
+					"id": 3156,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6419,7 +6419,7 @@
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3152,
+					"id": 3159,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6437,7 +6437,7 @@
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3161,
+					"id": 3168,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6455,7 +6455,7 @@
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3155,
+					"id": 3162,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6473,7 +6473,7 @@
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3159,
+					"id": 3166,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6491,7 +6491,7 @@
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3150,
+					"id": 3157,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6509,7 +6509,7 @@
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3158,
+					"id": 3165,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6527,7 +6527,7 @@
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3147,
+					"id": 3154,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6545,7 +6545,7 @@
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3153,
+					"id": 3160,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6563,7 +6563,7 @@
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3151,
+					"id": 3158,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6581,7 +6581,7 @@
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3156,
+					"id": 3163,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6599,7 +6599,7 @@
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3154,
+					"id": 3161,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6617,7 +6617,7 @@
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3160,
+					"id": 3167,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6635,7 +6635,7 @@
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3157,
+					"id": 3164,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6653,7 +6653,7 @@
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3146,
+					"id": 3153,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6676,22 +6676,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3148,
-						3149,
-						3152,
-						3161,
 						3155,
-						3159,
-						3150,
-						3158,
-						3147,
-						3153,
-						3151,
 						3156,
+						3159,
+						3168,
+						3162,
+						3166,
+						3157,
+						3165,
 						3154,
 						3160,
-						3157,
-						3146
+						3158,
+						3163,
+						3161,
+						3167,
+						3164,
+						3153
 					]
 				}
 			],
@@ -9855,7 +9855,7 @@
 			]
 		},
 		{
-			"id": 3168,
+			"id": 3175,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9880,7 +9880,7 @@
 			},
 			"children": [
 				{
-					"id": 3169,
+					"id": 3176,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9898,7 +9898,7 @@
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3171,
+					"id": 3178,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9916,7 +9916,7 @@
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3170,
+					"id": 3177,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9939,9 +9939,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3169,
-						3171,
-						3170
+						3176,
+						3178,
+						3177
 					]
 				}
 			],
@@ -9954,7 +9954,7 @@
 			]
 		},
 		{
-			"id": 2763,
+			"id": 2768,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -9964,7 +9964,7 @@
 			},
 			"children": [
 				{
-					"id": 2767,
+					"id": 2772,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9988,7 +9988,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2771,
+					"id": 2776,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10012,7 +10012,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2773,
+					"id": 2778,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10036,7 +10036,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2765,
+					"id": 2770,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10060,7 +10060,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2770,
+					"id": 2775,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10084,7 +10084,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2766,
+					"id": 2771,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10108,7 +10108,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2768,
+					"id": 2773,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10132,7 +10132,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2764,
+					"id": 2769,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10156,7 +10156,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2769,
+					"id": 2774,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10180,7 +10180,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2772,
+					"id": 2777,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10209,16 +10209,16 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2767,
+						2772,
+						2776,
+						2778,
+						2770,
+						2775,
 						2771,
 						2773,
-						2765,
-						2770,
-						2766,
-						2768,
-						2764,
 						2769,
-						2772
+						2774,
+						2777
 					]
 				}
 			],
@@ -10231,7 +10231,7 @@
 			]
 		},
 		{
-			"id": 3073,
+			"id": 3080,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10247,7 +10247,7 @@
 			},
 			"children": [
 				{
-					"id": 3076,
+					"id": 3083,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10271,7 +10271,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3074,
+					"id": 3081,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10289,7 +10289,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3075,
+					"id": 3082,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10312,9 +10312,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3076,
-						3074,
-						3075
+						3083,
+						3081,
+						3082
 					]
 				}
 			],
@@ -10327,14 +10327,14 @@
 			]
 		},
 		{
-			"id": 3067,
+			"id": 3074,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3069,
+					"id": 3076,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10349,7 +10349,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3070,
+					"id": 3077,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10364,7 +10364,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3068,
+					"id": 3075,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10384,9 +10384,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3069,
-						3070,
-						3068
+						3076,
+						3077,
+						3075
 					]
 				}
 			],
@@ -10399,7 +10399,7 @@
 			]
 		},
 		{
-			"id": 2774,
+			"id": 2779,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10416,7 +10416,7 @@
 			},
 			"children": [
 				{
-					"id": 2777,
+					"id": 2782,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10434,7 +10434,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2780,
+					"id": 2785,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10452,7 +10452,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2778,
+					"id": 2783,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10470,7 +10470,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2775,
+					"id": 2780,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10488,7 +10488,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2779,
+					"id": 2784,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10506,7 +10506,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2776,
+					"id": 2781,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10529,12 +10529,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2777,
+						2782,
+						2785,
+						2783,
 						2780,
-						2778,
-						2775,
-						2779,
-						2776
+						2784,
+						2781
 					]
 				}
 			],
@@ -13455,7 +13455,7 @@
 			]
 		},
 		{
-			"id": 3141,
+			"id": 3148,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13465,7 +13465,7 @@
 			},
 			"children": [
 				{
-					"id": 3143,
+					"id": 3150,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13483,7 +13483,7 @@
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3142,
+					"id": 3149,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13501,7 +13501,7 @@
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3144,
+					"id": 3151,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13524,9 +13524,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3143,
-						3142,
-						3144
+						3150,
+						3149,
+						3151
 					]
 				}
 			],
@@ -13539,7 +13539,7 @@
 			]
 		},
 		{
-			"id": 3176,
+			"id": 3183,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13555,7 +13555,7 @@
 			},
 			"children": [
 				{
-					"id": 3178,
+					"id": 3185,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13573,7 +13573,7 @@
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3179,
+					"id": 3186,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13591,7 +13591,7 @@
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3180,
+					"id": 3187,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13609,7 +13609,7 @@
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3177,
+					"id": 3184,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13632,10 +13632,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3178,
-						3179,
-						3180,
-						3177
+						3185,
+						3186,
+						3187,
+						3184
 					]
 				}
 			],
@@ -13648,7 +13648,7 @@
 			]
 		},
 		{
-			"id": 3077,
+			"id": 3084,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13664,7 +13664,7 @@
 			},
 			"children": [
 				{
-					"id": 3078,
+					"id": 3085,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13682,7 +13682,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3079,
+					"id": 3086,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13705,8 +13705,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3078,
-						3079
+						3085,
+						3086
 					]
 				}
 			],
@@ -13719,7 +13719,7 @@
 			]
 		},
 		{
-			"id": 3120,
+			"id": 3127,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13735,7 +13735,7 @@
 			},
 			"children": [
 				{
-					"id": 3124,
+					"id": 3131,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13753,7 +13753,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3125,
+					"id": 3132,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13771,7 +13771,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3121,
+					"id": 3128,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13789,7 +13789,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3122,
+					"id": 3129,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13813,7 +13813,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3126,
+					"id": 3133,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13831,7 +13831,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3123,
+					"id": 3130,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13849,7 +13849,7 @@
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3127,
+					"id": 3134,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13872,13 +13872,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3124,
-						3125,
-						3121,
-						3122,
-						3126,
-						3123,
-						3127
+						3131,
+						3132,
+						3128,
+						3129,
+						3133,
+						3130,
+						3134
 					]
 				}
 			],
@@ -13891,7 +13891,7 @@
 			]
 		},
 		{
-			"id": 3044,
+			"id": 3051,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -13901,7 +13901,7 @@
 			},
 			"children": [
 				{
-					"id": 3049,
+					"id": 3056,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13929,7 +13929,7 @@
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3046,
+					"id": 3053,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13957,7 +13957,7 @@
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3048,
+					"id": 3055,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13985,7 +13985,7 @@
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3045,
+					"id": 3052,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14013,7 +14013,7 @@
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3050,
+					"id": 3057,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14041,7 +14041,7 @@
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3047,
+					"id": 3054,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14074,12 +14074,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3049,
-						3046,
-						3048,
-						3045,
-						3050,
-						3047
+						3056,
+						3053,
+						3055,
+						3052,
+						3057,
+						3054
 					]
 				}
 			],
@@ -14252,14 +14252,14 @@
 			]
 		},
 		{
-			"id": 2752,
+			"id": 2757,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2753,
+					"id": 2758,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14274,7 +14274,7 @@
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2755,
+					"id": 2760,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14289,7 +14289,7 @@
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2754,
+					"id": 2759,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14304,7 +14304,7 @@
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2756,
+					"id": 2761,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14324,10 +14324,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2753,
-						2755,
-						2754,
-						2756
+						2758,
+						2760,
+						2759,
+						2761
 					]
 				}
 			],
@@ -14340,7 +14340,7 @@
 			]
 		},
 		{
-			"id": 3071,
+			"id": 3078,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14356,7 +14356,7 @@
 			},
 			"children": [
 				{
-					"id": 3072,
+					"id": 3079,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14379,7 +14379,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3072
+						3079
 					]
 				}
 			],
@@ -14704,7 +14704,7 @@
 			]
 		},
 		{
-			"id": 3215,
+			"id": 3222,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14720,7 +14720,7 @@
 			},
 			"children": [
 				{
-					"id": 3217,
+					"id": 3224,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14738,7 +14738,7 @@
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3216,
+					"id": 3223,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14761,8 +14761,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3217,
-						3216
+						3224,
+						3223
 					]
 				}
 			],
@@ -14775,7 +14775,7 @@
 			]
 		},
 		{
-			"id": 3211,
+			"id": 3218,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14791,7 +14791,7 @@
 			},
 			"children": [
 				{
-					"id": 3212,
+					"id": 3219,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14809,7 +14809,7 @@
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3213,
+					"id": 3220,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14827,7 +14827,7 @@
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3214,
+					"id": 3221,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14850,9 +14850,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3212,
-						3213,
-						3214
+						3219,
+						3220,
+						3221
 					]
 				}
 			],
@@ -14865,14 +14865,14 @@
 			]
 		},
 		{
-			"id": 3103,
+			"id": 3110,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3112,
+					"id": 3119,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14887,7 +14887,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3108,
+					"id": 3115,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14902,7 +14902,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3113,
+					"id": 3120,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14917,7 +14917,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3107,
+					"id": 3114,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14932,7 +14932,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3106,
+					"id": 3113,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14947,7 +14947,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3119,
+					"id": 3126,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14962,7 +14962,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3114,
+					"id": 3121,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14977,7 +14977,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3115,
+					"id": 3122,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14992,7 +14992,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3109,
+					"id": 3116,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15007,7 +15007,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3116,
+					"id": 3123,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15022,7 +15022,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3117,
+					"id": 3124,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15037,7 +15037,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3118,
+					"id": 3125,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15052,7 +15052,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3110,
+					"id": 3117,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15067,7 +15067,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3104,
+					"id": 3111,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15082,7 +15082,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3105,
+					"id": 3112,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15097,7 +15097,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3111,
+					"id": 3118,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15117,22 +15117,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3112,
-						3108,
-						3113,
-						3107,
-						3106,
 						3119,
-						3114,
 						3115,
-						3109,
+						3120,
+						3114,
+						3113,
+						3126,
+						3121,
+						3122,
 						3116,
+						3123,
+						3124,
+						3125,
 						3117,
-						3118,
-						3110,
-						3104,
-						3105,
-						3111
+						3111,
+						3112,
+						3118
 					]
 				}
 			],
@@ -15252,7 +15252,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3080,
+											"id": 3087,
 											"name": "VizPoint"
 										}
 									}
@@ -16484,7 +16484,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 900,
+							"line": 906,
 							"character": 4
 						}
 					],
@@ -16504,7 +16504,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2781,
+										"id": 2786,
 										"name": "DOMSelector"
 									}
 								},
@@ -16516,7 +16516,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2643,
+										"id": 2648,
 										"name": "AppViewConfig"
 									}
 								}
@@ -16548,7 +16548,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1396,
+							"line": 1402,
 							"character": 11
 						}
 					],
@@ -16722,7 +16722,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1265,
+							"line": 1271,
 							"character": 11
 						}
 					],
@@ -17072,7 +17072,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1370,
+							"line": 1376,
 							"character": 11
 						}
 					],
@@ -17197,7 +17197,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -17276,7 +17276,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -17288,7 +17288,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -17448,7 +17448,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1452,
+							"line": 1458,
 							"character": 17
 						}
 					],
@@ -17847,7 +17847,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -17954,7 +17954,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 891,
+					"line": 897,
 					"character": 13
 				}
 			],
@@ -19154,7 +19154,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -19238,7 +19238,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -19253,7 +19253,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -19838,7 +19838,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19986,7 +19986,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 628,
+							"line": 634,
 							"character": 4
 						}
 					],
@@ -20006,7 +20006,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2781,
+										"id": 2786,
 										"name": "DOMSelector"
 									}
 								},
@@ -20050,7 +20050,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1095,
+							"line": 1101,
 							"character": 11
 						}
 					],
@@ -20261,7 +20261,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1187,
+							"line": 1193,
 							"character": 11
 						}
 					],
@@ -20575,7 +20575,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1162,
+							"line": 1168,
 							"character": 11
 						}
 					],
@@ -20703,7 +20703,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -20782,7 +20782,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -20794,7 +20794,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -20954,7 +20954,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1151,
+							"line": 1157,
 							"character": 17
 						}
 					],
@@ -21168,7 +21168,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1076,
+							"line": 1082,
 							"character": 11
 						}
 					],
@@ -21340,7 +21340,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -21447,7 +21447,7 @@
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 618,
+					"line": 624,
 					"character": 13
 				}
 			],
@@ -22089,7 +22089,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -22171,7 +22171,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -22186,7 +22186,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -22758,7 +22758,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22919,7 +22919,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2781,
+										"id": 2786,
 										"name": "DOMSelector"
 									}
 								},
@@ -23534,7 +23534,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -23616,7 +23616,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -23631,7 +23631,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -24203,7 +24203,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -25457,7 +25457,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								}
@@ -25539,7 +25539,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2785,
+										"id": 2790,
 										"name": "MessageCallback"
 									}
 								},
@@ -25554,7 +25554,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2782,
+										"id": 2787,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -26123,7 +26123,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3103,
+										"id": 3110,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -26247,7 +26247,7 @@
 			]
 		},
 		{
-			"id": 2643,
+			"id": 2648,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -26263,7 +26263,7 @@
 			},
 			"children": [
 				{
-					"id": 2695,
+					"id": 2700,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26294,20 +26294,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2696,
+							"id": 2701,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2697,
+								"id": 2702,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2698,
+										"id": 2703,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -26343,7 +26343,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2732,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26385,7 +26385,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2668,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26422,7 +26422,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2729,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26461,7 +26461,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2750,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26499,7 +26499,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2720,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26548,7 +26548,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2704,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26577,7 +26577,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -26586,7 +26586,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2669,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26620,12 +26620,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3128,
+						"id": 3135,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2733,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26667,7 +26667,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2651,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26705,7 +26705,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2713,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26743,7 +26743,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2696,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26781,7 +26781,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2695,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26823,7 +26823,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2667,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26860,7 +26860,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2708,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26901,7 +26901,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2744,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26943,7 +26943,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2749,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -26985,7 +26985,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2734,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27027,7 +27027,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2688,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27051,7 +27051,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 854,
+							"line": 860,
 							"character": 4
 						}
 					],
@@ -27061,7 +27061,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2716,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27099,7 +27099,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2689,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27122,7 +27122,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 867,
+							"line": 873,
 							"character": 4
 						}
 					],
@@ -27132,7 +27132,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2682,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27170,7 +27170,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2652,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27208,7 +27208,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2664,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27246,7 +27246,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2686,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27270,7 +27270,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 821,
+							"line": 827,
 							"character": 4
 						}
 					],
@@ -27280,7 +27280,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2710,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27318,7 +27318,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2730,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27356,7 +27356,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2731,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27394,7 +27394,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2712,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27431,7 +27431,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2692,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27461,7 +27461,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -27470,7 +27470,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2665,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27504,7 +27504,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2697,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27550,7 +27550,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2739,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27582,7 +27582,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2763,
+							"id": 2768,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -27592,7 +27592,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2737,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27624,7 +27624,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2774,
+							"id": 2779,
 							"name": "HomepageModule"
 						}
 					},
@@ -27634,7 +27634,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2736,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27666,7 +27666,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3120,
+							"id": 3127,
 							"name": "ListPageColumns"
 						}
 					},
@@ -27676,7 +27676,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2656,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27714,7 +27714,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2653,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27752,7 +27752,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2650,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27790,7 +27790,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2747,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27832,7 +27832,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2740,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27874,7 +27874,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2655,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27912,7 +27912,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2654,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27950,7 +27950,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2662,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27987,7 +27987,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2657,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28025,7 +28025,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2661,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28059,7 +28059,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2670,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28085,12 +28085,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3067,
+						"id": 3074,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2705,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28128,7 +28128,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2726,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28165,7 +28165,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2725,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28205,7 +28205,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2751,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28243,7 +28243,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2675,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28277,7 +28277,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2753,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28315,7 +28315,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2677,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28349,7 +28349,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2752,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28387,7 +28387,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2745,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28429,7 +28429,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2743,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28467,7 +28467,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2755,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28509,7 +28509,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2673,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28546,7 +28546,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2676,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28580,7 +28580,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2724,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28614,7 +28614,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2674,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28648,7 +28648,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2735,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28686,7 +28686,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2671,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28724,7 +28724,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2678,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28761,7 +28761,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2680,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28795,7 +28795,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2715,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28833,7 +28833,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2699,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28871,7 +28871,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2687,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28898,7 +28898,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 838,
+							"line": 844,
 							"character": 4
 						}
 					],
@@ -28908,7 +28908,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2666,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28945,7 +28945,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2756,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28987,7 +28987,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2672,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29025,7 +29025,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2714,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29063,7 +29063,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2659,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29098,7 +29098,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2658,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29132,7 +29132,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2709,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29179,7 +29179,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2707,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29217,7 +29217,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2717,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29255,7 +29255,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2721,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29296,7 +29296,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2738,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29328,7 +29328,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2774,
+							"id": 2779,
 							"name": "HomepageModule"
 						}
 					},
@@ -29338,7 +29338,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2727,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29380,7 +29380,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2728,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29412,7 +29412,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -29422,7 +29422,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2722,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29463,7 +29463,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2719,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29500,7 +29500,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2742,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29542,7 +29542,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2748,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29584,7 +29584,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2741,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29626,7 +29626,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2746,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29668,7 +29668,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2754,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29710,7 +29710,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2649,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29748,7 +29748,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2684,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29783,7 +29783,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2683,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29818,7 +29818,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2685,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29835,14 +29835,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new AppEmbed('#embed-container', {\n   ... // other options\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [{ id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n   },\n})\n```\n"
+								"text": "\n```js\nconst embed = new AppEmbed('#embed-container', {\n   ... // other options\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [{ id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n       // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n       liveboardBrandName: 'Reports',\n       spotterBrandName: 'Analyst',\n       insightTileBrandName: 'Insight card',\n       insightTileViewPlanLabel: 'View plan',\n       insightTileLoaderText: 'Generating insight',\n   },\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 812,
+							"line": 818,
 							"character": 4
 						}
 					],
@@ -29853,7 +29853,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2660,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29887,7 +29887,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2681,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29925,7 +29925,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2723,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29966,7 +29966,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2698,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30012,7 +30012,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2690,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30031,13 +30031,13 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 873,
+							"line": 879,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3173,
+						"id": 3180,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -30047,103 +30047,103 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2695,
-						2727,
-						2663,
-						2724,
-						2745,
-						2715,
-						2699,
-						2664,
-						2728,
-						2646,
-						2708,
-						2691,
-						2690,
-						2662,
-						2703,
-						2739,
-						2744,
-						2729,
-						2683,
-						2711,
-						2684,
-						2677,
-						2647,
-						2659,
-						2681,
-						2705,
-						2725,
-						2726,
-						2707,
-						2687,
-						2660,
-						2692,
-						2734,
-						2732,
-						2731,
-						2651,
-						2648,
-						2645,
-						2742,
-						2735,
-						2650,
-						2649,
-						2657,
-						2652,
-						2656,
-						2665,
 						2700,
-						2721,
+						2732,
+						2668,
+						2729,
+						2750,
 						2720,
-						2746,
-						2670,
-						2748,
-						2672,
+						2704,
+						2669,
+						2733,
+						2651,
+						2713,
+						2696,
+						2695,
+						2667,
+						2708,
+						2744,
+						2749,
+						2734,
+						2688,
+						2716,
+						2689,
+						2682,
+						2652,
+						2664,
+						2686,
+						2710,
+						2730,
+						2731,
+						2712,
+						2692,
+						2665,
+						2697,
+						2739,
+						2737,
+						2736,
+						2656,
+						2653,
+						2650,
 						2747,
 						2740,
-						2738,
-						2750,
-						2668,
-						2671,
-						2719,
-						2669,
-						2730,
-						2666,
-						2673,
-						2675,
-						2710,
-						2694,
-						2682,
-						2661,
-						2751,
-						2667,
-						2709,
+						2655,
 						2654,
-						2653,
-						2704,
-						2702,
-						2712,
-						2716,
-						2733,
-						2722,
-						2723,
-						2717,
-						2714,
-						2737,
+						2662,
+						2657,
+						2661,
+						2670,
+						2705,
+						2726,
+						2725,
+						2751,
+						2675,
+						2753,
+						2677,
+						2752,
+						2745,
 						2743,
-						2736,
-						2741,
-						2749,
-						2644,
-						2679,
+						2755,
+						2673,
+						2676,
+						2724,
+						2674,
+						2735,
+						2671,
 						2678,
 						2680,
-						2655,
-						2676,
-						2718,
-						2693,
-						2685
+						2715,
+						2699,
+						2687,
+						2666,
+						2756,
+						2672,
+						2714,
+						2659,
+						2658,
+						2709,
+						2707,
+						2717,
+						2721,
+						2738,
+						2727,
+						2728,
+						2722,
+						2719,
+						2742,
+						2748,
+						2741,
+						2746,
+						2754,
+						2649,
+						2684,
+						2683,
+						2685,
+						2660,
+						2681,
+						2723,
+						2698,
+						2690
 					]
 				}
 			],
@@ -31050,7 +31050,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -31369,7 +31369,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -32251,7 +32251,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -32812,7 +32812,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -33421,7 +33421,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -33883,7 +33883,7 @@
 			]
 		},
 		{
-			"id": 3083,
+			"id": 3090,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33898,7 +33898,7 @@
 			},
 			"children": [
 				{
-					"id": 3084,
+					"id": 3091,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33915,14 +33915,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3085,
+							"id": 3092,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3086,
+									"id": 3093,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -33936,12 +33936,12 @@
 									],
 									"type": {
 										"type": "reference",
-										"id": 3080,
+										"id": 3087,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3087,
+									"id": 3094,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -33957,7 +33957,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3080,
+											"id": 3087,
 											"name": "VizPoint"
 										}
 									}
@@ -33968,8 +33968,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3086,
-										3087
+										3093,
+										3094
 									]
 								}
 							]
@@ -33977,7 +33977,7 @@
 					}
 				},
 				{
-					"id": 3088,
+					"id": 3095,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33992,14 +33992,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3089,
+							"id": 3096,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3097,
+									"id": 3104,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34020,7 +34020,7 @@
 									}
 								},
 								{
-									"id": 3098,
+									"id": 3105,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34041,7 +34041,7 @@
 									}
 								},
 								{
-									"id": 3091,
+									"id": 3098,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34059,7 +34059,7 @@
 									}
 								},
 								{
-									"id": 3090,
+									"id": 3097,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34077,7 +34077,7 @@
 									}
 								},
 								{
-									"id": 3092,
+									"id": 3099,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -34092,14 +34092,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3093,
+											"id": 3100,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3094,
+													"id": 3101,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -34114,14 +34114,14 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3095,
+															"id": 3102,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3096,
+																	"id": 3103,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -34144,7 +34144,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3096
+																		3103
 																	]
 																}
 															]
@@ -34157,7 +34157,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3094
+														3101
 													]
 												}
 											]
@@ -34170,23 +34170,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3097,
+										3104,
+										3105,
 										3098,
-										3091,
-										3090,
-										3092
+										3097,
+										3099
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3099,
+								"id": 3106,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3100,
+										"id": 3107,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -34205,7 +34205,7 @@
 					}
 				},
 				{
-					"id": 3101,
+					"id": 3108,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34224,7 +34224,7 @@
 					}
 				},
 				{
-					"id": 3102,
+					"id": 3109,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34249,10 +34249,10 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3084,
-						3088,
-						3101,
-						3102
+						3091,
+						3095,
+						3108,
+						3109
 					]
 				}
 			],
@@ -34265,7 +34265,7 @@
 			]
 		},
 		{
-			"id": 2820,
+			"id": 2825,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -34275,7 +34275,7 @@
 			},
 			"children": [
 				{
-					"id": 2874,
+					"id": 2879,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34298,7 +34298,7 @@
 					}
 				},
 				{
-					"id": 2873,
+					"id": 2878,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34321,7 +34321,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2848,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34344,7 +34344,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2849,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34367,7 +34367,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2851,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34390,7 +34390,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2850,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34413,7 +34413,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2830,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34436,7 +34436,7 @@
 					}
 				},
 				{
-					"id": 2886,
+					"id": 2891,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34459,7 +34459,7 @@
 					}
 				},
 				{
-					"id": 2887,
+					"id": 2892,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34482,7 +34482,7 @@
 					}
 				},
 				{
-					"id": 2884,
+					"id": 2889,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34505,7 +34505,7 @@
 					}
 				},
 				{
-					"id": 2885,
+					"id": 2890,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34528,7 +34528,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2853,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34551,7 +34551,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2858,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34574,7 +34574,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2855,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34597,7 +34597,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2857,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34620,7 +34620,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2856,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34643,7 +34643,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2854,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34666,7 +34666,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2863,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34689,7 +34689,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2860,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34712,7 +34712,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2862,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34735,7 +34735,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2861,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34758,7 +34758,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2859,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34781,7 +34781,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2867,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34804,7 +34804,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2866,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34827,7 +34827,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2865,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34850,7 +34850,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2864,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34873,7 +34873,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2852,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34896,7 +34896,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2987,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34909,7 +34909,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 883,
+							"line": 893,
 							"character": 4
 						}
 					],
@@ -34919,7 +34919,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2982,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34932,7 +34932,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 858,
+							"line": 868,
 							"character": 4
 						}
 					],
@@ -34942,7 +34942,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2977,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34951,52 +34951,6 @@
 					},
 					"comment": {
 						"shortText": "Font color of the legend label in the heatmap chart."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 833,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2969,
-					"name": "--ts-var-chart-heatmap-legend-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the legend title in the heatmap chart."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 828,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2972,
-					"name": "--ts-var-chart-treemap-legend-label-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the legend label in the treemap chart."
 					},
 					"sources": [
 						{
@@ -35011,15 +34965,15 @@
 					}
 				},
 				{
-					"id": 2971,
-					"name": "--ts-var-chart-treemap-legend-title-color",
+					"id": 2976,
+					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the legend title in the treemap chart."
+						"shortText": "Font color of the legend title in the heatmap chart."
 					},
 					"sources": [
 						{
@@ -35034,7 +34988,53 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2979,
+					"name": "--ts-var-chart-treemap-legend-label-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the legend label in the treemap chart."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 853,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2978,
+					"name": "--ts-var-chart-treemap-legend-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the legend title in the treemap chart."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 848,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2914,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35057,7 +35057,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2917,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35080,7 +35080,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2912,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35103,7 +35103,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2915,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35126,7 +35126,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2916,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35149,7 +35149,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2911,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35172,7 +35172,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2913,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35195,7 +35195,7 @@
 					}
 				},
 				{
-					"id": 2879,
+					"id": 2884,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35218,7 +35218,7 @@
 					}
 				},
 				{
-					"id": 2878,
+					"id": 2883,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35241,7 +35241,7 @@
 					}
 				},
 				{
-					"id": 2881,
+					"id": 2886,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35264,7 +35264,7 @@
 					}
 				},
 				{
-					"id": 2880,
+					"id": 2885,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35287,7 +35287,7 @@
 					}
 				},
 				{
-					"id": 2877,
+					"id": 2882,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35310,7 +35310,7 @@
 					}
 				},
 				{
-					"id": 2875,
+					"id": 2880,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35333,7 +35333,7 @@
 					}
 				},
 				{
-					"id": 2876,
+					"id": 2881,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35356,7 +35356,7 @@
 					}
 				},
 				{
-					"id": 2882,
+					"id": 2887,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35379,7 +35379,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2888,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35402,7 +35402,7 @@
 					}
 				},
 				{
-					"id": 2894,
+					"id": 2899,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35425,7 +35425,7 @@
 					}
 				},
 				{
-					"id": 2895,
+					"id": 2900,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35448,7 +35448,7 @@
 					}
 				},
 				{
-					"id": 2898,
+					"id": 2903,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35471,7 +35471,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2901,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35494,7 +35494,7 @@
 					}
 				},
 				{
-					"id": 2897,
+					"id": 2902,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35517,7 +35517,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2910,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35540,7 +35540,7 @@
 					}
 				},
 				{
-					"id": 2904,
+					"id": 2909,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35563,7 +35563,7 @@
 					}
 				},
 				{
-					"id": 2903,
+					"id": 2908,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35586,7 +35586,7 @@
 					}
 				},
 				{
-					"id": 2902,
+					"id": 2907,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35609,7 +35609,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2975,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35618,6 +35618,52 @@
 					},
 					"comment": {
 						"shortText": "Font color of the analyze text in the KPI widget."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 833,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2974,
+					"name": "--ts-var-kpi-comparison-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the comparison text in the KPI widget."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 828,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2973,
+					"name": "--ts-var-kpi-hero-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the hero text in the KPI widget."
 					},
 					"sources": [
 						{
@@ -35632,53 +35678,7 @@
 					}
 				},
 				{
-					"id": 2967,
-					"name": "--ts-var-kpi-comparison-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the comparison text in the KPI widget."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 818,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2966,
-					"name": "--ts-var-kpi-hero-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the hero text in the KPI widget."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 813,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2974,
+					"id": 2981,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35691,7 +35691,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 853,
+							"line": 863,
 							"character": 4
 						}
 					],
@@ -35701,7 +35701,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2980,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35714,7 +35714,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 848,
+							"line": 858,
 							"character": 4
 						}
 					],
@@ -35724,7 +35724,7 @@
 					}
 				},
 				{
-					"id": 2900,
+					"id": 2905,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35747,7 +35747,7 @@
 					}
 				},
 				{
-					"id": 2899,
+					"id": 2904,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35770,7 +35770,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2934,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35783,7 +35783,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 574,
+							"line": 584,
 							"character": 4
 						}
 					],
@@ -35793,7 +35793,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2947,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35803,147 +35803,6 @@
 					"comment": {
 						"shortText": "Background color of the filter chips in the Liveboard on active.",
 						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 683,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2939,
-					"name": "--ts-var-liveboard-chip--hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the filter chips in the Liveboard on hover.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 674,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2937,
-					"name": "--ts-var-liveboard-chip-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the filter chips in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 656,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2938,
-					"name": "--ts-var-liveboard-chip-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the filter chips in the Liveboard.",
-						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 665,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2945,
-					"name": "--ts-var-liveboard-cross-filter-layout-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the cross filter layout in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 708,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2943,
-					"name": "--ts-var-liveboard-dual-column-breakpoint",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Breakpoint for the dual column layout in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 698,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2942,
-					"name": "--ts-var-liveboard-edit-bar-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the edit bar in the Liveboard."
 					},
 					"sources": [
 						{
@@ -35958,7 +35817,148 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 2946,
+					"name": "--ts-var-liveboard-chip--hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the filter chips in the Liveboard on hover.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 684,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2944,
+					"name": "--ts-var-liveboard-chip-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the filter chips in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 666,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2945,
+					"name": "--ts-var-liveboard-chip-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the filter chips in the Liveboard.",
+						"text": "Please enable the Liveboard Masterpieces feature in your ThoughtSpot instance and\nthen set the isLiveboardMasterpiecesEnabled SDK flag to true to start modifying\nthis CSS variable.\n"
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 675,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2952,
+					"name": "--ts-var-liveboard-cross-filter-layout-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the cross filter layout in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 718,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2950,
+					"name": "--ts-var-liveboard-dual-column-breakpoint",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Breakpoint for the dual column layout in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 708,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2949,
+					"name": "--ts-var-liveboard-edit-bar-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the edit bar in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 703,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3036,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35967,98 +35967,6 @@
 					},
 					"comment": {
 						"shortText": "Border color of the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1131,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3033,
-					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color of unselected items in the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1151,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3034,
-					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover text color of unselected items in the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1156,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3030,
-					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the selected section in the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1136,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3031,
-					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the selected section in the Liveboard edit header toolbar."
 					},
 					"sources": [
 						{
@@ -36073,15 +35981,61 @@
 					}
 				},
 				{
-					"id": 3032,
-					"name": "--ts-var-liveboard-edit-toolbar-text",
+					"id": 3040,
+					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Text color of unselected items in the Liveboard edit header toolbar."
+						"shortText": "Hover background color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1161,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3041,
+					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover text color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1166,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3037,
+					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the selected section in the Liveboard edit header toolbar."
 					},
 					"sources": [
 						{
@@ -36096,7 +36050,53 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 3038,
+					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the selected section in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1151,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3039,
+					"name": "--ts-var-liveboard-edit-toolbar-text",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1156,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2935,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36110,7 +36110,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 583,
+							"line": 593,
 							"character": 4
 						}
 					],
@@ -36120,7 +36120,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2936,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36134,7 +36134,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 592,
+							"line": 602,
 							"character": 4
 						}
 					],
@@ -36144,7 +36144,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2940,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36158,7 +36158,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 620,
+							"line": 630,
 							"character": 4
 						}
 					],
@@ -36168,7 +36168,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2928,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36182,7 +36182,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 524,
+							"line": 534,
 							"character": 4
 						}
 					],
@@ -36192,7 +36192,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2943,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36206,7 +36206,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 647,
+							"line": 657,
 							"character": 4
 						}
 					],
@@ -36216,7 +36216,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2942,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36230,7 +36230,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 638,
+							"line": 648,
 							"character": 4
 						}
 					],
@@ -36240,7 +36240,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2933,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36254,7 +36254,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 569,
+							"line": 579,
 							"character": 4
 						}
 					],
@@ -36264,7 +36264,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2941,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36278,7 +36278,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 629,
+							"line": 639,
 							"character": 4
 						}
 					],
@@ -36288,7 +36288,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2931,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36302,7 +36302,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 551,
+							"line": 561,
 							"character": 4
 						}
 					],
@@ -36312,7 +36312,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2932,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36326,7 +36326,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 560,
+							"line": 570,
 							"character": 4
 						}
 					],
@@ -36336,7 +36336,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2939,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36350,7 +36350,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 611,
+							"line": 621,
 							"character": 4
 						}
 					],
@@ -36360,7 +36360,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2929,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36374,7 +36374,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 533,
+							"line": 543,
 							"character": 4
 						}
 					],
@@ -36384,7 +36384,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2930,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36398,7 +36398,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 542,
+							"line": 552,
 							"character": 4
 						}
 					],
@@ -36408,7 +36408,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2966,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36421,7 +36421,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 778,
+							"line": 788,
 							"character": 4
 						}
 					],
@@ -36431,7 +36431,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2963,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36440,52 +36440,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the action button in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 763,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2957,
-					"name": "--ts-var-liveboard-header-action-button-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the action button in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 768,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2958,
-					"name": "--ts-var-liveboard-header-action-button-hover-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the action button in the Liveboard header on hover."
 					},
 					"sources": [
 						{
@@ -36500,7 +36454,53 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2964,
+					"name": "--ts-var-liveboard-header-action-button-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the action button in the Liveboard header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 778,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2965,
+					"name": "--ts-var-liveboard-header-action-button-hover-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the action button in the Liveboard header on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 783,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2919,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36523,7 +36523,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2972,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36536,7 +36536,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 808,
+							"line": 818,
 							"character": 4
 						}
 					],
@@ -36546,7 +36546,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2967,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36555,75 +36555,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the badge in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 783,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2961,
-					"name": "--ts-var-liveboard-header-badge-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the badge in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 788,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2964,
-					"name": "--ts-var-liveboard-header-badge-hover-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the badge in the Liveboard header on hover."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 803,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2962,
-					"name": "--ts-var-liveboard-header-badge-modified-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the modified badge in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -36638,15 +36569,15 @@
 					}
 				},
 				{
-					"id": 2963,
-					"name": "--ts-var-liveboard-header-badge-modified-font-color",
+					"id": 2968,
+					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the modified badge in the Liveboard header."
+						"shortText": "Font color of the badge in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -36661,7 +36592,76 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2971,
+					"name": "--ts-var-liveboard-header-badge-hover-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the badge in the Liveboard header on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 813,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2969,
+					"name": "--ts-var-liveboard-header-badge-modified-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the modified badge in the Liveboard header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 803,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2970,
+					"name": "--ts-var-liveboard-header-badge-modified-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the modified badge in the Liveboard header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 808,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2920,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36684,7 +36684,53 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2924,
+					"name": "--ts-var-liveboard-insight-tile-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the insight tiles in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 510,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2923,
+					"name": "--ts-var-liveboard-insight-tile-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the insight tiles in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 505,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2918,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36707,7 +36753,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2938,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36720,7 +36766,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 602,
+							"line": 612,
 							"character": 4
 						}
 					],
@@ -36730,7 +36776,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2937,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36743,7 +36789,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 597,
+							"line": 607,
 							"character": 4
 						}
 					],
@@ -36753,7 +36799,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2951,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,236 +36808,6 @@
 					},
 					"comment": {
 						"shortText": "Breakpoint for the single column layout in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 703,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2999,
-					"name": "--ts-var-liveboard-styling-button-active-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the styling button in the Liveboard when active."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 978,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2996,
-					"name": "--ts-var-liveboard-styling-button-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the styling button in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 963,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2998,
-					"name": "--ts-var-liveboard-styling-button-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the styling button in the Liveboard on hover."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 973,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3000,
-					"name": "--ts-var-liveboard-styling-button-hover-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling button in the Liveboard on hover."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 983,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3001,
-					"name": "--ts-var-liveboard-styling-button-shadow",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Box shadow of the styling button in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 988,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2997,
-					"name": "--ts-var-liveboard-styling-button-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling button in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 968,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3002,
-					"name": "--ts-var-liveboard-styling-color-palette-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the color palette in the Liveboard styling panel."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 993,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2995,
-					"name": "--ts-var-liveboard-styling-panel-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the styling panel in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 958,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2994,
-					"name": "--ts-var-liveboard-styling-panel-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling panel in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 953,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2946,
-					"name": "--ts-var-liveboard-tab-active-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the active tab in the Liveboard."
 					},
 					"sources": [
 						{
@@ -37006,7 +36822,237 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 3006,
+					"name": "--ts-var-liveboard-styling-button-active-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the styling button in the Liveboard when active."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 988,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3003,
+					"name": "--ts-var-liveboard-styling-button-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the styling button in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 973,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3005,
+					"name": "--ts-var-liveboard-styling-button-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the styling button in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 983,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3007,
+					"name": "--ts-var-liveboard-styling-button-hover-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling button in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 993,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3008,
+					"name": "--ts-var-liveboard-styling-button-shadow",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Box shadow of the styling button in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 998,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3004,
+					"name": "--ts-var-liveboard-styling-button-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling button in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 978,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3009,
+					"name": "--ts-var-liveboard-styling-color-palette-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the color palette in the Liveboard styling panel."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1003,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3002,
+					"name": "--ts-var-liveboard-styling-panel-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the styling panel in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 968,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3001,
+					"name": "--ts-var-liveboard-styling-panel-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling panel in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 963,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2953,
+					"name": "--ts-var-liveboard-tab-active-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the active tab in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 723,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2954,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37019,7 +37065,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 718,
+							"line": 728,
 							"character": 4
 						}
 					],
@@ -37029,7 +37075,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2922,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37052,7 +37098,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2921,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37075,7 +37121,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2925,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37084,52 +37130,6 @@
 					},
 					"comment": {
 						"shortText": "Border radius of the tiles in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 505,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2919,
-					"name": "--ts-var-liveboard-tile-padding",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Padding of the tiles in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 510,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2920,
-					"name": "--ts-var-liveboard-tile-table-header-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the table header in the Liveboard."
 					},
 					"sources": [
 						{
@@ -37144,7 +37144,53 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2926,
+					"name": "--ts-var-liveboard-tile-padding",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Padding of the tiles in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 520,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2927,
+					"name": "--ts-var-liveboard-tile-table-header-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the table header in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 525,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2955,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37157,7 +37203,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 723,
+							"line": 733,
 							"character": 4
 						}
 					],
@@ -37167,7 +37213,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2956,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37180,7 +37226,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 728,
+							"line": 738,
 							"character": 4
 						}
 					],
@@ -37190,7 +37236,7 @@
 					}
 				},
 				{
-					"id": 2892,
+					"id": 2897,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37213,7 +37259,7 @@
 					}
 				},
 				{
-					"id": 2889,
+					"id": 2894,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37236,7 +37282,7 @@
 					}
 				},
 				{
-					"id": 2888,
+					"id": 2893,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37259,7 +37305,7 @@
 					}
 				},
 				{
-					"id": 2890,
+					"id": 2895,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37282,7 +37328,7 @@
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2898,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37305,7 +37351,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2896,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37328,7 +37374,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2831,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37351,7 +37397,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2832,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37374,7 +37420,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2961,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37387,7 +37433,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 753,
+							"line": 763,
 							"character": 4
 						}
 					],
@@ -37397,7 +37443,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2962,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37410,7 +37456,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 758,
+							"line": 768,
 							"character": 4
 						}
 					],
@@ -37420,7 +37466,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2957,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37429,29 +37475,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the parameter chips in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 733,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2952,
-					"name": "--ts-var-parameter-chip-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the parameter chips in the Liveboard on hover."
 					},
 					"sources": [
 						{
@@ -37466,7 +37489,30 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2959,
+					"name": "--ts-var-parameter-chip-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the parameter chips in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 753,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2960,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,6 +37521,29 @@
 					},
 					"comment": {
 						"shortText": "Font color of the parameter chips in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 758,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2958,
+					"name": "--ts-var-parameter-chip-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the parameter chips in the Liveboard."
 					},
 					"sources": [
 						{
@@ -37489,30 +37558,7 @@
 					}
 				},
 				{
-					"id": 2951,
-					"name": "--ts-var-parameter-chip-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the parameter chips in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 738,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2821,
+					"id": 2826,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37535,7 +37581,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2827,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37558,7 +37604,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2828,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37581,7 +37627,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2829,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37604,7 +37650,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2990,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37613,190 +37659,6 @@
 					},
 					"comment": {
 						"shortText": "Background color for the saved chats sidebar container."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 898,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2982,
-					"name": "--ts-var-saved-chats-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar container."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 893,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2987,
-					"name": "--ts-var-saved-chats-btn-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for buttons (new chat, toggle, footer) in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 918,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2988,
-					"name": "--ts-var-saved-chats-btn-hover-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color for buttons in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 923,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2991,
-					"name": "--ts-var-saved-chats-conv-active-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for the active/selected conversation in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 938,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2990,
-					"name": "--ts-var-saved-chats-conv-hover-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for conversation items on hover in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 933,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2989,
-					"name": "--ts-var-saved-chats-conv-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color for conversation items in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 928,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2992,
-					"name": "--ts-var-saved-chats-footer-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar footer."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 943,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2985,
-					"name": "--ts-var-saved-chats-header-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar header."
 					},
 					"sources": [
 						{
@@ -37811,38 +37673,15 @@
 					}
 				},
 				{
-					"id": 2993,
-					"name": "--ts-var-saved-chats-section-title-color",
+					"id": 2989,
+					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color for section title text (e.g., \"Recent\", \"Older\") in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 948,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2984,
-					"name": "--ts-var-saved-chats-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color for the saved chats sidebar container."
+						"shortText": "Border color for the saved chats sidebar container."
 					},
 					"sources": [
 						{
@@ -37857,15 +37696,199 @@
 					}
 				},
 				{
-					"id": 2986,
-					"name": "--ts-var-saved-chats-title-color",
+					"id": 2994,
+					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color for the saved chats sidebar title text."
+						"shortText": "Background color for buttons (new chat, toggle, footer) in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 928,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2995,
+					"name": "--ts-var-saved-chats-btn-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color for buttons in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 933,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2998,
+					"name": "--ts-var-saved-chats-conv-active-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the active/selected conversation in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 948,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2997,
+					"name": "--ts-var-saved-chats-conv-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for conversation items on hover in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 943,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2996,
+					"name": "--ts-var-saved-chats-conv-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for conversation items in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 938,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2999,
+					"name": "--ts-var-saved-chats-footer-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar footer."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 953,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2992,
+					"name": "--ts-var-saved-chats-header-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 918,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3000,
+					"name": "--ts-var-saved-chats-section-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for section title text (e.g., \"Recent\", \"Older\") in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 958,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2991,
+					"name": "--ts-var-saved-chats-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for the saved chats sidebar container."
 					},
 					"sources": [
 						{
@@ -37880,7 +37903,30 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2993,
+					"name": "--ts-var-saved-chats-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for the saved chats sidebar title text."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 923,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2840,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37903,7 +37949,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2844,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37926,7 +37972,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2845,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37949,7 +37995,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2843,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37972,7 +38018,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2839,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37995,7 +38041,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2842,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38018,7 +38064,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2836,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38041,7 +38087,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2837,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38064,7 +38110,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2838,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38087,7 +38133,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2833,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38110,7 +38156,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2834,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38133,7 +38179,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2835,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38156,7 +38202,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2841,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38179,7 +38225,7 @@
 					}
 				},
 				{
-					"id": 2901,
+					"id": 2906,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38202,7 +38248,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2948,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38215,7 +38261,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 688,
+							"line": 698,
 							"character": 4
 						}
 					],
@@ -38225,7 +38271,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2986,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38234,98 +38280,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the crosscorrelation card in the SpotIQ analyze."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 878,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2976,
-					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the forecasting card in the SpotIQ analyze."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 863,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2977,
-					"name": "--ts-var-spotiq-analyze-outlier-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the outlier card in the SpotIQ analyze."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 868,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2978,
-					"name": "--ts-var-spotiq-analyze-trend-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the trend card in the SpotIQ analyze."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 873,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2981,
-					"name": "--ts-var-spotter-chat-width",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Width of the Spotter chat window."
 					},
 					"sources": [
 						{
@@ -38340,7 +38294,99 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2983,
+					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the forecasting card in the SpotIQ analyze."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 873,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2984,
+					"name": "--ts-var-spotiq-analyze-outlier-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the outlier card in the SpotIQ analyze."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 878,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2985,
+					"name": "--ts-var-spotiq-analyze-trend-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the trend card in the SpotIQ analyze."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 883,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2988,
+					"name": "--ts-var-spotter-chat-width",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Width of the Spotter chat window."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 898,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2846,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38363,7 +38409,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2847,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38386,7 +38432,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3043,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38399,7 +38445,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1167,
+							"line": 1177,
 							"character": 4
 						}
 					],
@@ -38409,7 +38455,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3015,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38418,282 +38464,6 @@
 					},
 					"comment": {
 						"shortText": "Text color for the SpotterViz label in the empty state, displayed below\nthe SpotterViz icon."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1024,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3037,
-					"name": "--ts-var-spotterviz-expanded-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Expanded user chat message bubble border color in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1172,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3035,
-					"name": "--ts-var-spotterviz-footer-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the SpotterViz footer."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1161,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3004,
-					"name": "--ts-var-spotterviz-input-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1003,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3006,
-					"name": "--ts-var-spotterviz-input-cta-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "CTA color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1013,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3007,
-					"name": "--ts-var-spotterviz-input-cta-hover-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "CTA hover color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1018,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3005,
-					"name": "--ts-var-spotterviz-input-placeholder-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Placeholder text color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1008,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3027,
-					"name": "--ts-var-spotterviz-last-checkpoint-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the last checkpoint section in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1121,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3028,
-					"name": "--ts-var-spotterviz-last-checkpoint-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the last checkpoint section in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1126,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3013,
-					"name": "--ts-var-spotterviz-message-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the user chat message bubble in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1050,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3003,
-					"name": "--ts-var-spotterviz-panel-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Main panel background of the SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 998,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3009,
-					"name": "--ts-var-spotterviz-prompt-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the starter prompt cards in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1029,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3010,
-					"name": "--ts-var-spotterviz-prompt-card-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background hover color of the starter prompt cards in SpotterViz."
 					},
 					"sources": [
 						{
@@ -38708,20 +38478,20 @@
 					}
 				},
 				{
-					"id": 3038,
-					"name": "--ts-var-spotterviz-reference-icon-hover-background",
+					"id": 3044,
+					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the reference-mode toggle button in the SpotterViz\nchat input when it is unselected and the user hovers over it."
+						"shortText": "Expanded user chat message bubble border color in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1178,
+							"line": 1182,
 							"character": 4
 						}
 					],
@@ -38731,43 +38501,20 @@
 					}
 				},
 				{
-					"id": 3040,
-					"name": "--ts-var-spotterviz-reference-icon-selected-background",
+					"id": 3042,
+					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color for the reference-mode selected state — applies to\nboth the reference mode toggle button when active and the icon badge\non each referenced-entity chip in the chat input."
+						"shortText": "Text color of the SpotterViz footer."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1192,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3039,
-					"name": "--ts-var-spotterviz-reference-icon-selected-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Icon color for the reference-mode selected state — applies to\nboth the toggle button when active and the icon badge on each\nreferenced-entity chip in the chat input."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1185,
+							"line": 1171,
 							"character": 4
 						}
 					],
@@ -38778,19 +38525,65 @@
 				},
 				{
 					"id": 3011,
-					"name": "--ts-var-spotterviz-text-primary",
+					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Primary text color in SpotterViz, also used for tool response text,\nupvote/downvote buttons, and other primary content."
+						"shortText": "Background color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1040,
+							"line": 1013,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3013,
+					"name": "--ts-var-spotterviz-input-cta-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "CTA color of the chat input field in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1023,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3014,
+					"name": "--ts-var-spotterviz-input-cta-hover-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "CTA hover color of the chat input field in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1028,
 							"character": 4
 						}
 					],
@@ -38801,19 +38594,19 @@
 				},
 				{
 					"id": 3012,
-					"name": "--ts-var-spotterviz-text-secondary",
+					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Secondary text color in SpotterViz."
+						"shortText": "Placeholder text color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1045,
+							"line": 1018,
 							"character": 4
 						}
 					],
@@ -38823,20 +38616,20 @@
 					}
 				},
 				{
-					"id": 3017,
-					"name": "--ts-var-spotterviz-thinking-completed-header-color",
+					"id": 3034,
+					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color of the thinking step header when completed in SpotterViz."
+						"shortText": "Background color of the last checkpoint section in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1070,
+							"line": 1131,
 							"character": 4
 						}
 					],
@@ -38846,89 +38639,20 @@
 					}
 				},
 				{
-					"id": 3019,
-					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
+					"id": 3035,
+					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Hover background color for the working/work done CTA in SpotterViz."
+						"shortText": "Border color of the last checkpoint section in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1081,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3016,
-					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of the thinking step header when in progress in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1065,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3018,
-					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of the final completion indicator icon shown when all work is done.\nThe last green dot which is shown when work is done."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1076,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3022,
-					"name": "--ts-var-spotterviz-tool-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of tool call panels in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1096,
+							"line": 1136,
 							"character": 4
 						}
 					],
@@ -38939,152 +38663,14 @@
 				},
 				{
 					"id": 3020,
-					"name": "--ts-var-spotterviz-tool-call-background",
+					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of tool call panels in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1086,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3024,
-					"name": "--ts-var-spotterviz-tool-feedback-button-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the upvote/downvote feedback buttons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1106,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3025,
-					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color of the upvote/downvote feedback buttons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1111,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3023,
-					"name": "--ts-var-spotterviz-tool-json-input-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the JSON input panel inside a tool call in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1101,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3026,
-					"name": "--ts-var-spotterviz-tool-json-input-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the JSON input panel inside a tool call in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1116,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3021,
-					"name": "--ts-var-spotterviz-tool-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of tool titles and icons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1091,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3015,
-					"name": "--ts-var-spotterviz-usermessage-icon-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the user chat message expand button in SpotterViz."
+						"shortText": "Background color of the user chat message bubble in SpotterViz."
 					},
 					"sources": [
 						{
@@ -39099,15 +38685,176 @@
 					}
 				},
 				{
-					"id": 3014,
-					"name": "--ts-var-spotterviz-usermessage-icon-hover",
+					"id": 3010,
+					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Hover color for the user chat message expand button in SpotterViz."
+						"shortText": "Main panel background of the SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1008,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3016,
+					"name": "--ts-var-spotterviz-prompt-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the starter prompt cards in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1039,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3017,
+					"name": "--ts-var-spotterviz-prompt-card-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background hover color of the starter prompt cards in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1044,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3045,
+					"name": "--ts-var-spotterviz-reference-icon-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the reference-mode toggle button in the SpotterViz\nchat input when it is unselected and the user hovers over it."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1188,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3047,
+					"name": "--ts-var-spotterviz-reference-icon-selected-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the reference-mode selected state — applies to\nboth the reference mode toggle button when active and the icon badge\non each referenced-entity chip in the chat input."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1202,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3046,
+					"name": "--ts-var-spotterviz-reference-icon-selected-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Icon color for the reference-mode selected state — applies to\nboth the toggle button when active and the icon badge on each\nreferenced-entity chip in the chat input."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1195,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3018,
+					"name": "--ts-var-spotterviz-text-primary",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Primary text color in SpotterViz, also used for tool response text,\nupvote/downvote buttons, and other primary content."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1050,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3019,
+					"name": "--ts-var-spotterviz-text-secondary",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Secondary text color in SpotterViz."
 					},
 					"sources": [
 						{
@@ -39122,7 +38869,306 @@
 					}
 				},
 				{
-					"id": 2871,
+					"id": 3024,
+					"name": "--ts-var-spotterviz-thinking-completed-header-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the thinking step header when completed in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1080,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3026,
+					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color for the working/work done CTA in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1091,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3023,
+					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the thinking step header when in progress in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1075,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3025,
+					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the final completion indicator icon shown when all work is done.\nThe last green dot which is shown when work is done."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1086,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3029,
+					"name": "--ts-var-spotterviz-tool-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of tool call panels in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1106,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3027,
+					"name": "--ts-var-spotterviz-tool-call-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of tool call panels in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1096,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3031,
+					"name": "--ts-var-spotterviz-tool-feedback-button-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the upvote/downvote feedback buttons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1116,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3032,
+					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color of the upvote/downvote feedback buttons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1121,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3030,
+					"name": "--ts-var-spotterviz-tool-json-input-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the JSON input panel inside a tool call in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1111,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3033,
+					"name": "--ts-var-spotterviz-tool-json-input-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the JSON input panel inside a tool call in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1126,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3028,
+					"name": "--ts-var-spotterviz-tool-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of tool titles and icons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1101,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3022,
+					"name": "--ts-var-spotterviz-usermessage-icon-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the user chat message expand button in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1070,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3021,
+					"name": "--ts-var-spotterviz-usermessage-icon-hover",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover color for the user chat message expand button in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1065,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2876,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39145,7 +39191,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2874,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39168,7 +39214,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2875,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39191,7 +39237,7 @@
 					}
 				},
 				{
-					"id": 2866,
+					"id": 2871,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39214,7 +39260,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2872,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39237,7 +39283,7 @@
 					}
 				},
 				{
-					"id": 2868,
+					"id": 2873,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39260,7 +39306,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2877,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39283,7 +39329,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2868,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39306,7 +39352,7 @@
 					}
 				},
 				{
-					"id": 2864,
+					"id": 2869,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39329,7 +39375,7 @@
 					}
 				},
 				{
-					"id": 2865,
+					"id": 2870,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39357,226 +39403,228 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2874,
-						2873,
-						2843,
-						2844,
-						2846,
-						2845,
-						2825,
-						2886,
-						2887,
-						2884,
-						2885,
+						2879,
+						2878,
 						2848,
-						2853,
-						2850,
-						2852,
-						2851,
 						2849,
+						2851,
+						2850,
+						2830,
+						2891,
+						2892,
+						2889,
+						2890,
+						2853,
 						2858,
 						2855,
 						2857,
 						2856,
 						2854,
+						2863,
+						2860,
 						2862,
 						2861,
-						2860,
 						2859,
-						2847,
-						2980,
-						2975,
-						2970,
-						2969,
-						2972,
-						2971,
-						2909,
+						2867,
+						2866,
+						2865,
+						2864,
+						2852,
+						2987,
+						2982,
+						2977,
+						2976,
+						2979,
+						2978,
+						2914,
+						2917,
 						2912,
-						2907,
-						2910,
+						2915,
+						2916,
 						2911,
-						2906,
-						2908,
-						2879,
-						2878,
-						2881,
-						2880,
-						2877,
-						2875,
-						2876,
-						2882,
+						2913,
+						2884,
 						2883,
+						2886,
+						2885,
+						2882,
+						2880,
+						2881,
+						2887,
+						2888,
+						2899,
+						2900,
+						2903,
+						2901,
+						2902,
+						2910,
+						2909,
+						2908,
+						2907,
+						2975,
+						2974,
+						2973,
+						2981,
+						2980,
+						2905,
+						2904,
+						2934,
+						2947,
+						2946,
+						2944,
+						2945,
+						2952,
+						2950,
+						2949,
+						3036,
+						3040,
+						3041,
+						3037,
+						3038,
+						3039,
+						2935,
+						2936,
+						2940,
+						2928,
+						2943,
+						2942,
+						2933,
+						2941,
+						2931,
+						2932,
+						2939,
+						2929,
+						2930,
+						2966,
+						2963,
+						2964,
+						2965,
+						2919,
+						2972,
+						2967,
+						2968,
+						2971,
+						2969,
+						2970,
+						2920,
+						2924,
+						2923,
+						2918,
+						2938,
+						2937,
+						2951,
+						3006,
+						3003,
+						3005,
+						3007,
+						3008,
+						3004,
+						3009,
+						3002,
+						3001,
+						2953,
+						2954,
+						2922,
+						2921,
+						2925,
+						2926,
+						2927,
+						2955,
+						2956,
+						2897,
 						2894,
+						2893,
 						2895,
 						2898,
 						2896,
-						2897,
-						2905,
-						2904,
-						2903,
-						2902,
-						2968,
-						2967,
-						2966,
-						2974,
-						2973,
-						2900,
-						2899,
-						2927,
-						2940,
-						2939,
-						2937,
-						2938,
-						2945,
-						2943,
-						2942,
-						3029,
-						3033,
-						3034,
-						3030,
-						3031,
-						3032,
-						2928,
-						2929,
-						2933,
-						2921,
-						2936,
-						2935,
-						2926,
-						2934,
-						2924,
-						2925,
-						2932,
-						2922,
-						2923,
-						2959,
-						2956,
-						2957,
-						2958,
-						2914,
-						2965,
-						2960,
-						2961,
-						2964,
-						2962,
-						2963,
-						2915,
-						2913,
-						2931,
-						2930,
-						2944,
-						2999,
-						2996,
-						2998,
-						3000,
-						3001,
-						2997,
-						3002,
-						2995,
-						2994,
-						2946,
-						2947,
-						2917,
-						2916,
-						2918,
-						2919,
-						2920,
-						2948,
-						2949,
-						2892,
-						2889,
-						2888,
-						2890,
-						2893,
-						2891,
-						2826,
-						2827,
-						2954,
-						2955,
-						2950,
-						2952,
-						2953,
-						2951,
-						2821,
-						2822,
-						2823,
-						2824,
-						2983,
-						2982,
-						2987,
-						2988,
-						2991,
-						2990,
-						2989,
-						2992,
-						2985,
-						2993,
-						2984,
-						2986,
-						2835,
-						2839,
-						2840,
-						2838,
-						2834,
-						2837,
 						2831,
 						2832,
-						2833,
+						2961,
+						2962,
+						2957,
+						2959,
+						2960,
+						2958,
+						2826,
+						2827,
 						2828,
 						2829,
-						2830,
-						2836,
-						2901,
-						2941,
-						2979,
-						2976,
-						2977,
-						2978,
-						2981,
-						2841,
+						2990,
+						2989,
+						2994,
+						2995,
+						2998,
+						2997,
+						2996,
+						2999,
+						2992,
+						3000,
+						2991,
+						2993,
+						2840,
+						2844,
+						2845,
+						2843,
+						2839,
 						2842,
-						3036,
-						3008,
-						3037,
-						3035,
-						3004,
-						3006,
-						3007,
-						3005,
-						3027,
-						3028,
-						3013,
-						3003,
-						3009,
-						3010,
-						3038,
-						3040,
-						3039,
-						3011,
-						3012,
-						3017,
-						3019,
-						3016,
-						3018,
-						3022,
-						3020,
-						3024,
-						3025,
-						3023,
-						3026,
-						3021,
+						2836,
+						2837,
+						2838,
+						2833,
+						2834,
+						2835,
+						2841,
+						2906,
+						2948,
+						2986,
+						2983,
+						2984,
+						2985,
+						2988,
+						2846,
+						2847,
+						3043,
 						3015,
+						3044,
+						3042,
+						3011,
+						3013,
 						3014,
+						3012,
+						3034,
+						3035,
+						3020,
+						3010,
+						3016,
+						3017,
+						3045,
+						3047,
+						3046,
+						3018,
+						3019,
+						3024,
+						3026,
+						3023,
+						3025,
+						3029,
+						3027,
+						3031,
+						3032,
+						3030,
+						3033,
+						3028,
+						3022,
+						3021,
+						2876,
+						2874,
+						2875,
 						2871,
-						2869,
-						2870,
-						2866,
-						2867,
-						2868,
 						2872,
-						2863,
-						2864,
-						2865
+						2873,
+						2877,
+						2868,
+						2869,
+						2870
 					]
 				}
 			],
@@ -39589,7 +39637,7 @@
 			]
 		},
 		{
-			"id": 2808,
+			"id": 2813,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39599,7 +39647,7 @@
 			},
 			"children": [
 				{
-					"id": 2810,
+					"id": 2815,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39615,12 +39663,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2811,
+						"id": 2816,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2814,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39645,8 +39693,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2810,
-						2809
+						2815,
+						2814
 					]
 				}
 			],
@@ -39659,7 +39707,7 @@
 			]
 		},
 		{
-			"id": 2798,
+			"id": 2803,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -39675,7 +39723,7 @@
 			},
 			"children": [
 				{
-					"id": 2800,
+					"id": 2805,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39692,14 +39740,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2801,
+							"id": 2806,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2803,
+									"id": 2808,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39729,7 +39777,7 @@
 									}
 								},
 								{
-									"id": 2804,
+									"id": 2809,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39749,7 +39797,7 @@
 									}
 								},
 								{
-									"id": 2802,
+									"id": 2807,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -39792,21 +39840,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2803,
-										2804,
-										2802
+										2808,
+										2809,
+										2807
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2805,
+								"id": 2810,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2806,
+										"id": 2811,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -39825,7 +39873,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2812,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39845,7 +39893,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2804,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39861,7 +39909,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2808,
+						"id": 2813,
 						"name": "CustomStyles"
 					}
 				}
@@ -39871,9 +39919,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2800,
-						2807,
-						2799
+						2805,
+						2812,
+						2804
 					]
 				}
 			],
@@ -40358,7 +40406,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					}
 				},
@@ -40637,7 +40685,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3044,
+						"id": 3051,
 						"name": "LogLevel"
 					}
 				},
@@ -41165,7 +41213,7 @@
 			]
 		},
 		{
-			"id": 3162,
+			"id": 3169,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41194,7 +41242,7 @@
 			},
 			"children": [
 				{
-					"id": 3165,
+					"id": 3172,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41211,12 +41259,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3145,
+						"id": 3152,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3163,
+					"id": 3170,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41233,12 +41281,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3168,
+						"id": 3175,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3164,
+					"id": 3171,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41276,9 +41324,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3165,
-						3163,
-						3164
+						3172,
+						3170,
+						3171
 					]
 				}
 			],
@@ -41290,7 +41338,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 3166,
+				"id": 3173,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -41300,7 +41348,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3167,
+						"id": 3174,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -41317,7 +41365,7 @@
 			}
 		},
 		{
-			"id": 2757,
+			"id": 2762,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41333,7 +41381,7 @@
 			},
 			"children": [
 				{
-					"id": 2759,
+					"id": 2764,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41365,7 +41413,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2765,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41401,7 +41449,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2763,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41438,9 +41486,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2759,
-						2760,
-						2758
+						2764,
+						2765,
+						2763
 					]
 				}
 			],
@@ -41452,7 +41500,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2761,
+				"id": 2766,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -41462,7 +41510,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2762,
+						"id": 2767,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -41823,7 +41871,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -42262,7 +42310,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 600,
+							"line": 606,
 							"character": 4
 						}
 					],
@@ -42554,7 +42602,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44032,7 +44080,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -44449,14 +44497,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed-container', {\n   ... // other options\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [{ id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n   },\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed-container', {\n   ... // other options\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [{ id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n       // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n       liveboardBrandName: 'Reports',\n       spotterBrandName: 'Analyst',\n       insightTileBrandName: 'Insight card',\n       insightTileViewPlanLabel: 'View plan',\n       insightTileLoaderText: 'Generating insight',\n   },\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 587,
+							"line": 593,
 							"character": 4
 						}
 					],
@@ -44927,7 +44975,7 @@
 			]
 		},
 		{
-			"id": 3041,
+			"id": 3048,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44937,7 +44985,7 @@
 			},
 			"children": [
 				{
-					"id": 3042,
+					"id": 3049,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44958,7 +45006,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3050,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44997,8 +45045,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3042,
-						3043
+						3049,
+						3050
 					]
 				}
 			],
@@ -45265,7 +45313,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -45845,7 +45893,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -46439,7 +46487,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -47144,7 +47192,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47863,7 +47911,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48559,7 +48607,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -48848,7 +48896,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3173,
+						"id": 3180,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -49253,7 +49301,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49564,7 +49612,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50627,7 +50675,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2798,
+						"id": 2803,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -51150,7 +51198,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2757,
+						"id": 2762,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -51732,7 +51780,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3041,
+							"id": 3048,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -52636,7 +52684,7 @@
 					},
 					{
 						"tag": "example",
-						"text": "\n```js\nconst embed = new AppEmbed('#embed-container', {\n   ... // other options,\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [\n           { id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }\n       ],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n   },\n})\n```\n"
+						"text": "\n```js\nconst embed = new AppEmbed('#embed-container', {\n   ... // other options,\n   spotterViz: {\n       brandName: 'MyBrand',\n       brandHeadline: 'Hi, there! I\\'m',\n       description: 'Ask questions about your data',\n       inputChatPlaceholder: 'Ask a question...',\n       hideStarterPrompts: false,\n       customStarterPrompts: [\n           { id: '1', displayText: 'Top products', fullPrompt: 'What are the top products by revenue?' }\n       ],\n       // loaderHeadline and loaderTips require SDK: 1.51.0 | ThoughtSpot Cloud: 26.8.0.cl\n       loaderHeadline: 'Crunching the numbers...',\n       loaderTips: [\n           { label: 'Tip', text: 'try asking about revenue by region' },\n           { label: 'Tip', text: 'use natural language' },\n       ],\n       // liveboardBrandName, spotterBrandName, insightTileBrandName, insightTileViewPlanLabel and insightTileLoaderText require SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n       liveboardBrandName: 'Reports',\n       spotterBrandName: 'Analyst',\n       insightTileBrandName: 'Insight card',\n       insightTileViewPlanLabel: 'View plan',\n       insightTileLoaderText: 'Generating insight',\n   },\n})\n```\n"
 					}
 				]
 			},
@@ -52665,7 +52713,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 58,
+							"line": 64,
 							"character": 4
 						}
 					],
@@ -52698,7 +52746,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 51,
+							"line": 57,
 							"character": 4
 						}
 					],
@@ -52727,7 +52775,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 72,
+							"line": 78,
 							"character": 4
 						}
 					],
@@ -52735,7 +52783,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2636,
+							"id": 2641,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
@@ -52760,7 +52808,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 78,
+							"line": 84,
 							"character": 4
 						}
 					],
@@ -52793,7 +52841,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 65,
+							"line": 71,
 							"character": 4
 						}
 					],
@@ -52822,7 +52870,131 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 84,
+							"line": 90,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2638,
+					"name": "insightTileBrandName",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom term used to replace \"Insight tile\" in the UI and in the agent's responses.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "''\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/spotter-viz-utils.ts",
+							"line": 120,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2640,
+					"name": "insightTileLoaderText",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom loader text shown on the insight tile.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/spotter-viz-utils.ts",
+							"line": 130,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2639,
+					"name": "insightTileViewPlanLabel",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom term used to replace \"View plan\" in the insight tile menu.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/spotter-viz-utils.ts",
+							"line": 125,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2636,
+					"name": "liveboardBrandName",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom term used to replace \"Liveboard\" in the agent's responses.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "''\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/spotter-viz-utils.ts",
+							"line": 108,
 							"character": 4
 						}
 					],
@@ -52851,7 +53023,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 90,
+							"line": 96,
 							"character": 4
 						}
 					],
@@ -52880,7 +53052,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 96,
+							"line": 102,
 							"character": 4
 						}
 					],
@@ -52888,9 +53060,42 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2640,
+							"id": 2645,
 							"name": "SpotterVizLoaderTip"
 						}
+					}
+				},
+				{
+					"id": 2637,
+					"name": "spotterBrandName",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Custom term used to replace \"Spotter\" in the agent's responses.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "''\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/spotter-viz-utils.ts",
+							"line": 114,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
 					}
 				}
 			],
@@ -52905,21 +53110,26 @@
 						2632,
 						2630,
 						2633,
+						2638,
+						2640,
+						2639,
+						2636,
 						2634,
-						2635
+						2635,
+						2637
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/spotter-viz-utils.ts",
-					"line": 45,
+					"line": 51,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2640,
+			"id": 2645,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52939,7 +53149,7 @@
 			},
 			"children": [
 				{
-					"id": 2641,
+					"id": 2646,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52950,7 +53160,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 106,
+							"line": 140,
 							"character": 4
 						}
 					],
@@ -52960,7 +53170,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2647,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52971,7 +53181,7 @@
 					"sources": [
 						{
 							"fileName": "embed/spotter-viz-utils.ts",
-							"line": 108,
+							"line": 142,
 							"character": 4
 						}
 					],
@@ -52986,21 +53196,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2641,
-						2642
+						2646,
+						2647
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/spotter-viz-utils.ts",
-					"line": 104,
+					"line": 138,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2636,
+			"id": 2641,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53020,7 +53230,7 @@
 			},
 			"children": [
 				{
-					"id": 2638,
+					"id": 2643,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53041,7 +53251,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2644,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53062,7 +53272,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2642,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53088,9 +53298,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2638,
-						2639,
-						2637
+						2643,
+						2644,
+						2642
 					]
 				}
 			],
@@ -53165,7 +53375,7 @@
 			]
 		},
 		{
-			"id": 3173,
+			"id": 3180,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53185,7 +53395,7 @@
 			},
 			"children": [
 				{
-					"id": 3174,
+					"id": 3181,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53208,7 +53418,7 @@
 					}
 				},
 				{
-					"id": 3175,
+					"id": 3182,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53236,8 +53446,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3174,
-						3175
+						3181,
+						3182
 					]
 				}
 			],
@@ -53250,14 +53460,14 @@
 			]
 		},
 		{
-			"id": 3080,
+			"id": 3087,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3081,
+					"id": 3088,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53278,7 +53488,7 @@
 					}
 				},
 				{
-					"id": 3082,
+					"id": 3089,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53304,8 +53514,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3081,
-						3082
+						3088,
+						3089
 					]
 				}
 			],
@@ -53318,7 +53528,7 @@
 			]
 		},
 		{
-			"id": 2811,
+			"id": 2816,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53328,7 +53538,7 @@
 			},
 			"children": [
 				{
-					"id": 2813,
+					"id": 2818,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53358,20 +53568,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2814,
+							"id": 2819,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2815,
+								"id": 2820,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2816,
+										"id": 2821,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -53384,7 +53594,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2817,
+										"id": 2822,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -53397,14 +53607,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2818,
+											"id": 2823,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2819,
+													"id": 2824,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -53426,7 +53636,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2817,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53445,7 +53655,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2820,
+						"id": 2825,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -53455,8 +53665,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2813,
-						2812
+						2818,
+						2817
 					]
 				}
 			],
@@ -53761,7 +53971,7 @@
 			]
 		},
 		{
-			"id": 3172,
+			"id": 3179,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -53818,7 +54028,7 @@
 			}
 		},
 		{
-			"id": 2781,
+			"id": 2786,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -53845,7 +54055,7 @@
 			}
 		},
 		{
-			"id": 2785,
+			"id": 2790,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -53860,7 +54070,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2786,
+					"id": 2791,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -53883,7 +54093,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2787,
+							"id": 2792,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -53893,19 +54103,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2788,
+									"id": 2793,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2793,
+										"id": 2798,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2789,
+									"id": 2794,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -53915,7 +54125,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2790,
+											"id": 2795,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -53929,7 +54139,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2791,
+													"id": 2796,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -53939,7 +54149,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2792,
+															"id": 2797,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -53970,7 +54180,7 @@
 			}
 		},
 		{
-			"id": 2782,
+			"id": 2787,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -53994,14 +54204,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2783,
+					"id": 2788,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2784,
+							"id": 2789,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54029,7 +54239,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2784
+								2789
 							]
 						}
 					],
@@ -54044,7 +54254,7 @@
 			}
 		},
 		{
-			"id": 2793,
+			"id": 2798,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -54068,14 +54278,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2794,
+					"id": 2799,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2796,
+							"id": 2801,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54093,7 +54303,7 @@
 							}
 						},
 						{
-							"id": 2797,
+							"id": 2802,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54113,7 +54323,7 @@
 							}
 						},
 						{
-							"id": 2795,
+							"id": 2800,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -54136,9 +54346,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2796,
-								2797,
-								2795
+								2801,
+								2802,
+								2800
 							]
 						}
 					],
@@ -54799,7 +55009,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2752,
+									"id": 2757,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -54927,7 +55137,7 @@
 			]
 		},
 		{
-			"id": 3218,
+			"id": 3225,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -54943,7 +55153,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3219,
+					"id": 3226,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -54973,7 +55183,7 @@
 			]
 		},
 		{
-			"id": 3220,
+			"id": 3227,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -54987,7 +55197,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3221,
+					"id": 3228,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -55009,7 +55219,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3222,
+							"id": 3229,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55019,7 +55229,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3172,
+								"id": 3179,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -55197,7 +55407,7 @@
 			]
 		},
 		{
-			"id": 3051,
+			"id": 3058,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -55211,7 +55421,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3052,
+					"id": 3059,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -55221,7 +55431,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3053,
+							"id": 3060,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55233,7 +55443,7 @@
 							}
 						},
 						{
-							"id": 3054,
+							"id": 3061,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -55244,7 +55454,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3055,
+									"id": 3062,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -55272,36 +55482,36 @@
 				1768,
 				1775,
 				1934,
-				3181,
-				3184,
 				3188,
+				3191,
+				3195,
 				2360,
 				2168,
-				3136,
-				3132,
-				3204,
-				3128,
-				2174,
-				3145,
-				1966,
-				3168,
-				2763,
-				3073,
-				3067,
-				2774,
-				2082,
-				3141,
-				3176,
-				3077,
-				3120,
-				3044,
-				1925,
-				2752,
-				3071,
-				1950,
-				3215,
+				3143,
+				3139,
 				3211,
-				3103
+				3135,
+				2174,
+				3152,
+				1966,
+				3175,
+				2768,
+				3080,
+				3074,
+				2779,
+				2082,
+				3148,
+				3183,
+				3084,
+				3127,
+				3051,
+				1925,
+				2757,
+				3078,
+				1950,
+				3222,
+				3218,
+				3110
 			]
 		},
 		{
@@ -55323,20 +55533,20 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2643,
+				2648,
 				1785,
 				1204,
 				1530,
-				3083,
-				2820,
-				2808,
-				2798,
+				3090,
+				2825,
+				2813,
+				2803,
 				2364,
-				3162,
-				2757,
+				3169,
+				2762,
 				2530,
 				1946,
-				3041,
+				3048,
 				2479,
 				2415,
 				1915,
@@ -55345,12 +55555,12 @@
 				1458,
 				1516,
 				2627,
-				2640,
-				2636,
+				2645,
+				2641,
 				1922,
-				3173,
-				3080,
-				2811,
+				3180,
+				3087,
+				2816,
 				21,
 				28
 			]
@@ -55359,11 +55569,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3172,
-				2781,
-				2785,
-				2782,
-				2793
+				3179,
+				2786,
+				2790,
+				2787,
+				2798
 			]
 		},
 		{
@@ -55380,10 +55590,10 @@
 				4,
 				7,
 				25,
-				3218,
-				3220,
+				3225,
+				3227,
 				40,
-				3051
+				3058
 			]
 		}
 	],


### PR DESCRIPTION
Jira: 
1. https://thoughtspot.atlassian.net/browse/SCAL-321088
2. https://thoughtspot.atlassian.net/browse/SCAL-318580

Changes:
- **SpotterVizConfig** — added five optional branding/label overrides (SDK 1.52.0 | ThoughtSpot Cloud 26.9.0.cl):
  - **liveboardBrandName** — custom term to replace "Liveboard"  in UI and agent responses
  - **spotterBrandName** — custom term to replace "Spotter" in agent responses
  - **insightTileBrandName** — custom term to replace "Insight tile" in the UI and agent responses
  - **insightTileViewPlanLabel** — custom label for the "View plan" insight tile menu item
  - **insightTileLoaderText** — custom loader text for insight tile
- CSS variables — added two new CustomCssVariables entries for insight tile
 --ts-var-liveboard-insight-tile-font-color
 --ts-var-liveboard-insight-tile-background