### PR TITLE
SCAL-324803 POC fix(app-embed): restore scroll after SPA back-navigation with fullHeight + navV3

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -57,10 +57,10 @@ const testUrlParams = async (viewConfig: AppViewConfig, expectedUrl: string) => 
 };
 
 // Helper function to test setIframeHeightForNonEmbedLiveboard behavior.
-// cachedHeight pre-populates the route height cache to simulate a return visit.
+// cachedHeight pre-seeds the route height cache to simulate a return visit.
 const testSetIframeHeightBehavior = (
     currentPath: string,
-    shouldBeCalled: boolean,
+    expectedHeight: number | null,
     cachedHeight?: number,
 ) => {
     const appEmbed = new AppEmbed(getRootEl(), {
@@ -80,10 +80,10 @@ const testSetIframeHeightBehavior = (
         type: 'Route',
     });
 
-    if (shouldBeCalled) {
-        expect(spySetIFrameHeight).toHaveBeenCalled();
-    } else {
+    if (expectedHeight === null) {
         expect(spySetIFrameHeight).not.toHaveBeenCalled();
+    } else {
+        expect(spySetIFrameHeight).toHaveBeenCalledWith(expectedHeight);
     }
 };
 
@@ -2216,27 +2216,21 @@ describe('App embed tests', () => {
         });
 
         test('should not call setIFrameHeight if currentPath starts with "/embed/viz/"', () => {
-            testSetIframeHeightBehavior('/embed/viz/', false);
+            testSetIframeHeightBehavior('/embed/viz/', null);
         });
 
         test('should not call setIFrameHeight if currentPath starts with "/embed/insights/viz/"', () => {
-            testSetIframeHeightBehavior('/embed/insights/viz/', false);
+            testSetIframeHeightBehavior('/embed/insights/viz/', null);
         });
 
-        test('should call setIFrameHeight with default height on first visit (no cache)', () => {
-            testSetIframeHeightBehavior('/home', true);
+        test('should call setIFrameHeight with frameHeight on first visit (no cache)', () => {
+            // No cache → falls back to frameParams.height (720 from defaultViewConfig)
+            testSetIframeHeightBehavior('/home', 720);
         });
 
-        test('should call setIFrameHeight with cached height on return visit (scroll-lock fix)', () => {
-            // Returning to a page whose height is cached restores the correct
-            // height immediately, even if the SPA does not re-emit EmbedHeight.
-            testSetIframeHeightBehavior('/home', true, 1000);
-        });
-
-        test('should call setIFrameHeight with cached height for shorter page (height-bloat fix)', () => {
-            // Returning to a 1000px page after visiting a 2500px page must
-            // set 1000px, not stay at 2500px.
-            testSetIframeHeightBehavior('/home', true, 1000);
+        test('should restore cached height on return visit (scroll-lock + height-bloat fix)', () => {
+            // Page was previously at 1000px; returning must set 1000px not 2500px
+            testSetIframeHeightBehavior('/home', 1000, 1000);
         });
 
         test('should update iframe height correctly', async () => {

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -57,30 +57,24 @@ const testUrlParams = async (viewConfig: AppViewConfig, expectedUrl: string) => 
 };
 
 // Helper function to test setIframeHeightForNonEmbedLiveboard behavior.
-// previousPath simulates a prior navigation; height is only reset when
-// arriving at a non-liveboard page FROM a liveboard page.
+// cachedHeight pre-populates the route height cache to simulate a return visit.
 const testSetIframeHeightBehavior = (
     currentPath: string,
     shouldBeCalled: boolean,
-    previousPath?: string,
+    cachedHeight?: number,
 ) => {
     const appEmbed = new AppEmbed(getRootEl(), {
         ...defaultViewConfig,
         fullHeight: true,
     } as AppViewConfig) as any;
 
-    const spySetIFrameHeight = shouldBeCalled
-        ? jest.spyOn(appEmbed, 'setIFrameHeight').mockImplementation(jest.fn())
-        : jest.spyOn(appEmbed, 'setIFrameHeight');
+    if (cachedHeight !== undefined) {
+        appEmbed.routeHeightCache.set(currentPath, cachedHeight);
+    }
+
+    const spySetIFrameHeight = jest.spyOn(appEmbed, 'setIFrameHeight').mockImplementation(jest.fn());
 
     appEmbed.render();
-    if (previousPath !== undefined) {
-        appEmbed.setIframeHeightForNonEmbedLiveboard({
-            data: { currentPath: previousPath },
-            type: 'Route',
-        });
-        spySetIFrameHeight.mockClear();
-    }
     appEmbed.setIframeHeightForNonEmbedLiveboard({
         data: { currentPath },
         type: 'Route',
@@ -2229,17 +2223,20 @@ describe('App embed tests', () => {
             testSetIframeHeightBehavior('/embed/insights/viz/', false);
         });
 
-        test('should not call setIFrameHeight for non-liveboard to non-liveboard navigation', () => {
-            // A→B→A: no reset on return, EmbedHeight drives height
-            testSetIframeHeightBehavior('/some/other/path/', false, '/home');
+        test('should call setIFrameHeight with default height on first visit (no cache)', () => {
+            testSetIframeHeightBehavior('/home', true);
         });
 
-        test('should call setIFrameHeight when navigating from a liveboard to a non-liveboard page', () => {
-            testSetIframeHeightBehavior('/some/other/path/', true, '/liveboard/abc-123');
+        test('should call setIFrameHeight with cached height on return visit (scroll-lock fix)', () => {
+            // Returning to a page whose height is cached restores the correct
+            // height immediately, even if the SPA does not re-emit EmbedHeight.
+            testSetIframeHeightBehavior('/home', true, 1000);
         });
 
-        test('should not call setIFrameHeight on first navigation with no prior route', () => {
-            testSetIframeHeightBehavior('/some/other/path/', false);
+        test('should call setIFrameHeight with cached height for shorter page (height-bloat fix)', () => {
+            // Returning to a 1000px page after visiting a 2500px page must
+            // set 1000px, not stay at 2500px.
+            testSetIframeHeightBehavior('/home', true, 1000);
         });
 
         test('should update iframe height correctly', async () => {

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -56,10 +56,13 @@ const testUrlParams = async (viewConfig: AppViewConfig, expectedUrl: string) => 
     });
 };
 
-// Helper function to test setIframeHeightForNonEmbedLiveboard behavior
+// Helper function to test setIframeHeightForNonEmbedLiveboard behavior.
+// previousPath simulates a prior navigation; height is only reset when
+// arriving at a non-liveboard page FROM a liveboard page.
 const testSetIframeHeightBehavior = (
     currentPath: string,
-    shouldBeCalled: boolean
+    shouldBeCalled: boolean,
+    previousPath?: string,
 ) => {
     const appEmbed = new AppEmbed(getRootEl(), {
         ...defaultViewConfig,
@@ -71,6 +74,13 @@ const testSetIframeHeightBehavior = (
         : jest.spyOn(appEmbed, 'setIFrameHeight');
 
     appEmbed.render();
+    if (previousPath !== undefined) {
+        appEmbed.setIframeHeightForNonEmbedLiveboard({
+            data: { currentPath: previousPath },
+            type: 'Route',
+        });
+        spySetIFrameHeight.mockClear();
+    }
     appEmbed.setIframeHeightForNonEmbedLiveboard({
         data: { currentPath },
         type: 'Route',
@@ -2219,8 +2229,17 @@ describe('App embed tests', () => {
             testSetIframeHeightBehavior('/embed/insights/viz/', false);
         });
 
-        test('should call setIFrameHeight if currentPath starts with "/some/other/path/"', () => {
-            testSetIframeHeightBehavior('/some/other/path/', true);
+        test('should not call setIFrameHeight for non-liveboard to non-liveboard navigation', () => {
+            // A→B→A: no reset on return, EmbedHeight drives height
+            testSetIframeHeightBehavior('/some/other/path/', false, '/home');
+        });
+
+        test('should call setIFrameHeight when navigating from a liveboard to a non-liveboard page', () => {
+            testSetIframeHeightBehavior('/some/other/path/', true, '/liveboard/abc-123');
+        });
+
+        test('should not call setIFrameHeight on first navigation with no prior route', () => {
+            testSetIframeHeightBehavior('/some/other/path/', false);
         });
 
         test('should update iframe height correctly', async () => {

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -922,6 +922,8 @@ export class AppEmbed extends V1Embed {
 
     private defaultHeight = 500;
 
+    private previousRoutePath: string | null = null;
+
     private lazyLoadScrollContainers: HTMLElement[] = [];
 
     private lazyLoadResizeObserver: ResizeObserver | undefined;
@@ -1336,12 +1338,32 @@ export class AppEmbed extends V1Embed {
             '/import-tsl/PINBOARD_ANSWER_BOOK/',
         ];
 
-        if (liveboardRelatedRoutes.some((path) => data.data.currentPath.startsWith(path))) {
+        const currentPath = data.data.currentPath;
+
+        if (liveboardRelatedRoutes.some((path) => currentPath.startsWith(path))) {
             // Ignore the height reset of the frame, if the navigation is
             // only within the liveboard page.
+            this.previousRoutePath = currentPath;
             return;
         }
-        this.setIFrameHeight(frameHeight || this.defaultHeight);
+
+        // Only reset iframe height when navigating away FROM a liveboard route.
+        // For non-liveboard → non-liveboard transitions, skip the reset and let
+        // EmbedHeight events drive the height. Without this guard, SPA navigation
+        // (navV3) returning to a cached page never re-emits EmbedHeight (the
+        // ResizeObserver inside the iframe only fires on actual size changes), so
+        // the iframe stays permanently at the reset height and scroll breaks.
+        const comingFromLiveboard =
+            this.previousRoutePath !== null &&
+            liveboardRelatedRoutes.some((path) =>
+                this.previousRoutePath.startsWith(path),
+            );
+
+        this.previousRoutePath = currentPath;
+
+        if (comingFromLiveboard) {
+            this.setIFrameHeight(frameHeight || this.defaultHeight);
+        }
     };
 
     /**

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -922,7 +922,9 @@ export class AppEmbed extends V1Embed {
 
     private defaultHeight = 500;
 
-    private previousRoutePath: string | null = null;
+    private currentRoutePath: string | null = null;
+
+    private routeHeightCache: Map<string, number> = new Map();
 
     private lazyLoadScrollContainers: HTMLElement[] = [];
 
@@ -1314,7 +1316,11 @@ export class AppEmbed extends V1Embed {
      * @param data The event payload
      */
     protected updateIFrameHeight = (data: MessagePayload) => {
-        this.setIFrameHeight(Math.max(data.data, this.defaultHeight));
+        const height = Math.max(data.data, this.defaultHeight);
+        this.setIFrameHeight(height);
+        if (this.currentRoutePath) {
+            this.routeHeightCache.set(this.currentRoutePath, height);
+        }
         this.sendFullHeightLazyLoadData();
     };
 
@@ -1343,27 +1349,26 @@ export class AppEmbed extends V1Embed {
         if (liveboardRelatedRoutes.some((path) => currentPath.startsWith(path))) {
             // Ignore the height reset of the frame, if the navigation is
             // only within the liveboard page.
-            this.previousRoutePath = currentPath;
+            this.currentRoutePath = currentPath;
             return;
         }
 
-        // Only reset iframe height when navigating away FROM a liveboard route.
-        // For non-liveboard → non-liveboard transitions, skip the reset and let
-        // EmbedHeight events drive the height. Without this guard, SPA navigation
-        // (navV3) returning to a cached page never re-emits EmbedHeight (the
-        // ResizeObserver inside the iframe only fires on actual size changes), so
-        // the iframe stays permanently at the reset height and scroll breaks.
-        const comingFromLiveboard =
-            this.previousRoutePath !== null &&
-            liveboardRelatedRoutes.some((path) =>
-                this.previousRoutePath.startsWith(path),
-            );
+        this.currentRoutePath = currentPath;
 
-        this.previousRoutePath = currentPath;
-
-        if (comingFromLiveboard) {
-            this.setIFrameHeight(frameHeight || this.defaultHeight);
-        }
+        // Restore the previously observed height for this route, or fall back
+        // to the configured frame height / default. This prevents two issues:
+        //
+        // 1. Scroll lock on SPA back-navigation (navV3): returning to a cached
+        //    page does not trigger the TS app's ResizeObserver, so EmbedHeight
+        //    is never re-emitted. Without a cache, a blind reset to 500 px
+        //    would leave the iframe permanently too short.
+        //
+        // 2. Height bloat: when going from a taller page to a shorter page, the
+        //    cached height for the shorter route ensures the iframe shrinks
+        //    immediately rather than waiting for EmbedHeight, which may not
+        //    arrive if the SPA page was already rendered at that height.
+        const cachedHeight = this.routeHeightCache.get(currentPath);
+        this.setIFrameHeight(cachedHeight ?? frameHeight ?? this.defaultHeight);
     };
 
     /**

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1318,6 +1318,15 @@ export class AppEmbed extends V1Embed {
     protected updateIFrameHeight = (data: MessagePayload) => {
         const height = Math.max(data.data, this.defaultHeight);
         this.setIFrameHeight(height);
+        // On the first load, RouteChange has not fired yet (useUpdateEffect in
+        // the TS app skips the initial render). Derive the path from the iframe
+        // src so the cache is populated even for the landing page.
+        if (!this.currentRoutePath && this.iFrame?.src) {
+            const hashIndex = this.iFrame.src.indexOf('#/');
+            if (hashIndex !== -1) {
+                this.currentRoutePath = this.iFrame.src.slice(hashIndex + 1);
+            }
+        }
         if (this.currentRoutePath) {
             this.routeHeightCache.set(this.currentRoutePath, height);
         }
@@ -1355,18 +1364,13 @@ export class AppEmbed extends V1Embed {
 
         this.currentRoutePath = currentPath;
 
-        // Restore the previously observed height for this route, or fall back
-        // to the configured frame height / default. This prevents two issues:
-        //
-        // 1. Scroll lock on SPA back-navigation (navV3): returning to a cached
-        //    page does not trigger the TS app's ResizeObserver, so EmbedHeight
-        //    is never re-emitted. Without a cache, a blind reset to 500 px
-        //    would leave the iframe permanently too short.
-        //
-        // 2. Height bloat: when going from a taller page to a shorter page, the
-        //    cached height for the shorter route ensures the iframe shrinks
-        //    immediately rather than waiting for EmbedHeight, which may not
-        //    arrive if the SPA page was already rendered at that height.
+        // Use the last known height for this route if available.
+        // - Prevents scroll lock: returning to a cached SPA page (navV3) never
+        //   re-triggers the TS app's ResizeObserver, so EmbedHeight is not
+        //   re-emitted. The cache restores the correct height immediately.
+        // - Prevents height bloat: navigating from a taller page (2500px) to
+        //   a shorter one (1000px) restores 1000px from cache instead of
+        //   leaving the iframe at 2500px.
         const cachedHeight = this.routeHeightCache.get(currentPath);
         this.setIFrameHeight(cachedHeight ?? frameHeight ?? this.defaultHeight);
     };


### PR DESCRIPTION
## Summary

Fixes scroll locking in full-app embed when `fullHeight: true` and navV3
are enabled, and the user navigates Page A → Page B → Page A.
