### PR TITLE
SCAL-326328 Fixed Flag is not passing when preRender when is true in full app emebd

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -2533,3 +2533,72 @@ describe('AppEmbed visualOverrides tests', () => {
         await testVisualOverridesInEmbed(appEmbed, visualOverrides);
     });
 });
+
+describe('AppEmbed getEmbedParamsObject', () => {
+    beforeEach(() => {
+        cleanUp();
+        jest.spyOn(TsEmbed.prototype as any, 'getAppInitData').mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('getEmbedParams should use getEmbedParamsObject internally', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: true,
+        } as AppViewConfig);
+
+        const getEmbedParamsObjectSpy = jest.spyOn(appEmbed as any, 'getEmbedParamsObject');
+
+        await appEmbed.render();
+
+        expect(getEmbedParamsObjectSpy).toHaveBeenCalled();
+    });
+
+    test('getEmbedParamsObject should contain isFullHeightPinboard when fullHeight is true', () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: true,
+        } as AppViewConfig);
+
+        const params = (appEmbed as any).getEmbedParamsObject();
+
+        expect(params.isFullHeightPinboard).toBe(true);
+        expect(params.fullHeight).toBeUndefined();
+    });
+
+    test('getEmbedParamsObject should not contain isFullHeightPinboard when fullHeight is false', () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: false,
+        } as AppViewConfig);
+
+        const params = (appEmbed as any).getEmbedParamsObject();
+
+        expect(params.isFullHeightPinboard).toBeUndefined();
+    });
+
+    test('getUpdateEmbedParamsObject should contain isFullHeightPinboard when fullHeight is true', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: true,
+        } as AppViewConfig);
+
+        const params = await (appEmbed as any).getUpdateEmbedParamsObject();
+
+        expect(params.isFullHeightPinboard).toBe(true);
+    });
+
+    test('getUpdateEmbedParamsObject should not contain isFullHeightPinboard when fullHeight is false', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: false,
+        } as AppViewConfig);
+
+        const params = await (appEmbed as any).getUpdateEmbedParamsObject();
+
+        expect(params.isFullHeightPinboard).toBeUndefined();
+    });
+});

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -989,6 +989,11 @@ export class AppEmbed extends V1Embed {
      * embedded Liveboard or visualization.
      */
     protected getEmbedParams() {
+        const params = this.getEmbedParamsObject();
+        return getQueryParamString(params, true);
+    }
+
+    protected getEmbedParamsObject() {
         const {
             tag,
             hideTagFilterChips,
@@ -1282,9 +1287,7 @@ export class AppEmbed extends V1Embed {
             }
         }
 
-        const queryParams = getQueryParamString(params, true);
-
-        return queryParams;
+        return params;
     }
 
     private sendFullHeightLazyLoadData = () => {


### PR DESCRIPTION
**Root Cause**

`AppEmbed` only overrode `getEmbedParams()` (returns a **string**), not `getEmbedParamsObject()` (returns an **object**).

The prerender path calls `getUpdateEmbedParamsObject()` → `this.getEmbedParamsObject()`. Since `AppEmbed` never overrode `getEmbedParamsObject()`, it fell back to the base class which has no fullHeight logic — so `isFullHeightPinboard` was never set in `UpdateEmbedParams`.

`LiveboardEmbed` was fine because it already overrode `getEmbedParamsObject()`.

**Fix**

Split `AppEmbed.getEmbedParams()` into:
- `getEmbedParamsObject()` — builds and returns the params object (with `Param.fullHeight` → `isFullHeightPinboard`)
- `getEmbedParams()` — calls `getEmbedParamsObject()` and converts to query string

Now both the normal render path (`getEmbedParams`) and the prerender path (`getUpdateEmbedParamsObject` → `getEmbedParamsObject`) go through the same function, so `isFullHeightPinboard` is correctly populated in both cases.