### PR TITLE
SCAL-326416: remove radiant icon id fields from Spotter embed config

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -770,6 +770,45 @@ describe('App embed tests', () => {
         });
     });
 
+    test('should forward spotterChatPinConfig nested in spotterSidebarConfig in APP_INIT', async () => {
+        const spotterChatPinConfig = {
+            enabled: true,
+            pinLabel: 'Pin to top',
+            unpinLabel: 'Unpin',
+        };
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+                spotterChatPinConfig,
+            },
+        } as AppViewConfig);
+
+        mockMessageChannel();
+        appEmbed.render();
+
+        const mockPort: any = { postMessage: jest.fn() };
+        await executeAfterWait(() => {
+            postMessageToParent(
+                getIFrameEl().contentWindow,
+                { type: EmbedEvent.APP_INIT, data: {} },
+                mockPort,
+            );
+        });
+        await executeAfterWait(() => {
+            expect(mockPort.postMessage).toHaveBeenCalledWith({
+                type: EmbedEvent.APP_INIT,
+                data: expect.objectContaining({
+                    embedParams: expect.objectContaining({
+                        spotterSidebarConfig: expect.objectContaining({
+                            spotterChatPinConfig,
+                        }),
+                    }),
+                }),
+            });
+        });
+    });
+
     test('should include spotterShareConversationConfig in APP_INIT embedParams when provided', async () => {
         const spotterShareConversationConfig = {
             enableShareConversation: true,

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -775,7 +775,6 @@ describe('App embed tests', () => {
             enableShareConversation: true,
             spotterShareLabel: 'Share',
             spotterShareModalTitle: 'Share conversation',
-            spotterShareIcon: 'share',
         };
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -741,12 +741,11 @@ describe('SpotterEmbed APP_INIT embedParams', () => {
         });
     });
 
-    it('should pass spotterShareConversationConfig label/icon overrides through embedParams', async () => {
+    it('should pass spotterShareConversationConfig label overrides through embedParams', async () => {
         const spotterShareConversationConfig = {
             enableShareConversation: true,
             spotterShareLabel: 'Share',
             spotterShareModalTitle: 'Share conversation',
-            spotterShareIcon: 'share',
         };
         const response = await getAppInitResponse({
             worksheetId: 'ws1',

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -649,6 +649,24 @@ describe('SpotterEmbed APP_INIT embedParams', () => {
         });
     });
 
+    it('should forward spotterChatPinConfig nested in spotterSidebarConfig', async () => {
+        const spotterChatPinConfig = {
+            enabled: true,
+            pinLabel: 'Pin to top',
+            unpinLabel: 'Unpin',
+        };
+        const response = await getAppInitResponse({
+            worksheetId: 'ws1',
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+                spotterChatPinConfig,
+            },
+        });
+        expect(
+            response.data.embedParams.spotterSidebarConfig.spotterChatPinConfig,
+        ).toEqual(spotterChatPinConfig);
+    });
+
     it('should populate enablePastConversationsSidebar from deprecated standalone flag', async () => {
         const response = await getAppInitResponse({
             worksheetId: 'ws1',

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -28,7 +28,7 @@ export enum SpotterQueryMode {
  * Grouped into one object because pin exposes several related settings
  * (enable + label overrides), unlike single-item actions like rename or
  * delete.
- * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
  */
 export interface SpotterChatPinConfig {
     /**
@@ -37,20 +37,20 @@ export interface SpotterChatPinConfig {
      * the pin glyph are hidden and the PinSpotterConversation /
      * UnpinSpotterConversation host events are no-ops. Native (non-embedded)
      * Spotter is unaffected and ships pin enabled.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @default false
      */
     enabled?: boolean;
     /**
      * Custom label text for the pin action in the conversation edit menu.
      * Defaults to translated "Pin" text.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     pinLabel?: string;
     /**
      * Custom label text for the unpin action in the conversation edit menu.
      * Defaults to translated "Unpin" text.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     unpinLabel?: string;
 }
@@ -95,7 +95,7 @@ export interface SpotterSidebarViewConfig {
     /**
      * Pin/unpin conversation feature config (enable + label overrides).
      * Off by default in embed — hosts opt in via `enabled`.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     spotterChatPinConfig?: SpotterChatPinConfig;
     /**

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -26,7 +26,7 @@ export enum SpotterQueryMode {
 /**
  * Configuration for the pin/unpin conversation feature in the Spotter sidebar.
  * Grouped into one object because pin exposes several related settings
- * (enable + label/icon overrides), unlike single-item actions like rename or
+ * (enable + label overrides), unlike single-item actions like rename or
  * delete.
  * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
  */
@@ -53,12 +53,6 @@ export interface SpotterChatPinConfig {
      * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     unpinLabel?: string;
-    /**
-     * Custom icon for the pin glyph and the pin menu item. Accepts an icon id
-     * from the icon sprite. Defaults to the built-in PIN icon.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
-     */
-    icon?: string;
 }
 
 /**
@@ -99,7 +93,7 @@ export interface SpotterSidebarViewConfig {
      */
     spotterChatDeleteLabel?: string;
     /**
-     * Pin/unpin conversation feature config (enable + label/icon overrides).
+     * Pin/unpin conversation feature config (enable + label overrides).
      * Off by default in embed — hosts opt in via `enabled`.
      * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
@@ -232,18 +226,6 @@ export interface SpotterShareConversationConfig {
      * @default "Exit"
      */
     spotterSharedConversationExitLabel?: string;
-    /**
-     * Share icon id (radiant IconID string).
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
-     * @default "share"
-     */
-    spotterShareIcon?: string;
-    /**
-     * Empty-state group icon id (radiant IconID string).
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
-     * @default "userGroup"
-     */
-    spotterShareGroupIcon?: string;
 }
 
 /**

--- a/src/embed/events.spec.ts
+++ b/src/embed/events.spec.ts
@@ -82,6 +82,46 @@ describe('test communication between host app and ThoughtSpot', () => {
         });
     });
 
+    test('should trigger PinSpotterConversation host event to ThoughtSpot app', async () => {
+        mockMessageChannel();
+        const appEmbed = new AppEmbed(getRootEl(), defaultViewConfig);
+        await appEmbed.render();
+        const iframe = getIFrameEl();
+        jest.spyOn(iframe.contentWindow, 'postMessage');
+        await executeAfterWait(() => {
+            appEmbed.trigger(HostEvent.PinSpotterConversation, {
+                conversationId: 'c1',
+            });
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: HostEvent.PinSpotterConversation,
+                }),
+                expect.anything(),
+                expect.anything(),
+            );
+        });
+    });
+
+    test('should trigger UnpinSpotterConversation host event to ThoughtSpot app', async () => {
+        mockMessageChannel();
+        const appEmbed = new AppEmbed(getRootEl(), defaultViewConfig);
+        await appEmbed.render();
+        const iframe = getIFrameEl();
+        jest.spyOn(iframe.contentWindow, 'postMessage');
+        await executeAfterWait(() => {
+            appEmbed.trigger(HostEvent.UnpinSpotterConversation, {
+                conversationId: 'c1',
+            });
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: HostEvent.UnpinSpotterConversation,
+                }),
+                expect.anything(),
+                expect.anything(),
+            );
+        });
+    });
+
     // TODO: enable test once we are actually able to load stuff in the iframe
     xtest('should trigger iframe load event', async () => {
         const onLoadSpy = jest.fn();
@@ -511,6 +551,8 @@ describe('EmbedEvent basic routing', () => {
         ['SpotterConversationRenamed', EmbedEvent.SpotterConversationRenamed],
         ['SpotterConversationDeleted', EmbedEvent.SpotterConversationDeleted],
         ['SpotterConversationSelected', EmbedEvent.SpotterConversationSelected],
+        ['SpotterConversationPinned', EmbedEvent.SpotterConversationPinned],
+        ['SpotterConversationUnpinned', EmbedEvent.SpotterConversationUnpinned],
         ['EmbedPageContextChanged', EmbedEvent.EmbedPageContextChanged],
         ['Subscribed', EmbedEvent.Subscribed],
         ['SendTestScheduleEmail', EmbedEvent.SendTestScheduleEmail],

--- a/src/embed/spotter-utils.spec.ts
+++ b/src/embed/spotter-utils.spec.ts
@@ -128,7 +128,7 @@ describe('buildSpotterShareConversationAppInitData', () => {
         });
     });
 
-    it('passes label/icon override fields through untouched', () => {
+    it('passes label override fields through untouched', () => {
         const spotterShareConversationConfig = {
             enableShareConversation: true,
             spotterShareLabel: 'Share',
@@ -141,7 +141,6 @@ describe('buildSpotterShareConversationAppInitData', () => {
             spotterShareIncludeNewMessagesLabel: 'Include new messages',
             spotterShareUpToCurrentLabel: 'Share up to current moment',
             spotterShareStaleInfoLabel: 'This snapshot may be stale',
-            spotterShareIcon: 'share',
         };
         const result = buildSpotterShareConversationAppInitData(base, {
             spotterShareConversationConfig,

--- a/src/embed/spotter-utils.spec.ts
+++ b/src/embed/spotter-utils.spec.ts
@@ -40,6 +40,22 @@ describe('buildSpotterSidebarAppInitData', () => {
         });
     });
 
+    it('forwards a nested spotterChatPinConfig object through untouched', () => {
+        const spotterChatPinConfig = {
+            enabled: true,
+            pinLabel: 'Pin to top',
+            unpinLabel: 'Unpin',
+        };
+        const result = buildSpotterSidebarAppInitData(base, {
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+                spotterChatPinConfig,
+            },
+        }, noopError);
+        expect(result.embedParams?.spotterSidebarConfig?.spotterChatPinConfig)
+            .toEqual(spotterChatPinConfig);
+    });
+
     it('promotes standalone flag into spotterSidebarConfig.enablePastConversationsSidebar', () => {
         const result = buildSpotterSidebarAppInitData(base, { enablePastConversationsSidebar: true }, noopError);
         expect(result.embedParams?.spotterSidebarConfig?.enablePastConversationsSidebar).toBe(true);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3880,7 +3880,7 @@ export enum EmbedEvent {
     SpotterSharedConversationExitButtonClicked = 'spotterSharedConversationExitButtonClicked',
     /**
      * Emitted when a Spotter conversation is pinned.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * spotterEmbed.on(EmbedEvent.SpotterConversationPinned, (payload) => {
@@ -3892,7 +3892,7 @@ export enum EmbedEvent {
     SpotterConversationPinned = 'spotterConversationPinned',
     /**
      * Emitted when a Spotter conversation is unpinned.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * spotterEmbed.on(EmbedEvent.SpotterConversationUnpinned, (payload) => {
@@ -6270,7 +6270,7 @@ export enum HostEvent {
      * instance. Contact your admin or ThoughtSpot Support to enable chat history on your
      * instance.
      *
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * spotterEmbed.trigger(HostEvent.PinSpotterConversation, {
@@ -6288,7 +6288,7 @@ export enum HostEvent {
      * instance. Contact your admin or ThoughtSpot Support to enable chat history on your
      * instance.
      *
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * spotterEmbed.trigger(HostEvent.UnpinSpotterConversation, {
@@ -8290,7 +8290,7 @@ export enum Action {
     /**
      * Controls visibility and disable state of the pin/unpin action
      * in the Spotter conversation edit menu.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * disabledActions: [Action.SpotterChatPin]


### PR DESCRIPTION
Removes three icon-id config fields from the Spotter embed surface: `SpotterChatPinConfig.icon`, `spotterShareIcon`, `spotterShareGroupIcon`.

Radiant icon ids are internal and unpublished, so hosts have no way to discover valid values. Icon overrides already work via `customizations.iconSpriteUrl` ([customize-icons](https://developers.thoughtspot.com/docs/customize-icons)), which needs no per-feature config.