### PR TITLE
SCAL-325090 Add PreRenderConfig to control iframe z-index

### DIFF
--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -1282,6 +1282,44 @@ describe('Liveboard/viz embed tests', () => {
             expect(onSpy).toHaveBeenCalledWith(HostEvent.Navigate, 'embed/viz/lb1/viz1');
         }, 1002);
     });
+
+    test('navigateToLiveboard should call preRender when preRenderConfig.preRenderId is set', () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            preRenderConfig: {
+                preRenderId: 'config-pre-render-id',
+            },
+        } as LiveboardViewConfig);
+
+        const preRenderSpy = jest
+            .spyOn(liveboardEmbed, 'preRender')
+            .mockResolvedValue(liveboardEmbed);
+        liveboardEmbed.navigateToLiveboard('lb1');
+
+        expect(preRenderSpy).toHaveBeenCalledTimes(1);
+        expect(preRenderSpy).toHaveBeenCalledWith(true);
+    });
+
+    test('navigateToLiveboard should prefer preRenderConfig.preRenderId over top-level preRenderId', () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            preRenderId: 'top-level-id',
+            preRenderConfig: {
+                preRenderId: 'config-level-id',
+            },
+        } as LiveboardViewConfig);
+
+        const preRenderSpy = jest
+            .spyOn(liveboardEmbed, 'preRender')
+            .mockResolvedValue(liveboardEmbed);
+        liveboardEmbed.navigateToLiveboard('lb1');
+
+        expect(preRenderSpy).toHaveBeenCalledTimes(1);
+        expect(preRenderSpy).toHaveBeenCalledWith(true);
+    });
+
     test('should set runtime parametere values in url params', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -1240,7 +1240,7 @@ export class LiveboardEmbed extends V1Embed {
         this.viewConfig.personalizedViewId = personalizedViewId;
         if (this.isRendered) {
             this.trigger(HostEvent.Navigate, path.substring(1));
-        } else if (this.viewConfig.preRenderId) {
+        } else if (this.getPreRenderConfig().preRenderId) {
             this.preRender(true);
         } else {
             this.render();

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -3028,6 +3028,235 @@ describe('Unit test case for ts embed', () => {
                 libEmbed.destroy();
             });
         });
+
+        describe('preRenderConfig', () => {
+            beforeEach(() => {
+                (window as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+                    disconnect: jest.fn(),
+                    observe: jest.fn(),
+                    unobserve: jest.fn(),
+                }));
+            });
+
+            it('should use default z-index of -1000 when preRenderConfig is not set', async () => {
+                createRootEleForEmbed();
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    preRenderId: 'pre-render-config-defaults',
+                    liveboardId: 'myLiveboardId',
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                const preRenderWrapper = document.getElementById(preRenderIds.wrapper);
+
+                expect(preRenderWrapper.style.zIndex).toBe('-1000');
+
+                libEmbed.destroy();
+            });
+
+            it('should apply custom zIndex from preRenderConfig when hidden', async () => {
+                createRootEleForEmbed();
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    preRenderId: 'pre-render-config-custom-z-index',
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: {
+                        zIndex: -10,
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                const preRenderWrapper = document.getElementById(preRenderIds.wrapper);
+
+                expect(preRenderWrapper.style.zIndex).toBe('-10');
+
+                libEmbed.destroy();
+            });
+
+            it('should clear z-index on showPreRender and restore custom zIndex on hidePreRender', async () => {
+                createRootEleForEmbed();
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    preRenderId: 'pre-render-config-cycle',
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: {
+                        zIndex: -5,
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                const preRenderWrapper = document.getElementById(preRenderIds.wrapper);
+
+                expect(preRenderWrapper.style.zIndex).toBe('-5');
+
+                libEmbed.showPreRender();
+                expect(preRenderWrapper.style.zIndex).toBe('');
+
+                libEmbed.hidePreRender();
+                expect(preRenderWrapper.style.zIndex).toBe('-5');
+
+                libEmbed.destroy();
+            });
+
+            it('should use preRenderConfig.preRenderId to identify the pre-render instance', async () => {
+                createRootEleForEmbed();
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: {
+                        preRenderId: 'config-level-id',
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                expect(preRenderIds.wrapper).toContain('config-level-id');
+                expect(document.getElementById(preRenderIds.wrapper)).not.toBeNull();
+
+                libEmbed.destroy();
+            });
+
+            it('should prefer preRenderConfig.preRenderId over top-level preRenderId', async () => {
+                createRootEleForEmbed();
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderId: 'top-level-id',
+                    preRenderConfig: {
+                        preRenderId: 'config-level-id',
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                expect(preRenderIds.wrapper).toContain('config-level-id');
+                expect(preRenderIds.wrapper).not.toContain('top-level-id');
+
+                libEmbed.destroy();
+            });
+
+            it('should mount the wrapper into preRenderConfig.preRenderContainer', async () => {
+                createRootEleForEmbed();
+                const customContainer = document.createElement('div');
+                customContainer.id = 'config-level-container';
+                document.body.appendChild(customContainer);
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: {
+                        preRenderId: 'container-via-config',
+                        preRenderContainer: '#config-level-container',
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                const preRenderWrapper = document.getElementById(preRenderIds.wrapper);
+                expect(customContainer.contains(preRenderWrapper)).toBe(true);
+
+                libEmbed.destroy();
+                customContainer.remove();
+            });
+
+            it('should prefer preRenderConfig.preRenderContainer over top-level preRenderContainer', async () => {
+                createRootEleForEmbed();
+                const topContainer = document.createElement('div');
+                topContainer.id = 'top-level-container';
+                document.body.appendChild(topContainer);
+                const configContainer = document.createElement('div');
+                configContainer.id = 'config-level-container-2';
+                document.body.appendChild(configContainer);
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderContainer: '#top-level-container',
+                    preRenderConfig: {
+                        preRenderId: 'container-precedence',
+                        preRenderContainer: '#config-level-container-2',
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+
+                const preRenderIds = libEmbed.getPreRenderIds();
+                const preRenderWrapper = document.getElementById(preRenderIds.wrapper);
+                expect(configContainer.contains(preRenderWrapper)).toBe(true);
+                expect(topContainer.contains(preRenderWrapper)).toBe(false);
+
+                libEmbed.destroy();
+                topContainer.remove();
+                configContainer.remove();
+            });
+
+            it('should not attach ResizeObserver when preRenderConfig.doNotTrackPreRenderSize is true', async () => {
+                createRootEleForEmbed();
+                const observeMock = jest.fn();
+                (window as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+                    disconnect: jest.fn(),
+                    observe: observeMock,
+                    unobserve: jest.fn(),
+                }));
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: {
+                        preRenderId: 'no-track-via-config',
+                        doNotTrackPreRenderSize: true,
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+                libEmbed.showPreRender();
+
+                expect(observeMock).not.toHaveBeenCalled();
+
+                libEmbed.destroy();
+            });
+
+            it('should prefer preRenderConfig.doNotTrackPreRenderSize over top-level doNotTrackPreRenderSize', async () => {
+                createRootEleForEmbed();
+                const observeMock = jest.fn();
+                (window as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+                    disconnect: jest.fn(),
+                    observe: observeMock,
+                    unobserve: jest.fn(),
+                }));
+
+                const libEmbed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    doNotTrackPreRenderSize: false,
+                    preRenderConfig: {
+                        preRenderId: 'no-track-precedence',
+                        doNotTrackPreRenderSize: true,
+                    },
+                });
+
+                await libEmbed.preRender();
+                await waitFor(() => !!getIFrameEl());
+                libEmbed.showPreRender();
+
+                expect(observeMock).not.toHaveBeenCalled();
+
+                libEmbed.destroy();
+            });
+        });
     });
 
     describe('IdleSessionTimeout embedEvent for TrustedAuthTokenCookieless authType with autoLogin true', () => {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -967,14 +967,14 @@ export class TsEmbed {
      * backward compatibility.
      */
     protected getPreRenderConfig(): PreRenderConfig {
-        const base = this.viewConfig as BaseViewConfig;
-        const cfg = base.preRenderConfig ?? {};
+        const viewCfg = this.viewConfig as BaseViewConfig;
+        const preRenderCfg = viewCfg.preRenderConfig ?? {};
         return {
-            ...cfg,
-            preRenderId: cfg.preRenderId ?? base.preRenderId,
-            preRenderContainer: cfg.preRenderContainer ?? base.preRenderContainer,
-            doNotTrackPreRenderSize: cfg.doNotTrackPreRenderSize ?? base.doNotTrackPreRenderSize,
-            zIndex: cfg.zIndex,
+            ...preRenderCfg,
+            preRenderId: preRenderCfg.preRenderId ?? viewCfg.preRenderId,
+            preRenderContainer: preRenderCfg.preRenderContainer ?? viewCfg.preRenderContainer,
+            doNotTrackPreRenderSize: preRenderCfg.doNotTrackPreRenderSize ?? viewCfg.doNotTrackPreRenderSize,
+            zIndex: preRenderCfg.zIndex,
         };
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -66,6 +66,8 @@ import {
     MessagePayload,
     ContextType,
     ContextObject,
+    PreRenderConfig,
+    BaseViewConfig,
 } from '../types';
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { processEventData, processAuthFailure } from '../utils/processData';
@@ -960,10 +962,27 @@ export class TsEmbed {
     }
 
     /**
+     * Returns a merged {@link PreRenderConfig} object where each shared key
+     * prefers `preRenderConfig.key` over the top-level `viewConfig.key` for
+     * backward compatibility.
+     */
+    protected getPreRenderConfig(): PreRenderConfig {
+        const base = this.viewConfig as BaseViewConfig;
+        const cfg = base.preRenderConfig ?? {};
+        return {
+            ...cfg,
+            preRenderId: cfg.preRenderId ?? base.preRenderId,
+            preRenderContainer: cfg.preRenderContainer ?? base.preRenderContainer,
+            doNotTrackPreRenderSize: cfg.doNotTrackPreRenderSize ?? base.doNotTrackPreRenderSize,
+            zIndex: cfg.zIndex,
+        };
+    }
+
+    /**
      * Returns true if this embed instance is configured for pre-rendering.
      */
     protected isPreRenderEmbed() {
-        return !!this.viewConfig.preRenderId;
+        return !!this.getPreRenderConfig().preRenderId;
     }
     protected handleInsertionIntoDOM(child: string | Node): void {
         if (this.isPreRenderEmbed()) {
@@ -1176,7 +1195,7 @@ export class TsEmbed {
      * fresh element; an element passed directly cannot be re-resolved.
      */
     private resolvePreRenderContainerTarget(): HTMLElement {
-        const containerConfig = this.viewConfig.preRenderContainer;
+        const containerConfig = this.getPreRenderConfig().preRenderContainer;
         let container: Element | null = null;
         if (typeof containerConfig === 'string') {
             try {
@@ -1797,7 +1816,7 @@ export class TsEmbed {
             showPreRenderByDefault,
             replaceExistingPreRender,
         });
-        if (!this.viewConfig.preRenderId) {
+        if (!this.getPreRenderConfig().preRenderId) {
             logger.error(ERROR_MESSAGE.PRERENDER_ID_MISSING);
             return this;
         }
@@ -1986,14 +2005,14 @@ export class TsEmbed {
      */
     public async showPreRender(): Promise<TsEmbed> {
         uploadMixpanelEvent(MIXPANEL_EVENT.VISUAL_SDK_SHOW_PRE_RENDER, {
-            preRenderId: this.viewConfig.preRenderId,
+            preRenderId: this.getPreRenderConfig().preRenderId,
             embedComponentType: this.viewConfig.embedComponentType,
         });
 
         if (this.shouldWaitForRenderPromise) await this.isReadyForRenderPromise;
 
 
-        if (!this.viewConfig.preRenderId) {
+        if (!this.getPreRenderConfig().preRenderId) {
             logger.error(ERROR_MESSAGE.PRERENDER_ID_MISSING);
             return this;
         }
@@ -2038,7 +2057,7 @@ export class TsEmbed {
                 customContainer.addEventListener('scroll', this.containerScrollListener);
             }
 
-            if (!this.viewConfig.doNotTrackPreRenderSize) {
+            if (!this.getPreRenderConfig().doNotTrackPreRenderSize) {
                 const observeTarget = (this.insertedDomEl as HTMLElement) ?? this.hostElement;
                 this.resizeObserver = new ResizeObserver((entries) => {
                     entries.forEach((entry) => {
@@ -2112,7 +2131,7 @@ export class TsEmbed {
      */
     public hidePreRender(): void {
         uploadMixpanelEvent(MIXPANEL_EVENT.VISUAL_SDK_HIDE_PRE_RENDER, {
-            preRenderId: this.viewConfig.preRenderId,
+            preRenderId: this.getPreRenderConfig().preRenderId,
             embedComponentType: this.viewConfig.embedComponentType,
         });
 
@@ -2122,10 +2141,11 @@ export class TsEmbed {
             logger.warn('PreRender should be called before hiding it using hidePreRender.');
             return;
         }
+        const { zIndex } = this.getPreRenderConfig();
         const preRenderHideStyles = {
             opacity: '0',
             pointerEvents: 'none',
-            zIndex: '-1000',
+            zIndex: zIndex !== undefined ? String(zIndex) : '-1000',
             position: 'absolute',
             top: '0',
             left: '0',
@@ -2155,10 +2175,11 @@ export class TsEmbed {
      * @property {string} child - The HTML element ID for the PreRender child.
      */
     public getPreRenderIds() {
+        const preRenderId = this.getPreRenderConfig().preRenderId;
         return {
-            wrapper: `${PRERENDER_WRAPPER_ID_PREFIX}${this.viewConfig.preRenderId}`,
-            child: `tsEmbed-pre-render-child-${this.viewConfig.preRenderId}`,
-            placeHolder: `tsEmbed-pre-render-placeholder-${this.viewConfig.preRenderId}`,
+            wrapper: `${PRERENDER_WRAPPER_ID_PREFIX}${preRenderId}`,
+            child: `tsEmbed-pre-render-child-${preRenderId}`,
+            placeHolder: `tsEmbed-pre-render-placeholder-${preRenderId}`,
         };
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -974,7 +974,6 @@ export class TsEmbed {
             preRenderId: preRenderCfg.preRenderId ?? viewCfg.preRenderId,
             preRenderContainer: preRenderCfg.preRenderContainer ?? viewCfg.preRenderContainer,
             doNotTrackPreRenderSize: preRenderCfg.doNotTrackPreRenderSize ?? viewCfg.doNotTrackPreRenderSize,
-            zIndex: preRenderCfg.zIndex,
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -898,6 +898,62 @@ export interface FrameParams {
 }
 
 /**
+ * Configuration for the pre-render wrapper element.
+ * All properties here mirror the top-level preRender properties on
+ * {@link BaseViewConfig} and take precedence over them when both are set,
+ * so existing top-level usage continues to work without any changes.
+ *
+ * @version SDK: 1.51.0
+ * @example
+ * ```js
+ * init({ thoughtSpotHost: '...', authType: AuthType.None });
+ * const embed = new LiveboardEmbed('#tsEmbed', {
+ *   preRenderConfig: {
+ *     preRenderId: 'my-liveboard',
+ *     preRenderContainer: '#my-scroll-container',
+ *     doNotTrackPreRenderSize: false,
+ *     zIndex: -10,
+ *   },
+ * });
+ * embed.preRender();
+ * embed.showPreRender();
+ * ```
+ */
+export interface PreRenderConfig {
+    /**
+     * Pre-render ID to identify the pre-render instance.
+     * Takes precedence over the top-level `preRenderId` when both are set.
+     *
+     * @default undefined
+     */
+    preRenderId?: string;
+    /**
+     * The DOM element or CSS selector string specifying the container into
+     * which the pre-rendered wrapper is inserted.
+     * Takes precedence over the top-level `preRenderContainer` when both are set.
+     *
+     * @default document.body
+     */
+    preRenderContainer?: string | HTMLElement;
+    /**
+     * Disables the `ResizeObserver` that keeps the wrapper sized to the
+     * placeholder element.
+     * Takes precedence over the top-level `doNotTrackPreRenderSize` when both are set.
+     *
+     * @default false
+     */
+    doNotTrackPreRenderSize?: boolean;
+    /**
+     * CSS `z-index` value applied to the pre-render wrapper when hidden.
+     * Override this when the host page's stacking context does not reach `-1000`
+     * and the hidden wrapper still appears above other elements.
+     *
+     * @default -1000
+     */
+    zIndex?: number;
+}
+
+/**
  * The common configuration object for an embedded view.
  */
 export interface BaseViewConfig extends ApiInterceptFlags {
@@ -1087,6 +1143,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`, `SpotterAgentEmbed`, `SpotterEmbed`, `SearchBarEmbed`
      * @version SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw
+     * @deprecated Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead.
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed
@@ -1107,6 +1164,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * @type {boolean}
      * @default false
      * @version SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw
+     * @deprecated Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead.
      * @example
      * ```js
      * // Disable tracking PreRender size in the configuration
@@ -1148,6 +1206,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      *
      * @type {string | HTMLElement}
      * @version SDK: 1.49.2 | ThoughtSpot: *
+     * @deprecated Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead.
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#tsEmbed', {
@@ -1158,6 +1217,27 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * ```
      */
     preRenderContainer?: string | HTMLElement;
+    /**
+     * Configuration for the pre-render wrapper element.
+     * All properties here mirror the top-level preRender properties on
+     * `BaseViewConfig` and take precedence over them when both are set,
+     * so existing top-level usage continues to work without any changes.
+     * See {@link PreRenderConfig} for available options.
+     *
+     * @version SDK: 1.51.0
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#tsEmbed', {
+     *   preRenderConfig: {
+     *     preRenderId: 'my-liveboard',
+     *     zIndex: -10,
+     *   },
+     * });
+     * embed.preRender();
+     * embed.showPreRender();
+     * ```
+     */
+    preRenderConfig?: PreRenderConfig;
     /**
      * Enable the V2 shell. This can provide performance benefits
      * due to a lighter-weight shell.


### PR DESCRIPTION
Introduces PreRenderConfig interface and preRenderConfig property on BaseViewConfig to group all pre-render settings into a single config object
Adds zIndex to control the hidden wrapper's CSS z-index (default -1000), fixing cases where the hidden pre-render bleeds above other page content in shallow stacking contexts
Migrates preRenderId, preRenderContainer, and doNotTrackPreRenderSize into PreRenderConfig for backward compatibility — preRenderConfig.* takes precedence when both are set, existing top-level usage continues to work unchanged
Adds @default tags and fixes tag ordering on all preRender-related JSDoc in BaseViewConfig