### PR TITLE
fix(docs): correct enum member names in SDK doc examples

### DIFF
--- a/src/embed/base.ts
+++ b/src/embed/base.ts
@@ -233,7 +233,7 @@ export const getIsInitCalled = (): boolean => !!getValueFromWindow(initFlagKey)?
 /**
  * Initializes the Visual Embed SDK globally and perform
  * authentication if applicable. This function needs to be called before any ThoughtSpot
- * component like Liveboard etc can be embedded. But need not wait for AuthEvent.SUCCESS
+ * component like Liveboard etc can be embedded. But need not wait for AuthStatus.SUCCESS
  * to actually embed. That is handled internally.
  * @param embedConfig The configuration object containing ThoughtSpot host,
  * authentication mechanism and so on.

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -448,7 +448,7 @@ type EmbedComponent = typeof SearchEmbed
  * const ref = useEmbedRef();
  * useEffect(() => {
  * ref.current.trigger(
- *  EmbedEvent.UpdateRuntimeFilter,
+ *  HostEvent.UpdateRuntimeFilters,
  *  [{ columnName: 'name', operator: 'EQ', values: ['value']}]);
  * }, [])
  * return <LiveboardEmbed ref={ref} liveboardId={<id>} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -982,7 +982,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed
      * const embed = new <EmbedComponent>('#tsEmbed', {
      *    ... // other embed view config
-     *    hiddenActions: [Action.Download, Action.Export],
+     *    hiddenActions: [Action.Download, Action.ExportTML],
      * });
      * ```
      * @important
@@ -1004,7 +1004,7 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed
      * const embed = new <EmbedComponent>('#tsEmbed', {
      *    ... // other embed view config
-     *    visibleActions: [Action.Download, Action.Export],
+     *    visibleActions: [Action.Download, Action.ExportTML],
      * });
      * ```
      */
@@ -1609,7 +1609,7 @@ export interface HomePageConfig {
      *
      * const embed = new AppEmbed('#tsEmbed', {
      *    ... //other embed view config
-     *    hiddenListColumns : [ListPageColumns.Favorite,ListPageColumns.Author],
+     *    hiddenListColumns : [ListPageColumns.Favorites,ListPageColumns.Author],
      * })
      * ```
      */
@@ -2498,7 +2498,7 @@ export enum EmbedEvent {
      * @returns nonFilteredColumns - The columns that were not filtered
      * @example
      * ```js
-     * searchEmbed.on(EmbedEvent.DrillDown, {
+     * searchEmbed.on(EmbedEvent.Drilldown, {
      *    points: {
      *        clickedPoint,
      *        selectedPoints: selectedPoint
@@ -2559,7 +2559,7 @@ export enum EmbedEvent {
      * @version SDK: 1.1.0 | ThoughtSpot: ts7.may.cl, 8.4.1.sw
      * @example
      * ```js
-     * appEmbed.on(EmbedEvent.customAction, payload => {
+     * appEmbed.on(EmbedEvent.CustomAction, payload => {
      *     const data = payload.data;
      *     if (data.id === 'insert Custom Action ID here') {
      *         console.log('Custom Action event:', data.embedAnswerData);
@@ -2827,8 +2827,8 @@ export enum EmbedEvent {
      *
      * **Note**: This event is deprecated in v1.21.0.
      * To fire an event when a download action is initiated on a chart or table,
-     * use `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPDF`,
-     * `EmbedEvent.DownloadAsCSV`, or `EmbedEvent.DownloadAsXLSX`
+     * use `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPdf`,
+     * `EmbedEvent.DownloadAsCsv`, or `EmbedEvent.DownloadAsXlsx`
      * @version SDK: 1.11.0 | ThoughtSpot: 8.3.0.cl, 8.4.1.sw
      * @example
      * ```js
@@ -2878,10 +2878,10 @@ export enum EmbedEvent {
      * @example
      * ```js
      * //emit when action starts
-     * searchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {
+     * searchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {
      *   console.log('download CSV', payload)}, {start: true })
      * //emit when action ends
-     * searchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {
+     * searchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {
      *    console.log('download CSV', payload)})
      * ```
      */
@@ -4738,13 +4738,13 @@ export enum HostEvent {
      * Trigger the **Manage schedule** action on an embedded Liveboard
      * @example
      * ```js
-     *  liveboardEmbed.trigger(HostEvent.ScheduleList)
+     *  liveboardEmbed.trigger(HostEvent.SchedulesList)
      * ```
      * @example
      * ```js
      * // Manage schedules from liveboard context
      * import { ContextType } from '@thoughtspot/visual-embed-sdk';
-     * liveboardEmbed.trigger(HostEvent.ScheduleList, {}, ContextType.Liveboard);
+     * liveboardEmbed.trigger(HostEvent.SchedulesList, {}, ContextType.Liveboard);
      * ```
      * @version SDK: 1.15.0 | ThoughtSpot: 8.7.0.cl, 8.8.1.sw
      */
@@ -9162,7 +9162,7 @@ export type ApiInterceptFlags = {
      * const embed = new LiveboardEmbed('#embed', {
      *   ...viewConfig,
      *   enableApiIntercept: true,
-     *   interceptUrls: [InterceptedApiType.DATA],
+     *   interceptUrls: [InterceptedApiType.LiveboardData],
      * })
      * ```
      *


### PR DESCRIPTION
Doc comments are the source for the public API reference and are read verbatim by code-generating consumers, so an example naming a member that does not exist ships code that will not compile. ListPageColumns.Favorite was the reported case; a sweep of every EnumName.Member reference in the comments found 11 more.

- ListPageColumns.Favorite  -> Favorites
- EmbedEvent.DrillDown      -> Drilldown
- EmbedEvent.customAction   -> CustomAction
- EmbedEvent.DownloadAsPDF  -> DownloadAsPdf
- EmbedEvent.DownloadAsCSV  -> DownloadAsCsv (x3)
- EmbedEvent.DownloadAsXLSX -> DownloadAsXlsx
- HostEvent.ScheduleList    -> SchedulesList (x2)
- Action.Export             -> ExportTML (x2)
- InterceptedApiType.DATA   -> LiveboardData
- AuthEvent.SUCCESS         -> AuthStatus.SUCCESS (wrong enum)
- useEmbedRef example: EmbedEvent.UpdateRuntimeFilter ->
  HostEvent.UpdateRuntimeFilters (wrong enum and singular member;
  trigger() takes a HostEvent)

EmbedEvent.FatalError is left as-is: it is a documented forward reference to a planned event, and is allowlisted in the new spec.

Adds src/enum-doc-references.spec.ts, which reparses the enums and fails on any doc reference to a member that does not exist.

SCAL-327608