### PR TITLE
SCAL-331314 Add --ts-var-unsaved-filter-indicator-color CSS variable

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -813,6 +813,11 @@ export interface CustomCssVariables {
     '--ts-var-parameter-chip-active-text-color'?: string;
 
     /**
+     * Color of the unsaved filter indicator dot in the centralised filter modal.
+     */
+    '--ts-var-unsaved-filter-indicator-color'?: string;
+
+    /**
      * Background color of the action button in the Liveboard header.
      */
     '--ts-var-liveboard-header-action-button-background'?: string;

--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -813,7 +813,11 @@ export interface CustomCssVariables {
     '--ts-var-parameter-chip-active-text-color'?: string;
 
     /**
-     * Color of the unsaved filter indicator dot in the centralised filter modal.
+     * Color of the dot indicator shown on a filter or parameter chip in the
+     * centralized filter modal on a Liveboard. The dot appears when the
+     * filter or parameter value has been modified but the changes are not
+     * yet applied to the Liveboard.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.10.0.cl
      */
     '--ts-var-unsaved-filter-indicator-color'?: string;
 

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -36739,7 +36739,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 943,
+							"line": 947,
 							"character": 4
 						}
 					],
@@ -36762,7 +36762,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 918,
+							"line": 922,
 							"character": 4
 						}
 					],
@@ -36785,7 +36785,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 893,
+							"line": 897,
 							"character": 4
 						}
 					],
@@ -36808,7 +36808,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 888,
+							"line": 892,
 							"character": 4
 						}
 					],
@@ -36831,7 +36831,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 903,
+							"line": 907,
 							"character": 4
 						}
 					],
@@ -36854,7 +36854,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 898,
+							"line": 902,
 							"character": 4
 						}
 					],
@@ -37452,7 +37452,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 883,
+							"line": 887,
 							"character": 4
 						}
 					],
@@ -37475,7 +37475,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 878,
+							"line": 882,
 							"character": 4
 						}
 					],
@@ -37498,7 +37498,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 873,
+							"line": 877,
 							"character": 4
 						}
 					],
@@ -37521,7 +37521,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 913,
+							"line": 917,
 							"character": 4
 						}
 					],
@@ -37544,7 +37544,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 908,
+							"line": 912,
 							"character": 4
 						}
 					],
@@ -38008,7 +38008,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1191,
+							"line": 1195,
 							"character": 4
 						}
 					],
@@ -38031,7 +38031,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1211,
+							"line": 1215,
 							"character": 4
 						}
 					],
@@ -38054,7 +38054,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1216,
+							"line": 1220,
 							"character": 4
 						}
 					],
@@ -38077,7 +38077,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1196,
+							"line": 1200,
 							"character": 4
 						}
 					],
@@ -38100,7 +38100,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1201,
+							"line": 1205,
 							"character": 4
 						}
 					],
@@ -38123,7 +38123,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1206,
+							"line": 1210,
 							"character": 4
 						}
 					],
@@ -38458,7 +38458,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 838,
+							"line": 842,
 							"character": 4
 						}
 					],
@@ -38481,7 +38481,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 823,
+							"line": 827,
 							"character": 4
 						}
 					],
@@ -38504,7 +38504,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 828,
+							"line": 832,
 							"character": 4
 						}
 					],
@@ -38527,7 +38527,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 833,
+							"line": 837,
 							"character": 4
 						}
 					],
@@ -38573,7 +38573,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 868,
+							"line": 872,
 							"character": 4
 						}
 					],
@@ -38596,7 +38596,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 843,
+							"line": 847,
 							"character": 4
 						}
 					],
@@ -38619,7 +38619,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 848,
+							"line": 852,
 							"character": 4
 						}
 					],
@@ -38642,7 +38642,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 863,
+							"line": 867,
 							"character": 4
 						}
 					],
@@ -38665,7 +38665,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 853,
+							"line": 857,
 							"character": 4
 						}
 					],
@@ -38688,7 +38688,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 858,
+							"line": 862,
 							"character": 4
 						}
 					],
@@ -38872,7 +38872,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1038,
+							"line": 1042,
 							"character": 4
 						}
 					],
@@ -38895,7 +38895,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1023,
+							"line": 1027,
 							"character": 4
 						}
 					],
@@ -38918,7 +38918,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1033,
+							"line": 1037,
 							"character": 4
 						}
 					],
@@ -38941,7 +38941,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1043,
+							"line": 1047,
 							"character": 4
 						}
 					],
@@ -38964,7 +38964,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1048,
+							"line": 1052,
 							"character": 4
 						}
 					],
@@ -38987,7 +38987,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1028,
+							"line": 1032,
 							"character": 4
 						}
 					],
@@ -39010,7 +39010,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1053,
+							"line": 1057,
 							"character": 4
 						}
 					],
@@ -39033,7 +39033,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1018,
+							"line": 1022,
 							"character": 4
 						}
 					],
@@ -39056,7 +39056,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1013,
+							"line": 1017,
 							"character": 4
 						}
 					],
@@ -39700,7 +39700,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 958,
+							"line": 962,
 							"character": 4
 						}
 					],
@@ -39723,7 +39723,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 953,
+							"line": 957,
 							"character": 4
 						}
 					],
@@ -39746,7 +39746,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 978,
+							"line": 982,
 							"character": 4
 						}
 					],
@@ -39769,7 +39769,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 983,
+							"line": 987,
 							"character": 4
 						}
 					],
@@ -39792,7 +39792,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 998,
+							"line": 1002,
 							"character": 4
 						}
 					],
@@ -39815,7 +39815,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 993,
+							"line": 997,
 							"character": 4
 						}
 					],
@@ -39838,7 +39838,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 988,
+							"line": 992,
 							"character": 4
 						}
 					],
@@ -39861,7 +39861,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1003,
+							"line": 1007,
 							"character": 4
 						}
 					],
@@ -39884,7 +39884,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 968,
+							"line": 972,
 							"character": 4
 						}
 					],
@@ -39907,7 +39907,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1008,
+							"line": 1012,
 							"character": 4
 						}
 					],
@@ -39930,7 +39930,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 963,
+							"line": 967,
 							"character": 4
 						}
 					],
@@ -39953,7 +39953,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 973,
+							"line": 977,
 							"character": 4
 						}
 					],
@@ -40298,7 +40298,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1279,
+							"line": 1283,
 							"character": 4
 						}
 					],
@@ -40321,7 +40321,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1273,
+							"line": 1277,
 							"character": 4
 						}
 					],
@@ -40344,7 +40344,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1294,
+							"line": 1298,
 							"character": 4
 						}
 					],
@@ -40367,7 +40367,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1299,
+							"line": 1303,
 							"character": 4
 						}
 					],
@@ -40390,7 +40390,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1289,
+							"line": 1293,
 							"character": 4
 						}
 					],
@@ -40413,7 +40413,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1284,
+							"line": 1288,
 							"character": 4
 						}
 					],
@@ -40436,7 +40436,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1257,
+							"line": 1261,
 							"character": 4
 						}
 					],
@@ -40459,7 +40459,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1262,
+							"line": 1266,
 							"character": 4
 						}
 					],
@@ -40482,7 +40482,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1267,
+							"line": 1271,
 							"character": 4
 						}
 					],
@@ -40505,7 +40505,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1305,
+							"line": 1309,
 							"character": 4
 						}
 					],
@@ -40528,7 +40528,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1310,
+							"line": 1314,
 							"character": 4
 						}
 					],
@@ -40574,7 +40574,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 938,
+							"line": 942,
 							"character": 4
 						}
 					],
@@ -40597,7 +40597,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 923,
+							"line": 927,
 							"character": 4
 						}
 					],
@@ -40620,7 +40620,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 928,
+							"line": 932,
 							"character": 4
 						}
 					],
@@ -40643,7 +40643,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 933,
+							"line": 937,
 							"character": 4
 						}
 					],
@@ -40666,7 +40666,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 948,
+							"line": 952,
 							"character": 4
 						}
 					],
@@ -40735,7 +40735,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1227,
+							"line": 1231,
 							"character": 4
 						}
 					],
@@ -40758,7 +40758,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1084,
+							"line": 1088,
 							"character": 4
 						}
 					],
@@ -40781,7 +40781,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1232,
+							"line": 1236,
 							"character": 4
 						}
 					],
@@ -40804,7 +40804,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1221,
+							"line": 1225,
 							"character": 4
 						}
 					],
@@ -40827,7 +40827,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1063,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -40850,7 +40850,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1073,
+							"line": 1077,
 							"character": 4
 						}
 					],
@@ -40873,7 +40873,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1078,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -40896,7 +40896,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1068,
+							"line": 1072,
 							"character": 4
 						}
 					],
@@ -40919,7 +40919,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1181,
+							"line": 1185,
 							"character": 4
 						}
 					],
@@ -40942,7 +40942,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1186,
+							"line": 1190,
 							"character": 4
 						}
 					],
@@ -40965,7 +40965,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1110,
+							"line": 1114,
 							"character": 4
 						}
 					],
@@ -40988,7 +40988,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1058,
+							"line": 1062,
 							"character": 4
 						}
 					],
@@ -41011,7 +41011,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1089,
+							"line": 1093,
 							"character": 4
 						}
 					],
@@ -41034,7 +41034,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1094,
+							"line": 1098,
 							"character": 4
 						}
 					],
@@ -41057,7 +41057,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1238,
+							"line": 1242,
 							"character": 4
 						}
 					],
@@ -41080,7 +41080,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1252,
+							"line": 1256,
 							"character": 4
 						}
 					],
@@ -41103,7 +41103,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1245,
+							"line": 1249,
 							"character": 4
 						}
 					],
@@ -41126,7 +41126,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1100,
+							"line": 1104,
 							"character": 4
 						}
 					],
@@ -41149,7 +41149,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1105,
+							"line": 1109,
 							"character": 4
 						}
 					],
@@ -41172,7 +41172,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1130,
+							"line": 1134,
 							"character": 4
 						}
 					],
@@ -41195,7 +41195,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1141,
+							"line": 1145,
 							"character": 4
 						}
 					],
@@ -41218,7 +41218,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1125,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -41241,7 +41241,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1136,
+							"line": 1140,
 							"character": 4
 						}
 					],
@@ -41264,7 +41264,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1156,
+							"line": 1160,
 							"character": 4
 						}
 					],
@@ -41287,7 +41287,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1146,
+							"line": 1150,
 							"character": 4
 						}
 					],
@@ -41310,7 +41310,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1166,
+							"line": 1170,
 							"character": 4
 						}
 					],
@@ -41333,7 +41333,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1171,
+							"line": 1175,
 							"character": 4
 						}
 					],
@@ -41356,7 +41356,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1161,
+							"line": 1165,
 							"character": 4
 						}
 					],
@@ -41379,7 +41379,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1176,
+							"line": 1180,
 							"character": 4
 						}
 					],
@@ -41402,7 +41402,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1151,
+							"line": 1155,
 							"character": 4
 						}
 					],
@@ -41425,7 +41425,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1120,
+							"line": 1124,
 							"character": 4
 						}
 					],
@@ -41448,7 +41448,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1115,
+							"line": 1119,
 							"character": 4
 						}
 					],
@@ -41466,12 +41466,18 @@
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color of the unsaved filter indicator dot in the centralised filter modal."
+						"shortText": "Color of the dot indicator shown on a filter or parameter chip in the\ncentralized filter modal on a Liveboard. The dot appears when the\nfilter or parameter value has been modified but the changes are not\nyet applied to the Liveboard.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot: 26.10.0.cl\n"
+							}
+						]
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 818,
+							"line": 822,
 							"character": 4
 						}
 					],

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2233,
+			"id": 2251,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2356,
+					"id": 2374,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -49,14 +49,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7883,
+							"line": 7963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2253,
+					"id": 2271,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -77,14 +77,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6916,
+							"line": 6996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2246,
+					"id": 2264,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -105,14 +105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6845,
+							"line": 6925,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2245,
+					"id": 2263,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -129,14 +129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6834,
+							"line": 6914,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2251,
+					"id": 2269,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -153,14 +153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6897,
+							"line": 6977,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2252,
+					"id": 2270,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -177,14 +177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6906,
+							"line": 6986,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2254,
+					"id": 2272,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -205,14 +205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6926,
+							"line": 7006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2336,
+					"id": 2354,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -233,14 +233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7651,
+							"line": 7731,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2306,
+					"id": 2324,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -261,14 +261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7344,
+							"line": 7424,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2352,
+					"id": 2370,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -289,14 +289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7836,
+							"line": 7916,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2366,
+					"id": 2384,
 					"name": "AllLiveboardFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -317,14 +317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7995,
+							"line": 8075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"allLiveboardFilters\""
 				},
 				{
-					"id": 2305,
+					"id": 2323,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -345,14 +345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7332,
+							"line": 7412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2304,
+					"id": 2322,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7320,
+							"line": 7400,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2351,
+					"id": 2369,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -402,14 +402,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7825,
+							"line": 7905,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2318,
+					"id": 2336,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -430,14 +430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7466,
+							"line": 7546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2330,
+					"id": 2348,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -458,14 +458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7597,
+							"line": 7677,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2321,
+					"id": 2339,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -486,14 +486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7500,
+							"line": 7580,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2326,
+					"id": 2344,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -514,14 +514,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7555,
+							"line": 7635,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2320,
+					"id": 2338,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -542,14 +542,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7489,
+							"line": 7569,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2323,
+					"id": 2341,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -570,14 +570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7523,
+							"line": 7603,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2331,
+					"id": 2349,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -598,14 +598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7607,
+							"line": 7687,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2327,
+					"id": 2345,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -626,14 +626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7565,
+							"line": 7645,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2324,
+					"id": 2342,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -654,14 +654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7534,
+							"line": 7614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2329,
+					"id": 2347,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -682,14 +682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7587,
+							"line": 7667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2325,
+					"id": 2343,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -710,14 +710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7544,
+							"line": 7624,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2322,
+					"id": 2340,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -738,14 +738,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7511,
+							"line": 7591,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2328,
+					"id": 2346,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -766,14 +766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7575,
+							"line": 7655,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2319,
+					"id": 2337,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -794,14 +794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7477,
+							"line": 7557,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2365,
+					"id": 2383,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -822,14 +822,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7981,
+							"line": 8061,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2250,
+					"id": 2268,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -846,14 +846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6888,
+							"line": 6968,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2249,
+					"id": 2267,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -874,14 +874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6879,
+							"line": 6959,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2248,
+					"id": 2266,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -902,14 +902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6867,
+							"line": 6947,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2374,
+					"id": 2392,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -930,14 +930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8083,
+							"line": 8163,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2247,
+					"id": 2265,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -954,14 +954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6856,
+							"line": 6936,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2297,
+					"id": 2315,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -969,14 +969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7269,
+							"line": 7349,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2240,
+					"id": 2258,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -993,14 +993,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6793,
+							"line": 6873,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2296,
+					"id": 2314,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1017,14 +1017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7268,
+							"line": 7348,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2375,
+					"id": 2393,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1045,14 +1045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8093,
+							"line": 8173,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2389,
+					"id": 2407,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1073,14 +1073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8257,
+							"line": 8337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2349,
+					"id": 2367,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1101,14 +1101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7800,
+							"line": 7880,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2309,
+					"id": 2327,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1129,14 +1129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7374,
+							"line": 7454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2314,
+					"id": 2332,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1157,14 +1157,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7424,
+							"line": 7504,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2367,
+					"id": 2385,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1185,14 +1185,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8007,
+							"line": 8087,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2372,
+					"id": 2390,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1213,14 +1213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8064,
+							"line": 8144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2362,
+					"id": 2380,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1241,14 +1241,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7950,
+							"line": 8030,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2364,
+					"id": 2382,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1269,14 +1269,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7969,
+							"line": 8049,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2262,
+					"id": 2280,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1293,14 +1293,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6976,
+							"line": 7056,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2265,
+					"id": 2283,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1317,14 +1317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7009,
+							"line": 7089,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2264,
+					"id": 2282,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1342,14 +1342,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6999,
+							"line": 7079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2263,
+					"id": 2281,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1366,14 +1366,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6986,
+							"line": 7066,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2266,
+					"id": 2284,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1390,14 +1390,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7019,
+							"line": 7099,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2267,
+					"id": 2285,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1418,14 +1418,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7029,
+							"line": 7109,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2269,
+					"id": 2287,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1446,14 +1446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7053,
+							"line": 7133,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2268,
+					"id": 2286,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1474,14 +1474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7039,
+							"line": 7119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2271,
+					"id": 2289,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1502,14 +1502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7073,
+							"line": 7153,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2270,
+					"id": 2288,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1530,14 +1530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7063,
+							"line": 7143,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2301,
+					"id": 2319,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1554,14 +1554,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7285,
+							"line": 7365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2295,
+					"id": 2313,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1578,14 +1578,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7258,
+							"line": 7338,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2294,
+					"id": 2312,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1602,14 +1602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7249,
+							"line": 7329,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2279,
+					"id": 2297,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1626,14 +1626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7149,
+							"line": 7229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2239,
+					"id": 2257,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1650,14 +1650,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6784,
+							"line": 6864,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2308,
+					"id": 2326,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1678,14 +1678,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7363,
+							"line": 7443,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2299,
+					"id": 2317,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1693,14 +1693,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7274,
+							"line": 7354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2371,
+					"id": 2389,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1721,14 +1721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8053,
+							"line": 8133,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2340,
+					"id": 2358,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1749,14 +1749,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7695,
+							"line": 7775,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2357,
+					"id": 2375,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1777,14 +1777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7896,
+							"line": 7976,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2276,
+					"id": 2294,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1801,14 +1801,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7117,
+							"line": 7197,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2280,
+					"id": 2298,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1825,14 +1825,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7157,
+							"line": 7237,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2373,
+					"id": 2391,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1853,14 +1853,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8074,
+							"line": 8154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2337,
+					"id": 2355,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1881,14 +1881,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7661,
+							"line": 7741,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2338,
+					"id": 2356,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1909,14 +1909,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7672,
+							"line": 7752,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2293,
+					"id": 2311,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1933,14 +1933,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7238,
+							"line": 7318,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2273,
+					"id": 2291,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1958,14 +1958,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7089,
+							"line": 7169,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2274,
+					"id": 2292,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1982,14 +1982,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7099,
+							"line": 7179,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2376,
+					"id": 2394,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2011,14 +2011,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8112,
+							"line": 8192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2412,
+					"id": 2430,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2039,14 +2039,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8495,
+							"line": 8575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2363,
+					"id": 2381,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2067,14 +2067,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7960,
+							"line": 8040,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2287,
+					"id": 2305,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2091,14 +2091,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7199,
+							"line": 7279,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2382,
+					"id": 2400,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2119,14 +2119,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8178,
+							"line": 8258,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2347,
+					"id": 2365,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2147,14 +2147,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7768,
+							"line": 7848,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2238,
+					"id": 2256,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2171,14 +2171,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6775,
+							"line": 6855,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2344,
+					"id": 2362,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2195,14 +2195,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7736,
+							"line": 7816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2313,
+					"id": 2331,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,14 +2223,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7414,
+							"line": 7494,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2384,
+					"id": 2402,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,14 +2251,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8204,
+							"line": 8284,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2361,
+					"id": 2379,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,14 +2279,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7939,
+							"line": 8019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2335,
+					"id": 2353,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,14 +2307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7641,
+							"line": 7721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2342,
+					"id": 2360,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2334,14 +2334,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7716,
+							"line": 7796,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2388,
+					"id": 2406,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2362,14 +2362,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8247,
+							"line": 8327,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2387,
+					"id": 2405,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2390,14 +2390,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8237,
+							"line": 8317,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2343,
+					"id": 2361,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2414,14 +2414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7725,
+							"line": 7805,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2354,
+					"id": 2372,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2446,14 +2446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7860,
+							"line": 7940,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2355,
+					"id": 2373,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2474,14 +2474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7872,
+							"line": 7952,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2386,
+					"id": 2404,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2502,14 +2502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8227,
+							"line": 8307,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2358,
+					"id": 2376,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2530,14 +2530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7907,
+							"line": 7987,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2345,
+					"id": 2363,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2562,14 +2562,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7748,
+							"line": 7828,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2346,
+					"id": 2364,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2590,14 +2590,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7758,
+							"line": 7838,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2290,
+					"id": 2308,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2614,14 +2614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7216,
+							"line": 7296,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2380,
+					"id": 2398,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2638,14 +2638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8156,
+							"line": 8236,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2277,
+					"id": 2295,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2662,14 +2662,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7127,
+							"line": 7207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2368,
+					"id": 2386,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2690,14 +2690,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8019,
+							"line": 8099,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2383,
+					"id": 2401,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2718,14 +2718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8191,
+							"line": 8271,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2303,
+					"id": 2321,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2743,14 +2743,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7310,
+							"line": 7390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2418,
+					"id": 2436,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2771,14 +2771,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8568,
+							"line": 8648,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2281,
+					"id": 2299,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2795,14 +2795,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7167,
+							"line": 7247,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2381,
+					"id": 2399,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2823,14 +2823,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8168,
+							"line": 8248,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2317,
+					"id": 2335,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2851,14 +2851,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7455,
+							"line": 7535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2307,
+					"id": 2325,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2879,14 +2879,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7354,
+							"line": 7434,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2353,
+					"id": 2371,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2907,14 +2907,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7847,
+							"line": 7927,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2333,
+					"id": 2351,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2935,14 +2935,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7621,
+							"line": 7701,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2310,
+					"id": 2328,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2966,14 +2966,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7383,
+							"line": 7463,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2302,
+					"id": 2320,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2990,14 +2990,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7294,
+							"line": 7374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2334,
+					"id": 2352,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3018,14 +3018,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7631,
+							"line": 7711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2369,
+					"id": 2387,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3046,14 +3046,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8031,
+							"line": 8111,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2341,
+					"id": 2359,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3074,14 +3074,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7707,
+							"line": 7787,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2234,
+					"id": 2252,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3098,14 +3098,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6744,
+							"line": 6824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2237,
+					"id": 2255,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3122,14 +3122,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6762,
+							"line": 6842,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2242,
+					"id": 2260,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3146,14 +3146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6807,
+							"line": 6887,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2243,
+					"id": 2261,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3170,14 +3170,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6816,
+							"line": 6896,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2413,
+					"id": 2431,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3198,14 +3198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8507,
+							"line": 8587,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2300,
+					"id": 2318,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3213,14 +3213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7275,
+							"line": 7355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2244,
+					"id": 2262,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3237,14 +3237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6825,
+							"line": 6905,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2259,
+					"id": 2277,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3255,14 +3255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6951,
+							"line": 7031,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2339,
+					"id": 2357,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3283,14 +3283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7682,
+							"line": 7762,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2261,
+					"id": 2279,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3307,14 +3307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6966,
+							"line": 7046,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2256,
+					"id": 2274,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3331,14 +3331,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6939,
+							"line": 7019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2421,
+					"id": 2439,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3359,14 +3359,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8601,
+							"line": 8681,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2422,
+					"id": 2440,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3387,14 +3387,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8612,
+							"line": 8692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2420,
+					"id": 2438,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3415,14 +3415,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8590,
+							"line": 8670,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2423,
+					"id": 2441,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3443,14 +3443,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8623,
+							"line": 8703,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2419,
+					"id": 2437,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3471,14 +3471,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8579,
+							"line": 8659,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2424,
+					"id": 2442,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3499,14 +3499,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8634,
+							"line": 8714,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2409,
+					"id": 2427,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3527,14 +3527,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8461,
+							"line": 8541,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2410,
+					"id": 2428,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3555,14 +3555,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8472,
+							"line": 8552,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2406,
+					"id": 2424,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3583,14 +3583,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8430,
+							"line": 8510,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2396,
+					"id": 2414,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3611,14 +3611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8327,
+							"line": 8407,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2411,
+					"id": 2429,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3639,14 +3639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8483,
+							"line": 8563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2407,
+					"id": 2425,
 					"name": "SpotterChatPin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3667,14 +3667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8440,
+							"line": 8520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatPin\""
 				},
 				{
-					"id": 2397,
+					"id": 2415,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3695,14 +3695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8337,
+							"line": 8417,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2408,
+					"id": 2426,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3723,14 +3723,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8450,
+							"line": 8530,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2370,
+					"id": 2388,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3751,14 +3751,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8042,
+							"line": 8122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2394,
+					"id": 2412,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3779,14 +3779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8307,
+							"line": 8387,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2395,
+					"id": 2413,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3807,14 +3807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8317,
+							"line": 8397,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2398,
+					"id": 2416,
 					"name": "SpotterShareConversationButtonHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3835,14 +3835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8348,
+							"line": 8428,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeader\""
 				},
 				{
-					"id": 2399,
+					"id": 2417,
 					"name": "SpotterShareConversationMenuItemSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3863,14 +3863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8359,
+							"line": 8439,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebar\""
 				},
 				{
-					"id": 2404,
+					"id": 2422,
 					"name": "SpotterShareIncludeNewMessagesCheckbox",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3891,14 +3891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8410,
+							"line": 8490,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckbox\""
 				},
 				{
-					"id": 2405,
+					"id": 2423,
 					"name": "SpotterShareStaleInfoBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3919,14 +3919,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8420,
+							"line": 8500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissButton\""
 				},
 				{
-					"id": 2403,
+					"id": 2421,
 					"name": "SpotterShareUpToCurrentInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3947,14 +3947,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8400,
+							"line": 8480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareUpToCurrentInfo\""
 				},
 				{
-					"id": 2400,
+					"id": 2418,
 					"name": "SpotterSharedConversationBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3975,14 +3975,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8369,
+							"line": 8449,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBanner\""
 				},
 				{
-					"id": 2401,
+					"id": 2419,
 					"name": "SpotterSharedConversationBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4003,14 +4003,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8379,
+							"line": 8459,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBannerDismissButton\""
 				},
 				{
-					"id": 2402,
+					"id": 2420,
 					"name": "SpotterSharedConversationExitButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,14 +4031,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8390,
+							"line": 8470,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButton\""
 				},
 				{
-					"id": 2392,
+					"id": 2410,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4059,14 +4059,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8287,
+							"line": 8367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2391,
+					"id": 2409,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4087,14 +4087,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8277,
+							"line": 8357,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2393,
+					"id": 2411,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4115,14 +4115,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8297,
+							"line": 8377,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2379,
+					"id": 2397,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4143,14 +4143,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8145,
+							"line": 8225,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2416,
+					"id": 2434,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4171,14 +4171,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8543,
+							"line": 8623,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2415,
+					"id": 2433,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4199,14 +4199,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8531,
+							"line": 8611,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2414,
+					"id": 2432,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4227,14 +4227,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8519,
+							"line": 8599,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2417,
+					"id": 2435,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4255,14 +4255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8557,
+							"line": 8637,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2377,
+					"id": 2395,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4283,14 +4283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8123,
+							"line": 8203,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2378,
+					"id": 2396,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4311,14 +4311,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8134,
+							"line": 8214,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2292,
+					"id": 2310,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4335,14 +4335,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7230,
+							"line": 7310,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2312,
+					"id": 2330,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4363,14 +4363,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7404,
+							"line": 7484,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2311,
+					"id": 2329,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4391,14 +4391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7393,
+							"line": 7473,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2315,
+					"id": 2333,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4419,14 +4419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7434,
+							"line": 7514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2316,
+					"id": 2334,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4447,14 +4447,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7444,
+							"line": 7524,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2348,
+					"id": 2366,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4479,14 +4479,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7787,
+							"line": 7867,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2278,
+					"id": 2296,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4503,14 +4503,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7139,
+							"line": 7219,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2390,
+					"id": 2408,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4531,14 +4531,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8267,
+							"line": 8347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2385,
+					"id": 2403,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4559,14 +4559,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8216,
+							"line": 8296,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2360,
+					"id": 2378,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4587,14 +4587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7929,
+							"line": 8009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2275,
+					"id": 2293,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4611,14 +4611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7108,
+							"line": 7188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2350,
+					"id": 2368,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4639,14 +4639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7811,
+							"line": 7891,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2359,
+					"id": 2377,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4667,7 +4667,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7918,
+							"line": 7998,
 							"character": 4
 						}
 					],
@@ -4679,192 +4679,192 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2356,
-						2253,
-						2246,
-						2245,
-						2251,
-						2252,
-						2254,
-						2336,
-						2306,
-						2352,
-						2366,
-						2305,
-						2304,
-						2351,
-						2318,
-						2330,
-						2321,
-						2326,
-						2320,
-						2323,
-						2331,
-						2327,
-						2324,
-						2329,
-						2325,
-						2322,
-						2328,
-						2319,
-						2365,
-						2250,
-						2249,
-						2248,
 						2374,
-						2247,
-						2297,
-						2240,
-						2296,
-						2375,
-						2389,
-						2349,
-						2309,
-						2314,
-						2367,
-						2372,
-						2362,
-						2364,
-						2262,
-						2265,
+						2271,
 						2264,
 						2263,
-						2266,
-						2267,
 						2269,
-						2268,
-						2271,
 						2270,
-						2301,
-						2295,
-						2294,
-						2279,
-						2239,
-						2308,
-						2299,
-						2371,
-						2340,
-						2357,
-						2276,
-						2280,
-						2373,
-						2337,
-						2338,
-						2293,
-						2273,
-						2274,
-						2376,
-						2412,
-						2363,
-						2287,
-						2382,
-						2347,
-						2238,
-						2344,
-						2313,
-						2384,
-						2361,
-						2335,
-						2342,
-						2388,
-						2387,
-						2343,
+						2272,
 						2354,
-						2355,
-						2386,
-						2358,
-						2345,
-						2346,
-						2290,
-						2380,
-						2277,
-						2368,
-						2383,
-						2303,
-						2418,
-						2281,
-						2381,
-						2317,
-						2307,
-						2353,
-						2333,
-						2310,
-						2302,
-						2334,
-						2369,
-						2341,
-						2234,
-						2237,
-						2242,
-						2243,
-						2413,
-						2300,
-						2244,
-						2259,
-						2339,
-						2261,
-						2256,
-						2421,
-						2422,
-						2420,
-						2423,
-						2419,
-						2424,
-						2409,
-						2410,
-						2406,
-						2396,
-						2411,
-						2407,
-						2397,
-						2408,
+						2324,
 						2370,
-						2394,
-						2395,
-						2398,
-						2399,
-						2404,
-						2405,
-						2403,
-						2400,
-						2401,
-						2402,
-						2392,
-						2391,
-						2393,
-						2379,
-						2416,
-						2415,
-						2414,
-						2417,
-						2377,
-						2378,
-						2292,
-						2312,
-						2311,
-						2315,
-						2316,
+						2384,
+						2323,
+						2322,
+						2369,
+						2336,
 						2348,
-						2278,
-						2390,
+						2339,
+						2344,
+						2338,
+						2341,
+						2349,
+						2345,
+						2342,
+						2347,
+						2343,
+						2340,
+						2346,
+						2337,
+						2383,
+						2268,
+						2267,
+						2266,
+						2392,
+						2265,
+						2315,
+						2258,
+						2314,
+						2393,
+						2407,
+						2367,
+						2327,
+						2332,
 						2385,
+						2390,
+						2380,
+						2382,
+						2280,
+						2283,
+						2282,
+						2281,
+						2284,
+						2285,
+						2287,
+						2286,
+						2289,
+						2288,
+						2319,
+						2313,
+						2312,
+						2297,
+						2257,
+						2326,
+						2317,
+						2389,
+						2358,
+						2375,
+						2294,
+						2298,
+						2391,
+						2355,
+						2356,
+						2311,
+						2291,
+						2292,
+						2394,
+						2430,
+						2381,
+						2305,
+						2400,
+						2365,
+						2256,
+						2362,
+						2331,
+						2402,
+						2379,
+						2353,
 						2360,
-						2275,
-						2350,
-						2359
+						2406,
+						2405,
+						2361,
+						2372,
+						2373,
+						2404,
+						2376,
+						2363,
+						2364,
+						2308,
+						2398,
+						2295,
+						2386,
+						2401,
+						2321,
+						2436,
+						2299,
+						2399,
+						2335,
+						2325,
+						2371,
+						2351,
+						2328,
+						2320,
+						2352,
+						2387,
+						2359,
+						2252,
+						2255,
+						2260,
+						2261,
+						2431,
+						2318,
+						2262,
+						2277,
+						2357,
+						2279,
+						2274,
+						2439,
+						2440,
+						2438,
+						2441,
+						2437,
+						2442,
+						2427,
+						2428,
+						2424,
+						2414,
+						2429,
+						2425,
+						2415,
+						2426,
+						2388,
+						2412,
+						2413,
+						2416,
+						2417,
+						2422,
+						2423,
+						2421,
+						2418,
+						2419,
+						2420,
+						2410,
+						2409,
+						2411,
+						2397,
+						2434,
+						2433,
+						2432,
+						2435,
+						2395,
+						2396,
+						2310,
+						2330,
+						2329,
+						2333,
+						2334,
+						2366,
+						2296,
+						2408,
+						2403,
+						2378,
+						2293,
+						2368,
+						2377
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6735,
+					"line": 6815,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1817,
+			"id": 1835,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4880,7 +4880,7 @@
 			},
 			"children": [
 				{
-					"id": 1818,
+					"id": 1836,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4903,7 +4903,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1818
+						1836
 					]
 				}
 			],
@@ -4916,7 +4916,7 @@
 			]
 		},
 		{
-			"id": 1802,
+			"id": 1820,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4932,7 +4932,7 @@
 			},
 			"children": [
 				{
-					"id": 1805,
+					"id": 1823,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4951,7 +4951,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1807,
+					"id": 1825,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4970,7 +4970,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1804,
+					"id": 1822,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4989,7 +4989,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1806,
+					"id": 1824,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5008,7 +5008,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1803,
+					"id": 1821,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5027,7 +5027,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1808,
+					"id": 1826,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5051,12 +5051,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1805,
-						1807,
-						1804,
-						1806,
-						1803,
-						1808
+						1823,
+						1825,
+						1822,
+						1824,
+						1821,
+						1826
 					]
 				}
 			],
@@ -5069,7 +5069,7 @@
 			]
 		},
 		{
-			"id": 1809,
+			"id": 1827,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5085,7 +5085,7 @@
 			},
 			"children": [
 				{
-					"id": 1810,
+					"id": 1828,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5103,7 +5103,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1814,
+					"id": 1832,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5121,7 +5121,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1816,
+					"id": 1834,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5139,7 +5139,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1811,
+					"id": 1829,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5163,7 +5163,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1813,
+					"id": 1831,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5196,7 +5196,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1815,
+					"id": 1833,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5225,12 +5225,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1810,
-						1814,
-						1816,
-						1811,
-						1813,
-						1815
+						1828,
+						1832,
+						1834,
+						1829,
+						1831,
+						1833
 					]
 				}
 			],
@@ -5243,7 +5243,7 @@
 			]
 		},
 		{
-			"id": 1969,
+			"id": 1987,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5259,7 +5259,7 @@
 			},
 			"children": [
 				{
-					"id": 1980,
+					"id": 1998,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5278,7 +5278,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1971,
+					"id": 1989,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5307,7 +5307,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1970,
+					"id": 1988,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5331,7 +5331,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1976,
+					"id": 1994,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5349,7 +5349,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1974,
+					"id": 1992,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5382,7 +5382,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1978,
+					"id": 1996,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5406,7 +5406,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1979,
+					"id": 1997,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5439,13 +5439,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1980,
-						1971,
-						1970,
-						1976,
-						1974,
-						1978,
-						1979
+						1998,
+						1989,
+						1988,
+						1994,
+						1992,
+						1996,
+						1997
 					]
 				}
 			],
@@ -5458,7 +5458,7 @@
 			]
 		},
 		{
-			"id": 3293,
+			"id": 3316,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5474,7 +5474,7 @@
 			},
 			"children": [
 				{
-					"id": 3295,
+					"id": 3318,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5485,14 +5485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9339,
+							"line": 9419,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3294,
+					"id": 3317,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5503,7 +5503,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9337,
+							"line": 9417,
 							"character": 4
 						}
 					],
@@ -5515,21 +5515,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3295,
-						3294
+						3318,
+						3317
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9335,
+					"line": 9415,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3296,
+			"id": 3319,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5545,7 +5545,7 @@
 			},
 			"children": [
 				{
-					"id": 3298,
+					"id": 3321,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5556,14 +5556,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9350,
+							"line": 9430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3299,
+					"id": 3322,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5574,14 +5574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9352,
+							"line": 9432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3297,
+					"id": 3320,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5592,7 +5592,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9348,
+							"line": 9428,
 							"character": 4
 						}
 					],
@@ -5604,22 +5604,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3298,
-						3299,
-						3297
+						3321,
+						3322,
+						3320
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9346,
+					"line": 9426,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3300,
+			"id": 3323,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5635,7 +5635,7 @@
 			},
 			"children": [
 				{
-					"id": 3303,
+					"id": 3326,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5646,14 +5646,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9304,
+							"line": 9384,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3304,
+					"id": 3327,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5664,14 +5664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3306,
+					"id": 3329,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5682,14 +5682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9310,
+							"line": 9390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3311,
+					"id": 3334,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5700,14 +5700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9320,
+							"line": 9400,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3307,
+					"id": 3330,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5718,14 +5718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9312,
+							"line": 9392,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3309,
+					"id": 3332,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5736,14 +5736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9316,
+							"line": 9396,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3301,
+					"id": 3324,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5754,14 +5754,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9300,
+							"line": 9380,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3313,
+					"id": 3336,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5772,14 +5772,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9324,
+							"line": 9404,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3302,
+					"id": 3325,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5790,14 +5790,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9302,
+							"line": 9382,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3315,
+					"id": 3338,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5808,14 +5808,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9328,
+							"line": 9408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3314,
+					"id": 3337,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5826,14 +5826,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9326,
+							"line": 9406,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3308,
+					"id": 3331,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5844,14 +5844,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9314,
+							"line": 9394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3310,
+					"id": 3333,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5862,14 +5862,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9318,
+							"line": 9398,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3312,
+					"id": 3335,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5880,14 +5880,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9322,
+							"line": 9402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3305,
+					"id": 3328,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5898,7 +5898,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9308,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -5910,34 +5910,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3303,
-						3304,
-						3306,
-						3311,
-						3307,
-						3309,
-						3301,
-						3313,
-						3302,
-						3315,
-						3314,
-						3308,
-						3310,
-						3312,
-						3305
+						3326,
+						3327,
+						3329,
+						3334,
+						3330,
+						3332,
+						3324,
+						3336,
+						3325,
+						3338,
+						3337,
+						3331,
+						3333,
+						3335,
+						3328
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9298,
+					"line": 9378,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2425,
+			"id": 2443,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5947,7 +5947,7 @@
 			},
 			"children": [
 				{
-					"id": 2428,
+					"id": 2446,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5955,14 +5955,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8734,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2426,
+					"id": 2444,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5970,14 +5970,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8652,
+							"line": 8732,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2427,
+					"id": 2445,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5985,7 +5985,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8653,
+							"line": 8733,
 							"character": 4
 						}
 					],
@@ -5997,22 +5997,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2428,
-						2426,
-						2427
+						2446,
+						2444,
+						2445
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8651,
+					"line": 8731,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2223,
+			"id": 2241,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6036,7 +6036,7 @@
 			},
 			"children": [
 				{
-					"id": 2226,
+					"id": 2244,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6047,14 +6047,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9102,
+							"line": 9182,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2225,
+					"id": 2243,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6065,14 +6065,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9098,
+							"line": 9178,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2228,
+					"id": 2246,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6083,14 +6083,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9111,
+							"line": 9191,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2224,
+					"id": 2242,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6101,14 +6101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9094,
+							"line": 9174,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2227,
+					"id": 2245,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6119,7 +6119,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9106,
+							"line": 9186,
 							"character": 4
 						}
 					],
@@ -6131,24 +6131,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2226,
-						2225,
-						2228,
-						2224,
-						2227
+						2244,
+						2243,
+						2246,
+						2242,
+						2245
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9090,
+					"line": 9170,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3247,
+			"id": 3270,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6158,7 +6158,7 @@
 			},
 			"children": [
 				{
-					"id": 3250,
+					"id": 3273,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6169,14 +6169,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8791,
+							"line": 8871,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3248,
+					"id": 3271,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6187,14 +6187,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8764,
+							"line": 8844,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3251,
+					"id": 3274,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6205,14 +6205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8802,
+							"line": 8882,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3249,
+					"id": 3272,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6223,7 +6223,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8778,
+							"line": 8858,
 							"character": 4
 						}
 					],
@@ -6235,23 +6235,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3250,
-						3248,
-						3251,
-						3249
+						3273,
+						3271,
+						3274,
+						3272
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8754,
+					"line": 8834,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3243,
+			"id": 3266,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6261,7 +6261,7 @@
 			},
 			"children": [
 				{
-					"id": 3246,
+					"id": 3269,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6272,14 +6272,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8745,
+							"line": 8825,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3245,
+					"id": 3268,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6290,14 +6290,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8737,
+							"line": 8817,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3244,
+					"id": 3267,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6308,7 +6308,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8732,
+							"line": 8812,
 							"character": 4
 						}
 					],
@@ -6320,22 +6320,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3246,
-						3245,
-						3244
+						3269,
+						3268,
+						3267
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8727,
+					"line": 8807,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3316,
+			"id": 3339,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6351,7 +6351,7 @@
 			},
 			"children": [
 				{
-					"id": 3321,
+					"id": 3344,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6362,14 +6362,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9369,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3317,
+					"id": 3340,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6380,14 +6380,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9281,
+							"line": 9361,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3319,
+					"id": 3342,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6398,14 +6398,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9285,
+							"line": 9365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3318,
+					"id": 3341,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6416,14 +6416,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9283,
+							"line": 9363,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3320,
+					"id": 3343,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6434,14 +6434,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9287,
+							"line": 9367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3322,
+					"id": 3345,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6452,7 +6452,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9291,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -6464,25 +6464,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3321,
-						3317,
-						3319,
-						3318,
-						3320,
-						3322
+						3344,
+						3340,
+						3342,
+						3341,
+						3343,
+						3345
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9279,
+					"line": 9359,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3239,
+			"id": 3262,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6492,7 +6492,7 @@
 			},
 			"children": [
 				{
-					"id": 3241,
+					"id": 3264,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6510,7 +6510,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3240,
+					"id": 3263,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6528,7 +6528,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3242,
+					"id": 3265,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6551,9 +6551,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3241,
-						3240,
-						3242
+						3264,
+						3263,
+						3265
 					]
 				}
 			],
@@ -6566,7 +6566,7 @@
 			]
 		},
 		{
-			"id": 2229,
+			"id": 2247,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6576,7 +6576,7 @@
 			},
 			"children": [
 				{
-					"id": 2231,
+					"id": 2249,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6587,14 +6587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6520,
+							"line": 6600,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2232,
+					"id": 2250,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6605,14 +6605,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6524,
+							"line": 6604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2230,
+					"id": 2248,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6623,7 +6623,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6516,
+							"line": 6596,
 							"character": 4
 						}
 					],
@@ -6635,22 +6635,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2231,
-						2232,
-						2230
+						2249,
+						2250,
+						2248
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6512,
+					"line": 6592,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3256,
+			"id": 3279,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6674,7 +6674,7 @@
 			},
 			"children": [
 				{
-					"id": 3259,
+					"id": 3282,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6685,14 +6685,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8968,
+							"line": 9048,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3260,
+					"id": 3283,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6703,14 +6703,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8971,
+							"line": 9051,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3263,
+					"id": 3286,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6721,14 +6721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8980,
+							"line": 9060,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3272,
+					"id": 3295,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6739,14 +6739,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9007,
+							"line": 9087,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3266,
+					"id": 3289,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6757,14 +6757,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8989,
+							"line": 9069,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3270,
+					"id": 3293,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6775,14 +6775,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9001,
+							"line": 9081,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3261,
+					"id": 3284,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6793,14 +6793,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8974,
+							"line": 9054,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3269,
+					"id": 3292,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6811,14 +6811,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8998,
+							"line": 9078,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3258,
+					"id": 3281,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6829,14 +6829,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8965,
+							"line": 9045,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3264,
+					"id": 3287,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6847,14 +6847,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8983,
+							"line": 9063,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3262,
+					"id": 3285,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6865,14 +6865,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8977,
+							"line": 9057,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3267,
+					"id": 3290,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6883,14 +6883,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8992,
+							"line": 9072,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3265,
+					"id": 3288,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6901,14 +6901,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8986,
+							"line": 9066,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3271,
+					"id": 3294,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6919,14 +6919,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9004,
+							"line": 9084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3273,
+					"id": 3296,
 					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6937,14 +6937,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9010,
+							"line": 9090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3268,
+					"id": 3291,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6955,14 +6955,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8995,
+							"line": 9075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3257,
+					"id": 3280,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6973,7 +6973,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8962,
+							"line": 9042,
 							"character": 4
 						}
 					],
@@ -6985,36 +6985,36 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3259,
-						3260,
-						3263,
-						3272,
-						3266,
-						3270,
-						3261,
-						3269,
-						3258,
-						3264,
-						3262,
-						3267,
-						3265,
-						3271,
-						3273,
-						3268,
-						3257
+						3282,
+						3283,
+						3286,
+						3295,
+						3289,
+						3293,
+						3284,
+						3292,
+						3281,
+						3287,
+						3285,
+						3290,
+						3288,
+						3294,
+						3296,
+						3291,
+						3280
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8960,
+					"line": 9040,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2001,
+			"id": 2019,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7039,7 +7039,7 @@
 			},
 			"children": [
 				{
-					"id": 2038,
+					"id": 2056,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7060,14 +7060,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2942,
+							"line": 3022,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2029,
+					"id": 2047,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7088,14 +7088,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2805,
+							"line": 2885,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2009,
+					"id": 2027,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7120,14 +7120,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2553,
+							"line": 2633,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2091,
+					"id": 2109,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7148,14 +7148,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3608,
+							"line": 3688,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2055,
+					"id": 2073,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7176,14 +7176,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3155,
+							"line": 3235,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2014,
+					"id": 2032,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7208,14 +7208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2663,
+							"line": 2743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2051,
+					"id": 2069,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7236,14 +7236,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3123,
+							"line": 3203,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2037,
+					"id": 2055,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7264,14 +7264,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2931,
+							"line": 3011,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2101,
+					"id": 2119,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7293,14 +7293,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3774,
+							"line": 3854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2080,
+					"id": 2098,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7333,14 +7333,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3412,
+							"line": 3492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2015,
+					"id": 2033,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7361,14 +7361,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2676,
+							"line": 2756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2003,
+					"id": 2021,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7393,14 +7393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2455,
+							"line": 2535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2062,
+					"id": 2080,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7421,14 +7421,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3231,
+							"line": 3311,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2078,
+					"id": 2096,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7465,14 +7465,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3398,
+							"line": 3478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2049,
+					"id": 2067,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7493,14 +7493,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3101,
+							"line": 3181,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2064,
+					"id": 2082,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7521,14 +7521,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3251,
+							"line": 3331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2044,
+					"id": 2062,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7549,14 +7549,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3034,
+							"line": 3114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2070,
+					"id": 2088,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7573,14 +7573,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3310,
+							"line": 3390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2085,
+					"id": 2103,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7598,14 +7598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3558,
+							"line": 3638,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2086,
+					"id": 2104,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7622,14 +7622,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3563,
+							"line": 3643,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2079,
+					"id": 2097,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7646,14 +7646,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3403,
+							"line": 3483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2065,
+					"id": 2083,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7674,14 +7674,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3262,
+							"line": 3342,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2010,
+					"id": 2028,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7703,21 +7703,21 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nappEmbed.on(EmbedEvent.customAction, payload => {\n    const data = payload.data;\n    if (data.id === 'insert Custom Action ID here') {\n        console.log('Custom Action event:', data.embedAnswerData);\n    }\n})\n```\n"
+								"text": "\n```js\nappEmbed.on(EmbedEvent.CustomAction, payload => {\n    const data = payload.data;\n    if (data.id === 'insert Custom Action ID here') {\n        console.log('Custom Action event:', data.embedAnswerData);\n    }\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2570,
+							"line": 2650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2005,
+					"id": 2023,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7746,14 +7746,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2483,
+							"line": 2563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2092,
+					"id": 2110,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7774,14 +7774,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3619,
+							"line": 3699,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2008,
+					"id": 2026,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7806,14 +7806,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2541,
+							"line": 2621,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2060,
+					"id": 2078,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7834,14 +7834,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3213,
+							"line": 3293,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2076,
+					"id": 2094,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7870,14 +7870,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3370,
+							"line": 3450,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2077,
+					"id": 2095,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7902,14 +7902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3377,
+							"line": 3457,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2027,
+					"id": 2045,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7930,14 +7930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2772,
+							"line": 2852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2026,
+					"id": 2044,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7958,21 +7958,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2761,
+							"line": 2841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2031,
+					"id": 2049,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
 						"shortText": "Emitted when the download action is triggered on an Answer.",
-						"text": "**Note**: This event is deprecated in v1.21.0.\nTo fire an event when a download action is initiated on a chart or table,\nuse `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPDF`,\n`EmbedEvent.DownloadAsCSV`, or `EmbedEvent.DownloadAsXLSX`",
+						"text": "**Note**: This event is deprecated in v1.21.0.\nTo fire an event when a download action is initiated on a chart or table,\nuse `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPdf`,\n`EmbedEvent.DownloadAsCsv`, or `EmbedEvent.DownloadAsXlsx`",
 						"tags": [
 							{
 								"tag": "version",
@@ -7987,14 +7987,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2840,
+							"line": 2920,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2034,
+					"id": 2052,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8008,21 +8008,21 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n//emit when action starts\nsearchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {\n  console.log('download CSV', payload)}, {start: true })\n//emit when action ends\nsearchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {\n   console.log('download CSV', payload)})\n```\n"
+								"text": "\n```js\n//emit when action starts\nsearchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {\n  console.log('download CSV', payload)}, {start: true })\n//emit when action ends\nsearchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {\n   console.log('download CSV', payload)})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2888,
+							"line": 2968,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2033,
+					"id": 2051,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8043,14 +8043,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2872,
+							"line": 2952,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2032,
+					"id": 2050,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8071,14 +8071,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2856,
+							"line": 2936,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2035,
+					"id": 2053,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8099,14 +8099,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2904,
+							"line": 2984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2036,
+					"id": 2054,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8127,14 +8127,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2915,
+							"line": 2995,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2043,
+					"id": 2061,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8155,14 +8155,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3023,
+							"line": 3103,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2042,
+					"id": 2060,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8183,14 +8183,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3011,
+							"line": 3091,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2007,
+					"id": 2025,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8216,7 +8216,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nsearchEmbed.on(EmbedEvent.DrillDown, {\n   points: {\n       clickedPoint,\n       selectedPoints: selectedPoint\n   },\n   autoDrillDown: true,\n})\n```\nIn this example, `VizPointDoubleClick` event is used for\ntriggering the `DrillDown` event when an area or specific\ndata point on a table or chart is double-clicked."
+								"text": "\n```js\nsearchEmbed.on(EmbedEvent.Drilldown, {\n   points: {\n       clickedPoint,\n       selectedPoints: selectedPoint\n   },\n   autoDrillDown: true,\n})\n```\nIn this example, `VizPointDoubleClick` event is used for\ntriggering the `DrillDown` event when an area or specific\ndata point on a table or chart is double-clicked."
 							},
 							{
 								"tag": "example",
@@ -8227,14 +8227,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2529,
+							"line": 2609,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2057,
+					"id": 2075,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8255,14 +8255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3177,
+							"line": 3257,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2046,
+					"id": 2064,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8283,14 +8283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3057,
+							"line": 3137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2119,
+					"id": 2137,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8311,14 +8311,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4012,
+							"line": 4092,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 2013,
+					"id": 2031,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8348,14 +8348,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2653,
+							"line": 2733,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2063,
+					"id": 2081,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8376,14 +8376,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3241,
+							"line": 3321,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2047,
+					"id": 2065,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8404,14 +8404,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3074,
+							"line": 3154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2068,
+					"id": 2086,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8432,14 +8432,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3300,
+							"line": 3380,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2021,
+					"id": 2039,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8460,14 +8460,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2718,
+							"line": 2798,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2002,
+					"id": 2020,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8488,14 +8488,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2443,
+							"line": 2523,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2095,
+					"id": 2113,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8516,14 +8516,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3652,
+							"line": 3732,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2094,
+					"id": 2112,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8544,14 +8544,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3641,
+							"line": 3721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2054,
+					"id": 2072,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8572,14 +8572,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3144,
+							"line": 3224,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2028,
+					"id": 2046,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8604,14 +8604,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2794,
+							"line": 2874,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2004,
+					"id": 2022,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8636,14 +8636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2469,
+							"line": 2549,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2058,
+					"id": 2076,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8664,14 +8664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3188,
+							"line": 3268,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2024,
+					"id": 2042,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8692,14 +8692,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2744,
+							"line": 2824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2082,
+					"id": 2100,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8730,14 +8730,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3483,
+							"line": 3563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2100,
+					"id": 2118,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8758,14 +8758,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3708,
+							"line": 3788,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2083,
+					"id": 2101,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8782,14 +8782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3502,
+							"line": 3582,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2039,
+					"id": 2057,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8810,14 +8810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2963,
+							"line": 3043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2059,
+					"id": 2077,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8842,14 +8842,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3203,
+							"line": 3283,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2090,
+					"id": 2108,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8870,14 +8870,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3597,
+							"line": 3677,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2006,
+					"id": 2024,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8898,14 +8898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2492,
+							"line": 2572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2129,
+					"id": 2147,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8926,14 +8926,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4154,
+							"line": 4234,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2081,
+					"id": 2099,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8950,14 +8950,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3417,
+							"line": 3497,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2075,
+					"id": 2093,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8990,14 +8990,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3361,
+							"line": 3441,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2096,
+					"id": 2114,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9018,14 +9018,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3663,
+							"line": 3743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2022,
+					"id": 2040,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9046,14 +9046,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2728,
+							"line": 2808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2030,
+					"id": 2048,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9074,14 +9074,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2824,
+							"line": 2904,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2048,
+					"id": 2066,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9102,14 +9102,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3085,
+							"line": 3165,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2073,
+					"id": 2091,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9146,14 +9146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3343,
+							"line": 3423,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2074,
+					"id": 2092,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9186,14 +9186,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3352,
+							"line": 3432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2056,
+					"id": 2074,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9214,14 +9214,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3166,
+							"line": 3246,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2061,
+					"id": 2079,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9242,14 +9242,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3222,
+							"line": 3302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2121,
+					"id": 2139,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9270,14 +9270,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4051,
+							"line": 4131,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2041,
+					"id": 2059,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9298,14 +9298,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2999,
+							"line": 3079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2050,
+					"id": 2068,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9326,14 +9326,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3112,
+							"line": 3192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2040,
+					"id": 2058,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9354,14 +9354,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2981,
+							"line": 3061,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2103,
+					"id": 2121,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9382,14 +9382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3798,
+							"line": 3878,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2114,
+					"id": 2132,
 					"name": "SpotterConversationPinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9410,14 +9410,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3938,
+							"line": 4018,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationPinned\""
 				},
 				{
-					"id": 2102,
+					"id": 2120,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9438,14 +9438,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3786,
+							"line": 3866,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2116,
+					"id": 2134,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9466,14 +9466,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3962,
+							"line": 4042,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2107,
+					"id": 2125,
 					"name": "SpotterConversationShareRevoked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9494,14 +9494,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3853,
+							"line": 3933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShareRevoked\""
 				},
 				{
-					"id": 2106,
+					"id": 2124,
 					"name": "SpotterConversationShared",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9522,14 +9522,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3839,
+							"line": 3919,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShared\""
 				},
 				{
-					"id": 2115,
+					"id": 2133,
 					"name": "SpotterConversationUnpinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9550,14 +9550,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3950,
+							"line": 4030,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationUnpinned\""
 				},
 				{
-					"id": 2089,
+					"id": 2107,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9578,14 +9578,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3586,
+							"line": 3666,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2097,
+					"id": 2115,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9606,14 +9606,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3674,
+							"line": 3754,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2098,
+					"id": 2116,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9634,14 +9634,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3685,
+							"line": 3765,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2093,
+					"id": 2111,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9662,14 +9662,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3630,
+							"line": 3710,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2117,
+					"id": 2135,
 					"name": "SpotterResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9695,14 +9695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3987,
+							"line": 4067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterResponseComplete\""
 				},
 				{
-					"id": 2104,
+					"id": 2122,
 					"name": "SpotterShareConversationButtonHeaderClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9723,14 +9723,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3811,
+							"line": 3891,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeaderClicked\""
 				},
 				{
-					"id": 2105,
+					"id": 2123,
 					"name": "SpotterShareConversationMenuItemSidebarClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9751,14 +9751,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3823,
+							"line": 3903,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebarClicked\""
 				},
 				{
-					"id": 2109,
+					"id": 2127,
 					"name": "SpotterShareIncludeNewMessagesCheckboxToggled",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9779,14 +9779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3878,
+							"line": 3958,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckboxToggled\""
 				},
 				{
-					"id": 2112,
+					"id": 2130,
 					"name": "SpotterShareModalCancelButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9807,14 +9807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3914,
+							"line": 3994,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalCancelButtonClicked\""
 				},
 				{
-					"id": 2111,
+					"id": 2129,
 					"name": "SpotterShareModalConfirmButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9835,14 +9835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3903,
+							"line": 3983,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalConfirmButtonClicked\""
 				},
 				{
-					"id": 2110,
+					"id": 2128,
 					"name": "SpotterShareStaleInfoBannerDismissed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9863,14 +9863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3890,
+							"line": 3970,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissed\""
 				},
 				{
-					"id": 2113,
+					"id": 2131,
 					"name": "SpotterSharedConversationExitButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9891,14 +9891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3926,
+							"line": 4006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButtonClicked\""
 				},
 				{
-					"id": 2108,
+					"id": 2126,
 					"name": "SpotterSharedConversationViewed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9919,14 +9919,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3866,
+							"line": 3946,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationViewed\""
 				},
 				{
-					"id": 2125,
+					"id": 2143,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9947,14 +9947,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4103,
+							"line": 4183,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2126,
+					"id": 2144,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9975,14 +9975,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4116,
+							"line": 4196,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2128,
+					"id": 2146,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10003,14 +10003,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4140,
+							"line": 4220,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2127,
+					"id": 2145,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10031,14 +10031,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4128,
+							"line": 4208,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2122,
+					"id": 2140,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10059,14 +10059,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4064,
+							"line": 4144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2123,
+					"id": 2141,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10087,14 +10087,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4077,
+							"line": 4157,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2124,
+					"id": 2142,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10115,14 +10115,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4090,
+							"line": 4170,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2120,
+					"id": 2138,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10148,14 +10148,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4036,
+							"line": 4116,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2084,
+					"id": 2102,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10177,14 +10177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3545,
+							"line": 3625,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2069,
+					"id": 2087,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10201,14 +10201,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3305,
+							"line": 3385,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2071,
+					"id": 2089,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10245,14 +10245,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3322,
+							"line": 3402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2072,
+					"id": 2090,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10285,14 +10285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3332,
+							"line": 3412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2045,
+					"id": 2063,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10313,14 +10313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3045,
+							"line": 3125,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2012,
+					"id": 2030,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10349,14 +10349,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2601,
+							"line": 2681,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2011,
+					"id": 2029,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10381,14 +10381,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2582,
+							"line": 2662,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2066,
+					"id": 2084,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10409,7 +10409,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3273,
+							"line": 3353,
 							"character": 4
 						}
 					],
@@ -10421,133 +10421,133 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2038,
-						2029,
-						2009,
-						2091,
-						2055,
-						2014,
-						2051,
-						2037,
-						2101,
-						2080,
-						2015,
-						2003,
-						2062,
-						2078,
-						2049,
-						2064,
-						2044,
-						2070,
-						2085,
-						2086,
-						2079,
-						2065,
-						2010,
-						2005,
-						2092,
-						2008,
-						2060,
-						2076,
-						2077,
-						2027,
-						2026,
-						2031,
-						2034,
-						2033,
-						2032,
-						2035,
-						2036,
-						2043,
-						2042,
-						2007,
-						2057,
-						2046,
-						2119,
-						2013,
-						2063,
-						2047,
-						2068,
-						2021,
-						2002,
-						2095,
-						2094,
-						2054,
-						2028,
-						2004,
-						2058,
-						2024,
-						2082,
-						2100,
-						2083,
-						2039,
-						2059,
-						2090,
-						2006,
-						2129,
-						2081,
-						2075,
-						2096,
-						2022,
-						2030,
-						2048,
-						2073,
-						2074,
 						2056,
-						2061,
-						2121,
-						2041,
-						2050,
-						2040,
-						2103,
-						2114,
-						2102,
-						2116,
-						2107,
-						2106,
-						2115,
-						2089,
-						2097,
-						2098,
-						2093,
-						2117,
-						2104,
-						2105,
+						2047,
+						2027,
 						2109,
-						2112,
-						2111,
+						2073,
+						2032,
+						2069,
+						2055,
+						2119,
+						2098,
+						2033,
+						2021,
+						2080,
+						2096,
+						2067,
+						2082,
+						2062,
+						2088,
+						2103,
+						2104,
+						2097,
+						2083,
+						2028,
+						2023,
 						2110,
+						2026,
+						2078,
+						2094,
+						2095,
+						2045,
+						2044,
+						2049,
+						2052,
+						2051,
+						2050,
+						2053,
+						2054,
+						2061,
+						2060,
+						2025,
+						2075,
+						2064,
+						2137,
+						2031,
+						2081,
+						2065,
+						2086,
+						2039,
+						2020,
 						2113,
+						2112,
+						2072,
+						2046,
+						2022,
+						2076,
+						2042,
+						2100,
+						2118,
+						2101,
+						2057,
+						2077,
 						2108,
+						2024,
+						2147,
+						2099,
+						2093,
+						2114,
+						2040,
+						2048,
+						2066,
+						2091,
+						2092,
+						2074,
+						2079,
+						2139,
+						2059,
+						2068,
+						2058,
+						2121,
+						2132,
+						2120,
+						2134,
 						2125,
-						2126,
-						2128,
-						2127,
+						2124,
+						2133,
+						2107,
+						2115,
+						2116,
+						2111,
+						2135,
 						2122,
 						2123,
-						2124,
-						2120,
-						2084,
-						2069,
-						2071,
-						2072,
-						2045,
-						2012,
-						2011,
-						2066
+						2127,
+						2130,
+						2129,
+						2128,
+						2131,
+						2126,
+						2143,
+						2144,
+						2146,
+						2145,
+						2140,
+						2141,
+						2142,
+						2138,
+						2102,
+						2087,
+						2089,
+						2090,
+						2063,
+						2030,
+						2029,
+						2084
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2430,
+					"line": 2510,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3280,
+			"id": 3303,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10572,7 +10572,7 @@
 			},
 			"children": [
 				{
-					"id": 3281,
+					"id": 3304,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10583,14 +10583,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8922,
+							"line": 9002,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3283,
+					"id": 3306,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10601,14 +10601,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8926,
+							"line": 9006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3282,
+					"id": 3305,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10619,7 +10619,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8924,
+							"line": 9004,
 							"character": 4
 						}
 					],
@@ -10631,22 +10631,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3281,
-						3283,
-						3282
+						3304,
+						3306,
+						3305
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8920,
+					"line": 9000,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2846,
+			"id": 2868,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10656,7 +10656,7 @@
 			},
 			"children": [
 				{
-					"id": 2850,
+					"id": 2872,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10680,7 +10680,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2857,
+					"id": 2879,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10704,7 +10704,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 2854,
+					"id": 2876,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10728,7 +10728,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2856,
+					"id": 2878,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10752,7 +10752,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2848,
+					"id": 2870,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10776,7 +10776,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2853,
+					"id": 2875,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10800,7 +10800,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2849,
+					"id": 2871,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10824,7 +10824,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2851,
+					"id": 2873,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10848,7 +10848,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2847,
+					"id": 2869,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10872,7 +10872,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2852,
+					"id": 2874,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10896,7 +10896,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2855,
+					"id": 2877,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10925,17 +10925,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2850,
-						2857,
-						2854,
-						2856,
-						2848,
-						2853,
-						2849,
-						2851,
-						2847,
-						2852,
-						2855
+						2872,
+						2879,
+						2876,
+						2878,
+						2870,
+						2875,
+						2871,
+						2873,
+						2869,
+						2874,
+						2877
 					]
 				}
 			],
@@ -10948,7 +10948,7 @@
 			]
 		},
 		{
-			"id": 3183,
+			"id": 3206,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10964,7 +10964,7 @@
 			},
 			"children": [
 				{
-					"id": 3186,
+					"id": 3209,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10988,7 +10988,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3184,
+					"id": 3207,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11012,7 +11012,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3185,
+					"id": 3208,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11035,9 +11035,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3186,
-						3184,
-						3185
+						3209,
+						3207,
+						3208
 					]
 				}
 			],
@@ -11050,14 +11050,14 @@
 			]
 		},
 		{
-			"id": 3177,
+			"id": 3200,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3179,
+					"id": 3202,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11072,7 +11072,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3180,
+					"id": 3203,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11087,7 +11087,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3178,
+					"id": 3201,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11107,9 +11107,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3179,
-						3180,
-						3178
+						3202,
+						3203,
+						3201
 					]
 				}
 			],
@@ -11122,7 +11122,7 @@
 			]
 		},
 		{
-			"id": 2858,
+			"id": 2880,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11139,7 +11139,7 @@
 			},
 			"children": [
 				{
-					"id": 2861,
+					"id": 2883,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11150,14 +11150,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2302,
+							"line": 2382,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2864,
+					"id": 2886,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11168,14 +11168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2314,
+							"line": 2394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2862,
+					"id": 2884,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11186,14 +11186,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2306,
+							"line": 2386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2859,
+					"id": 2881,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11204,14 +11204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2294,
+							"line": 2374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2863,
+					"id": 2885,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11222,14 +11222,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2310,
+							"line": 2390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2860,
+					"id": 2882,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11240,7 +11240,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2298,
+							"line": 2378,
 							"character": 4
 						}
 					],
@@ -11252,25 +11252,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2861,
-						2864,
-						2862,
-						2859,
-						2863,
-						2860
+						2883,
+						2886,
+						2884,
+						2881,
+						2885,
+						2882
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2290,
+					"line": 2370,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2130,
+			"id": 2148,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11303,7 +11303,7 @@
 			},
 			"children": [
 				{
-					"id": 2154,
+					"id": 2172,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11324,14 +11324,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4871,
+							"line": 4951,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2142,
+					"id": 2160,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11361,14 +11361,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4569,
+							"line": 4649,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2200,
+					"id": 2218,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11394,14 +11394,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6237,
+							"line": 6317,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2207,
+					"id": 2225,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11427,14 +11427,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6309,
+							"line": 6389,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2184,
+					"id": 2202,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11455,14 +11455,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5893,
+							"line": 5973,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2210,
+					"id": 2228,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11488,14 +11488,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6347,
+							"line": 6427,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2204,
+					"id": 2222,
 					"name": "CloseSpotterShareConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11516,14 +11516,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6276,
+							"line": 6356,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterShareConversation\""
 				},
 				{
-					"id": 2221,
+					"id": 2239,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11544,14 +11544,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6493,
+							"line": 6573,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2161,
+					"id": 2179,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11593,14 +11593,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5104,
+							"line": 5184,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2158,
+					"id": 2176,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11638,14 +11638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4979,
+							"line": 5059,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2201,
+					"id": 2219,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11666,14 +11666,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6246,
+							"line": 6326,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2165,
+					"id": 2183,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11707,14 +11707,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5257,
+							"line": 5337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2206,
+					"id": 2224,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11735,14 +11735,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6294,
+							"line": 6374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2212,
+					"id": 2230,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11763,14 +11763,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6367,
+							"line": 6447,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2167,
+					"id": 2185,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11800,14 +11800,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5319,
+							"line": 5399,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2169,
+					"id": 2187,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11841,14 +11841,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5389,
+							"line": 5469,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2152,
+					"id": 2170,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11886,14 +11886,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4849,
+							"line": 4929,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2168,
+					"id": 2186,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11918,14 +11918,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5350,
+							"line": 5430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2170,
+					"id": 2188,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11959,14 +11959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5428,
+							"line": 5508,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2153,
+					"id": 2171,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11987,14 +11987,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4861,
+							"line": 4941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2132,
+					"id": 2150,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12032,14 +12032,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4329,
+							"line": 4409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2160,
+					"id": 2178,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12078,14 +12078,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5059,
+							"line": 5139,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2198,
+					"id": 2216,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12115,14 +12115,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6211,
+							"line": 6291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2150,
+					"id": 2168,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12151,14 +12151,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4795,
+							"line": 4875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2205,
+					"id": 2223,
 					"name": "ExitSpotterSharedConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12179,14 +12179,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6285,
+							"line": 6365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ExitSpotterSharedConversation\""
 				},
 				{
-					"id": 2157,
+					"id": 2175,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12216,14 +12216,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4948,
+							"line": 5028,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2149,
+					"id": 2167,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12252,14 +12252,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4773,
+							"line": 4853,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2183,
+					"id": 2201,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12285,14 +12285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5883,
+							"line": 5963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2177,
+					"id": 2195,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12317,14 +12317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5638,
+							"line": 5718,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2180,
+					"id": 2198,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12349,14 +12349,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5809,
+							"line": 5889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 2135,
+					"id": 2153,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12381,14 +12381,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4356,
+							"line": 4436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2189,
+					"id": 2207,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12414,14 +12414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6016,
+							"line": 6096,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2163,
+					"id": 2181,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12458,14 +12458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5195,
+							"line": 5275,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2179,
+					"id": 2197,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12490,14 +12490,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5787,
+							"line": 5867,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2219,
+					"id": 2237,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12518,14 +12518,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6473,
+							"line": 6553,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2146,
+					"id": 2164,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12550,14 +12550,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4721,
+							"line": 4801,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2155,
+					"id": 2173,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12602,14 +12602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4916,
+							"line": 4996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2159,
+					"id": 2177,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12651,14 +12651,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5014,
+							"line": 5094,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2175,
+					"id": 2193,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12692,14 +12692,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5594,
+							"line": 5674,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2139,
+					"id": 2157,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12726,14 +12726,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4472,
+							"line": 4552,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2140,
+					"id": 2158,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12771,14 +12771,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4519,
+							"line": 4599,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2141,
+					"id": 2159,
 					"name": "OpenParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12808,14 +12808,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4551,
+							"line": 4631,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openParameter\""
 				},
 				{
-					"id": 2220,
+					"id": 2238,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12836,14 +12836,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6483,
+							"line": 6563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2145,
+					"id": 2163,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12897,14 +12897,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4705,
+							"line": 4785,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2214,
+					"id": 2232,
 					"name": "PinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12926,14 +12926,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6400,
+							"line": 6480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinSpotterConversation\""
 				},
 				{
-					"id": 2162,
+					"id": 2180,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12975,14 +12975,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5149,
+							"line": 5229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2199,
+					"id": 2217,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13007,14 +13007,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6226,
+							"line": 6306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2222,
+					"id": 2240,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13035,14 +13035,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6504,
+							"line": 6584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2156,
+					"id": 2174,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13071,14 +13071,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4930,
+							"line": 5010,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2143,
+					"id": 2161,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13108,14 +13108,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4587,
+							"line": 4667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2186,
+					"id": 2204,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13140,14 +13140,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5920,
+							"line": 6000,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2187,
+					"id": 2205,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13168,14 +13168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5929,
+							"line": 6009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2176,
+					"id": 2194,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13200,14 +13200,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5612,
+							"line": 5692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2202,
+					"id": 2220,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13228,14 +13228,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6255,
+							"line": 6335,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2172,
+					"id": 2190,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13269,14 +13269,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5505,
+							"line": 5585,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2194,
+					"id": 2212,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13318,14 +13318,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6145,
+							"line": 6225,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2147,
+					"id": 2165,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13350,14 +13350,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4736,
+							"line": 4816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2148,
+					"id": 2166,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13367,11 +13367,11 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\n liveboardEmbed.trigger(HostEvent.ScheduleList)\n```"
+								"text": "\n```js\n liveboardEmbed.trigger(HostEvent.SchedulesList)\n```"
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Manage schedules from liveboard context\nimport { ContextType } from '@thoughtspot/visual-embed-sdk';\nliveboardEmbed.trigger(HostEvent.ScheduleList, {}, ContextType.Liveboard);\n```"
+								"text": "\n```js\n// Manage schedules from liveboard context\nimport { ContextType } from '@thoughtspot/visual-embed-sdk';\nliveboardEmbed.trigger(HostEvent.SchedulesList, {}, ContextType.Liveboard);\n```"
 							},
 							{
 								"tag": "version",
@@ -13382,14 +13382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4751,
+							"line": 4831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2131,
+					"id": 2149,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13415,14 +13415,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4260,
+							"line": 4340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2192,
+					"id": 2210,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13451,14 +13451,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6075,
+							"line": 6155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2217,
+					"id": 2235,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13483,14 +13483,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6450,
+							"line": 6530,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2137,
+					"id": 2155,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13520,14 +13520,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4398,
+							"line": 4478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2182,
+					"id": 2200,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13557,14 +13557,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5853,
+							"line": 5933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2181,
+					"id": 2199,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13594,14 +13594,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5831,
+							"line": 5911,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2136,
+					"id": 2154,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13631,14 +13631,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4378,
+							"line": 4458,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2171,
+					"id": 2189,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13667,14 +13667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5453,
+							"line": 5533,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2203,
+					"id": 2221,
 					"name": "ShareSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13695,14 +13695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6267,
+							"line": 6347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ShareSpotterConversation\""
 				},
 				{
-					"id": 2164,
+					"id": 2182,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13736,14 +13736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5228,
+							"line": 5308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2166,
+					"id": 2184,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13777,14 +13777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5291,
+							"line": 5371,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2197,
+					"id": 2215,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13814,14 +13814,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6195,
+							"line": 6275,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2218,
+					"id": 2236,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13847,14 +13847,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6463,
+							"line": 6543,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2213,
+					"id": 2231,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13876,14 +13876,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6381,
+							"line": 6461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2174,
+					"id": 2192,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13917,14 +13917,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5564,
+							"line": 5644,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2173,
+					"id": 2191,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13958,14 +13958,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5534,
+							"line": 5614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2196,
+					"id": 2214,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13991,14 +13991,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6170,
+							"line": 6250,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2215,
+					"id": 2233,
 					"name": "UnpinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14020,14 +14020,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6418,
+							"line": 6498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UnpinSpotterConversation\""
 				},
 				{
-					"id": 2185,
+					"id": 2203,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14048,14 +14048,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5909,
+							"line": 5989,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2178,
+					"id": 2196,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14101,14 +14101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5766,
+							"line": 5846,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2188,
+					"id": 2206,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14142,14 +14142,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5979,
+							"line": 6059,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2190,
+					"id": 2208,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14174,14 +14174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6034,
+							"line": 6114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2191,
+					"id": 2209,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14198,14 +14198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6042,
+							"line": 6122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2138,
+					"id": 2156,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14240,14 +14240,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4441,
+							"line": 4521,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2151,
+					"id": 2169,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14272,14 +14272,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4810,
+							"line": 4890,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2144,
+					"id": 2162,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14300,7 +14300,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4603,
+							"line": 4683,
 							"character": 4
 						}
 					],
@@ -14312,103 +14312,103 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2154,
-						2142,
-						2200,
-						2207,
-						2184,
-						2210,
-						2204,
-						2221,
-						2161,
-						2158,
-						2201,
-						2165,
-						2206,
-						2212,
-						2167,
-						2169,
-						2152,
-						2168,
-						2170,
-						2153,
-						2132,
-						2160,
-						2198,
-						2150,
-						2205,
-						2157,
-						2149,
-						2183,
-						2177,
-						2180,
-						2135,
-						2189,
-						2163,
-						2179,
-						2219,
-						2146,
-						2155,
-						2159,
-						2175,
-						2139,
-						2140,
-						2141,
-						2220,
-						2145,
-						2214,
-						2162,
-						2199,
-						2222,
-						2156,
-						2143,
-						2186,
-						2187,
-						2176,
-						2202,
 						2172,
-						2194,
-						2147,
-						2148,
-						2131,
-						2192,
-						2217,
-						2137,
-						2182,
-						2181,
-						2136,
-						2171,
-						2203,
-						2164,
-						2166,
-						2197,
+						2160,
 						2218,
-						2213,
-						2174,
-						2173,
-						2196,
-						2215,
+						2225,
+						2202,
+						2228,
+						2222,
+						2239,
+						2179,
+						2176,
+						2219,
+						2183,
+						2224,
+						2230,
 						2185,
-						2178,
+						2187,
+						2170,
+						2186,
 						2188,
+						2171,
+						2150,
+						2178,
+						2216,
+						2168,
+						2223,
+						2175,
+						2167,
+						2201,
+						2195,
+						2198,
+						2153,
+						2207,
+						2181,
+						2197,
+						2237,
+						2164,
+						2173,
+						2177,
+						2193,
+						2157,
+						2158,
+						2159,
+						2238,
+						2163,
+						2232,
+						2180,
+						2217,
+						2240,
+						2174,
+						2161,
+						2204,
+						2205,
+						2194,
+						2220,
 						2190,
+						2212,
+						2165,
+						2166,
+						2149,
+						2210,
+						2235,
+						2155,
+						2200,
+						2199,
+						2154,
+						2189,
+						2221,
+						2182,
+						2184,
+						2215,
+						2236,
+						2231,
+						2192,
 						2191,
-						2138,
-						2151,
-						2144
+						2214,
+						2233,
+						2203,
+						2196,
+						2206,
+						2208,
+						2209,
+						2156,
+						2169,
+						2162
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4230,
+					"line": 4310,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3252,
+			"id": 3275,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14418,7 +14418,7 @@
 			},
 			"children": [
 				{
-					"id": 3254,
+					"id": 3277,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14429,14 +14429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9144,
+							"line": 9224,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3253,
+					"id": 3276,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14447,14 +14447,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9140,
+							"line": 9220,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3255,
+					"id": 3278,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14465,7 +14465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9148,
+							"line": 9228,
 							"character": 4
 						}
 					],
@@ -14477,22 +14477,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3254,
-						3253,
-						3255
+						3277,
+						3276,
+						3278
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9136,
+					"line": 9216,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3288,
+			"id": 3311,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14508,7 +14508,7 @@
 			},
 			"children": [
 				{
-					"id": 3290,
+					"id": 3313,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14519,14 +14519,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9414,
+							"line": 9494,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3291,
+					"id": 3314,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14537,14 +14537,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9416,
+							"line": 9496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3292,
+					"id": 3315,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14555,14 +14555,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9418,
+							"line": 9498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3289,
+					"id": 3312,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14573,7 +14573,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9412,
+							"line": 9492,
 							"character": 4
 						}
 					],
@@ -14585,23 +14585,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3290,
-						3291,
-						3292,
-						3289
+						3313,
+						3314,
+						3315,
+						3312
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9410,
+					"line": 9490,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3187,
+			"id": 3210,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14617,7 +14617,7 @@
 			},
 			"children": [
 				{
-					"id": 3188,
+					"id": 3211,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14635,7 +14635,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3189,
+					"id": 3212,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14658,8 +14658,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3188,
-						3189
+						3211,
+						3212
 					]
 				}
 			],
@@ -14672,7 +14672,7 @@
 			]
 		},
 		{
-			"id": 3231,
+			"id": 3254,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14688,7 +14688,7 @@
 			},
 			"children": [
 				{
-					"id": 3235,
+					"id": 3258,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14699,14 +14699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2340,
+							"line": 2420,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3236,
+					"id": 3259,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14717,14 +14717,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2344,
+							"line": 2424,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3232,
+					"id": 3255,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14735,14 +14735,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2327,
+							"line": 2407,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3233,
+					"id": 3256,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14759,14 +14759,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2332,
+							"line": 2412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3237,
+					"id": 3260,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14777,14 +14777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2348,
+							"line": 2428,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3234,
+					"id": 3257,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14795,14 +14795,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2336,
+							"line": 2416,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3238,
+					"id": 3261,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14813,7 +14813,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2352,
+							"line": 2432,
 							"character": 4
 						}
 					],
@@ -14825,26 +14825,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3235,
-						3236,
-						3232,
-						3233,
-						3237,
-						3234,
-						3238
+						3258,
+						3259,
+						3255,
+						3256,
+						3260,
+						3257,
+						3261
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2323,
+					"line": 2403,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3150,
+			"id": 3173,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14854,7 +14854,7 @@
 			},
 			"children": [
 				{
-					"id": 3155,
+					"id": 3178,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14875,14 +14875,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8876,
+							"line": 8956,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3152,
+					"id": 3175,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14903,14 +14903,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8837,
+							"line": 8917,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3154,
+					"id": 3177,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14931,14 +14931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8862,
+							"line": 8942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3151,
+					"id": 3174,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14959,14 +14959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8825,
+							"line": 8905,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3156,
+					"id": 3179,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14987,14 +14987,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8888,
+							"line": 8968,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3153,
+					"id": 3176,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15015,7 +15015,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8849,
+							"line": 8929,
 							"character": 4
 						}
 					],
@@ -15027,25 +15027,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3155,
-						3152,
-						3154,
-						3151,
-						3156,
-						3153
+						3178,
+						3175,
+						3177,
+						3174,
+						3179,
+						3176
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8812,
+					"line": 8892,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1959,
+			"id": 1977,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15055,7 +15055,7 @@
 			},
 			"children": [
 				{
-					"id": 1962,
+					"id": 1980,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15073,7 +15073,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1968,
+					"id": 1986,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15091,7 +15091,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 1965,
+					"id": 1983,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15109,7 +15109,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1960,
+					"id": 1978,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15127,7 +15127,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1963,
+					"id": 1981,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15145,7 +15145,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1967,
+					"id": 1985,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15163,7 +15163,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1961,
+					"id": 1979,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15181,7 +15181,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1966,
+					"id": 1984,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15204,14 +15204,14 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1962,
-						1968,
-						1965,
-						1960,
-						1963,
-						1967,
-						1961,
-						1966
+						1980,
+						1986,
+						1983,
+						1978,
+						1981,
+						1985,
+						1979,
+						1984
 					]
 				}
 			],
@@ -15224,14 +15224,14 @@
 			]
 		},
 		{
-			"id": 2835,
+			"id": 2857,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2836,
+					"id": 2858,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15239,14 +15239,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8641,
+							"line": 8721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2838,
+					"id": 2860,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15254,14 +15254,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8643,
+							"line": 8723,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2837,
+					"id": 2859,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15269,14 +15269,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8642,
+							"line": 8722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2839,
+					"id": 2861,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15284,7 +15284,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8644,
+							"line": 8724,
 							"character": 4
 						}
 					],
@@ -15296,23 +15296,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2836,
-						2838,
-						2837,
-						2839
+						2858,
+						2860,
+						2859,
+						2861
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8640,
+					"line": 8720,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3181,
+			"id": 3204,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15328,7 +15328,7 @@
 			},
 			"children": [
 				{
-					"id": 3182,
+					"id": 3205,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15351,7 +15351,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3182
+						3205
 					]
 				}
 			],
@@ -15364,7 +15364,7 @@
 			]
 		},
 		{
-			"id": 1985,
+			"id": 2003,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15374,7 +15374,7 @@
 			},
 			"children": [
 				{
-					"id": 1993,
+					"id": 2011,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15385,14 +15385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2248,
+							"line": 2328,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 1998,
+					"id": 2016,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15403,14 +15403,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2268,
+							"line": 2348,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 1997,
+					"id": 2015,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15421,14 +15421,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2264,
+							"line": 2344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 1995,
+					"id": 2013,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15439,14 +15439,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2256,
+							"line": 2336,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 1996,
+					"id": 2014,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15457,14 +15457,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2260,
+							"line": 2340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 1992,
+					"id": 2010,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15475,14 +15475,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2244,
+							"line": 2324,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 1994,
+					"id": 2012,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15493,14 +15493,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2252,
+							"line": 2332,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 1986,
+					"id": 2004,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15511,14 +15511,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2220,
+							"line": 2300,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 1991,
+					"id": 2009,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15529,14 +15529,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2240,
+							"line": 2320,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 1990,
+					"id": 2008,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15547,14 +15547,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2236,
+							"line": 2316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 1999,
+					"id": 2017,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15565,14 +15565,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2272,
+							"line": 2352,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 1989,
+					"id": 2007,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15583,14 +15583,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2232,
+							"line": 2312,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 1988,
+					"id": 2006,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15601,14 +15601,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2228,
+							"line": 2308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 1987,
+					"id": 2005,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15619,14 +15619,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2224,
+							"line": 2304,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2000,
+					"id": 2018,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15637,7 +15637,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2276,
+							"line": 2356,
 							"character": 4
 						}
 					],
@@ -15649,34 +15649,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1993,
-						1998,
-						1997,
-						1995,
-						1996,
-						1992,
-						1994,
-						1986,
-						1991,
-						1990,
-						1999,
-						1989,
-						1988,
-						1987,
-						2000
+						2011,
+						2016,
+						2015,
+						2013,
+						2014,
+						2010,
+						2012,
+						2004,
+						2009,
+						2008,
+						2017,
+						2007,
+						2006,
+						2005,
+						2018
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2216,
+					"line": 2296,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1540,
+			"id": 1555,
 			"name": "SpotterQueryMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15692,7 +15692,7 @@
 			},
 			"children": [
 				{
-					"id": 1541,
+					"id": 1556,
 					"name": "FAST_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15707,7 +15707,7 @@
 					"defaultValue": "\"fastSearch\""
 				},
 				{
-					"id": 1542,
+					"id": 1557,
 					"name": "RESEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15727,8 +15727,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1541,
-						1542
+						1556,
+						1557
 					]
 				}
 			],
@@ -15741,7 +15741,7 @@
 			]
 		},
 		{
-			"id": 3327,
+			"id": 3350,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15757,7 +15757,7 @@
 			},
 			"children": [
 				{
-					"id": 3329,
+					"id": 3352,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15768,14 +15768,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9442,
+							"line": 9522,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3328,
+					"id": 3351,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15786,7 +15786,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9440,
+							"line": 9520,
 							"character": 4
 						}
 					],
@@ -15798,21 +15798,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3329,
-						3328
+						3352,
+						3351
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9438,
+					"line": 9518,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3323,
+			"id": 3346,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15828,7 +15828,7 @@
 			},
 			"children": [
 				{
-					"id": 3324,
+					"id": 3347,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15839,14 +15839,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9427,
+							"line": 9507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3325,
+					"id": 3348,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15857,14 +15857,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9429,
+							"line": 9509,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3326,
+					"id": 3349,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15875,7 +15875,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9431,
+							"line": 9511,
 							"character": 4
 						}
 					],
@@ -15887,29 +15887,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3324,
-						3325,
-						3326
+						3347,
+						3348,
+						3349
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9425,
+					"line": 9505,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3213,
+			"id": 3236,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3222,
+					"id": 3245,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15924,7 +15924,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3218,
+					"id": 3241,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15939,7 +15939,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3223,
+					"id": 3246,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15954,7 +15954,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3217,
+					"id": 3240,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15969,7 +15969,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3216,
+					"id": 3239,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15984,7 +15984,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3230,
+					"id": 3253,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15999,7 +15999,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3224,
+					"id": 3247,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16014,7 +16014,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3229,
+					"id": 3252,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16029,7 +16029,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 3225,
+					"id": 3248,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16044,7 +16044,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3219,
+					"id": 3242,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16059,7 +16059,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3226,
+					"id": 3249,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16074,7 +16074,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3227,
+					"id": 3250,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16089,7 +16089,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3228,
+					"id": 3251,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16104,7 +16104,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3220,
+					"id": 3243,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16119,7 +16119,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3214,
+					"id": 3237,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16134,7 +16134,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3215,
+					"id": 3238,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16149,7 +16149,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3221,
+					"id": 3244,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16169,23 +16169,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3222,
-						3218,
-						3223,
-						3217,
-						3216,
-						3230,
-						3224,
-						3229,
-						3225,
-						3219,
-						3226,
-						3227,
-						3228,
-						3220,
-						3214,
-						3215,
-						3221
+						3245,
+						3241,
+						3246,
+						3240,
+						3239,
+						3253,
+						3247,
+						3252,
+						3248,
+						3242,
+						3249,
+						3250,
+						3251,
+						3243,
+						3237,
+						3238,
+						3244
 					]
 				}
 			],
@@ -16198,7 +16198,7 @@
 			]
 		},
 		{
-			"id": 1872,
+			"id": 1890,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -16227,7 +16227,7 @@
 			},
 			"children": [
 				{
-					"id": 1873,
+					"id": 1891,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16244,7 +16244,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1874,
+							"id": 1892,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -16254,7 +16254,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1875,
+									"id": 1893,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16262,12 +16262,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1949,
+										"id": 1967,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1876,
+									"id": 1894,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16279,7 +16279,7 @@
 									}
 								},
 								{
-									"id": 1877,
+									"id": 1895,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16291,7 +16291,7 @@
 									}
 								},
 								{
-									"id": 1878,
+									"id": 1896,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16305,7 +16305,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3190,
+											"id": 3213,
 											"name": "VizPoint"
 										}
 									}
@@ -16313,14 +16313,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1872,
+								"id": 1890,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1887,
+					"id": 1905,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16336,7 +16336,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1888,
+							"id": 1906,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16347,7 +16347,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1889,
+									"id": 1907,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16376,7 +16376,7 @@
 					]
 				},
 				{
-					"id": 1890,
+					"id": 1908,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16392,7 +16392,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1891,
+							"id": 1909,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16408,7 +16408,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1892,
+									"id": 1910,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16437,7 +16437,7 @@
 					]
 				},
 				{
-					"id": 1943,
+					"id": 1961,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16453,14 +16453,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1944,
+							"id": 1962,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1945,
+									"id": 1963,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16485,7 +16485,7 @@
 					]
 				},
 				{
-					"id": 1893,
+					"id": 1911,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16501,7 +16501,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1894,
+							"id": 1912,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16512,7 +16512,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1895,
+									"id": 1913,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16524,7 +16524,7 @@
 									}
 								},
 								{
-									"id": 1896,
+									"id": 1914,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16532,12 +16532,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1985,
+										"id": 2003,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1897,
+									"id": 1915,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16583,7 +16583,7 @@
 					]
 				},
 				{
-					"id": 1933,
+					"id": 1951,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16599,7 +16599,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1934,
+							"id": 1952,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16610,7 +16610,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1935,
+									"id": 1953,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16624,7 +16624,7 @@
 									}
 								},
 								{
-									"id": 1936,
+									"id": 1954,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16652,7 +16652,7 @@
 					]
 				},
 				{
-					"id": 1911,
+					"id": 1929,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16668,7 +16668,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1912,
+							"id": 1930,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16679,7 +16679,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1913,
+									"id": 1931,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16692,7 +16692,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1914,
+									"id": 1932,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16721,7 +16721,7 @@
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1922,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16737,7 +16737,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1923,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16748,7 +16748,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1906,
+									"id": 1924,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16761,7 +16761,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1907,
+									"id": 1925,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16780,14 +16780,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1908,
+											"id": 1926,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1909,
+													"id": 1927,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16798,7 +16798,7 @@
 													}
 												},
 												{
-													"id": 1910,
+													"id": 1928,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16814,8 +16814,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1909,
-														1910
+														1927,
+														1928
 													]
 												}
 											]
@@ -16828,7 +16828,7 @@
 					]
 				},
 				{
-					"id": 1915,
+					"id": 1933,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16844,7 +16844,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1916,
+							"id": 1934,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16855,7 +16855,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1917,
+									"id": 1935,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16868,7 +16868,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1918,
+									"id": 1936,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16883,7 +16883,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1919,
+									"id": 1937,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16912,7 +16912,7 @@
 					]
 				},
 				{
-					"id": 1939,
+					"id": 1957,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16928,7 +16928,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1940,
+							"id": 1958,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16947,7 +16947,7 @@
 					]
 				},
 				{
-					"id": 1920,
+					"id": 1938,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16963,7 +16963,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1939,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16974,7 +16974,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1940,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16987,7 +16987,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1923,
+									"id": 1941,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17008,7 +17008,7 @@
 					]
 				},
 				{
-					"id": 1924,
+					"id": 1942,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17024,7 +17024,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1925,
+							"id": 1943,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17034,7 +17034,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1926,
+									"id": 1944,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17047,7 +17047,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1927,
+									"id": 1945,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17060,7 +17060,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1928,
+									"id": 1946,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17083,7 +17083,7 @@
 					]
 				},
 				{
-					"id": 1901,
+					"id": 1919,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17099,14 +17099,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1902,
+							"id": 1920,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1903,
+									"id": 1921,
 									"name": "fetchSQLWithAllColumns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17132,7 +17132,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1955,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17148,7 +17148,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1956,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17159,14 +17159,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1949,
+								"id": 1967,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1882,
+					"id": 1900,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17182,7 +17182,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1883,
+							"id": 1901,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17204,7 +17204,7 @@
 					]
 				},
 				{
-					"id": 1941,
+					"id": 1959,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17220,7 +17220,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1942,
+							"id": 1960,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17239,7 +17239,7 @@
 					]
 				},
 				{
-					"id": 1929,
+					"id": 1947,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17255,7 +17255,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1930,
+							"id": 1948,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17275,7 +17275,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1931,
+									"id": 1949,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17290,7 +17290,7 @@
 									}
 								},
 								{
-									"id": 1932,
+									"id": 1950,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17302,7 +17302,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1956,
+											"id": 1974,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -17313,7 +17313,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -17323,7 +17323,7 @@
 					]
 				},
 				{
-					"id": 1884,
+					"id": 1902,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17339,7 +17339,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1885,
+							"id": 1903,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17350,7 +17350,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1886,
+									"id": 1904,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17379,7 +17379,7 @@
 					]
 				},
 				{
-					"id": 1946,
+					"id": 1964,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17395,14 +17395,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1947,
+							"id": 1965,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1948,
+									"id": 1966,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17421,7 +17421,7 @@
 					]
 				},
 				{
-					"id": 1898,
+					"id": 1916,
 					"name": "updateDisplayMode",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17437,14 +17437,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1899,
+							"id": 1917,
 							"name": "updateDisplayMode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1900,
+									"id": 1918,
 									"name": "displayMode",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17475,32 +17475,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1873
+						1891
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1887,
-						1890,
-						1943,
-						1893,
-						1933,
+						1905,
+						1908,
+						1961,
 						1911,
-						1904,
-						1915,
-						1939,
-						1920,
-						1924,
-						1901,
-						1937,
-						1882,
-						1941,
+						1951,
 						1929,
-						1884,
-						1946,
-						1898
+						1922,
+						1933,
+						1957,
+						1938,
+						1942,
+						1919,
+						1955,
+						1900,
+						1959,
+						1947,
+						1902,
+						1964,
+						1916
 					]
 				}
 			],
@@ -17513,7 +17513,7 @@
 			]
 		},
 		{
-			"id": 903,
+			"id": 911,
 			"name": "AppEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -17529,7 +17529,7 @@
 			},
 			"children": [
 				{
-					"id": 904,
+					"id": 912,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -17543,40 +17543,40 @@
 					],
 					"signatures": [
 						{
-							"id": 905,
+							"id": 913,
 							"name": "new AppEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 906,
+									"id": 914,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2887,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 907,
+									"id": 915,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2719,
+										"id": 2740,
 										"name": "AppViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 903,
+								"id": 911,
 								"name": "AppEmbed"
 							},
 							"overwrites": {
@@ -17591,7 +17591,7 @@
 					}
 				},
 				{
-					"id": 947,
+					"id": 955,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17607,7 +17607,7 @@
 					],
 					"signatures": [
 						{
-							"id": 948,
+							"id": 956,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17637,7 +17637,7 @@
 					}
 				},
 				{
-					"id": 1132,
+					"id": 1142,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17647,13 +17647,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1133,
+							"id": 1143,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17669,7 +17669,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1134,
+									"id": 1144,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17690,7 +17690,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -17708,7 +17708,7 @@
 					}
 				},
 				{
-					"id": 1097,
+					"id": 1107,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17718,13 +17718,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1098,
+							"id": 1108,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17765,7 +17765,7 @@
 					}
 				},
 				{
-					"id": 924,
+					"id": 932,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17781,7 +17781,7 @@
 					],
 					"signatures": [
 						{
-							"id": 925,
+							"id": 933,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17797,7 +17797,7 @@
 					]
 				},
 				{
-					"id": 1093,
+					"id": 1103,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17807,13 +17807,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1094,
+							"id": 1104,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17834,7 +17834,7 @@
 					}
 				},
 				{
-					"id": 1126,
+					"id": 1136,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17844,13 +17844,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1127,
+							"id": 1137,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17872,14 +17872,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1128,
+									"id": 1138,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1130,
+											"id": 1140,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17891,7 +17891,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1131,
+											"id": 1141,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17903,7 +17903,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1129,
+											"id": 1139,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17920,9 +17920,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1130,
-												1131,
-												1129
+												1140,
+												1141,
+												1139
 											]
 										}
 									]
@@ -17940,7 +17940,7 @@
 					}
 				},
 				{
-					"id": 1106,
+					"id": 1116,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17950,13 +17950,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1107,
+							"id": 1117,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17972,7 +17972,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1108,
+									"id": 1118,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17980,20 +17980,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1109,
+											"id": 1119,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1110,
+												"id": 1120,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1111,
+														"id": 1121,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -18038,7 +18038,7 @@
 					}
 				},
 				{
-					"id": 1112,
+					"id": 1122,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18048,13 +18048,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1113,
+							"id": 1123,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18075,7 +18075,7 @@
 					}
 				},
 				{
-					"id": 1124,
+					"id": 1134,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18085,13 +18085,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1125,
+							"id": 1135,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18115,7 +18115,7 @@
 					}
 				},
 				{
-					"id": 943,
+					"id": 951,
 					"name": "navigateToPage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18131,7 +18131,7 @@
 					],
 					"signatures": [
 						{
-							"id": 944,
+							"id": 952,
 							"name": "navigateToPage",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18147,7 +18147,7 @@
 							},
 							"parameters": [
 								{
-									"id": 945,
+									"id": 953,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18170,7 +18170,7 @@
 									}
 								},
 								{
-									"id": 946,
+									"id": 954,
 									"name": "noReload",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18193,7 +18193,7 @@
 					]
 				},
 				{
-					"id": 1062,
+					"id": 1072,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18203,13 +18203,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1063,
+							"id": 1073,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18225,7 +18225,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1064,
+									"id": 1074,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18235,12 +18235,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1065,
+									"id": 1075,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18250,7 +18250,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -18271,7 +18271,7 @@
 					}
 				},
 				{
-					"id": 962,
+					"id": 970,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18281,13 +18281,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2284,
+							"line": 2304,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 963,
+							"id": 971,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18310,38 +18310,38 @@
 							},
 							"parameters": [
 								{
-									"id": 964,
+									"id": 972,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 965,
+									"id": 973,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 966,
+									"id": 974,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18363,7 +18363,7 @@
 					}
 				},
 				{
-					"id": 1102,
+					"id": 1112,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18373,13 +18373,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1103,
+							"id": 1113,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18389,7 +18389,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1104,
+									"id": 1114,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18404,7 +18404,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1105,
+									"id": 1115,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18438,7 +18438,7 @@
 					}
 				},
 				{
-					"id": 1114,
+					"id": 1124,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18448,13 +18448,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1115,
+							"id": 1125,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18491,7 +18491,7 @@
 					}
 				},
 				{
-					"id": 955,
+					"id": 963,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18507,7 +18507,7 @@
 					],
 					"signatures": [
 						{
-							"id": 956,
+							"id": 964,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18520,7 +18520,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 903,
+										"id": 911,
 										"name": "AppEmbed"
 									}
 								],
@@ -18538,7 +18538,7 @@
 					}
 				},
 				{
-					"id": 1118,
+					"id": 1128,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18548,13 +18548,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1119,
+							"id": 1129,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18584,7 +18584,7 @@
 					}
 				},
 				{
-					"id": 1099,
+					"id": 1109,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18594,13 +18594,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1100,
+							"id": 1110,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18618,7 +18618,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1101,
+									"id": 1111,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18631,12 +18631,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -18659,7 +18659,7 @@
 					}
 				},
 				{
-					"id": 1122,
+					"id": 1132,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18669,13 +18669,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1123,
+							"id": 1133,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18705,7 +18705,7 @@
 					}
 				},
 				{
-					"id": 1080,
+					"id": 1090,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18715,13 +18715,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1081,
+							"id": 1091,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18742,40 +18742,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1082,
+									"id": 1092,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1083,
+									"id": 1093,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1084,
+									"id": 1094,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1085,
+									"id": 1095,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18789,7 +18789,7 @@
 									}
 								},
 								{
-									"id": 1086,
+									"id": 1096,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18814,7 +18814,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1087,
+									"id": 1097,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18866,7 +18866,7 @@
 					}
 				},
 				{
-					"id": 1088,
+					"id": 1098,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18876,13 +18876,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1089,
+							"id": 1099,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18893,21 +18893,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1090,
+									"id": 1100,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1091,
+									"id": 1101,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18921,7 +18921,7 @@
 									}
 								},
 								{
-									"id": 1092,
+									"id": 1102,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18974,33 +18974,33 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						904
+						912
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						947,
-						1132,
-						1097,
-						924,
-						1093,
-						1126,
-						1106,
+						955,
+						1142,
+						1107,
+						932,
+						1103,
+						1136,
+						1116,
+						1122,
+						1134,
+						951,
+						1072,
+						970,
 						1112,
 						1124,
-						943,
-						1062,
-						962,
-						1102,
-						1114,
-						955,
-						1118,
-						1099,
-						1122,
-						1080,
-						1088
+						963,
+						1128,
+						1109,
+						1132,
+						1090,
+						1098
 					]
 				}
 			],
@@ -19019,7 +19019,7 @@
 			]
 		},
 		{
-			"id": 1243,
+			"id": 1255,
 			"name": "BodylessConversation",
 			"kind": 128,
 			"kindString": "Class",
@@ -19043,7 +19043,7 @@
 			},
 			"children": [
 				{
-					"id": 1244,
+					"id": 1256,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19057,45 +19057,45 @@
 					],
 					"signatures": [
 						{
-							"id": 1245,
+							"id": 1257,
 							"name": "new BodylessConversation",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1246,
+									"id": 1258,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1205,
+										"id": 1216,
 										"name": "BodylessConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1243,
+								"id": 1255,
 								"name": "BodylessConversation"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1137,
+								"id": 1147,
 								"name": "SpotterAgentEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1136,
+						"id": 1146,
 						"name": "SpotterAgentEmbed.constructor"
 					}
 				},
 				{
-					"id": 1247,
+					"id": 1259,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19111,14 +19111,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1248,
+							"id": 1260,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1249,
+									"id": 1261,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19138,14 +19138,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1250,
+													"id": 1262,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1252,
+															"id": 1264,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19156,7 +19156,7 @@
 															}
 														},
 														{
-															"id": 1251,
+															"id": 1263,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19167,7 +19167,7 @@
 															}
 														},
 														{
-															"id": 1253,
+															"id": 1265,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19184,9 +19184,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1252,
-																1251,
-																1253
+																1264,
+																1263,
+																1265
 															]
 														}
 													]
@@ -19195,14 +19195,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1254,
+													"id": 1266,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1255,
+															"id": 1267,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19213,7 +19213,7 @@
 															}
 														},
 														{
-															"id": 1257,
+															"id": 1269,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19224,7 +19224,7 @@
 															}
 														},
 														{
-															"id": 1256,
+															"id": 1268,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19241,9 +19241,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1255,
-																1257,
-																1256
+																1267,
+																1269,
+																1268
 															]
 														}
 													]
@@ -19256,19 +19256,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1141,
+								"id": 1151,
 								"name": "SpotterAgentEmbed.sendMessage"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1140,
+						"id": 1150,
 						"name": "SpotterAgentEmbed.sendMessage"
 					}
 				},
 				{
-					"id": 1258,
+					"id": 1270,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19284,7 +19284,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1259,
+							"id": 1271,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19295,7 +19295,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1260,
+									"id": 1272,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19318,14 +19318,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1261,
+													"id": 1273,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1263,
+															"id": 1275,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19337,7 +19337,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1262,
+															"id": 1274,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19353,8 +19353,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1263,
-																1262
+																1275,
+																1274
 															]
 														}
 													]
@@ -19363,14 +19363,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1264,
+													"id": 1276,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1265,
+															"id": 1277,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19378,14 +19378,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1266,
+																	"id": 1278,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1272,
+																			"id": 1284,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19397,7 +19397,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1271,
+																			"id": 1283,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19409,7 +19409,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1267,
+																			"id": 1279,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19421,7 +19421,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1270,
+																			"id": 1282,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19433,7 +19433,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1268,
+																			"id": 1280,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19445,7 +19445,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1269,
+																			"id": 1281,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19462,12 +19462,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1272,
-																				1271,
-																				1267,
-																				1270,
-																				1268,
-																				1269
+																				1284,
+																				1283,
+																				1279,
+																				1282,
+																				1280,
+																				1281
 																			]
 																		}
 																	]
@@ -19476,7 +19476,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1273,
+															"id": 1285,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19492,8 +19492,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1265,
-																1273
+																1277,
+																1285
 															]
 														}
 													]
@@ -19506,14 +19506,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1152,
+								"id": 1162,
 								"name": "SpotterAgentEmbed.sendMessageData"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1151,
+						"id": 1161,
 						"name": "SpotterAgentEmbed.sendMessageData"
 					}
 				}
@@ -19523,15 +19523,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1244
+						1256
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1247,
-						1258
+						1259,
+						1270
 					]
 				}
 			],
@@ -19545,13 +19545,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1135,
+					"id": 1145,
 					"name": "SpotterAgentEmbed"
 				}
 			]
 		},
 		{
-			"id": 1616,
+			"id": 1632,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19579,7 +19579,7 @@
 			},
 			"children": [
 				{
-					"id": 1617,
+					"id": 1633,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19593,14 +19593,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1618,
+							"id": 1634,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1619,
+									"id": 1635,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19611,38 +19611,38 @@
 									}
 								},
 								{
-									"id": 1620,
+									"id": 1636,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1557,
+										"id": 1572,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1616,
+								"id": 1632,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1276,
+								"id": 1288,
 								"name": "SpotterEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1275,
+						"id": 1287,
 						"name": "SpotterEmbed.constructor"
 					}
 				},
 				{
-					"id": 1777,
+					"id": 1795,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19652,13 +19652,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1796,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19678,19 +19678,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1436,
+								"id": 1450,
 								"name": "SpotterEmbed.destroy"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1435,
+						"id": 1449,
 						"name": "SpotterEmbed.destroy"
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1817,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19700,13 +19700,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1818,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19722,7 +19722,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1801,
+									"id": 1819,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19743,7 +19743,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -19751,19 +19751,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1458,
+								"id": 1472,
 								"name": "SpotterEmbed.getAnswerService"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1457,
+						"id": 1471,
 						"name": "SpotterEmbed.getAnswerService"
 					}
 				},
 				{
-					"id": 1762,
+					"id": 1780,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19773,13 +19773,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1763,
+							"id": 1781,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19810,19 +19810,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1421,
+								"id": 1435,
 								"name": "SpotterEmbed.getCurrentContext"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1420,
+						"id": 1434,
 						"name": "SpotterEmbed.getCurrentContext"
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1642,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19838,7 +19838,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1627,
+							"id": 1643,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19849,19 +19849,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1285,
+								"id": 1297,
 								"name": "SpotterEmbed.getIframeSrc"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1284,
+						"id": 1296,
 						"name": "SpotterEmbed.getIframeSrc"
 					}
 				},
 				{
-					"id": 1793,
+					"id": 1811,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19871,13 +19871,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1794,
+							"id": 1812,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19899,14 +19899,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1795,
+									"id": 1813,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1797,
+											"id": 1815,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19918,7 +19918,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1798,
+											"id": 1816,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19930,7 +19930,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1796,
+											"id": 1814,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19947,9 +19947,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1797,
-												1798,
-												1796
+												1815,
+												1816,
+												1814
 											]
 										}
 									]
@@ -19957,19 +19957,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1452,
+								"id": 1466,
 								"name": "SpotterEmbed.getPreRenderIds"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1451,
+						"id": 1465,
 						"name": "SpotterEmbed.getPreRenderIds"
 					}
 				},
 				{
-					"id": 1771,
+					"id": 1789,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19979,13 +19979,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1772,
+							"id": 1790,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20001,7 +20001,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1773,
+									"id": 1791,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20009,20 +20009,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1774,
+											"id": 1792,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1775,
+												"id": 1793,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1776,
+														"id": 1794,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -20057,19 +20057,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1430,
+								"id": 1444,
 								"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1429,
+						"id": 1443,
 						"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 					}
 				},
 				{
-					"id": 1779,
+					"id": 1797,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20079,13 +20079,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1780,
+							"id": 1798,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20096,19 +20096,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1438,
+								"id": 1452,
 								"name": "SpotterEmbed.getUnderlyingFrameElement"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1437,
+						"id": 1451,
 						"name": "SpotterEmbed.getUnderlyingFrameElement"
 					}
 				},
 				{
-					"id": 1791,
+					"id": 1809,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20118,13 +20118,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1792,
+							"id": 1810,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20138,19 +20138,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1450,
+								"id": 1464,
 								"name": "SpotterEmbed.hidePreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1449,
+						"id": 1463,
 						"name": "SpotterEmbed.hidePreRender"
 					}
 				},
 				{
-					"id": 1729,
+					"id": 1747,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20160,13 +20160,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1730,
+							"id": 1748,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20182,7 +20182,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1731,
+									"id": 1749,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20192,12 +20192,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1732,
+									"id": 1750,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20207,7 +20207,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -20218,19 +20218,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1388,
+								"id": 1402,
 								"name": "SpotterEmbed.off"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1387,
+						"id": 1401,
 						"name": "SpotterEmbed.off"
 					}
 				},
 				{
-					"id": 1723,
+					"id": 1741,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20240,13 +20240,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1724,
+							"id": 1742,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20266,7 +20266,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1725,
+									"id": 1743,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20276,12 +20276,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1726,
+									"id": 1744,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20291,12 +20291,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1727,
+									"id": 1745,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20306,13 +20306,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1728,
+									"id": 1746,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20331,19 +20331,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1382,
+								"id": 1396,
 								"name": "SpotterEmbed.on"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1381,
+						"id": 1395,
 						"name": "SpotterEmbed.on"
 					}
 				},
 				{
-					"id": 1767,
+					"id": 1785,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20353,13 +20353,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1768,
+							"id": 1786,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20369,7 +20369,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1769,
+									"id": 1787,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20384,7 +20384,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1770,
+									"id": 1788,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20408,19 +20408,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1426,
+								"id": 1440,
 								"name": "SpotterEmbed.preRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1425,
+						"id": 1439,
 						"name": "SpotterEmbed.preRender"
 					}
 				},
 				{
-					"id": 1781,
+					"id": 1799,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20430,13 +20430,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1782,
+							"id": 1800,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20463,19 +20463,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1440,
+								"id": 1454,
 								"name": "SpotterEmbed.prerenderGeneric"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1439,
+						"id": 1453,
 						"name": "SpotterEmbed.prerenderGeneric"
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1644,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20491,7 +20491,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1629,
+							"id": 1645,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20501,7 +20501,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1274,
+										"id": 1286,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -20509,19 +20509,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1287,
+								"id": 1299,
 								"name": "SpotterEmbed.render"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1286,
+						"id": 1298,
 						"name": "SpotterEmbed.render"
 					}
 				},
 				{
-					"id": 1785,
+					"id": 1803,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20531,13 +20531,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1786,
+							"id": 1804,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20557,19 +20557,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1444,
+								"id": 1458,
 								"name": "SpotterEmbed.showPreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1443,
+						"id": 1457,
 						"name": "SpotterEmbed.showPreRender"
 					}
 				},
 				{
-					"id": 1764,
+					"id": 1782,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20579,13 +20579,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1765,
+							"id": 1783,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20603,7 +20603,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1766,
+									"id": 1784,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20616,12 +20616,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -20634,19 +20634,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1423,
+								"id": 1437,
 								"name": "SpotterEmbed.subscribedEvent"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1422,
+						"id": 1436,
 						"name": "SpotterEmbed.subscribedEvent"
 					}
 				},
 				{
-					"id": 1789,
+					"id": 1807,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20656,13 +20656,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1790,
+							"id": 1808,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20682,19 +20682,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1448,
+								"id": 1462,
 								"name": "SpotterEmbed.syncPreRenderStyle"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1447,
+						"id": 1461,
 						"name": "SpotterEmbed.syncPreRenderStyle"
 					}
 				},
 				{
-					"id": 1747,
+					"id": 1765,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20704,13 +20704,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1748,
+							"id": 1766,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20731,40 +20731,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1749,
+									"id": 1767,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1750,
+									"id": 1768,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1751,
+									"id": 1769,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1752,
+									"id": 1770,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20778,7 +20778,7 @@
 									}
 								},
 								{
-									"id": 1753,
+									"id": 1771,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20803,7 +20803,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1754,
+									"id": 1772,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20845,19 +20845,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1406,
+								"id": 1420,
 								"name": "SpotterEmbed.trigger"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1405,
+						"id": 1419,
 						"name": "SpotterEmbed.trigger"
 					}
 				},
 				{
-					"id": 1755,
+					"id": 1773,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20867,13 +20867,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1756,
+							"id": 1774,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20884,21 +20884,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1757,
+									"id": 1775,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1758,
+									"id": 1776,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20912,7 +20912,7 @@
 									}
 								},
 								{
-									"id": 1759,
+									"id": 1777,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20950,14 +20950,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1414,
+								"id": 1428,
 								"name": "SpotterEmbed.triggerUIPassThrough"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1413,
+						"id": 1427,
 						"name": "SpotterEmbed.triggerUIPassThrough"
 					}
 				}
@@ -20967,31 +20967,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1617
+						1633
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1777,
-						1799,
-						1762,
-						1626,
-						1793,
-						1771,
-						1779,
-						1791,
-						1729,
-						1723,
-						1767,
-						1781,
-						1628,
-						1785,
-						1764,
+						1795,
+						1817,
+						1780,
+						1642,
+						1811,
 						1789,
+						1797,
+						1809,
 						1747,
-						1755
+						1741,
+						1785,
+						1799,
+						1644,
+						1803,
+						1782,
+						1807,
+						1765,
+						1773
 					]
 				}
 			],
@@ -21005,13 +21005,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1274,
+					"id": 1286,
 					"name": "SpotterEmbed"
 				}
 			]
 		},
 		{
-			"id": 655,
+			"id": 661,
 			"name": "LiveboardEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -21031,7 +21031,7 @@
 			},
 			"children": [
 				{
-					"id": 656,
+					"id": 662,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -21045,40 +21045,40 @@
 					],
 					"signatures": [
 						{
-							"id": 657,
+							"id": 663,
 							"name": "new LiveboardEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 658,
+									"id": 664,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2887,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 659,
+									"id": 665,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2597,
+										"id": 2617,
 										"name": "LiveboardViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 655,
+								"id": 661,
 								"name": "LiveboardEmbed"
 							},
 							"overwrites": {
@@ -21093,7 +21093,7 @@
 					}
 				},
 				{
-					"id": 719,
+					"id": 725,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21109,7 +21109,7 @@
 					],
 					"signatures": [
 						{
-							"id": 720,
+							"id": 726,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21139,7 +21139,7 @@
 					}
 				},
 				{
-					"id": 900,
+					"id": 908,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21149,13 +21149,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 901,
+							"id": 909,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21171,7 +21171,7 @@
 							},
 							"parameters": [
 								{
-									"id": 902,
+									"id": 910,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21192,7 +21192,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -21210,7 +21210,7 @@
 					}
 				},
 				{
-					"id": 867,
+					"id": 875,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21220,13 +21220,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 868,
+							"id": 876,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21267,7 +21267,7 @@
 					}
 				},
 				{
-					"id": 865,
+					"id": 873,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21277,13 +21277,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 866,
+							"id": 874,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21304,7 +21304,7 @@
 					}
 				},
 				{
-					"id": 735,
+					"id": 741,
 					"name": "getLiveboardUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21320,7 +21320,7 @@
 					],
 					"signatures": [
 						{
-							"id": 736,
+							"id": 742,
 							"name": "getLiveboardUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21337,7 +21337,7 @@
 					]
 				},
 				{
-					"id": 894,
+					"id": 902,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21347,13 +21347,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 895,
+							"id": 903,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21375,14 +21375,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 896,
+									"id": 904,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 898,
+											"id": 906,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21394,7 +21394,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 899,
+											"id": 907,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21406,7 +21406,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 897,
+											"id": 905,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21423,9 +21423,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												898,
-												899,
-												897
+												906,
+												907,
+												905
 											]
 										}
 									]
@@ -21443,7 +21443,7 @@
 					}
 				},
 				{
-					"id": 876,
+					"id": 884,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21453,13 +21453,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 877,
+							"id": 885,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21475,7 +21475,7 @@
 							},
 							"parameters": [
 								{
-									"id": 878,
+									"id": 886,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21483,20 +21483,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 879,
+											"id": 887,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 880,
+												"id": 888,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 881,
+														"id": 889,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -21541,7 +21541,7 @@
 					}
 				},
 				{
-					"id": 882,
+					"id": 890,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21551,13 +21551,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 883,
+							"id": 891,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21578,7 +21578,7 @@
 					}
 				},
 				{
-					"id": 892,
+					"id": 900,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21588,13 +21588,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 893,
+							"id": 901,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21618,7 +21618,7 @@
 					}
 				},
 				{
-					"id": 729,
+					"id": 735,
 					"name": "navigateToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21634,14 +21634,14 @@
 					],
 					"signatures": [
 						{
-							"id": 730,
+							"id": 736,
 							"name": "navigateToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 731,
+									"id": 737,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21652,7 +21652,7 @@
 									}
 								},
 								{
-									"id": 732,
+									"id": 738,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21665,7 +21665,7 @@
 									}
 								},
 								{
-									"id": 733,
+									"id": 739,
 									"name": "activeTabId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21678,7 +21678,7 @@
 									}
 								},
 								{
-									"id": 734,
+									"id": 740,
 									"name": "personalizedViewId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21699,7 +21699,7 @@
 					]
 				},
 				{
-					"id": 842,
+					"id": 850,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21709,13 +21709,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 843,
+							"id": 851,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21731,7 +21731,7 @@
 							},
 							"parameters": [
 								{
-									"id": 844,
+									"id": 852,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21741,12 +21741,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 845,
+									"id": 853,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21756,7 +21756,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -21777,7 +21777,7 @@
 					}
 				},
 				{
-					"id": 742,
+					"id": 748,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21787,13 +21787,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2284,
+							"line": 2304,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 743,
+							"id": 749,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21816,38 +21816,38 @@
 							},
 							"parameters": [
 								{
-									"id": 744,
+									"id": 750,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 745,
+									"id": 751,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 746,
+									"id": 752,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21869,7 +21869,7 @@
 					}
 				},
 				{
-					"id": 872,
+					"id": 880,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21879,13 +21879,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 873,
+							"id": 881,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21895,7 +21895,7 @@
 							},
 							"parameters": [
 								{
-									"id": 874,
+									"id": 882,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21910,7 +21910,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 875,
+									"id": 883,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21944,7 +21944,7 @@
 					}
 				},
 				{
-					"id": 884,
+					"id": 892,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21954,13 +21954,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 885,
+							"id": 893,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21997,7 +21997,7 @@
 					}
 				},
 				{
-					"id": 727,
+					"id": 733,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22013,7 +22013,7 @@
 					],
 					"signatures": [
 						{
-							"id": 728,
+							"id": 734,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22026,7 +22026,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 655,
+										"id": 661,
 										"name": "LiveboardEmbed"
 									}
 								],
@@ -22044,7 +22044,7 @@
 					}
 				},
 				{
-					"id": 886,
+					"id": 894,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22054,13 +22054,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 887,
+							"id": 895,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22090,7 +22090,7 @@
 					}
 				},
 				{
-					"id": 869,
+					"id": 877,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22100,13 +22100,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 870,
+							"id": 878,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22124,7 +22124,7 @@
 							},
 							"parameters": [
 								{
-									"id": 871,
+									"id": 879,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22137,12 +22137,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -22165,7 +22165,7 @@
 					}
 				},
 				{
-					"id": 890,
+					"id": 898,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22175,13 +22175,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 891,
+							"id": 899,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22211,7 +22211,7 @@
 					}
 				},
 				{
-					"id": 711,
+					"id": 717,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22227,7 +22227,7 @@
 					],
 					"signatures": [
 						{
-							"id": 712,
+							"id": 718,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22238,40 +22238,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 713,
+									"id": 719,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 714,
+									"id": 720,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 715,
+									"id": 721,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 716,
+									"id": 722,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22285,7 +22285,7 @@
 									}
 								},
 								{
-									"id": 717,
+									"id": 723,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22310,7 +22310,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 718,
+									"id": 724,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22359,7 +22359,7 @@
 					}
 				},
 				{
-					"id": 860,
+					"id": 868,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22369,13 +22369,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 861,
+							"id": 869,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22386,21 +22386,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 862,
+									"id": 870,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 863,
+									"id": 871,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22414,7 +22414,7 @@
 									}
 								},
 								{
-									"id": 864,
+									"id": 872,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22467,33 +22467,33 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						656
+						662
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						719,
-						900,
-						867,
-						865,
-						735,
-						894,
-						876,
-						882,
-						892,
-						729,
-						842,
-						742,
-						872,
+						725,
+						908,
+						875,
+						873,
+						741,
+						902,
 						884,
-						727,
-						886,
-						869,
 						890,
-						711,
-						860
+						900,
+						735,
+						850,
+						748,
+						880,
+						892,
+						733,
+						894,
+						877,
+						898,
+						717,
+						868
 					]
 				}
 			],
@@ -22512,7 +22512,7 @@
 			]
 		},
 		{
-			"id": 254,
+			"id": 256,
 			"name": "SearchBarEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -22532,7 +22532,7 @@
 			},
 			"children": [
 				{
-					"id": 255,
+					"id": 257,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -22546,14 +22546,14 @@
 					],
 					"signatures": [
 						{
-							"id": 256,
+							"id": 258,
 							"name": "new SearchBarEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 257,
+									"id": 259,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22564,21 +22564,21 @@
 									}
 								},
 								{
-									"id": 258,
+									"id": 260,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2545,
+										"id": 2564,
 										"name": "SearchBarViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 254,
+								"id": 256,
 								"name": "SearchBarEmbed"
 							},
 							"overwrites": {
@@ -22593,7 +22593,7 @@
 					}
 				},
 				{
-					"id": 422,
+					"id": 426,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22603,13 +22603,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 423,
+							"id": 427,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22639,7 +22639,7 @@
 					}
 				},
 				{
-					"id": 444,
+					"id": 448,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22649,13 +22649,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 445,
+							"id": 449,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22671,7 +22671,7 @@
 							},
 							"parameters": [
 								{
-									"id": 446,
+									"id": 450,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22692,7 +22692,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -22710,7 +22710,7 @@
 					}
 				},
 				{
-					"id": 407,
+					"id": 411,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22720,13 +22720,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 408,
+							"id": 412,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22767,7 +22767,7 @@
 					}
 				},
 				{
-					"id": 403,
+					"id": 407,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22777,13 +22777,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 404,
+							"id": 408,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22804,7 +22804,7 @@
 					}
 				},
 				{
-					"id": 438,
+					"id": 442,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22814,13 +22814,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 439,
+							"id": 443,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22842,14 +22842,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 440,
+									"id": 444,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 442,
+											"id": 446,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22861,7 +22861,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 443,
+											"id": 447,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22873,7 +22873,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 441,
+											"id": 445,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22890,9 +22890,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												442,
-												443,
-												441
+												446,
+												447,
+												445
 											]
 										}
 									]
@@ -22910,7 +22910,7 @@
 					}
 				},
 				{
-					"id": 416,
+					"id": 420,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22920,13 +22920,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 417,
+							"id": 421,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22942,7 +22942,7 @@
 							},
 							"parameters": [
 								{
-									"id": 418,
+									"id": 422,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22950,20 +22950,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 419,
+											"id": 423,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 420,
+												"id": 424,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 421,
+														"id": 425,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -23008,7 +23008,7 @@
 					}
 				},
 				{
-					"id": 424,
+					"id": 428,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23018,13 +23018,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 425,
+							"id": 429,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23045,7 +23045,7 @@
 					}
 				},
 				{
-					"id": 436,
+					"id": 440,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23055,13 +23055,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 437,
+							"id": 441,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23085,7 +23085,7 @@
 					}
 				},
 				{
-					"id": 372,
+					"id": 376,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23095,13 +23095,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 373,
+							"id": 377,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23117,7 +23117,7 @@
 							},
 							"parameters": [
 								{
-									"id": 374,
+									"id": 378,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23127,12 +23127,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 375,
+									"id": 379,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23142,7 +23142,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -23163,7 +23163,7 @@
 					}
 				},
 				{
-					"id": 366,
+					"id": 370,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23173,13 +23173,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 367,
+							"id": 371,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23199,7 +23199,7 @@
 							},
 							"parameters": [
 								{
-									"id": 368,
+									"id": 372,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23209,12 +23209,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 369,
+									"id": 373,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23224,12 +23224,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 370,
+									"id": 374,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23239,13 +23239,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 371,
+									"id": 375,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23274,7 +23274,7 @@
 					}
 				},
 				{
-					"id": 412,
+					"id": 416,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23284,13 +23284,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 413,
+							"id": 417,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23300,7 +23300,7 @@
 							},
 							"parameters": [
 								{
-									"id": 414,
+									"id": 418,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23315,7 +23315,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 415,
+									"id": 419,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23349,7 +23349,7 @@
 					}
 				},
 				{
-					"id": 426,
+					"id": 430,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23359,13 +23359,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 427,
+							"id": 431,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23402,7 +23402,7 @@
 					}
 				},
 				{
-					"id": 265,
+					"id": 267,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23418,7 +23418,7 @@
 					],
 					"signatures": [
 						{
-							"id": 266,
+							"id": 268,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23431,7 +23431,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 254,
+										"id": 256,
 										"name": "SearchBarEmbed"
 									}
 								],
@@ -23449,7 +23449,7 @@
 					}
 				},
 				{
-					"id": 430,
+					"id": 434,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23459,13 +23459,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 431,
+							"id": 435,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23495,7 +23495,7 @@
 					}
 				},
 				{
-					"id": 409,
+					"id": 413,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23505,13 +23505,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 410,
+							"id": 414,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23529,7 +23529,7 @@
 							},
 							"parameters": [
 								{
-									"id": 411,
+									"id": 415,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23542,12 +23542,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -23570,7 +23570,7 @@
 					}
 				},
 				{
-					"id": 434,
+					"id": 438,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23580,13 +23580,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 435,
+							"id": 439,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23616,7 +23616,7 @@
 					}
 				},
 				{
-					"id": 390,
+					"id": 394,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23626,13 +23626,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 391,
+							"id": 395,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23653,40 +23653,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 392,
+									"id": 396,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 393,
+									"id": 397,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 394,
+									"id": 398,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 395,
+									"id": 399,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23700,7 +23700,7 @@
 									}
 								},
 								{
-									"id": 396,
+									"id": 400,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23725,7 +23725,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 397,
+									"id": 401,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23777,7 +23777,7 @@
 					}
 				},
 				{
-					"id": 398,
+					"id": 402,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23787,13 +23787,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 399,
+							"id": 403,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23804,21 +23804,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 400,
+									"id": 404,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 401,
+									"id": 405,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23832,7 +23832,7 @@
 									}
 								},
 								{
-									"id": 402,
+									"id": 406,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23885,31 +23885,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						255
+						257
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						422,
-						444,
-						407,
-						403,
-						438,
-						416,
-						424,
-						436,
-						372,
-						366,
-						412,
 						426,
-						265,
+						448,
+						411,
+						407,
+						442,
+						420,
+						428,
+						440,
+						376,
+						370,
+						416,
 						430,
-						409,
+						267,
 						434,
-						390,
-						398
+						413,
+						438,
+						394,
+						402
 					]
 				}
 			],
@@ -23972,7 +23972,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2887,
 										"name": "DOMSelector"
 									}
 								},
@@ -23984,7 +23984,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2480,
+										"id": 2498,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -24006,7 +24006,7 @@
 					}
 				},
 				{
-					"id": 229,
+					"id": 231,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24016,13 +24016,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 230,
+							"id": 232,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24052,7 +24052,7 @@
 					}
 				},
 				{
-					"id": 251,
+					"id": 253,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24062,13 +24062,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 252,
+							"id": 254,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24084,7 +24084,7 @@
 							},
 							"parameters": [
 								{
-									"id": 253,
+									"id": 255,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24105,7 +24105,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -24123,7 +24123,7 @@
 					}
 				},
 				{
-					"id": 214,
+					"id": 216,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24133,13 +24133,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 215,
+							"id": 217,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24212,7 +24212,7 @@
 					]
 				},
 				{
-					"id": 210,
+					"id": 212,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24222,13 +24222,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 211,
+							"id": 213,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24249,7 +24249,7 @@
 					}
 				},
 				{
-					"id": 245,
+					"id": 247,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24259,13 +24259,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 246,
+							"id": 248,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24287,14 +24287,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 247,
+									"id": 249,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 249,
+											"id": 251,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24306,7 +24306,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 250,
+											"id": 252,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24318,7 +24318,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 248,
+											"id": 250,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24335,9 +24335,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												249,
-												250,
-												248
+												251,
+												252,
+												250
 											]
 										}
 									]
@@ -24355,7 +24355,7 @@
 					}
 				},
 				{
-					"id": 223,
+					"id": 225,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24365,13 +24365,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 224,
+							"id": 226,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24387,7 +24387,7 @@
 							},
 							"parameters": [
 								{
-									"id": 225,
+									"id": 227,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24395,20 +24395,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 226,
+											"id": 228,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 227,
+												"id": 229,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 228,
+														"id": 230,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -24453,7 +24453,7 @@
 					}
 				},
 				{
-					"id": 231,
+					"id": 233,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24463,13 +24463,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 232,
+							"id": 234,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24490,7 +24490,7 @@
 					}
 				},
 				{
-					"id": 243,
+					"id": 245,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24500,13 +24500,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 244,
+							"id": 246,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24530,7 +24530,7 @@
 					}
 				},
 				{
-					"id": 179,
+					"id": 181,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24540,13 +24540,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 180,
+							"id": 182,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24562,7 +24562,7 @@
 							},
 							"parameters": [
 								{
-									"id": 181,
+									"id": 183,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24572,12 +24572,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 182,
+									"id": 184,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24587,7 +24587,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -24608,7 +24608,7 @@
 					}
 				},
 				{
-					"id": 173,
+					"id": 175,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24618,13 +24618,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 174,
+							"id": 176,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24644,7 +24644,7 @@
 							},
 							"parameters": [
 								{
-									"id": 175,
+									"id": 177,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24654,12 +24654,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 176,
+									"id": 178,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24669,12 +24669,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 177,
+									"id": 179,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24684,13 +24684,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 178,
+									"id": 180,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24719,7 +24719,7 @@
 					}
 				},
 				{
-					"id": 219,
+					"id": 221,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24729,13 +24729,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 220,
+							"id": 222,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24745,7 +24745,7 @@
 							},
 							"parameters": [
 								{
-									"id": 221,
+									"id": 223,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24760,7 +24760,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 222,
+									"id": 224,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24794,7 +24794,7 @@
 					}
 				},
 				{
-					"id": 233,
+					"id": 235,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24804,13 +24804,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 234,
+							"id": 236,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24894,7 +24894,7 @@
 					}
 				},
 				{
-					"id": 237,
+					"id": 239,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24904,13 +24904,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 238,
+							"id": 240,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24940,7 +24940,7 @@
 					}
 				},
 				{
-					"id": 216,
+					"id": 218,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24950,13 +24950,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 217,
+							"id": 219,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24974,7 +24974,7 @@
 							},
 							"parameters": [
 								{
-									"id": 218,
+									"id": 220,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24987,12 +24987,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -25015,7 +25015,7 @@
 					}
 				},
 				{
-					"id": 241,
+					"id": 243,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25025,13 +25025,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 242,
+							"id": 244,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25061,7 +25061,7 @@
 					}
 				},
 				{
-					"id": 197,
+					"id": 199,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25071,13 +25071,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 198,
+							"id": 200,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25098,40 +25098,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 199,
+									"id": 201,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 200,
+									"id": 202,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 201,
+									"id": 203,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 202,
+									"id": 204,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25145,7 +25145,7 @@
 									}
 								},
 								{
-									"id": 203,
+									"id": 205,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25170,7 +25170,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 204,
+									"id": 206,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25222,7 +25222,7 @@
 					}
 				},
 				{
-					"id": 205,
+					"id": 207,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25232,13 +25232,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 206,
+							"id": 208,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25249,21 +25249,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 207,
+									"id": 209,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 208,
+									"id": 210,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25277,7 +25277,7 @@
 									}
 								},
 								{
-									"id": 209,
+									"id": 211,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25337,25 +25337,25 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						229,
-						251,
-						214,
-						78,
-						210,
-						245,
-						223,
 						231,
-						243,
-						179,
-						173,
-						219,
-						233,
-						80,
-						237,
+						253,
 						216,
-						241,
-						197,
-						205
+						78,
+						212,
+						247,
+						225,
+						233,
+						245,
+						181,
+						175,
+						221,
+						235,
+						80,
+						239,
+						218,
+						243,
+						199,
+						207
 					]
 				}
 			],
@@ -25374,7 +25374,7 @@
 			]
 		},
 		{
-			"id": 1135,
+			"id": 1145,
 			"name": "SpotterAgentEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -25398,7 +25398,7 @@
 			},
 			"children": [
 				{
-					"id": 1136,
+					"id": 1146,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -25412,35 +25412,35 @@
 					],
 					"signatures": [
 						{
-							"id": 1137,
+							"id": 1147,
 							"name": "new SpotterAgentEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1138,
+									"id": 1148,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1167,
+										"id": 1177,
 										"name": "SpotterAgentEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1135,
+								"id": 1145,
 								"name": "SpotterAgentEmbed"
 							}
 						}
 					]
 				},
 				{
-					"id": 1140,
+					"id": 1150,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25456,14 +25456,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1141,
+							"id": 1151,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1142,
+									"id": 1152,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25483,14 +25483,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1143,
+													"id": 1153,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1145,
+															"id": 1155,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25501,7 +25501,7 @@
 															}
 														},
 														{
-															"id": 1144,
+															"id": 1154,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25512,7 +25512,7 @@
 															}
 														},
 														{
-															"id": 1146,
+															"id": 1156,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25529,9 +25529,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1145,
-																1144,
-																1146
+																1155,
+																1154,
+																1156
 															]
 														}
 													]
@@ -25540,14 +25540,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1147,
+													"id": 1157,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1148,
+															"id": 1158,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25558,7 +25558,7 @@
 															}
 														},
 														{
-															"id": 1150,
+															"id": 1160,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25569,7 +25569,7 @@
 															}
 														},
 														{
-															"id": 1149,
+															"id": 1159,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25586,9 +25586,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1148,
-																1150,
-																1149
+																1158,
+																1160,
+																1159
 															]
 														}
 													]
@@ -25603,7 +25603,7 @@
 					]
 				},
 				{
-					"id": 1151,
+					"id": 1161,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25619,7 +25619,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1152,
+							"id": 1162,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25630,7 +25630,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1153,
+									"id": 1163,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25653,14 +25653,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1154,
+													"id": 1164,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1156,
+															"id": 1166,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25672,7 +25672,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1155,
+															"id": 1165,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25688,8 +25688,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1156,
-																1155
+																1166,
+																1165
 															]
 														}
 													]
@@ -25698,14 +25698,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1157,
+													"id": 1167,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1158,
+															"id": 1168,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25713,14 +25713,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1159,
+																	"id": 1169,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1165,
+																			"id": 1175,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25732,7 +25732,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1164,
+																			"id": 1174,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25744,7 +25744,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1160,
+																			"id": 1170,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25756,7 +25756,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1163,
+																			"id": 1173,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25768,7 +25768,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1161,
+																			"id": 1171,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25780,7 +25780,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1162,
+																			"id": 1172,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25797,12 +25797,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1165,
-																				1164,
-																				1160,
-																				1163,
-																				1161,
-																				1162
+																				1175,
+																				1174,
+																				1170,
+																				1173,
+																				1171,
+																				1172
 																			]
 																		}
 																	]
@@ -25811,7 +25811,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1166,
+															"id": 1176,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25827,8 +25827,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1158,
-																1166
+																1168,
+																1176
 															]
 														}
 													]
@@ -25848,15 +25848,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1136
+						1146
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1140,
-						1151
+						1150,
+						1161
 					]
 				}
 			],
@@ -25870,13 +25870,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1243,
+					"id": 1255,
 					"name": "BodylessConversation"
 				}
 			]
 		},
 		{
-			"id": 1274,
+			"id": 1286,
 			"name": "SpotterEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -25900,7 +25900,7 @@
 			},
 			"children": [
 				{
-					"id": 1275,
+					"id": 1287,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -25914,14 +25914,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1276,
+							"id": 1288,
 							"name": "new SpotterEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1277,
+									"id": 1289,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25932,21 +25932,21 @@
 									}
 								},
 								{
-									"id": 1278,
+									"id": 1290,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1460,
+										"id": 1474,
 										"name": "SpotterEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1274,
+								"id": 1286,
 								"name": "SpotterEmbed"
 							},
 							"overwrites": {
@@ -25961,7 +25961,7 @@
 					}
 				},
 				{
-					"id": 1435,
+					"id": 1449,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25971,13 +25971,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1436,
+							"id": 1450,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26007,7 +26007,7 @@
 					}
 				},
 				{
-					"id": 1457,
+					"id": 1471,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26017,13 +26017,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1458,
+							"id": 1472,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26039,7 +26039,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1459,
+									"id": 1473,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26060,7 +26060,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1890,
 										"name": "AnswerService"
 									}
 								],
@@ -26078,7 +26078,7 @@
 					}
 				},
 				{
-					"id": 1420,
+					"id": 1434,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26088,13 +26088,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1421,
+							"id": 1435,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26135,7 +26135,7 @@
 					}
 				},
 				{
-					"id": 1284,
+					"id": 1296,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26151,7 +26151,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1285,
+							"id": 1297,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26172,7 +26172,7 @@
 					}
 				},
 				{
-					"id": 1451,
+					"id": 1465,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26182,13 +26182,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1452,
+							"id": 1466,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26210,14 +26210,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1453,
+									"id": 1467,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1455,
+											"id": 1469,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26229,7 +26229,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1456,
+											"id": 1470,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26241,7 +26241,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1454,
+											"id": 1468,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26258,9 +26258,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1455,
-												1456,
-												1454
+												1469,
+												1470,
+												1468
 											]
 										}
 									]
@@ -26278,7 +26278,7 @@
 					}
 				},
 				{
-					"id": 1429,
+					"id": 1443,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26288,13 +26288,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1430,
+							"id": 1444,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26310,7 +26310,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1431,
+									"id": 1445,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26318,20 +26318,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1432,
+											"id": 1446,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1433,
+												"id": 1447,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1434,
+														"id": 1448,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -26376,7 +26376,7 @@
 					}
 				},
 				{
-					"id": 1437,
+					"id": 1451,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26386,13 +26386,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1438,
+							"id": 1452,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26413,7 +26413,7 @@
 					}
 				},
 				{
-					"id": 1449,
+					"id": 1463,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26423,13 +26423,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1450,
+							"id": 1464,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26453,7 +26453,7 @@
 					}
 				},
 				{
-					"id": 1387,
+					"id": 1401,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26463,13 +26463,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1388,
+							"id": 1402,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26485,7 +26485,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1389,
+									"id": 1403,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26495,12 +26495,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1390,
+									"id": 1404,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26510,7 +26510,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								}
@@ -26531,7 +26531,7 @@
 					}
 				},
 				{
-					"id": 1381,
+					"id": 1395,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26541,13 +26541,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1382,
+							"id": 1396,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26567,7 +26567,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1383,
+									"id": 1397,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26577,12 +26577,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2019,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1384,
+									"id": 1398,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26592,12 +26592,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2891,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1385,
+									"id": 1399,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26607,13 +26607,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2888,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1386,
+									"id": 1400,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26642,7 +26642,7 @@
 					}
 				},
 				{
-					"id": 1425,
+					"id": 1439,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26652,13 +26652,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1426,
+							"id": 1440,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26668,7 +26668,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1427,
+									"id": 1441,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26683,7 +26683,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1428,
+									"id": 1442,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26717,7 +26717,7 @@
 					}
 				},
 				{
-					"id": 1439,
+					"id": 1453,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26727,13 +26727,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1440,
+							"id": 1454,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26770,7 +26770,7 @@
 					}
 				},
 				{
-					"id": 1286,
+					"id": 1298,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26786,7 +26786,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1287,
+							"id": 1299,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26796,7 +26796,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1274,
+										"id": 1286,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -26814,7 +26814,7 @@
 					}
 				},
 				{
-					"id": 1443,
+					"id": 1457,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26824,13 +26824,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1444,
+							"id": 1458,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26860,7 +26860,7 @@
 					}
 				},
 				{
-					"id": 1422,
+					"id": 1436,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26870,13 +26870,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1423,
+							"id": 1437,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26894,7 +26894,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1424,
+									"id": 1438,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26907,12 +26907,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2251,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2148,
 												"name": "HostEvent"
 											}
 										]
@@ -26935,7 +26935,7 @@
 					}
 				},
 				{
-					"id": 1447,
+					"id": 1461,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26945,13 +26945,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1448,
+							"id": 1462,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26981,7 +26981,7 @@
 					}
 				},
 				{
-					"id": 1405,
+					"id": 1419,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26991,13 +26991,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1406,
+							"id": 1420,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27018,40 +27018,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1407,
+									"id": 1421,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2148,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1408,
+									"id": 1422,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1409,
+									"id": 1423,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2241,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1410,
+									"id": 1424,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27065,7 +27065,7 @@
 									}
 								},
 								{
-									"id": 1411,
+									"id": 1425,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27090,7 +27090,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1412,
+									"id": 1426,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27142,7 +27142,7 @@
 					}
 				},
 				{
-					"id": 1413,
+					"id": 1427,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -27152,13 +27152,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1414,
+							"id": 1428,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27169,21 +27169,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1415,
+									"id": 1429,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3236,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1416,
+									"id": 1430,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27197,7 +27197,7 @@
 									}
 								},
 								{
-									"id": 1417,
+									"id": 1431,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27250,31 +27250,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1275
+						1287
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1435,
-						1457,
-						1420,
-						1284,
-						1451,
-						1429,
-						1437,
 						1449,
-						1387,
-						1381,
-						1425,
-						1439,
-						1286,
+						1471,
+						1434,
+						1296,
+						1465,
 						1443,
-						1422,
-						1447,
-						1405,
-						1413
+						1451,
+						1463,
+						1401,
+						1395,
+						1439,
+						1453,
+						1298,
+						1457,
+						1436,
+						1461,
+						1419,
+						1427
 					]
 				}
 			],
@@ -27294,13 +27294,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1616,
+					"id": 1632,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2719,
+			"id": 2740,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27316,7 +27316,7 @@
 			},
 			"children": [
 				{
-					"id": 2776,
+					"id": 2797,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27340,27 +27340,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2777,
+							"id": 2798,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2778,
+								"id": 2799,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2779,
+										"id": 2800,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27396,7 +27396,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2831,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27424,7 +27424,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -27438,7 +27438,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2760,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27475,7 +27475,7 @@
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2828,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27499,13 +27499,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2443,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -27514,7 +27514,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2849,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27538,7 +27538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2030,
+							"line": 2110,
 							"character": 4
 						}
 					],
@@ -27552,7 +27552,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2819,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27584,7 +27584,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -27601,7 +27601,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2801,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27624,13 +27624,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27639,7 +27639,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2761,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27673,12 +27673,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3239,
+						"id": 3262,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2832,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27706,7 +27706,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -27720,7 +27720,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2775,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27754,12 +27754,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1555,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2743,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27797,7 +27797,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2811,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27821,7 +27821,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -27835,7 +27835,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2793,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27859,7 +27859,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -27873,7 +27873,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2792,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27897,7 +27897,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -27905,7 +27905,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -27915,7 +27915,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2759,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27952,7 +27952,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2805,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27971,6 +27971,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -27979,7 +27983,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -27993,7 +27997,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2843,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28021,7 +28025,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 2006,
 							"character": 4
 						}
 					],
@@ -28035,7 +28039,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2848,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28063,7 +28067,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2014,
+							"line": 2094,
 							"character": 4
 						}
 					],
@@ -28077,7 +28081,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2833,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28105,7 +28109,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -28119,7 +28123,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2784,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28153,7 +28157,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2815,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28177,7 +28181,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -28191,7 +28195,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2785,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28224,7 +28228,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2776,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28262,7 +28266,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2744,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28300,7 +28304,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2756,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28338,7 +28342,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2782,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28372,7 +28376,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2808,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28396,7 +28400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -28410,7 +28414,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2829,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28434,7 +28438,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -28448,7 +28452,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2830,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28472,7 +28476,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -28486,7 +28490,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2810,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28509,7 +28513,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -28523,7 +28527,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2789,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28547,13 +28551,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28562,7 +28566,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2757,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28596,7 +28600,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2794,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28613,7 +28617,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -28624,7 +28628,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -28632,7 +28636,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -28642,7 +28646,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2838,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28666,7 +28670,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1686,
+							"line": 1766,
 							"character": 4
 						}
 					],
@@ -28674,7 +28678,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2846,
+							"id": 2868,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -28684,7 +28688,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2836,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28708,7 +28712,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1639,
+							"line": 1719,
 							"character": 4
 						}
 					],
@@ -28716,7 +28720,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2858,
+							"id": 2880,
 							"name": "HomepageModule"
 						}
 					},
@@ -28726,7 +28730,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2835,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28743,14 +28747,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nimport { ListPageColumns } from '@thoughtspot/visual-embed-sdk';\n\nconst embed = new AppEmbed('#tsEmbed', {\n   ... //other embed view config\n   hiddenListColumns : [ListPageColumns.Favorite,ListPageColumns.Author],\n})\n```\n"
+								"text": "\n```js\nimport { ListPageColumns } from '@thoughtspot/visual-embed-sdk';\n\nconst embed = new AppEmbed('#tsEmbed', {\n   ... //other embed view config\n   hiddenListColumns : [ListPageColumns.Favorites,ListPageColumns.Author],\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1696,
 							"character": 4
 						}
 					],
@@ -28758,7 +28762,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3231,
+							"id": 3254,
 							"name": "ListPageColumns"
 						}
 					},
@@ -28768,7 +28772,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2748,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28806,7 +28810,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2745,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28844,7 +28848,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2742,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28882,7 +28886,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2846,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28910,7 +28914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1981,
+							"line": 2061,
 							"character": 4
 						}
 					],
@@ -28924,7 +28928,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2839,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28952,7 +28956,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1862,
+							"line": 1942,
 							"character": 4
 						}
 					],
@@ -28966,7 +28970,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2747,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29004,7 +29008,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2746,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29042,7 +29046,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2754,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29079,7 +29083,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2749,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29117,7 +29121,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2753,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29151,7 +29155,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2762,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29177,12 +29181,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3177,
+						"id": 3200,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2802,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29206,7 +29210,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -29220,7 +29224,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2825,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29243,7 +29247,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -29257,7 +29261,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2824,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29269,7 +29273,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -29280,7 +29284,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -29297,7 +29301,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2850,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29325,7 +29329,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2049,
+							"line": 2129,
 							"character": 4
 						}
 					],
@@ -29339,7 +29343,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2767,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29377,7 +29381,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2853,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29401,7 +29405,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2099,
+							"line": 2179,
 							"character": 4
 						}
 					],
@@ -29415,7 +29419,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2769,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29453,7 +29457,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2852,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29477,7 +29481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2082,
+							"line": 2162,
 							"character": 4
 						}
 					],
@@ -29491,7 +29495,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2844,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29519,7 +29523,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1943,
+							"line": 2023,
 							"character": 4
 						}
 					],
@@ -29533,7 +29537,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2842,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29557,7 +29561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1909,
+							"line": 1989,
 							"character": 4
 						}
 					],
@@ -29571,7 +29575,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2855,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29599,7 +29603,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2131,
+							"line": 2211,
 							"character": 4
 						}
 					],
@@ -29613,7 +29617,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2765,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29650,7 +29654,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2768,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29688,7 +29692,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2823,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29708,7 +29712,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -29722,7 +29726,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2766,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29756,7 +29760,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2851,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29780,7 +29784,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2067,
+							"line": 2147,
 							"character": 4
 						}
 					],
@@ -29794,7 +29798,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2834,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29818,7 +29822,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -29832,7 +29836,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2763,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29870,7 +29874,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2770,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29907,7 +29911,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2772,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29941,7 +29945,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2814,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29965,7 +29969,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -29979,7 +29983,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2796,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30003,7 +30007,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -30017,7 +30021,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2783,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30054,7 +30058,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2758,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30095,7 +30099,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2856,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30123,7 +30127,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2147,
+							"line": 2227,
 							"character": 4
 						}
 					],
@@ -30137,7 +30141,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2764,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30175,7 +30179,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2813,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30199,7 +30203,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -30213,7 +30217,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2812,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30237,7 +30241,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -30251,7 +30255,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2751,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30281,12 +30285,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1959,
+						"id": 1977,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2750,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30320,7 +30324,44 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2807,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "AllEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2806,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30336,6 +30377,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -30344,7 +30389,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -30367,7 +30412,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2804,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30383,6 +30428,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -30391,7 +30440,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -30405,7 +30454,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2816,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30429,7 +30478,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -30443,7 +30492,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2820,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30470,7 +30519,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -30484,7 +30533,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2837,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30508,7 +30557,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1663,
+							"line": 1743,
 							"character": 4
 						}
 					],
@@ -30516,7 +30565,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2858,
+							"id": 2880,
 							"name": "HomepageModule"
 						}
 					},
@@ -30526,7 +30575,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2826,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30550,7 +30599,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -30558,7 +30607,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30568,7 +30617,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2827,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30592,7 +30641,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -30600,7 +30649,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30610,7 +30659,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2821,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30637,7 +30686,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -30651,7 +30700,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2818,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30674,7 +30723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -30688,7 +30737,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2841,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30716,7 +30765,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1894,
+							"line": 1974,
 							"character": 4
 						}
 					],
@@ -30730,7 +30779,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2847,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30758,7 +30807,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1998,
+							"line": 2078,
 							"character": 4
 						}
 					],
@@ -30772,7 +30821,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2840,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30800,7 +30849,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1878,
+							"line": 1958,
 							"character": 4
 						}
 					],
@@ -30814,7 +30863,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2845,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30842,7 +30891,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1960,
+							"line": 2040,
 							"character": 4
 						}
 					],
@@ -30856,7 +30905,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2854,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30884,7 +30933,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2115,
+							"line": 2195,
 							"character": 4
 						}
 					],
@@ -30898,7 +30947,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2741,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30936,7 +30985,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2774,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30974,7 +31023,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2778,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31004,12 +31053,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1534,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2780,
 					"name": "spotterDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31046,7 +31095,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2779,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31076,12 +31125,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1558,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2777,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31111,12 +31160,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1540,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2781,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31146,12 +31195,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2698,
+						"id": 2719,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2752,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31185,7 +31234,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2773,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31223,7 +31272,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2787,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31261,7 +31310,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2822,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31288,7 +31337,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -31302,7 +31351,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2795,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31323,14 +31372,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -31338,7 +31387,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -31348,7 +31397,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2786,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31373,7 +31422,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3285,
+						"id": 3308,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -31383,110 +31432,111 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2776,
-						2809,
-						2739,
-						2806,
-						2827,
 						2797,
-						2780,
-						2740,
-						2810,
-						2754,
-						2722,
-						2789,
-						2772,
-						2771,
-						2738,
-						2784,
-						2821,
-						2826,
-						2811,
-						2763,
-						2793,
-						2764,
-						2755,
-						2723,
-						2735,
-						2761,
-						2786,
-						2807,
-						2808,
-						2788,
-						2768,
-						2736,
-						2773,
-						2816,
-						2814,
-						2813,
-						2727,
-						2724,
-						2721,
-						2824,
-						2817,
-						2726,
-						2725,
-						2733,
-						2728,
-						2732,
-						2741,
-						2781,
-						2803,
-						2802,
-						2828,
-						2746,
 						2831,
-						2748,
-						2830,
-						2822,
-						2820,
-						2833,
-						2744,
-						2747,
-						2801,
-						2745,
-						2829,
-						2812,
-						2742,
-						2749,
-						2751,
-						2792,
-						2775,
-						2762,
-						2737,
-						2834,
-						2743,
-						2791,
-						2790,
-						2730,
-						2729,
-						2785,
-						2783,
-						2794,
-						2798,
-						2815,
-						2804,
-						2805,
-						2799,
-						2796,
-						2819,
-						2825,
-						2818,
-						2823,
-						2832,
-						2720,
-						2753,
-						2757,
-						2759,
-						2758,
-						2756,
 						2760,
-						2731,
-						2752,
+						2828,
+						2849,
+						2819,
+						2801,
+						2761,
+						2832,
+						2775,
+						2743,
+						2811,
+						2793,
+						2792,
+						2759,
+						2805,
+						2843,
+						2848,
+						2833,
+						2784,
+						2815,
+						2785,
+						2776,
+						2744,
+						2756,
+						2782,
+						2808,
+						2829,
+						2830,
+						2810,
+						2789,
+						2757,
+						2794,
+						2838,
+						2836,
+						2835,
+						2748,
+						2745,
+						2742,
+						2846,
+						2839,
+						2747,
+						2746,
+						2754,
+						2749,
+						2753,
+						2762,
+						2802,
+						2825,
+						2824,
+						2850,
+						2767,
+						2853,
+						2769,
+						2852,
+						2844,
+						2842,
+						2855,
+						2765,
+						2768,
+						2823,
 						2766,
-						2800,
+						2851,
+						2834,
+						2763,
+						2770,
+						2772,
+						2814,
+						2796,
+						2783,
+						2758,
+						2856,
+						2764,
+						2813,
+						2812,
+						2751,
+						2750,
+						2807,
+						2806,
+						2804,
+						2816,
+						2820,
+						2837,
+						2826,
+						2827,
+						2821,
+						2818,
+						2841,
+						2847,
+						2840,
+						2845,
+						2854,
+						2741,
 						2774,
-						2765
+						2778,
+						2780,
+						2779,
+						2777,
+						2781,
+						2752,
+						2773,
+						2787,
+						2822,
+						2795,
+						2786
 					]
 				}
 			],
@@ -31505,7 +31555,7 @@
 			]
 		},
 		{
-			"id": 1819,
+			"id": 1837,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31521,14 +31571,14 @@
 			},
 			"children": [
 				{
-					"id": 1856,
+					"id": 1874,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1857,
+							"id": 1875,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31538,19 +31588,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1858,
+									"id": 1876,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1818,
+										"id": 1836,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1859,
+									"id": 1877,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31574,14 +31624,14 @@
 					]
 				},
 				{
-					"id": 1860,
+					"id": 1878,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1861,
+							"id": 1879,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31591,7 +31641,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1862,
+									"id": 1880,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31599,12 +31649,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1827,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1863,
+									"id": 1881,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31613,21 +31663,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1864,
+											"id": 1882,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1865,
+													"id": 1883,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1866,
+															"id": 1884,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31653,7 +31703,7 @@
 									}
 								},
 								{
-									"id": 1867,
+									"id": 1885,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31665,7 +31715,7 @@
 									}
 								},
 								{
-									"id": 1868,
+									"id": 1886,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31681,21 +31731,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1837,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1820,
+					"id": 1838,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1821,
+							"id": 1839,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31705,249 +31755,15 @@
 							},
 							"parameters": [
 								{
-									"id": 1822,
-									"name": "event",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"comment": {},
-									"type": {
-										"type": "reference",
-										"id": 1810,
-										"name": "FAILURE"
-									}
-								},
-								{
-									"id": 1823,
-									"name": "listener",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"comment": {
-										"text": "\n"
-									},
-									"type": {
-										"type": "reflection",
-										"declaration": {
-											"id": 1824,
-											"name": "__type",
-											"kind": 65536,
-											"kindString": "Type literal",
-											"flags": {},
-											"signatures": [
-												{
-													"id": 1825,
-													"name": "__type",
-													"kind": 4096,
-													"kindString": "Call signature",
-													"flags": {},
-													"parameters": [
-														{
-															"id": 1826,
-															"name": "failureType",
-															"kind": 32768,
-															"kindString": "Parameter",
-															"flags": {},
-															"type": {
-																"type": "reference",
-																"id": 1802,
-																"name": "AuthFailureType"
-															}
-														}
-													],
-													"type": {
-														"type": "intrinsic",
-														"name": "void"
-													}
-												}
-											]
-										}
-									}
-								}
-							],
-							"type": {
-								"type": "reference",
-								"id": 1819,
-								"name": "AuthEventEmitter"
-							}
-						},
-						{
-							"id": 1827,
-							"name": "on",
-							"kind": 4096,
-							"kindString": "Call signature",
-							"flags": {},
-							"comment": {
-								"shortText": "Register a listener on Auth SDK success."
-							},
-							"parameters": [
-								{
-									"id": 1828,
-									"name": "event",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"comment": {},
-									"type": {
-										"type": "union",
-										"types": [
-											{
-												"type": "reference",
-												"id": 1811,
-												"name": "SDK_SUCCESS"
-											},
-											{
-												"type": "reference",
-												"id": 1814,
-												"name": "LOGOUT"
-											},
-											{
-												"type": "reference",
-												"id": 1815,
-												"name": "WAITING_FOR_POPUP"
-											},
-											{
-												"type": "reference",
-												"id": 1816,
-												"name": "SAML_POPUP_CLOSED_NO_AUTH"
-											}
-										]
-									}
-								},
-								{
-									"id": 1829,
-									"name": "listener",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"comment": {
-										"text": "\n"
-									},
-									"type": {
-										"type": "reflection",
-										"declaration": {
-											"id": 1830,
-											"name": "__type",
-											"kind": 65536,
-											"kindString": "Type literal",
-											"flags": {},
-											"signatures": [
-												{
-													"id": 1831,
-													"name": "__type",
-													"kind": 4096,
-													"kindString": "Call signature",
-													"flags": {},
-													"type": {
-														"type": "intrinsic",
-														"name": "void"
-													}
-												}
-											]
-										}
-									}
-								}
-							],
-							"type": {
-								"type": "reference",
-								"id": 1819,
-								"name": "AuthEventEmitter"
-							}
-						},
-						{
-							"id": 1832,
-							"name": "on",
-							"kind": 4096,
-							"kindString": "Call signature",
-							"flags": {},
-							"parameters": [
-								{
-									"id": 1833,
-									"name": "event",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"type": {
-										"type": "reference",
-										"id": 1813,
-										"name": "SUCCESS"
-									}
-								},
-								{
-									"id": 1834,
-									"name": "listener",
-									"kind": 32768,
-									"kindString": "Parameter",
-									"flags": {},
-									"type": {
-										"type": "reflection",
-										"declaration": {
-											"id": 1835,
-											"name": "__type",
-											"kind": 65536,
-											"kindString": "Type literal",
-											"flags": {},
-											"signatures": [
-												{
-													"id": 1836,
-													"name": "__type",
-													"kind": 4096,
-													"kindString": "Call signature",
-													"flags": {},
-													"parameters": [
-														{
-															"id": 1837,
-															"name": "sessionInfo",
-															"kind": 32768,
-															"kindString": "Parameter",
-															"flags": {},
-															"type": {
-																"type": "intrinsic",
-																"name": "any"
-															}
-														}
-													],
-													"type": {
-														"type": "intrinsic",
-														"name": "void"
-													}
-												}
-											]
-										}
-									}
-								}
-							],
-							"type": {
-								"type": "reference",
-								"id": 1819,
-								"name": "AuthEventEmitter"
-							}
-						}
-					]
-				},
-				{
-					"id": 1838,
-					"name": "once",
-					"kind": 2048,
-					"kindString": "Method",
-					"flags": {},
-					"signatures": [
-						{
-							"id": 1839,
-							"name": "once",
-							"kind": 4096,
-							"kindString": "Call signature",
-							"flags": {},
-							"parameters": [
-								{
 									"id": 1840,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
+									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1828,
 										"name": "FAILURE"
 									}
 								},
@@ -31957,6 +31773,9 @@
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
+									"comment": {
+										"text": "\n"
+									},
 									"type": {
 										"type": "reflection",
 										"declaration": {
@@ -31981,7 +31800,7 @@
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1802,
+																"id": 1820,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31998,16 +31817,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1837,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
 							"id": 1845,
-							"name": "once",
+							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
+							"comment": {
+								"shortText": "Register a listener on Auth SDK success."
+							},
 							"parameters": [
 								{
 									"id": 1846,
@@ -32015,27 +31837,28 @@
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
+									"comment": {},
 									"type": {
 										"type": "union",
 										"types": [
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1829,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1814,
+												"id": 1832,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1815,
+												"id": 1833,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1816,
+												"id": 1834,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
@@ -32047,6 +31870,9 @@
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
+									"comment": {
+										"text": "\n"
+									},
 									"type": {
 										"type": "reflection",
 										"declaration": {
@@ -32074,13 +31900,13 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1837,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
 							"id": 1850,
-							"name": "once",
+							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
@@ -32093,7 +31919,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1813,
+										"id": 1831,
 										"name": "SUCCESS"
 									}
 								},
@@ -32143,21 +31969,245 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1837,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1869,
+					"id": 1856,
+					"name": "once",
+					"kind": 2048,
+					"kindString": "Method",
+					"flags": {},
+					"signatures": [
+						{
+							"id": 1857,
+							"name": "once",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {},
+							"parameters": [
+								{
+									"id": 1858,
+									"name": "event",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"id": 1828,
+										"name": "FAILURE"
+									}
+								},
+								{
+									"id": 1859,
+									"name": "listener",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 1860,
+											"name": "__type",
+											"kind": 65536,
+											"kindString": "Type literal",
+											"flags": {},
+											"signatures": [
+												{
+													"id": 1861,
+													"name": "__type",
+													"kind": 4096,
+													"kindString": "Call signature",
+													"flags": {},
+													"parameters": [
+														{
+															"id": 1862,
+															"name": "failureType",
+															"kind": 32768,
+															"kindString": "Parameter",
+															"flags": {},
+															"type": {
+																"type": "reference",
+																"id": 1820,
+																"name": "AuthFailureType"
+															}
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "void"
+													}
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"id": 1837,
+								"name": "AuthEventEmitter"
+							}
+						},
+						{
+							"id": 1863,
+							"name": "once",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {},
+							"parameters": [
+								{
+									"id": 1864,
+									"name": "event",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"id": 1829,
+												"name": "SDK_SUCCESS"
+											},
+											{
+												"type": "reference",
+												"id": 1832,
+												"name": "LOGOUT"
+											},
+											{
+												"type": "reference",
+												"id": 1833,
+												"name": "WAITING_FOR_POPUP"
+											},
+											{
+												"type": "reference",
+												"id": 1834,
+												"name": "SAML_POPUP_CLOSED_NO_AUTH"
+											}
+										]
+									}
+								},
+								{
+									"id": 1865,
+									"name": "listener",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 1866,
+											"name": "__type",
+											"kind": 65536,
+											"kindString": "Type literal",
+											"flags": {},
+											"signatures": [
+												{
+													"id": 1867,
+													"name": "__type",
+													"kind": 4096,
+													"kindString": "Call signature",
+													"flags": {},
+													"type": {
+														"type": "intrinsic",
+														"name": "void"
+													}
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"id": 1837,
+								"name": "AuthEventEmitter"
+							}
+						},
+						{
+							"id": 1868,
+							"name": "once",
+							"kind": 4096,
+							"kindString": "Call signature",
+							"flags": {},
+							"parameters": [
+								{
+									"id": 1869,
+									"name": "event",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"id": 1831,
+										"name": "SUCCESS"
+									}
+								},
+								{
+									"id": 1870,
+									"name": "listener",
+									"kind": 32768,
+									"kindString": "Parameter",
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 1871,
+											"name": "__type",
+											"kind": 65536,
+											"kindString": "Type literal",
+											"flags": {},
+											"signatures": [
+												{
+													"id": 1872,
+													"name": "__type",
+													"kind": 4096,
+													"kindString": "Call signature",
+													"flags": {},
+													"parameters": [
+														{
+															"id": 1873,
+															"name": "sessionInfo",
+															"kind": 32768,
+															"kindString": "Parameter",
+															"flags": {},
+															"type": {
+																"type": "intrinsic",
+																"name": "any"
+															}
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "void"
+													}
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"id": 1837,
+								"name": "AuthEventEmitter"
+							}
+						}
+					]
+				},
+				{
+					"id": 1887,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1870,
+							"id": 1888,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -32167,7 +32217,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1871,
+									"id": 1889,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32177,14 +32227,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1827,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1837,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -32196,11 +32246,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1856,
-						1860,
-						1820,
+						1874,
+						1878,
 						1838,
-						1869
+						1856,
+						1887
 					]
 				}
 			],
@@ -32213,7 +32263,7 @@
 			]
 		},
 		{
-			"id": 1205,
+			"id": 1216,
 			"name": "BodylessConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32233,7 +32283,7 @@
 			},
 			"children": [
 				{
-					"id": 1216,
+					"id": 1227,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32257,27 +32307,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1217,
+							"id": 1228,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1218,
+								"id": 1229,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1219,
+										"id": 1230,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -32309,12 +32359,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1178,
+						"id": 1188,
 						"name": "SpotterAgentEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1236,
+					"id": 1248,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32346,7 +32396,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -32359,12 +32409,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1198,
+						"id": 1209,
 						"name": "SpotterAgentEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1220,
+					"id": 1231,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32387,23 +32437,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1182,
+						"id": 1192,
 						"name": "SpotterAgentEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1229,
+					"id": 1241,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32427,7 +32477,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -32437,12 +32487,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1191,
+						"id": 1202,
 						"name": "SpotterAgentEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1212,
+					"id": 1223,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32466,7 +32516,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -32476,12 +32526,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1174,
+						"id": 1184,
 						"name": "SpotterAgentEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1211,
+					"id": 1222,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32505,7 +32555,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -32513,18 +32563,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1173,
+						"id": 1183,
 						"name": "SpotterAgentEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1224,
+					"id": 1235,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32543,6 +32593,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -32551,7 +32605,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -32561,12 +32615,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1186,
+						"id": 1196,
 						"name": "SpotterAgentEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1233,
+					"id": 1245,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32590,7 +32644,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -32600,12 +32654,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1195,
+						"id": 1206,
 						"name": "SpotterAgentEmbedViewConfig.enableLinkOverridesV2"
 					}
 				},
 				{
-					"id": 1226,
+					"id": 1238,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32629,7 +32683,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -32639,12 +32693,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1188,
+						"id": 1199,
 						"name": "SpotterAgentEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1228,
+					"id": 1240,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32667,7 +32721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -32677,12 +32731,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1190,
+						"id": 1201,
 						"name": "SpotterAgentEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1208,
+					"id": 1219,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32706,23 +32760,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1170,
+						"id": 1180,
 						"name": "SpotterAgentEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1213,
+					"id": 1224,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32739,7 +32793,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -32750,7 +32804,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -32758,18 +32812,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1175,
+						"id": 1185,
 						"name": "SpotterAgentEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1221,
+					"id": 1232,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32793,7 +32847,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -32803,12 +32857,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1183,
+						"id": 1193,
 						"name": "SpotterAgentEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1242,
+					"id": 1254,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32831,7 +32885,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -32841,12 +32895,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1204,
+						"id": 1215,
 						"name": "SpotterAgentEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1241,
+					"id": 1253,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32858,7 +32912,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -32869,7 +32923,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -32882,12 +32936,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1203,
+						"id": 1214,
 						"name": "SpotterAgentEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1240,
+					"id": 1252,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32907,7 +32961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -32917,12 +32971,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1202,
+						"id": 1213,
 						"name": "SpotterAgentEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1232,
+					"id": 1244,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32946,7 +33000,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -32956,12 +33010,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1194,
+						"id": 1205,
 						"name": "SpotterAgentEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1215,
+					"id": 1226,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32985,7 +33039,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -32995,12 +33049,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1177,
+						"id": 1187,
 						"name": "SpotterAgentEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1231,
+					"id": 1243,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33024,7 +33078,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -33034,12 +33088,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1193,
+						"id": 1204,
 						"name": "SpotterAgentEmbedViewConfig.overrideHistoryState"
 					}
 				},
 				{
-					"id": 1230,
+					"id": 1242,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33063,7 +33117,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -33073,12 +33127,50 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1192,
+						"id": 1203,
 						"name": "SpotterAgentEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1225,
+					"id": 1237,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1198,
+						"name": "SpotterAgentEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 1236,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33094,6 +33186,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -33102,7 +33198,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -33121,12 +33217,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1187,
+						"id": 1197,
 						"name": "SpotterAgentEmbedViewConfig.preRenderContainer"
 					}
 				},
 				{
-					"id": 1223,
+					"id": 1234,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33142,6 +33238,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -33150,7 +33250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -33160,12 +33260,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1185,
+						"id": 1195,
 						"name": "SpotterAgentEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1237,
+					"id": 1249,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33192,7 +33292,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -33202,12 +33302,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1199,
+						"id": 1210,
 						"name": "SpotterAgentEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1238,
+					"id": 1250,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33234,7 +33334,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -33244,12 +33344,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1200,
+						"id": 1211,
 						"name": "SpotterAgentEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1235,
+					"id": 1247,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33272,7 +33372,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -33282,12 +33382,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1197,
+						"id": 1208,
 						"name": "SpotterAgentEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1239,
+					"id": 1251,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33314,7 +33414,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -33324,12 +33424,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1201,
+						"id": 1212,
 						"name": "SpotterAgentEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1214,
+					"id": 1225,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33350,14 +33450,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -33365,18 +33465,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1176,
+						"id": 1186,
 						"name": "SpotterAgentEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1206,
+					"id": 1217,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33397,7 +33497,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1168,
+						"id": 1178,
 						"name": "SpotterAgentEmbedViewConfig.worksheetId"
 					}
 				}
@@ -33407,34 +33507,35 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1216,
-						1236,
-						1220,
-						1229,
-						1212,
-						1211,
-						1224,
-						1233,
-						1226,
-						1228,
-						1208,
-						1213,
-						1221,
-						1242,
-						1241,
-						1240,
-						1232,
-						1215,
+						1227,
+						1248,
 						1231,
-						1230,
-						1225,
+						1241,
 						1223,
-						1237,
-						1238,
+						1222,
 						1235,
-						1239,
-						1214,
-						1206
+						1245,
+						1238,
+						1240,
+						1219,
+						1224,
+						1232,
+						1254,
+						1253,
+						1252,
+						1244,
+						1226,
+						1243,
+						1242,
+						1237,
+						1236,
+						1234,
+						1249,
+						1250,
+						1247,
+						1251,
+						1225,
+						1217
 					]
 				}
 			],
@@ -33448,13 +33549,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1167,
+					"id": 1177,
 					"name": "SpotterAgentEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1557,
+			"id": 1572,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33474,7 +33575,7 @@
 			},
 			"children": [
 				{
-					"id": 1589,
+					"id": 1604,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33498,27 +33599,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1590,
+							"id": 1605,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1591,
+								"id": 1606,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1592,
+										"id": 1607,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33550,12 +33651,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1492,
+						"id": 1506,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1625,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33587,7 +33688,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -33600,12 +33701,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1512,
+						"id": 1527,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1608,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33628,23 +33729,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1496,
+						"id": 1510,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1578,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33682,12 +33783,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1466,
+						"id": 1480,
 						"name": "SpotterEmbedViewConfig.dataPanelV2"
 					}
 				},
 				{
-					"id": 1559,
+					"id": 1574,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33724,12 +33825,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1462,
+						"id": 1476,
 						"name": "SpotterEmbedViewConfig.dataSources"
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1587,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33763,17 +33864,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1555,
 						"name": "SpotterQueryMode"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1475,
+						"id": 1489,
 						"name": "SpotterEmbedViewConfig.defaultQueryMode"
 					}
 				},
 				{
-					"id": 1602,
+					"id": 1618,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33797,7 +33898,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -33807,12 +33908,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1505,
+						"id": 1520,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1561,
+					"id": 1576,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33846,12 +33947,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1464,
+						"id": 1478,
 						"name": "SpotterEmbedViewConfig.disableSourceSelection"
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1600,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33875,7 +33976,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -33885,12 +33986,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1488,
+						"id": 1502,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1599,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33914,7 +34015,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -33922,18 +34023,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1487,
+						"id": 1501,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1612,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33952,6 +34053,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -33960,7 +34065,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -33970,12 +34075,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1500,
+						"id": 1514,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1622,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33999,7 +34104,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -34009,12 +34114,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1509,
+						"id": 1524,
 						"name": "SpotterEmbedViewConfig.enableLinkOverridesV2"
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1589,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34052,12 +34157,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1477,
+						"id": 1491,
 						"name": "SpotterEmbedViewConfig.enablePastConversationsSidebar"
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1588,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34091,12 +34196,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1476,
+						"id": 1490,
 						"name": "SpotterEmbedViewConfig.enableStopAnswerGenerationEmbed"
 					}
 				},
 				{
-					"id": 1599,
+					"id": 1615,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34120,7 +34225,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -34130,12 +34235,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1502,
+						"id": 1517,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1567,
+					"id": 1582,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34169,12 +34274,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1470,
+						"id": 1484,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeFiltersfromURL"
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1584,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34208,12 +34313,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1472,
+						"id": 1486,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeParametersfromURL"
 					}
 				},
 				{
-					"id": 1601,
+					"id": 1617,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34236,7 +34341,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -34246,12 +34351,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1504,
+						"id": 1519,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1596,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34275,23 +34380,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1484,
+						"id": 1498,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1601,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34308,7 +34413,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -34319,7 +34424,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -34327,18 +34432,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1489,
+						"id": 1503,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1580,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34372,12 +34477,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1468,
+						"id": 1482,
 						"name": "SpotterEmbedViewConfig.hideSampleQuestions"
 					}
 				},
 				{
-					"id": 1562,
+					"id": 1577,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34411,12 +34516,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1465,
+						"id": 1479,
 						"name": "SpotterEmbedViewConfig.hideSourceSelection"
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1609,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34440,7 +34545,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -34450,12 +34555,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1497,
+						"id": 1511,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1631,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34478,7 +34583,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -34488,12 +34593,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1518,
+						"id": 1533,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1630,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34505,7 +34610,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -34516,7 +34621,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -34529,12 +34634,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1517,
+						"id": 1532,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1629,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34554,7 +34659,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -34564,12 +34669,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1516,
+						"id": 1531,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1621,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34593,7 +34698,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -34603,12 +34708,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1508,
+						"id": 1523,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1603,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34632,7 +34737,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -34642,12 +34747,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1491,
+						"id": 1505,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1620,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34671,7 +34776,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -34681,12 +34786,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1507,
+						"id": 1522,
 						"name": "SpotterEmbedViewConfig.overrideHistoryState"
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1619,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34710,7 +34815,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -34720,12 +34825,50 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1506,
+						"id": 1521,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1614,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1516,
+						"name": "SpotterEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 1613,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34741,6 +34884,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -34749,7 +34896,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -34768,12 +34915,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1501,
+						"id": 1515,
 						"name": "SpotterEmbedViewConfig.preRenderContainer"
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1611,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34789,6 +34936,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -34797,7 +34948,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -34807,12 +34958,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1499,
+						"id": 1513,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1626,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34839,7 +34990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -34849,12 +35000,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1513,
+						"id": 1528,
 						"name": "SpotterEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1581,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34886,18 +35037,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1469,
+						"id": 1483,
 						"name": "SpotterEmbedViewConfig.runtimeFilters"
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1583,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34929,18 +35080,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1471,
+						"id": 1485,
 						"name": "SpotterEmbedViewConfig.runtimeParameters"
 					}
 				},
 				{
-					"id": 1560,
+					"id": 1575,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34963,12 +35114,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1463,
+						"id": 1477,
 						"name": "SpotterEmbedViewConfig.searchOptions"
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1593,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35002,12 +35153,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1481,
+						"id": 1495,
 						"name": "SpotterEmbedViewConfig.sharedConversationId"
 					}
 				},
 				{
-					"id": 1611,
+					"id": 1627,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35034,7 +35185,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -35044,12 +35195,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1514,
+						"id": 1529,
 						"name": "SpotterEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1608,
+					"id": 1624,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35072,7 +35223,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -35082,12 +35233,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1511,
+						"id": 1526,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1579,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35121,12 +35272,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1467,
+						"id": 1481,
 						"name": "SpotterEmbedViewConfig.showSpotterLimitations"
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1586,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35164,12 +35315,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1474,
+						"id": 1488,
 						"name": "SpotterEmbedViewConfig.showSpotterRadiance"
 					}
 				},
 				{
-					"id": 1576,
+					"id": 1591,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35199,17 +35350,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1534,
 						"name": "SpotterChatViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1479,
+						"id": 1493,
 						"name": "SpotterEmbedViewConfig.spotterChatConfig"
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1592,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35239,17 +35390,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1558,
 						"name": "SpotterShareConversationConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1480,
+						"id": 1494,
 						"name": "SpotterEmbedViewConfig.spotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1590,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35279,17 +35430,17 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1540,
 						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1478,
+						"id": 1492,
 						"name": "SpotterEmbedViewConfig.spotterSidebarConfig"
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1585,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35327,12 +35478,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1473,
+						"id": 1487,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1594,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35370,12 +35521,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1482,
+						"id": 1496,
 						"name": "SpotterEmbedViewConfig.updatedSpotterExperience"
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1628,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35402,7 +35553,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -35412,12 +35563,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1515,
+						"id": 1530,
 						"name": "SpotterEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1602,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35438,14 +35589,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -35453,18 +35604,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1490,
+						"id": 1504,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1558,
+					"id": 1573,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35487,7 +35638,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1461,
+						"id": 1475,
 						"name": "SpotterEmbedViewConfig.worksheetId"
 					}
 				}
@@ -35497,55 +35648,56 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1589,
-						1609,
-						1593,
-						1563,
-						1559,
-						1572,
-						1602,
-						1561,
-						1585,
-						1584,
-						1597,
-						1606,
+						1604,
+						1625,
+						1608,
+						1578,
 						1574,
-						1573,
+						1587,
+						1618,
+						1576,
+						1600,
 						1599,
-						1567,
-						1569,
-						1601,
-						1581,
-						1586,
-						1565,
-						1562,
-						1594,
+						1612,
+						1622,
+						1589,
+						1588,
 						1615,
+						1582,
+						1584,
+						1617,
+						1596,
+						1601,
+						1580,
+						1577,
+						1609,
+						1631,
+						1630,
+						1629,
+						1621,
+						1603,
+						1620,
+						1619,
 						1614,
 						1613,
-						1605,
-						1588,
-						1604,
-						1603,
-						1598,
-						1596,
-						1610,
-						1566,
-						1568,
-						1560,
-						1578,
 						1611,
-						1608,
-						1564,
-						1571,
-						1576,
-						1577,
+						1626,
+						1581,
+						1583,
 						1575,
-						1570,
+						1593,
+						1627,
+						1624,
 						1579,
-						1612,
-						1587,
-						1558
+						1586,
+						1591,
+						1592,
+						1590,
+						1585,
+						1594,
+						1628,
+						1602,
+						1573
 					]
 				}
 			],
@@ -35559,13 +35711,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1460,
+					"id": 1474,
 					"name": "SpotterEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 3193,
+			"id": 3216,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35580,7 +35732,7 @@
 			},
 			"children": [
 				{
-					"id": 3194,
+					"id": 3217,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35590,21 +35742,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8685,
+							"line": 8765,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3195,
+							"id": 3218,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3196,
+									"id": 3219,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35612,18 +35764,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8686,
+											"line": 8766,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3190,
+										"id": 3213,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3197,
+									"id": 3220,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35631,7 +35783,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8687,
+											"line": 8767,
 											"character": 8
 										}
 									],
@@ -35639,7 +35791,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3190,
+											"id": 3213,
 											"name": "VizPoint"
 										}
 									}
@@ -35650,8 +35802,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3196,
-										3197
+										3219,
+										3220
 									]
 								}
 							]
@@ -35659,7 +35811,7 @@
 					}
 				},
 				{
-					"id": 3198,
+					"id": 3221,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35667,21 +35819,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8689,
+							"line": 8769,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3199,
+							"id": 3222,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3207,
+									"id": 3230,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35689,7 +35841,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8697,
+											"line": 8777,
 											"character": 8
 										}
 									],
@@ -35702,7 +35854,7 @@
 									}
 								},
 								{
-									"id": 3208,
+									"id": 3231,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35710,7 +35862,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8698,
+											"line": 8778,
 											"character": 8
 										}
 									],
@@ -35723,7 +35875,7 @@
 									}
 								},
 								{
-									"id": 3201,
+									"id": 3224,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35731,7 +35883,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8691,
+											"line": 8771,
 											"character": 8
 										}
 									],
@@ -35741,7 +35893,7 @@
 									}
 								},
 								{
-									"id": 3200,
+									"id": 3223,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35749,7 +35901,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8690,
+											"line": 8770,
 											"character": 8
 										}
 									],
@@ -35759,7 +35911,7 @@
 									}
 								},
 								{
-									"id": 3202,
+									"id": 3225,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35767,21 +35919,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8692,
+											"line": 8772,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3203,
+											"id": 3226,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3204,
+													"id": 3227,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -35789,21 +35941,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8693,
+															"line": 8773,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3205,
+															"id": 3228,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3206,
+																	"id": 3229,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -35811,7 +35963,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8694,
+																			"line": 8774,
 																			"character": 16
 																		}
 																	],
@@ -35826,7 +35978,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3206
+																		3229
 																	]
 																}
 															]
@@ -35839,7 +35991,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3204
+														3227
 													]
 												}
 											]
@@ -35852,23 +36004,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3207,
-										3208,
-										3201,
-										3200,
-										3202
+										3230,
+										3231,
+										3224,
+										3223,
+										3225
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3209,
+								"id": 3232,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3210,
+										"id": 3233,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -35887,7 +36039,7 @@
 					}
 				},
 				{
-					"id": 3211,
+					"id": 3234,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35895,18 +36047,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8701,
+							"line": 8781,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1949,
+						"id": 1967,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3212,
+					"id": 3235,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35916,7 +36068,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8702,
+							"line": 8782,
 							"character": 4
 						}
 					],
@@ -35931,23 +36083,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3194,
-						3198,
-						3211,
-						3212
+						3217,
+						3221,
+						3234,
+						3235
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8684,
+					"line": 8764,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2904,
+			"id": 2926,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35957,7 +36109,7 @@
 			},
 			"children": [
 				{
-					"id": 2967,
+					"id": 2989,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35980,7 +36132,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2988,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36003,7 +36155,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2958,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36026,7 +36178,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2959,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36049,7 +36201,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2961,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36072,7 +36224,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2960,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36095,7 +36247,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2931,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36118,7 +36270,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 3001,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36141,7 +36293,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 3002,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36164,7 +36316,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2999,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36187,7 +36339,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 3000,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36210,7 +36362,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2963,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36233,7 +36385,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2968,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36256,7 +36408,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2965,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36279,7 +36431,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2967,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36302,7 +36454,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2966,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36325,7 +36477,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2964,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36348,7 +36500,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2973,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36371,7 +36523,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2970,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36394,7 +36546,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2972,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36417,7 +36569,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2971,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36440,7 +36592,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2969,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36463,7 +36615,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2977,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36486,7 +36638,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2976,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36509,7 +36661,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2975,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36532,7 +36684,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2974,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36555,7 +36707,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2962,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36578,7 +36730,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3098,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36591,7 +36743,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 938,
+							"line": 943,
 							"character": 4
 						}
 					],
@@ -36601,7 +36753,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3093,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36614,7 +36766,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 913,
+							"line": 918,
 							"character": 4
 						}
 					],
@@ -36624,7 +36776,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3088,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36633,75 +36785,6 @@
 					},
 					"comment": {
 						"shortText": "Font color of the legend label in the heatmap chart."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 888,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3064,
-					"name": "--ts-var-chart-heatmap-legend-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the legend title in the heatmap chart."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 883,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3067,
-					"name": "--ts-var-chart-treemap-legend-label-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the legend label in the treemap chart."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 898,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3066,
-					"name": "--ts-var-chart-treemap-legend-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the legend title in the treemap chart."
 					},
 					"sources": [
 						{
@@ -36716,7 +36799,76 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3087,
+					"name": "--ts-var-chart-heatmap-legend-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the legend title in the heatmap chart."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 888,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3090,
+					"name": "--ts-var-chart-treemap-legend-label-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the legend label in the treemap chart."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 903,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3089,
+					"name": "--ts-var-chart-treemap-legend-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the legend title in the treemap chart."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 898,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3024,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36739,7 +36891,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3027,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,7 +36914,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3022,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36785,7 +36937,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3025,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36808,7 +36960,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3026,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36831,7 +36983,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3021,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36854,7 +37006,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3023,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36877,7 +37029,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2994,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36900,7 +37052,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2993,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36923,7 +37075,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2996,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36946,7 +37098,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2995,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36969,7 +37121,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2992,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36992,7 +37144,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2990,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37015,7 +37167,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2991,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37038,7 +37190,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2997,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37061,7 +37213,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2998,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37084,7 +37236,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 3009,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37107,7 +37259,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 3010,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37130,7 +37282,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 3013,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37153,7 +37305,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 3011,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37176,7 +37328,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 3012,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37199,7 +37351,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3020,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37222,7 +37374,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3019,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37245,7 +37397,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 3018,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37268,7 +37420,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3017,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37291,7 +37443,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3086,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37300,6 +37452,29 @@
 					},
 					"comment": {
 						"shortText": "Font color of the analyze text in the KPI widget."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 883,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3085,
+					"name": "--ts-var-kpi-comparison-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the comparison text in the KPI widget."
 					},
 					"sources": [
 						{
@@ -37314,15 +37489,15 @@
 					}
 				},
 				{
-					"id": 3062,
-					"name": "--ts-var-kpi-comparison-color",
+					"id": 3084,
+					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the comparison text in the KPI widget."
+						"shortText": "Font color of the hero text in the KPI widget."
 					},
 					"sources": [
 						{
@@ -37337,20 +37512,20 @@
 					}
 				},
 				{
-					"id": 3061,
-					"name": "--ts-var-kpi-hero-color",
+					"id": 3092,
+					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the hero text in the KPI widget."
+						"shortText": "Color of the negative change in the KPI."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 868,
+							"line": 913,
 							"character": 4
 						}
 					],
@@ -37360,15 +37535,15 @@
 					}
 				},
 				{
-					"id": 3069,
-					"name": "--ts-var-kpi-negative-change-color",
+					"id": 3091,
+					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color of the negative change in the KPI."
+						"shortText": "Color of the positive change in the KPI."
 					},
 					"sources": [
 						{
@@ -37383,30 +37558,7 @@
 					}
 				},
 				{
-					"id": 3068,
-					"name": "--ts-var-kpi-positive-change-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of the positive change in the KPI."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 903,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 2913,
+					"id": 2935,
 					"name": "--ts-var-left-nav-active-tab-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37429,7 +37581,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2936,
 					"name": "--ts-var-left-nav-active-tab-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37452,7 +37604,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2934,
 					"name": "--ts-var-left-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,7 +37627,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2938,
 					"name": "--ts-var-left-nav-item-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37498,7 +37650,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2940,
 					"name": "--ts-var-left-nav-item-selection-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37521,7 +37673,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2939,
 					"name": "--ts-var-left-nav-item-selection-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37544,7 +37696,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2937,
 					"name": "--ts-var-left-nav-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37567,7 +37719,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2941,
 					"name": "--ts-var-left-nav-tab-icon-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37590,7 +37742,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2942,
 					"name": "--ts-var-left-nav-tab-icon-inactive-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37613,7 +37765,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 3015,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37636,7 +37788,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 3014,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37659,7 +37811,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3044,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37682,7 +37834,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3057,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37706,7 +37858,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3056,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37730,7 +37882,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3054,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37754,7 +37906,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3055,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37778,7 +37930,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3062,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37801,7 +37953,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3060,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37824,7 +37976,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3059,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37847,7 +37999,7 @@
 					}
 				},
 				{
-					"id": 3124,
+					"id": 3147,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37856,75 +38008,6 @@
 					},
 					"comment": {
 						"shortText": "Border color of the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1186,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3128,
-					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color of unselected items in the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1206,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3129,
-					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover text color of unselected items in the Liveboard edit header toolbar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1211,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3125,
-					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the selected section in the Liveboard edit header toolbar."
 					},
 					"sources": [
 						{
@@ -37939,15 +38022,61 @@
 					}
 				},
 				{
-					"id": 3126,
-					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
+					"id": 3151,
+					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Text color of the selected section in the Liveboard edit header toolbar."
+						"shortText": "Hover background color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1211,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3152,
+					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover text color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1216,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3148,
+					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the selected section in the Liveboard edit header toolbar."
 					},
 					"sources": [
 						{
@@ -37962,15 +38091,15 @@
 					}
 				},
 				{
-					"id": 3127,
-					"name": "--ts-var-liveboard-edit-toolbar-text",
+					"id": 3149,
+					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Text color of unselected items in the Liveboard edit header toolbar."
+						"shortText": "Text color of the selected section in the Liveboard edit header toolbar."
 					},
 					"sources": [
 						{
@@ -37985,7 +38114,30 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3150,
+					"name": "--ts-var-liveboard-edit-toolbar-text",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of unselected items in the Liveboard edit header toolbar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1206,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3045,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38009,7 +38161,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3046,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38033,7 +38185,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3050,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38057,7 +38209,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3038,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38081,7 +38233,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3053,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38105,7 +38257,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3052,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38129,7 +38281,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3043,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38153,7 +38305,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3051,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38177,7 +38329,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3041,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38201,7 +38353,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3042,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38225,7 +38377,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3049,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38249,7 +38401,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3039,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38273,7 +38425,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3040,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38297,7 +38449,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3077,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38310,7 +38462,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 833,
+							"line": 838,
 							"character": 4
 						}
 					],
@@ -38320,7 +38472,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3074,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38329,29 +38481,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the action button in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 818,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3052,
-					"name": "--ts-var-liveboard-header-action-button-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the action button in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -38366,15 +38495,15 @@
 					}
 				},
 				{
-					"id": 3053,
-					"name": "--ts-var-liveboard-header-action-button-hover-color",
+					"id": 3075,
+					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the action button in the Liveboard header on hover."
+						"shortText": "Font color of the action button in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -38389,7 +38518,30 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3076,
+					"name": "--ts-var-liveboard-header-action-button-hover-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the action button in the Liveboard header on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 833,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3029,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38412,7 +38564,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3083,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38425,7 +38577,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 863,
+							"line": 868,
 							"character": 4
 						}
 					],
@@ -38435,7 +38587,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3078,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38444,29 +38596,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the badge in the Liveboard header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 838,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3056,
-					"name": "--ts-var-liveboard-header-badge-font-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the badge in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -38481,38 +38610,15 @@
 					}
 				},
 				{
-					"id": 3059,
-					"name": "--ts-var-liveboard-header-badge-hover-color",
+					"id": 3079,
+					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the badge in the Liveboard header on hover."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 858,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3057,
-					"name": "--ts-var-liveboard-header-badge-modified-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the modified badge in the Liveboard header."
+						"shortText": "Font color of the badge in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -38527,15 +38633,38 @@
 					}
 				},
 				{
-					"id": 3058,
-					"name": "--ts-var-liveboard-header-badge-modified-font-color",
+					"id": 3082,
+					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the modified badge in the Liveboard header."
+						"shortText": "Font color of the badge in the Liveboard header on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 863,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3080,
+					"name": "--ts-var-liveboard-header-badge-modified-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the modified badge in the Liveboard header."
 					},
 					"sources": [
 						{
@@ -38550,7 +38679,30 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3081,
+					"name": "--ts-var-liveboard-header-badge-modified-font-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the modified badge in the Liveboard header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 858,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3030,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38573,7 +38725,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3034,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38596,7 +38748,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3033,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38619,7 +38771,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3028,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38642,7 +38794,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3048,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38665,7 +38817,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3047,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38688,7 +38840,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3061,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38711,7 +38863,7 @@
 					}
 				},
 				{
-					"id": 3094,
+					"id": 3117,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38720,75 +38872,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the styling button in the Liveboard when active."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1033,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3091,
-					"name": "--ts-var-liveboard-styling-button-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the styling button in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1018,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3093,
-					"name": "--ts-var-liveboard-styling-button-hover-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the styling button in the Liveboard on hover."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1028,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3095,
-					"name": "--ts-var-liveboard-styling-button-hover-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling button in the Liveboard on hover."
 					},
 					"sources": [
 						{
@@ -38803,38 +38886,15 @@
 					}
 				},
 				{
-					"id": 3096,
-					"name": "--ts-var-liveboard-styling-button-shadow",
+					"id": 3114,
+					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Box shadow of the styling button in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1043,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3092,
-					"name": "--ts-var-liveboard-styling-button-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling button in the Liveboard."
+						"shortText": "Background color of the styling button in the Liveboard."
 					},
 					"sources": [
 						{
@@ -38849,15 +38909,61 @@
 					}
 				},
 				{
-					"id": 3097,
-					"name": "--ts-var-liveboard-styling-color-palette-background",
+					"id": 3116,
+					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the color palette in the Liveboard styling panel."
+						"shortText": "Background color of the styling button in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1033,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3118,
+					"name": "--ts-var-liveboard-styling-button-hover-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling button in the Liveboard on hover."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1043,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3119,
+					"name": "--ts-var-liveboard-styling-button-shadow",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Box shadow of the styling button in the Liveboard."
 					},
 					"sources": [
 						{
@@ -38872,7 +38978,53 @@
 					}
 				},
 				{
-					"id": 3090,
+					"id": 3115,
+					"name": "--ts-var-liveboard-styling-button-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling button in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1028,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3120,
+					"name": "--ts-var-liveboard-styling-color-palette-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the color palette in the Liveboard styling panel."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1053,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3113,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38881,6 +39033,29 @@
 					},
 					"comment": {
 						"shortText": "Border color of the styling panel in the Liveboard."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1018,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3112,
+					"name": "--ts-var-liveboard-styling-panel-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the styling panel in the Liveboard."
 					},
 					"sources": [
 						{
@@ -38895,30 +39070,7 @@
 					}
 				},
 				{
-					"id": 3089,
-					"name": "--ts-var-liveboard-styling-panel-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the styling panel in the Liveboard."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1008,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3041,
+					"id": 3063,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38941,7 +39093,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3064,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38964,7 +39116,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3032,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38987,7 +39139,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3031,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39010,7 +39162,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3035,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39033,7 +39185,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3036,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39056,7 +39208,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3037,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39079,7 +39231,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3065,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39102,7 +39254,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3066,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39125,7 +39277,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 3007,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39148,7 +39300,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 3004,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39171,7 +39323,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 3003,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39194,7 +39346,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 3005,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39217,7 +39369,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 3008,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39240,7 +39392,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 3006,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39263,7 +39415,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2932,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39286,7 +39438,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2933,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39309,7 +39461,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3071,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39332,7 +39484,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3072,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39355,7 +39507,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3067,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39378,7 +39530,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3069,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39401,7 +39553,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3070,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39424,7 +39576,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3068,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39447,7 +39599,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2927,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39470,7 +39622,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2928,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39493,7 +39645,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2929,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39516,7 +39668,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2930,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39539,7 +39691,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3101,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39548,236 +39700,6 @@
 					},
 					"comment": {
 						"shortText": "Background color for the saved chats sidebar container."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 953,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3077,
-					"name": "--ts-var-saved-chats-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar container."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 948,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3082,
-					"name": "--ts-var-saved-chats-btn-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for buttons (new chat, toggle, footer) in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 973,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3083,
-					"name": "--ts-var-saved-chats-btn-hover-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color for buttons in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 978,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3086,
-					"name": "--ts-var-saved-chats-conv-active-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for the active/selected conversation in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 993,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3085,
-					"name": "--ts-var-saved-chats-conv-hover-bg",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color for conversation items on hover in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 988,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3084,
-					"name": "--ts-var-saved-chats-conv-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color for conversation items in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 983,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3087,
-					"name": "--ts-var-saved-chats-footer-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar footer."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 998,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3080,
-					"name": "--ts-var-saved-chats-header-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color for the saved chats sidebar header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 963,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3088,
-					"name": "--ts-var-saved-chats-section-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color for section title text (e.g., \"Recent\", \"Older\") in the saved chats sidebar."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1003,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3079,
-					"name": "--ts-var-saved-chats-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color for the saved chats sidebar container."
 					},
 					"sources": [
 						{
@@ -39792,15 +39714,176 @@
 					}
 				},
 				{
-					"id": 3081,
-					"name": "--ts-var-saved-chats-title-color",
+					"id": 3100,
+					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color for the saved chats sidebar title text."
+						"shortText": "Border color for the saved chats sidebar container."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 953,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3105,
+					"name": "--ts-var-saved-chats-btn-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for buttons (new chat, toggle, footer) in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 978,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3106,
+					"name": "--ts-var-saved-chats-btn-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color for buttons in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 983,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3109,
+					"name": "--ts-var-saved-chats-conv-active-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the active/selected conversation in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 998,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3108,
+					"name": "--ts-var-saved-chats-conv-hover-bg",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for conversation items on hover in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 993,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3107,
+					"name": "--ts-var-saved-chats-conv-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for conversation items in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 988,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3110,
+					"name": "--ts-var-saved-chats-footer-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar footer."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1003,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3103,
+					"name": "--ts-var-saved-chats-header-border",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color for the saved chats sidebar header."
 					},
 					"sources": [
 						{
@@ -39815,7 +39898,76 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 3111,
+					"name": "--ts-var-saved-chats-section-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for section title text (e.g., \"Recent\", \"Older\") in the saved chats sidebar."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1008,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3102,
+					"name": "--ts-var-saved-chats-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color for the saved chats sidebar container."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 963,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3104,
+					"name": "--ts-var-saved-chats-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color for the saved chats sidebar title text."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 973,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2950,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39838,7 +39990,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2954,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39861,7 +40013,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2955,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39884,7 +40036,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2953,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39907,7 +40059,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2949,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39930,7 +40082,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2952,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39953,7 +40105,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2946,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39976,7 +40128,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2947,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39999,7 +40151,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2948,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40022,7 +40174,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2943,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40045,7 +40197,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2944,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40068,7 +40220,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2945,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40091,7 +40243,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2951,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40114,7 +40266,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3016,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40137,7 +40289,7 @@
 					}
 				},
 				{
-					"id": 3140,
+					"id": 3163,
 					"name": "--ts-var-share-chat-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40146,121 +40298,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the share chat header's inner title/actions row.\nDefaults to transparent."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1274,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3139,
-					"name": "--ts-var-share-chat-header-container-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background gradient color-stop of the share chat header's outer container\n(sender's pre-share header). Defaults to transparent."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1268,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3143,
-					"name": "--ts-var-share-chat-header-input-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the title input field in the share chat header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1289,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3144,
-					"name": "--ts-var-share-chat-header-input-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the title input field in the share chat header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1294,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3142,
-					"name": "--ts-var-share-chat-header-input-text-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the title input field in the share chat header."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1284,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3141,
-					"name": "--ts-var-share-chat-header-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Font color of the title text in the share chat header."
 					},
 					"sources": [
 						{
@@ -40275,20 +40312,20 @@
 					}
 				},
 				{
-					"id": 3136,
-					"name": "--ts-var-shared-conv-header-background",
+					"id": 3162,
+					"name": "--ts-var-share-chat-header-container-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the shared conversation header (recipient's read-only view)."
+						"shortText": "Background gradient color-stop of the share chat header's outer container\n(sender's pre-share header). Defaults to transparent."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1252,
+							"line": 1273,
 							"character": 4
 						}
 					],
@@ -40298,15 +40335,107 @@
 					}
 				},
 				{
-					"id": 3137,
-					"name": "--ts-var-shared-conv-header-border-color",
+					"id": 3166,
+					"name": "--ts-var-share-chat-header-input-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Border color of the shared conversation header."
+						"shortText": "Background color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1294,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3167,
+					"name": "--ts-var-share-chat-header-input-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1299,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3165,
+					"name": "--ts-var-share-chat-header-input-text-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the title input field in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1289,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3164,
+					"name": "--ts-var-share-chat-header-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Font color of the title text in the share chat header."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1284,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3159,
+					"name": "--ts-var-shared-conv-header-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the shared conversation header (recipient's read-only view)."
 					},
 					"sources": [
 						{
@@ -40321,15 +40450,15 @@
 					}
 				},
 				{
-					"id": 3138,
-					"name": "--ts-var-shared-conv-title-color",
+					"id": 3160,
+					"name": "--ts-var-shared-conv-header-border-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Font color of the title text in the shared conversation header."
+						"shortText": "Border color of the shared conversation header."
 					},
 					"sources": [
 						{
@@ -40344,20 +40473,20 @@
 					}
 				},
 				{
-					"id": 3145,
-					"name": "--ts-var-shimmer-background",
+					"id": 3161,
+					"name": "--ts-var-shared-conv-title-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the shimmer loading effect. Also affects the\nsaved chats sidebar's new-chat shimmer, which shares the same style."
+						"shortText": "Font color of the title text in the shared conversation header."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1300,
+							"line": 1267,
 							"character": 4
 						}
 					],
@@ -40367,15 +40496,15 @@
 					}
 				},
 				{
-					"id": 3146,
-					"name": "--ts-var-shimmer-sweep-background",
+					"id": 3168,
+					"name": "--ts-var-shimmer-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the shimmer sweep animation's gradient mid-stop."
+						"shortText": "Background color of the shimmer loading effect. Also affects the\nsaved chats sidebar's new-chat shimmer, which shares the same style."
 					},
 					"sources": [
 						{
@@ -40390,7 +40519,30 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3169,
+					"name": "--ts-var-shimmer-sweep-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the shimmer sweep animation's gradient mid-stop."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1310,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3058,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40413,7 +40565,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3097,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40426,7 +40578,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 933,
+							"line": 938,
 							"character": 4
 						}
 					],
@@ -40436,7 +40588,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3094,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40445,29 +40597,6 @@
 					},
 					"comment": {
 						"shortText": "Background color of the forecasting card in the SpotIQ analyze."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 918,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3072,
-					"name": "--ts-var-spotiq-analyze-outlier-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the outlier card in the SpotIQ analyze."
 					},
 					"sources": [
 						{
@@ -40482,15 +40611,15 @@
 					}
 				},
 				{
-					"id": 3073,
-					"name": "--ts-var-spotiq-analyze-trend-card-background",
+					"id": 3095,
+					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the trend card in the SpotIQ analyze."
+						"shortText": "Background color of the outlier card in the SpotIQ analyze."
 					},
 					"sources": [
 						{
@@ -40505,7 +40634,30 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3096,
+					"name": "--ts-var-spotiq-analyze-trend-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the trend card in the SpotIQ analyze."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 933,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3099,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40518,7 +40670,7 @@
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 943,
+							"line": 948,
 							"character": 4
 						}
 					],
@@ -40528,7 +40680,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2956,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40551,7 +40703,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2957,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40574,7 +40726,7 @@
 					}
 				},
 				{
-					"id": 3131,
+					"id": 3154,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40583,52 +40735,6 @@
 					},
 					"comment": {
 						"shortText": "Shared border color used throughout SpotterViz: input box, user message,\nheader underline, left panel border, thinking step connector and dots."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1222,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3103,
-					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color for the SpotterViz label in the empty state, displayed below\nthe SpotterViz icon."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1079,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3132,
-					"name": "--ts-var-spotterviz-expanded-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Expanded user chat message bubble border color in SpotterViz."
 					},
 					"sources": [
 						{
@@ -40643,222 +40749,15 @@
 					}
 				},
 				{
-					"id": 3130,
-					"name": "--ts-var-spotterviz-footer-text-color",
+					"id": 3126,
+					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Text color of the SpotterViz footer."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1216,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3099,
-					"name": "--ts-var-spotterviz-input-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1058,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3101,
-					"name": "--ts-var-spotterviz-input-cta-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "CTA color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1068,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3102,
-					"name": "--ts-var-spotterviz-input-cta-hover-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "CTA hover color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1073,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3100,
-					"name": "--ts-var-spotterviz-input-placeholder-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Placeholder text color of the chat input field in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1063,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3122,
-					"name": "--ts-var-spotterviz-last-checkpoint-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the last checkpoint section in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1176,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3123,
-					"name": "--ts-var-spotterviz-last-checkpoint-border",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of the last checkpoint section in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1181,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3108,
-					"name": "--ts-var-spotterviz-message-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the user chat message bubble in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1105,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3098,
-					"name": "--ts-var-spotterviz-panel-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Main panel background of the SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1053,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3104,
-					"name": "--ts-var-spotterviz-prompt-card-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the starter prompt cards in SpotterViz."
+						"shortText": "Text color for the SpotterViz label in the empty state, displayed below\nthe SpotterViz icon."
 					},
 					"sources": [
 						{
@@ -40873,20 +40772,20 @@
 					}
 				},
 				{
-					"id": 3105,
-					"name": "--ts-var-spotterviz-prompt-card-hover-background",
+					"id": 3155,
+					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background hover color of the starter prompt cards in SpotterViz."
+						"shortText": "Expanded user chat message bubble border color in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1089,
+							"line": 1232,
 							"character": 4
 						}
 					],
@@ -40896,20 +40795,20 @@
 					}
 				},
 				{
-					"id": 3133,
-					"name": "--ts-var-spotterviz-reference-icon-hover-background",
+					"id": 3153,
+					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color of the reference-mode toggle button in the SpotterViz\nchat input when it is unselected and the user hovers over it."
+						"shortText": "Text color of the SpotterViz footer."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1233,
+							"line": 1221,
 							"character": 4
 						}
 					],
@@ -40919,20 +40818,20 @@
 					}
 				},
 				{
-					"id": 3135,
-					"name": "--ts-var-spotterviz-reference-icon-selected-background",
+					"id": 3122,
+					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Background color for the reference-mode selected state — applies to\nboth the reference mode toggle button when active and the icon badge\non each referenced-entity chip in the chat input."
+						"shortText": "Background color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1247,
+							"line": 1063,
 							"character": 4
 						}
 					],
@@ -40942,20 +40841,20 @@
 					}
 				},
 				{
-					"id": 3134,
-					"name": "--ts-var-spotterviz-reference-icon-selected-color",
+					"id": 3124,
+					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Icon color for the reference-mode selected state — applies to\nboth the toggle button when active and the icon badge on each\nreferenced-entity chip in the chat input."
+						"shortText": "CTA color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1240,
+							"line": 1073,
 							"character": 4
 						}
 					],
@@ -40965,20 +40864,20 @@
 					}
 				},
 				{
-					"id": 3106,
-					"name": "--ts-var-spotterviz-text-primary",
+					"id": 3125,
+					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Primary text color in SpotterViz, also used for tool response text,\nupvote/downvote buttons, and other primary content."
+						"shortText": "CTA hover color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1095,
+							"line": 1078,
 							"character": 4
 						}
 					],
@@ -40988,20 +40887,20 @@
 					}
 				},
 				{
-					"id": 3107,
-					"name": "--ts-var-spotterviz-text-secondary",
+					"id": 3123,
+					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Secondary text color in SpotterViz."
+						"shortText": "Placeholder text color of the chat input field in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1100,
+							"line": 1068,
 							"character": 4
 						}
 					],
@@ -41011,20 +40910,20 @@
 					}
 				},
 				{
-					"id": 3112,
-					"name": "--ts-var-spotterviz-thinking-completed-header-color",
+					"id": 3145,
+					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color of the thinking step header when completed in SpotterViz."
+						"shortText": "Background color of the last checkpoint section in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1125,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -41034,20 +40933,20 @@
 					}
 				},
 				{
-					"id": 3114,
-					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
+					"id": 3146,
+					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Hover background color for the working/work done CTA in SpotterViz."
+						"shortText": "Border color of the last checkpoint section in SpotterViz."
 					},
 					"sources": [
 						{
 							"fileName": "css-variables.ts",
-							"line": 1136,
+							"line": 1186,
 							"character": 4
 						}
 					],
@@ -41057,245 +40956,15 @@
 					}
 				},
 				{
-					"id": 3111,
-					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
+					"id": 3131,
+					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
 					"flags": {
 						"isOptional": true
 					},
 					"comment": {
-						"shortText": "Color of the thinking step header when in progress in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1120,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3113,
-					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of the final completion indicator icon shown when all work is done.\nThe last green dot which is shown when work is done."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1131,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3117,
-					"name": "--ts-var-spotterviz-tool-border-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Border color of tool call panels in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1151,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3115,
-					"name": "--ts-var-spotterviz-tool-call-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of tool call panels in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1141,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3119,
-					"name": "--ts-var-spotterviz-tool-feedback-button-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the upvote/downvote feedback buttons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1161,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3120,
-					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover background color of the upvote/downvote feedback buttons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1166,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3118,
-					"name": "--ts-var-spotterviz-tool-json-input-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the JSON input panel inside a tool call in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1156,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3121,
-					"name": "--ts-var-spotterviz-tool-json-input-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Text color of the JSON input panel inside a tool call in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1171,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3116,
-					"name": "--ts-var-spotterviz-tool-title-color",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Color of tool titles and icons in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1146,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3110,
-					"name": "--ts-var-spotterviz-usermessage-icon-background",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Background color of the user chat message expand button in SpotterViz."
-					},
-					"sources": [
-						{
-							"fileName": "css-variables.ts",
-							"line": 1115,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 3109,
-					"name": "--ts-var-spotterviz-usermessage-icon-hover",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Hover color for the user chat message expand button in SpotterViz."
+						"shortText": "Background color of the user chat message bubble in SpotterViz."
 					},
 					"sources": [
 						{
@@ -41310,7 +40979,513 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 3121,
+					"name": "--ts-var-spotterviz-panel-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Main panel background of the SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1058,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3127,
+					"name": "--ts-var-spotterviz-prompt-card-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the starter prompt cards in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1089,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3128,
+					"name": "--ts-var-spotterviz-prompt-card-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background hover color of the starter prompt cards in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1094,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3156,
+					"name": "--ts-var-spotterviz-reference-icon-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the reference-mode toggle button in the SpotterViz\nchat input when it is unselected and the user hovers over it."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1238,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3158,
+					"name": "--ts-var-spotterviz-reference-icon-selected-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color for the reference-mode selected state — applies to\nboth the reference mode toggle button when active and the icon badge\non each referenced-entity chip in the chat input."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1252,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3157,
+					"name": "--ts-var-spotterviz-reference-icon-selected-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Icon color for the reference-mode selected state — applies to\nboth the toggle button when active and the icon badge on each\nreferenced-entity chip in the chat input."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1245,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3129,
+					"name": "--ts-var-spotterviz-text-primary",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Primary text color in SpotterViz, also used for tool response text,\nupvote/downvote buttons, and other primary content."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1100,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3130,
+					"name": "--ts-var-spotterviz-text-secondary",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Secondary text color in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1105,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3135,
+					"name": "--ts-var-spotterviz-thinking-completed-header-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the thinking step header when completed in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1130,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3137,
+					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color for the working/work done CTA in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1141,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3134,
+					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the thinking step header when in progress in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1125,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3136,
+					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the final completion indicator icon shown when all work is done.\nThe last green dot which is shown when work is done."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1136,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3140,
+					"name": "--ts-var-spotterviz-tool-border-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Border color of tool call panels in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1156,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3138,
+					"name": "--ts-var-spotterviz-tool-call-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of tool call panels in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1146,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3142,
+					"name": "--ts-var-spotterviz-tool-feedback-button-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the upvote/downvote feedback buttons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1166,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3143,
+					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover background color of the upvote/downvote feedback buttons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1171,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3141,
+					"name": "--ts-var-spotterviz-tool-json-input-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the JSON input panel inside a tool call in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1161,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3144,
+					"name": "--ts-var-spotterviz-tool-json-input-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Text color of the JSON input panel inside a tool call in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1176,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3139,
+					"name": "--ts-var-spotterviz-tool-title-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of tool titles and icons in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1151,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3133,
+					"name": "--ts-var-spotterviz-usermessage-icon-background",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Background color of the user chat message expand button in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1120,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3132,
+					"name": "--ts-var-spotterviz-usermessage-icon-hover",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Hover color for the user chat message expand button in SpotterViz."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 1115,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 3073,
+					"name": "--ts-var-unsaved-filter-indicator-color",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Color of the unsaved filter indicator dot in the centralised filter modal."
+					},
+					"sources": [
+						{
+							"fileName": "css-variables.ts",
+							"line": 818,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 2986,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41333,7 +41508,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2984,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41356,7 +41531,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2985,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41379,7 +41554,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2981,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41402,7 +41577,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2982,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41425,7 +41600,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2983,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41448,7 +41623,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2987,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41471,7 +41646,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2978,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41494,7 +41669,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2979,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41517,7 +41692,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2980,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41545,248 +41720,249 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
+						2989,
+						2988,
+						2958,
+						2959,
+						2961,
+						2960,
+						2931,
+						3001,
+						3002,
+						2999,
+						3000,
+						2963,
+						2968,
+						2965,
 						2967,
 						2966,
-						2936,
-						2937,
-						2939,
-						2938,
-						2909,
-						2979,
-						2980,
-						2977,
-						2978,
-						2941,
-						2946,
-						2943,
-						2945,
-						2944,
-						2942,
-						2951,
-						2948,
-						2950,
-						2949,
-						2947,
-						2955,
-						2954,
-						2953,
-						2952,
-						2940,
-						3075,
-						3070,
-						3065,
-						3064,
-						3067,
-						3066,
-						3002,
-						3005,
-						3000,
-						3003,
-						3004,
-						2999,
-						3001,
-						2972,
-						2971,
-						2974,
+						2964,
 						2973,
 						2970,
-						2968,
+						2972,
+						2971,
 						2969,
-						2975,
+						2977,
 						2976,
-						2987,
-						2988,
-						2991,
-						2989,
-						2990,
-						2998,
-						2997,
-						2996,
-						2995,
-						3063,
-						3062,
-						3061,
-						3069,
-						3068,
-						2913,
-						2914,
-						2912,
-						2916,
-						2918,
-						2917,
-						2915,
-						2919,
-						2920,
-						2993,
-						2992,
-						3022,
-						3035,
-						3034,
-						3032,
-						3033,
-						3040,
-						3038,
-						3037,
-						3124,
-						3128,
-						3129,
-						3125,
-						3126,
-						3127,
-						3023,
-						3024,
-						3028,
-						3016,
-						3031,
-						3030,
-						3021,
-						3029,
-						3019,
-						3020,
-						3027,
-						3017,
-						3018,
-						3054,
-						3051,
-						3052,
-						3053,
-						3007,
-						3060,
-						3055,
-						3056,
-						3059,
-						3057,
-						3058,
-						3008,
-						3012,
-						3011,
-						3006,
-						3026,
-						3025,
-						3039,
-						3094,
-						3091,
+						2975,
+						2974,
+						2962,
+						3098,
 						3093,
-						3095,
-						3096,
-						3092,
-						3097,
+						3088,
+						3087,
 						3090,
 						3089,
-						3041,
-						3042,
-						3010,
+						3024,
+						3027,
+						3022,
+						3025,
+						3026,
+						3021,
+						3023,
+						2994,
+						2993,
+						2996,
+						2995,
+						2992,
+						2990,
+						2991,
+						2997,
+						2998,
 						3009,
+						3010,
 						3013,
-						3014,
-						3015,
-						3043,
-						3044,
-						2985,
-						2982,
-						2981,
-						2983,
-						2986,
-						2984,
-						2910,
-						2911,
-						3049,
-						3050,
-						3045,
-						3047,
-						3048,
-						3046,
-						2905,
-						2906,
-						2907,
-						2908,
-						3078,
-						3077,
-						3082,
-						3083,
+						3011,
+						3012,
+						3020,
+						3019,
+						3018,
+						3017,
 						3086,
 						3085,
 						3084,
-						3087,
-						3080,
-						3088,
+						3092,
+						3091,
+						2935,
+						2936,
+						2934,
+						2938,
+						2940,
+						2939,
+						2937,
+						2941,
+						2942,
+						3015,
+						3014,
+						3044,
+						3057,
+						3056,
+						3054,
+						3055,
+						3062,
+						3060,
+						3059,
+						3147,
+						3151,
+						3152,
+						3148,
+						3149,
+						3150,
+						3045,
+						3046,
+						3050,
+						3038,
+						3053,
+						3052,
+						3043,
+						3051,
+						3041,
+						3042,
+						3049,
+						3039,
+						3040,
+						3077,
+						3074,
+						3075,
+						3076,
+						3029,
+						3083,
+						3078,
 						3079,
+						3082,
+						3080,
 						3081,
-						2928,
+						3030,
+						3034,
+						3033,
+						3028,
+						3048,
+						3047,
+						3061,
+						3117,
+						3114,
+						3116,
+						3118,
+						3119,
+						3115,
+						3120,
+						3113,
+						3112,
+						3063,
+						3064,
+						3032,
+						3031,
+						3035,
+						3036,
+						3037,
+						3065,
+						3066,
+						3007,
+						3004,
+						3003,
+						3005,
+						3008,
+						3006,
 						2932,
 						2933,
-						2931,
-						2927,
-						2930,
-						2924,
-						2925,
-						2926,
-						2921,
-						2922,
-						2923,
-						2929,
-						2994,
-						3140,
-						3139,
-						3143,
-						3144,
-						3142,
-						3141,
-						3136,
-						3137,
-						3138,
-						3145,
-						3146,
-						3036,
-						3074,
 						3071,
 						3072,
-						3073,
-						3076,
-						2934,
-						2935,
-						3131,
-						3103,
-						3132,
-						3130,
-						3099,
+						3067,
+						3069,
+						3070,
+						3068,
+						2927,
+						2928,
+						2929,
+						2930,
 						3101,
-						3102,
 						3100,
-						3122,
-						3123,
-						3108,
-						3098,
-						3104,
 						3105,
-						3133,
-						3135,
-						3134,
 						3106,
-						3107,
-						3112,
-						3114,
-						3111,
-						3113,
-						3117,
-						3115,
-						3119,
-						3120,
-						3118,
-						3121,
-						3116,
-						3110,
 						3109,
-						2964,
-						2962,
-						2963,
-						2959,
-						2960,
-						2961,
-						2965,
+						3108,
+						3107,
+						3110,
+						3103,
+						3111,
+						3102,
+						3104,
+						2950,
+						2954,
+						2955,
+						2953,
+						2949,
+						2952,
+						2946,
+						2947,
+						2948,
+						2943,
+						2944,
+						2945,
+						2951,
+						3016,
+						3163,
+						3162,
+						3166,
+						3167,
+						3165,
+						3164,
+						3159,
+						3160,
+						3161,
+						3168,
+						3169,
+						3058,
+						3097,
+						3094,
+						3095,
+						3096,
+						3099,
 						2956,
 						2957,
-						2958
+						3154,
+						3126,
+						3155,
+						3153,
+						3122,
+						3124,
+						3125,
+						3123,
+						3145,
+						3146,
+						3131,
+						3121,
+						3127,
+						3128,
+						3156,
+						3158,
+						3157,
+						3129,
+						3130,
+						3135,
+						3137,
+						3134,
+						3136,
+						3140,
+						3138,
+						3142,
+						3143,
+						3141,
+						3144,
+						3139,
+						3133,
+						3132,
+						3073,
+						2986,
+						2984,
+						2985,
+						2981,
+						2982,
+						2983,
+						2987,
+						2978,
+						2979,
+						2980
 					]
 				}
 			],
@@ -41799,7 +41975,7 @@
 			]
 		},
 		{
-			"id": 2892,
+			"id": 2914,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41809,7 +41985,7 @@
 			},
 			"children": [
 				{
-					"id": 2894,
+					"id": 2916,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41825,12 +42001,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2895,
+						"id": 2917,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2915,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41855,8 +42031,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2894,
-						2893
+						2916,
+						2915
 					]
 				}
 			],
@@ -41869,7 +42045,7 @@
 			]
 		},
 		{
-			"id": 2882,
+			"id": 2904,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41885,7 +42061,7 @@
 			},
 			"children": [
 				{
-					"id": 2884,
+					"id": 2906,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41902,14 +42078,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2885,
+							"id": 2907,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2887,
+									"id": 2909,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -41939,7 +42115,7 @@
 									}
 								},
 								{
-									"id": 2888,
+									"id": 2910,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -41959,7 +42135,7 @@
 									}
 								},
 								{
-									"id": 2886,
+									"id": 2908,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42002,21 +42178,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2887,
-										2888,
-										2886
+										2909,
+										2910,
+										2908
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2889,
+								"id": 2911,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2890,
+										"id": 2912,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42035,7 +42211,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2913,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42055,7 +42231,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2905,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42071,7 +42247,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2892,
+						"id": 2914,
 						"name": "CustomStyles"
 					}
 				}
@@ -42081,9 +42257,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2884,
-						2891,
-						2883
+						2906,
+						2913,
+						2905
 					]
 				}
 			],
@@ -42096,7 +42272,7 @@
 			]
 		},
 		{
-			"id": 2429,
+			"id": 2447,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42112,7 +42288,7 @@
 			},
 			"children": [
 				{
-					"id": 2470,
+					"id": 2488,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42142,20 +42318,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2471,
+							"id": 2489,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2472,
+								"id": 2490,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2473,
+										"id": 2491,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42187,7 +42363,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2450,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42210,7 +42386,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2470,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42252,7 +42428,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2472,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42281,7 +42457,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2449,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42298,12 +42474,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1969,
+						"id": 1987,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2462,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42332,7 +42508,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2473,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42365,7 +42541,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2465,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42394,7 +42570,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2497,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42427,7 +42603,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2485,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42456,7 +42632,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2495,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42500,7 +42676,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2492,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42543,7 +42719,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2469,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42568,12 +42744,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2483,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42602,7 +42778,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2467,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42632,7 +42808,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2494,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42669,7 +42845,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2487,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42698,7 +42874,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2463,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42731,7 +42907,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2493,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42751,7 +42927,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2461,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42780,7 +42956,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2456,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42814,7 +42990,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2481,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42847,12 +43023,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3150,
+						"id": 3173,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2464,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42881,7 +43057,7 @@
 					}
 				},
 				{
-					"id": 2437,
+					"id": 2455,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42914,7 +43090,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2484,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42943,7 +43119,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2454,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42967,7 +43143,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2479,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42996,7 +43172,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2466,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43029,7 +43205,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2457,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43059,7 +43235,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2459,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43088,7 +43264,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2480,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43117,7 +43293,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2460,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43146,7 +43322,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2468,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43175,7 +43351,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2448,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43196,7 +43372,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2471,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43219,7 +43395,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2453,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43242,7 +43418,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2496,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43275,7 +43451,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2451,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -43291,7 +43467,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2434,
+							"id": 2452,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -43319,50 +43495,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2470,
-						2432,
-						2452,
-						2454,
-						2431,
-						2444,
-						2455,
-						2447,
-						2479,
-						2467,
-						2477,
-						2474,
-						2451,
-						2465,
-						2449,
-						2476,
-						2469,
-						2445,
-						2475,
-						2443,
-						2438,
-						2463,
-						2446,
-						2437,
-						2466,
-						2436,
-						2461,
-						2448,
-						2439,
-						2441,
-						2462,
-						2442,
+						2488,
 						2450,
-						2430,
+						2470,
+						2472,
+						2449,
+						2462,
+						2473,
+						2465,
+						2497,
+						2485,
+						2495,
+						2492,
+						2469,
+						2483,
+						2467,
+						2494,
+						2487,
+						2463,
+						2493,
+						2461,
+						2456,
+						2481,
+						2464,
+						2455,
+						2484,
+						2454,
+						2479,
+						2466,
+						2457,
+						2459,
+						2480,
+						2460,
+						2468,
+						2448,
+						2471,
 						2453,
-						2435,
-						2478
+						2496
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2433
+						2451
 					]
 				}
 			],
@@ -43375,7 +43551,7 @@
 			]
 		},
 		{
-			"id": 3274,
+			"id": 3297,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43404,7 +43580,7 @@
 			},
 			"children": [
 				{
-					"id": 3277,
+					"id": 3300,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43415,18 +43591,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9069,
+							"line": 9149,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3256,
+						"id": 3279,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3275,
+					"id": 3298,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43437,18 +43613,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9065,
+							"line": 9145,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3280,
+						"id": 3303,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3276,
+					"id": 3299,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43459,7 +43635,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9067,
+							"line": 9147,
 							"character": 4
 						}
 					],
@@ -43486,21 +43662,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3277,
-						3275,
-						3276
+						3300,
+						3298,
+						3299
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9063,
+					"line": 9143,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3278,
+				"id": 3301,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43510,7 +43686,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3279,
+						"id": 3302,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43527,7 +43703,7 @@
 			}
 		},
 		{
-			"id": 2840,
+			"id": 2862,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43543,7 +43719,7 @@
 			},
 			"children": [
 				{
-					"id": 2842,
+					"id": 2864,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43575,7 +43751,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2865,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43611,7 +43787,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2863,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43648,9 +43824,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2842,
-						2843,
-						2841
+						2864,
+						2865,
+						2863
 					]
 				}
 			],
@@ -43662,7 +43838,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2844,
+				"id": 2866,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43672,7 +43848,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2845,
+						"id": 2867,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43706,7 +43882,7 @@
 			}
 		},
 		{
-			"id": 2597,
+			"id": 2617,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43722,7 +43898,7 @@
 			},
 			"children": [
 				{
-					"id": 2609,
+					"id": 2629,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43756,7 +43932,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2663,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43780,27 +43956,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2644,
+							"id": 2664,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2645,
+								"id": 2665,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2646,
+										"id": 2666,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43836,7 +44012,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2697,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43864,7 +44040,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -43878,7 +44054,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2694,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43902,13 +44078,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2443,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -43917,7 +44093,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2711,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43941,7 +44117,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2030,
+							"line": 2110,
 							"character": 4
 						}
 					],
@@ -43955,7 +44131,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2685,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43987,7 +44163,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -44004,7 +44180,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2667,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44027,13 +44203,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44042,7 +44218,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2698,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44070,7 +44246,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -44084,7 +44260,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2619,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44126,7 +44302,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2677,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44150,7 +44326,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -44164,7 +44340,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2659,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44188,7 +44364,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -44202,7 +44378,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2658,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44226,7 +44402,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -44234,7 +44410,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -44244,7 +44420,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2671,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44263,6 +44439,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -44271,7 +44451,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -44285,7 +44465,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2705,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44313,7 +44493,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 2006,
 							"character": 4
 						}
 					],
@@ -44327,7 +44507,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2710,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44355,7 +44535,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2014,
+							"line": 2094,
 							"character": 4
 						}
 					],
@@ -44369,7 +44549,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2699,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44397,7 +44577,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -44411,7 +44591,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2681,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44435,7 +44615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -44449,7 +44629,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2652,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44482,7 +44662,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2644,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44512,7 +44692,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2649,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44546,7 +44726,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2674,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44570,7 +44750,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -44584,7 +44764,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2621,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44621,7 +44801,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2695,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44645,7 +44825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -44659,7 +44839,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2696,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44683,7 +44863,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -44697,7 +44877,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2676,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44720,7 +44900,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -44734,7 +44914,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2655,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44758,13 +44938,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44773,7 +44953,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2618,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44807,7 +44987,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2660,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44824,7 +45004,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -44835,7 +45015,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -44843,7 +45023,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -44853,7 +45033,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2636,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44890,7 +45070,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2708,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44918,7 +45098,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1981,
+							"line": 2061,
 							"character": 4
 						}
 					],
@@ -44932,7 +45112,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2701,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44960,7 +45140,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1862,
+							"line": 1942,
 							"character": 4
 						}
 					],
@@ -44974,7 +45154,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2631,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45008,7 +45188,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2668,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45032,7 +45212,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -45046,7 +45226,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2691,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45069,7 +45249,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -45083,7 +45263,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2690,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45095,7 +45275,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -45106,7 +45286,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -45123,7 +45303,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2712,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45151,7 +45331,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2049,
+							"line": 2129,
 							"character": 4
 						}
 					],
@@ -45165,7 +45345,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2640,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45203,7 +45383,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2715,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45227,7 +45407,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2099,
+							"line": 2179,
 							"character": 4
 						}
 					],
@@ -45241,7 +45421,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2642,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45279,7 +45459,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2714,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45303,7 +45483,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2082,
+							"line": 2162,
 							"character": 4
 						}
 					],
@@ -45317,7 +45497,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2706,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45345,7 +45525,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1943,
+							"line": 2023,
 							"character": 4
 						}
 					],
@@ -45359,7 +45539,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2704,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45383,7 +45563,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1909,
+							"line": 1989,
 							"character": 4
 						}
 					],
@@ -45397,7 +45577,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2717,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45425,7 +45605,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2131,
+							"line": 2211,
 							"character": 4
 						}
 					],
@@ -45439,7 +45619,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2638,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45476,7 +45656,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2641,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45514,7 +45694,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2689,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45534,7 +45714,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -45548,7 +45728,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2639,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45582,7 +45762,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2713,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45606,7 +45786,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2067,
+							"line": 2147,
 							"character": 4
 						}
 					],
@@ -45620,7 +45800,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2700,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45644,7 +45824,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -45658,7 +45838,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2643,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45695,7 +45875,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2645,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45729,7 +45909,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2680,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45753,7 +45933,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -45767,7 +45947,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2622,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45801,7 +45981,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2628,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45835,7 +46015,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2662,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45859,7 +46039,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -45873,7 +46053,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2620,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45910,7 +46090,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2718,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45938,7 +46118,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2147,
+							"line": 2227,
 							"character": 4
 						}
 					],
@@ -45952,7 +46132,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2679,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45976,7 +46156,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -45990,7 +46170,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2678,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46014,7 +46194,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -46028,7 +46208,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2630,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46062,7 +46242,44 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2673,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2672,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46078,6 +46295,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -46086,7 +46307,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -46109,7 +46330,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2670,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46125,6 +46346,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -46133,7 +46358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -46147,7 +46372,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2625,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46181,7 +46406,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2682,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46205,7 +46430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -46219,7 +46444,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2686,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46246,7 +46471,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -46260,7 +46485,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2692,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46284,7 +46509,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -46292,7 +46517,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46302,7 +46527,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2693,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46326,7 +46551,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -46334,7 +46559,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46344,7 +46569,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2687,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46371,7 +46596,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -46385,7 +46610,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2684,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46408,7 +46633,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -46422,7 +46647,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2703,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46450,7 +46675,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1894,
+							"line": 1974,
 							"character": 4
 						}
 					],
@@ -46464,7 +46689,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2709,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46492,7 +46717,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1998,
+							"line": 2078,
 							"character": 4
 						}
 					],
@@ -46506,7 +46731,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2702,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46534,7 +46759,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1878,
+							"line": 1958,
 							"character": 4
 						}
 					],
@@ -46548,7 +46773,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2707,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46576,7 +46801,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1960,
+							"line": 2040,
 							"character": 4
 						}
 					],
@@ -46590,7 +46815,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2716,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46618,7 +46843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2115,
+							"line": 2195,
 							"character": 4
 						}
 					],
@@ -46632,7 +46857,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2632,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46666,7 +46891,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2646,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46699,7 +46924,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2648,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46737,7 +46962,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2650,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46767,12 +46992,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1534,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2651,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46802,12 +47027,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2698,
+						"id": 2719,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2647,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46845,7 +47070,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2653,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46883,7 +47108,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2688,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46910,7 +47135,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -46924,7 +47149,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2661,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46945,14 +47170,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -46960,7 +47185,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -46970,7 +47195,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2637,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47007,7 +47232,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2626,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47044,7 +47269,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2624,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47083,92 +47308,93 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2609,
-						2643,
-						2676,
-						2673,
-						2690,
-						2664,
-						2647,
-						2677,
-						2599,
-						2656,
-						2639,
-						2638,
-						2651,
-						2684,
-						2689,
-						2678,
-						2660,
-						2632,
-						2624,
 						2629,
-						2653,
-						2601,
-						2674,
-						2675,
-						2655,
-						2635,
-						2598,
-						2640,
-						2616,
-						2687,
-						2680,
-						2611,
-						2648,
-						2670,
-						2669,
-						2691,
-						2620,
-						2694,
-						2622,
-						2693,
-						2685,
-						2683,
-						2696,
-						2618,
-						2621,
-						2668,
-						2619,
-						2692,
-						2679,
-						2623,
-						2625,
-						2659,
-						2602,
-						2608,
-						2642,
-						2600,
-						2697,
-						2658,
-						2657,
-						2610,
-						2652,
-						2650,
-						2605,
-						2661,
-						2665,
-						2671,
-						2672,
-						2666,
 						2663,
-						2682,
-						2688,
-						2681,
-						2686,
-						2695,
-						2612,
-						2626,
-						2628,
-						2630,
-						2631,
-						2627,
-						2633,
+						2697,
+						2694,
+						2711,
+						2685,
 						2667,
+						2698,
+						2619,
+						2677,
+						2659,
+						2658,
+						2671,
+						2705,
+						2710,
+						2699,
+						2681,
+						2652,
+						2644,
+						2649,
+						2674,
+						2621,
+						2695,
+						2696,
+						2676,
+						2655,
+						2618,
+						2660,
+						2636,
+						2708,
+						2701,
+						2631,
+						2668,
+						2691,
+						2690,
+						2712,
+						2640,
+						2715,
+						2642,
+						2714,
+						2706,
+						2704,
+						2717,
+						2638,
 						2641,
-						2617,
-						2606,
-						2604
+						2689,
+						2639,
+						2713,
+						2700,
+						2643,
+						2645,
+						2680,
+						2622,
+						2628,
+						2662,
+						2620,
+						2718,
+						2679,
+						2678,
+						2630,
+						2673,
+						2672,
+						2670,
+						2625,
+						2682,
+						2686,
+						2692,
+						2693,
+						2687,
+						2684,
+						2703,
+						2709,
+						2702,
+						2707,
+						2716,
+						2632,
+						2646,
+						2648,
+						2650,
+						2651,
+						2647,
+						2653,
+						2688,
+						2661,
+						2637,
+						2626,
+						2624
 					]
 				}
 			],
@@ -47195,7 +47421,7 @@
 			]
 		},
 		{
-			"id": 1981,
+			"id": 1999,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47205,7 +47431,7 @@
 			},
 			"children": [
 				{
-					"id": 1982,
+					"id": 2000,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47216,7 +47442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2363,
+							"line": 2443,
 							"character": 4
 						}
 					],
@@ -47226,7 +47452,7 @@
 					}
 				},
 				{
-					"id": 1983,
+					"id": 2001,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47237,18 +47463,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2367,
+							"line": 2447,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1985,
+						"id": 2003,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 1984,
+					"id": 2002,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47259,7 +47485,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2373,
+							"line": 2453,
 							"character": 4
 						}
 					],
@@ -47294,22 +47520,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1982,
-						1983,
-						1984
+						2000,
+						2001,
+						2002
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2359,
+					"line": 2439,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3147,
+			"id": 3170,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47319,7 +47545,7 @@
 			},
 			"children": [
 				{
-					"id": 3148,
+					"id": 3171,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47330,7 +47556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2383,
+							"line": 2463,
 							"character": 4
 						}
 					],
@@ -47340,7 +47566,7 @@
 					}
 				},
 				{
-					"id": 3149,
+					"id": 3172,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47351,7 +47577,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2387,
+							"line": 2467,
 							"character": 4
 						}
 					],
@@ -47379,21 +47605,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3148,
-						3149
+						3171,
+						3172
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2379,
+					"line": 2459,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2545,
+			"id": 2564,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47408,7 +47634,7 @@
 			},
 			"children": [
 				{
-					"id": 2560,
+					"id": 2579,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47432,27 +47658,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2561,
+							"id": 2580,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2562,
+								"id": 2581,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2563,
+										"id": 2582,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47488,7 +47714,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2613,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47516,7 +47742,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -47530,7 +47756,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2610,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47554,13 +47780,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2443,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47569,7 +47795,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2601,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47601,7 +47827,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -47618,7 +47844,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2583,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47641,13 +47867,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47656,7 +47882,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2614,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47684,7 +47910,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -47698,7 +47924,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2566,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47732,7 +47958,7 @@
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2565,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47773,7 +47999,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2593,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47797,7 +48023,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -47811,7 +48037,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2575,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47835,7 +48061,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -47849,7 +48075,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2574,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47873,7 +48099,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -47881,7 +48107,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -47891,7 +48117,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2587,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47910,6 +48136,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -47918,7 +48148,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -47932,7 +48162,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2615,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47960,7 +48190,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -47974,7 +48204,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2597,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47998,7 +48228,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -48012,7 +48242,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2590,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48036,7 +48266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -48050,7 +48280,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2611,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48074,7 +48304,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -48088,7 +48318,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2612,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48112,7 +48342,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -48126,7 +48356,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2569,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48160,7 +48390,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2592,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48183,7 +48413,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -48197,7 +48427,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2571,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48221,13 +48451,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48236,7 +48466,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2576,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48253,7 +48483,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -48264,7 +48494,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -48272,7 +48502,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -48282,7 +48512,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2584,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48306,7 +48536,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -48320,7 +48550,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2607,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48343,7 +48573,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -48357,7 +48587,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2606,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48369,7 +48599,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -48380,7 +48610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -48397,7 +48627,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2605,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48417,7 +48647,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -48431,7 +48661,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2616,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48455,7 +48685,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -48469,7 +48699,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2596,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48493,7 +48723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -48507,7 +48737,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2578,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48531,7 +48761,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -48545,7 +48775,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2595,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48569,7 +48799,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -48583,7 +48813,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2594,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48607,7 +48837,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -48621,7 +48851,44 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2589,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2588,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48637,6 +48904,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -48645,7 +48916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -48668,7 +48939,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2586,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48684,6 +48955,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -48692,7 +48967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -48706,7 +48981,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2598,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48730,7 +49005,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -48744,7 +49019,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2602,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48771,7 +49046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -48785,7 +49060,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2608,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48809,7 +49084,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -48817,7 +49092,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -48827,7 +49102,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2609,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48851,7 +49126,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -48859,7 +49134,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -48869,7 +49144,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2568,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48903,7 +49178,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2603,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48930,7 +49205,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -48944,7 +49219,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2600,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48967,7 +49242,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -48981,7 +49256,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2604,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49008,7 +49283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -49022,7 +49297,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2567,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49056,7 +49331,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2577,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49077,14 +49352,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -49092,7 +49367,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -49107,48 +49382,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2560,
-						2593,
-						2590,
-						2581,
-						2564,
-						2594,
-						2547,
-						2546,
-						2573,
-						2556,
-						2555,
-						2568,
-						2595,
-						2577,
-						2570,
-						2591,
-						2592,
-						2550,
-						2572,
-						2552,
-						2557,
+						2579,
+						2613,
+						2610,
+						2601,
+						2583,
+						2614,
+						2566,
 						2565,
-						2587,
-						2586,
-						2585,
-						2596,
-						2576,
-						2559,
+						2593,
 						2575,
 						2574,
+						2587,
+						2615,
+						2597,
+						2590,
+						2611,
+						2612,
 						2569,
-						2567,
-						2578,
-						2582,
-						2588,
-						2589,
-						2549,
-						2583,
-						2580,
+						2592,
+						2571,
+						2576,
 						2584,
-						2548,
-						2558
+						2607,
+						2606,
+						2605,
+						2616,
+						2596,
+						2578,
+						2595,
+						2594,
+						2589,
+						2588,
+						2586,
+						2598,
+						2602,
+						2608,
+						2609,
+						2568,
+						2603,
+						2600,
+						2604,
+						2567,
+						2577
 					]
 				}
 			],
@@ -49171,7 +49447,7 @@
 			]
 		},
 		{
-			"id": 2480,
+			"id": 2498,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49187,7 +49463,7 @@
 			},
 			"children": [
 				{
-					"id": 2518,
+					"id": 2536,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49211,27 +49487,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2519,
+							"id": 2537,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2520,
+								"id": 2538,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2521,
+										"id": 2539,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -49267,7 +49543,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2510,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49301,7 +49577,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2500,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49335,7 +49611,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2499,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49369,7 +49645,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2523,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49397,7 +49673,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -49411,7 +49687,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2513,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49448,7 +49724,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2520,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49472,13 +49748,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2443,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -49487,7 +49763,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2557,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49519,7 +49795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -49536,7 +49812,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2540,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49559,13 +49835,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49574,7 +49850,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2514,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49612,7 +49888,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2524,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49640,7 +49916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -49654,7 +49930,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2506,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49688,7 +49964,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2505,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49724,7 +50000,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2550,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49748,7 +50024,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -49762,7 +50038,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2532,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49786,7 +50062,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -49800,7 +50076,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2531,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49824,7 +50100,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -49832,7 +50108,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -49842,7 +50118,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2544,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49861,6 +50137,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -49869,7 +50149,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -49883,7 +50163,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2525,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49911,7 +50191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -49925,7 +50205,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2554,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49949,7 +50229,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -49963,7 +50243,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2503,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49997,7 +50277,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2547,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50021,7 +50301,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -50035,7 +50315,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2521,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50059,7 +50339,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -50073,7 +50353,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2522,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50097,7 +50377,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -50111,7 +50391,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2509,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50145,7 +50425,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2549,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50168,7 +50448,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -50182,7 +50462,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2515,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50220,7 +50500,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2504,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50254,7 +50534,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2528,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50278,13 +50558,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50293,7 +50573,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2533,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50310,7 +50590,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -50321,7 +50601,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -50329,7 +50609,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -50339,7 +50619,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2501,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50373,7 +50653,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2502,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50407,7 +50687,7 @@
 					}
 				},
 				{
-					"id": 2493,
+					"id": 2511,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50441,7 +50721,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2541,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50465,7 +50745,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -50479,7 +50759,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2563,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50502,7 +50782,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -50516,7 +50796,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2562,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50528,7 +50808,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -50539,7 +50819,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -50556,7 +50836,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2561,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50576,7 +50856,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -50590,7 +50870,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2526,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50614,7 +50894,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -50628,7 +50908,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2553,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50652,7 +50932,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -50666,7 +50946,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2535,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50690,7 +50970,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -50704,7 +50984,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2516,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50742,7 +51022,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2552,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50766,7 +51046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -50780,7 +51060,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2551,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50804,7 +51084,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -50818,7 +51098,44 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2546,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 2545,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50834,6 +51151,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -50842,7 +51163,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -50865,7 +51186,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2543,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50881,6 +51202,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -50889,7 +51214,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -50903,7 +51228,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2558,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50930,7 +51255,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -50944,7 +51269,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2518,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50968,7 +51293,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -50976,7 +51301,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -50986,7 +51311,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2519,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51010,7 +51335,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -51018,7 +51343,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -51028,7 +51353,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2508,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51058,7 +51383,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2507,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51087,7 +51412,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2559,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51114,7 +51439,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -51128,7 +51453,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2556,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51151,7 +51476,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -51165,7 +51490,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2560,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51192,7 +51517,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -51206,7 +51531,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2512,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51236,7 +51561,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2534,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51257,14 +51582,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -51272,7 +51597,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -51282,7 +51607,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2517,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51307,7 +51632,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3285,
+						"id": 3308,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -51317,61 +51642,62 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2518,
-						2492,
-						2482,
-						2481,
-						2505,
-						2495,
-						2502,
-						2538,
-						2522,
-						2496,
-						2506,
-						2488,
-						2487,
-						2531,
-						2514,
-						2513,
-						2526,
-						2507,
-						2535,
-						2485,
-						2528,
-						2503,
-						2504,
-						2491,
-						2530,
-						2497,
-						2486,
+						2536,
 						2510,
-						2515,
-						2483,
-						2484,
-						2493,
-						2523,
-						2544,
-						2543,
-						2542,
-						2508,
-						2534,
-						2517,
-						2498,
-						2533,
-						2532,
-						2527,
-						2525,
-						2539,
 						2500,
-						2501,
-						2490,
-						2489,
+						2499,
+						2523,
+						2513,
+						2520,
+						2557,
 						2540,
-						2537,
+						2514,
+						2524,
+						2506,
+						2505,
+						2550,
+						2532,
+						2531,
+						2544,
+						2525,
+						2554,
+						2503,
+						2547,
+						2521,
+						2522,
+						2509,
+						2549,
+						2515,
+						2504,
+						2528,
+						2533,
+						2501,
+						2502,
+						2511,
 						2541,
-						2494,
+						2563,
+						2562,
+						2561,
+						2526,
+						2553,
+						2535,
 						2516,
-						2499
+						2552,
+						2551,
+						2546,
+						2545,
+						2543,
+						2558,
+						2518,
+						2519,
+						2508,
+						2507,
+						2559,
+						2556,
+						2560,
+						2512,
+						2534,
+						2517
 					]
 				}
 			],
@@ -51404,14 +51730,14 @@
 			]
 		},
 		{
-			"id": 1949,
+			"id": 1967,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1952,
+					"id": 1970,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51426,14 +51752,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1953,
+							"id": 1971,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1955,
+									"id": 1973,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51451,7 +51777,7 @@
 									}
 								},
 								{
-									"id": 1954,
+									"id": 1972,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51474,8 +51800,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1955,
-										1954
+										1973,
+										1972
 									]
 								}
 							]
@@ -51483,7 +51809,7 @@
 					}
 				},
 				{
-					"id": 1951,
+					"id": 1969,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51501,7 +51827,7 @@
 					}
 				},
 				{
-					"id": 1950,
+					"id": 1968,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51524,9 +51850,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1952,
-						1951,
-						1950
+						1970,
+						1969,
+						1968
 					]
 				}
 			],
@@ -51539,7 +51865,7 @@
 			]
 		},
 		{
-			"id": 1167,
+			"id": 1177,
 			"name": "SpotterAgentEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -51555,7 +51881,7 @@
 			},
 			"children": [
 				{
-					"id": 1178,
+					"id": 1188,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51579,27 +51905,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1179,
+							"id": 1189,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1180,
+								"id": 1190,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1181,
+										"id": 1191,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -51635,7 +51961,7 @@
 					}
 				},
 				{
-					"id": 1198,
+					"id": 1209,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51667,7 +51993,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -51684,7 +52010,7 @@
 					}
 				},
 				{
-					"id": 1182,
+					"id": 1192,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51707,13 +52033,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -51722,7 +52048,7 @@
 					}
 				},
 				{
-					"id": 1191,
+					"id": 1202,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51746,7 +52072,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -51760,7 +52086,7 @@
 					}
 				},
 				{
-					"id": 1174,
+					"id": 1184,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51784,7 +52110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -51798,7 +52124,7 @@
 					}
 				},
 				{
-					"id": 1173,
+					"id": 1183,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51822,7 +52148,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -51830,7 +52156,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -51840,7 +52166,7 @@
 					}
 				},
 				{
-					"id": 1186,
+					"id": 1196,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51859,6 +52185,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -51867,7 +52197,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -51881,7 +52211,7 @@
 					}
 				},
 				{
-					"id": 1195,
+					"id": 1206,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51905,7 +52235,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -51919,7 +52249,7 @@
 					}
 				},
 				{
-					"id": 1188,
+					"id": 1199,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51943,7 +52273,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -51957,7 +52287,7 @@
 					}
 				},
 				{
-					"id": 1190,
+					"id": 1201,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51980,7 +52310,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -51994,7 +52324,7 @@
 					}
 				},
 				{
-					"id": 1170,
+					"id": 1180,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52018,13 +52348,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -52033,7 +52363,7 @@
 					}
 				},
 				{
-					"id": 1175,
+					"id": 1185,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52050,7 +52380,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -52061,7 +52391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -52069,7 +52399,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -52079,7 +52409,7 @@
 					}
 				},
 				{
-					"id": 1183,
+					"id": 1193,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52103,7 +52433,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -52117,7 +52447,7 @@
 					}
 				},
 				{
-					"id": 1204,
+					"id": 1215,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52140,7 +52470,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -52154,7 +52484,7 @@
 					}
 				},
 				{
-					"id": 1203,
+					"id": 1214,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52166,7 +52496,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -52177,7 +52507,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -52194,7 +52524,7 @@
 					}
 				},
 				{
-					"id": 1202,
+					"id": 1213,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52214,7 +52544,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -52228,7 +52558,7 @@
 					}
 				},
 				{
-					"id": 1194,
+					"id": 1205,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52252,7 +52582,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -52266,7 +52596,7 @@
 					}
 				},
 				{
-					"id": 1177,
+					"id": 1187,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52290,7 +52620,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -52304,7 +52634,7 @@
 					}
 				},
 				{
-					"id": 1193,
+					"id": 1204,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52328,7 +52658,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -52342,7 +52672,7 @@
 					}
 				},
 				{
-					"id": 1192,
+					"id": 1203,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52366,7 +52696,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -52380,7 +52710,44 @@
 					}
 				},
 				{
-					"id": 1187,
+					"id": 1198,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 1197,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52396,6 +52763,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -52404,7 +52775,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -52427,7 +52798,7 @@
 					}
 				},
 				{
-					"id": 1185,
+					"id": 1195,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52443,6 +52814,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -52451,7 +52826,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -52465,7 +52840,7 @@
 					}
 				},
 				{
-					"id": 1199,
+					"id": 1210,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52492,7 +52867,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -52506,7 +52881,7 @@
 					}
 				},
 				{
-					"id": 1200,
+					"id": 1211,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52533,7 +52908,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -52547,7 +52922,7 @@
 					}
 				},
 				{
-					"id": 1197,
+					"id": 1208,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52570,7 +52945,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -52584,7 +52959,7 @@
 					}
 				},
 				{
-					"id": 1201,
+					"id": 1212,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52611,7 +52986,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -52625,7 +53000,7 @@
 					}
 				},
 				{
-					"id": 1176,
+					"id": 1186,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52646,14 +53021,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -52661,7 +53036,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -52671,7 +53046,7 @@
 					}
 				},
 				{
-					"id": 1168,
+					"id": 1178,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52697,34 +53072,35 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1178,
-						1198,
-						1182,
-						1191,
-						1174,
-						1173,
-						1186,
-						1195,
 						1188,
-						1190,
-						1170,
-						1175,
+						1209,
+						1192,
+						1202,
+						1184,
 						1183,
+						1196,
+						1206,
+						1199,
+						1201,
+						1180,
+						1185,
+						1193,
+						1215,
+						1214,
+						1213,
+						1205,
+						1187,
 						1204,
 						1203,
-						1202,
-						1194,
-						1177,
-						1193,
-						1192,
-						1187,
-						1185,
-						1199,
-						1200,
+						1198,
 						1197,
-						1201,
-						1176,
-						1168
+						1195,
+						1210,
+						1211,
+						1208,
+						1212,
+						1186,
+						1178
 					]
 				}
 			],
@@ -52754,13 +53130,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1205,
+					"id": 1216,
 					"name": "BodylessConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1519,
+			"id": 1534,
 			"name": "SpotterChatViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52780,7 +53156,7 @@
 			},
 			"children": [
 				{
-					"id": 1524,
+					"id": 1539,
 					"name": "enableStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52814,7 +53190,7 @@
 					}
 				},
 				{
-					"id": 1520,
+					"id": 1535,
 					"name": "hideToolResponseCardBranding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52843,7 +53219,7 @@
 					}
 				},
 				{
-					"id": 1522,
+					"id": 1537,
 					"name": "spotterFileUploadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52877,7 +53253,7 @@
 					}
 				},
 				{
-					"id": 1523,
+					"id": 1538,
 					"name": "spotterFileUploadFileTypes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52907,7 +53283,7 @@
 					}
 				},
 				{
-					"id": 1521,
+					"id": 1536,
 					"name": "toolResponseCardBrandingLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52935,11 +53311,11 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1524,
-						1520,
-						1522,
-						1523,
-						1521
+						1539,
+						1535,
+						1537,
+						1538,
+						1536
 					]
 				}
 			],
@@ -52952,7 +53328,7 @@
 			]
 		},
 		{
-			"id": 1460,
+			"id": 1474,
 			"name": "SpotterEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52968,7 +53344,7 @@
 			},
 			"children": [
 				{
-					"id": 1492,
+					"id": 1506,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52992,27 +53368,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1493,
+							"id": 1507,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1494,
+								"id": 1508,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1495,
+										"id": 1509,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -53048,7 +53424,7 @@
 					}
 				},
 				{
-					"id": 1512,
+					"id": 1527,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53080,7 +53456,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -53097,7 +53473,7 @@
 					}
 				},
 				{
-					"id": 1496,
+					"id": 1510,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53120,13 +53496,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2904,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -53135,7 +53511,7 @@
 					}
 				},
 				{
-					"id": 1466,
+					"id": 1480,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53173,7 +53549,7 @@
 					}
 				},
 				{
-					"id": 1462,
+					"id": 1476,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53210,7 +53586,7 @@
 					}
 				},
 				{
-					"id": 1475,
+					"id": 1489,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53244,12 +53620,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1555,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 1505,
+					"id": 1520,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53273,7 +53649,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -53287,7 +53663,7 @@
 					}
 				},
 				{
-					"id": 1464,
+					"id": 1478,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53321,7 +53697,7 @@
 					}
 				},
 				{
-					"id": 1488,
+					"id": 1502,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53345,7 +53721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -53359,7 +53735,7 @@
 					}
 				},
 				{
-					"id": 1487,
+					"id": 1501,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53383,7 +53759,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -53391,7 +53767,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -53401,7 +53777,7 @@
 					}
 				},
 				{
-					"id": 1500,
+					"id": 1514,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53420,6 +53796,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -53428,7 +53808,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -53442,7 +53822,7 @@
 					}
 				},
 				{
-					"id": 1509,
+					"id": 1524,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53466,7 +53846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -53480,7 +53860,7 @@
 					}
 				},
 				{
-					"id": 1477,
+					"id": 1491,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53518,7 +53898,7 @@
 					}
 				},
 				{
-					"id": 1476,
+					"id": 1490,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53552,7 +53932,7 @@
 					}
 				},
 				{
-					"id": 1502,
+					"id": 1517,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53576,7 +53956,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -53590,7 +53970,7 @@
 					}
 				},
 				{
-					"id": 1470,
+					"id": 1484,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53624,7 +54004,7 @@
 					}
 				},
 				{
-					"id": 1472,
+					"id": 1486,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53658,7 +54038,7 @@
 					}
 				},
 				{
-					"id": 1504,
+					"id": 1519,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53681,7 +54061,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -53695,7 +54075,7 @@
 					}
 				},
 				{
-					"id": 1484,
+					"id": 1498,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53719,13 +54099,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2862,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -53734,7 +54114,7 @@
 					}
 				},
 				{
-					"id": 1489,
+					"id": 1503,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53751,7 +54131,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -53762,7 +54142,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -53770,7 +54150,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -53780,7 +54160,7 @@
 					}
 				},
 				{
-					"id": 1468,
+					"id": 1482,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53814,7 +54194,7 @@
 					}
 				},
 				{
-					"id": 1465,
+					"id": 1479,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53848,7 +54228,7 @@
 					}
 				},
 				{
-					"id": 1497,
+					"id": 1511,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53872,7 +54252,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -53886,7 +54266,7 @@
 					}
 				},
 				{
-					"id": 1518,
+					"id": 1533,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53909,7 +54289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9272,
 							"character": 4
 						}
 					],
@@ -53923,7 +54303,7 @@
 					}
 				},
 				{
-					"id": 1517,
+					"id": 1532,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53935,7 +54315,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -53946,7 +54326,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9255,
 							"character": 4
 						}
 					],
@@ -53963,7 +54343,7 @@
 					}
 				},
 				{
-					"id": 1516,
+					"id": 1531,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53983,7 +54363,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9239,
 							"character": 4
 						}
 					],
@@ -53997,7 +54377,7 @@
 					}
 				},
 				{
-					"id": 1508,
+					"id": 1523,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54021,7 +54401,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -54035,7 +54415,7 @@
 					}
 				},
 				{
-					"id": 1491,
+					"id": 1505,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54059,7 +54439,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -54073,7 +54453,7 @@
 					}
 				},
 				{
-					"id": 1507,
+					"id": 1522,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54097,7 +54477,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -54111,7 +54491,7 @@
 					}
 				},
 				{
-					"id": 1506,
+					"id": 1521,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54135,7 +54515,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -54149,7 +54529,44 @@
 					}
 				},
 				{
-					"id": 1501,
+					"id": 1516,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 1515,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54165,6 +54582,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -54173,7 +54594,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -54196,7 +54617,7 @@
 					}
 				},
 				{
-					"id": 1499,
+					"id": 1513,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54212,6 +54633,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -54220,7 +54645,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -54234,7 +54659,7 @@
 					}
 				},
 				{
-					"id": 1513,
+					"id": 1528,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54261,7 +54686,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -54275,7 +54700,7 @@
 					}
 				},
 				{
-					"id": 1469,
+					"id": 1483,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54307,13 +54732,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 1999,
 							"name": "RuntimeFilter"
 						}
 					}
 				},
 				{
-					"id": 1471,
+					"id": 1485,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54345,13 +54770,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3170,
 							"name": "RuntimeParameter"
 						}
 					}
 				},
 				{
-					"id": 1463,
+					"id": 1477,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54374,7 +54799,7 @@
 					}
 				},
 				{
-					"id": 1481,
+					"id": 1495,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54408,7 +54833,7 @@
 					}
 				},
 				{
-					"id": 1514,
+					"id": 1529,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54435,7 +54860,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -54449,7 +54874,7 @@
 					}
 				},
 				{
-					"id": 1511,
+					"id": 1526,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54472,7 +54897,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -54486,7 +54911,7 @@
 					}
 				},
 				{
-					"id": 1467,
+					"id": 1481,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54520,7 +54945,7 @@
 					}
 				},
 				{
-					"id": 1474,
+					"id": 1488,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54558,7 +54983,7 @@
 					}
 				},
 				{
-					"id": 1479,
+					"id": 1493,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54588,12 +55013,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1534,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 1480,
+					"id": 1494,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54623,12 +55048,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1558,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 1478,
+					"id": 1492,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54658,12 +55083,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1540,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 1473,
+					"id": 1487,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54701,7 +55126,7 @@
 					}
 				},
 				{
-					"id": 1482,
+					"id": 1496,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54739,7 +55164,7 @@
 					}
 				},
 				{
-					"id": 1515,
+					"id": 1530,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54766,7 +55191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -54780,7 +55205,7 @@
 					}
 				},
 				{
-					"id": 1490,
+					"id": 1504,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54801,14 +55226,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -54816,7 +55241,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2251,
 							"name": "Action"
 						}
 					},
@@ -54826,7 +55251,7 @@
 					}
 				},
 				{
-					"id": 1461,
+					"id": 1475,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54854,55 +55279,56 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1492,
-						1512,
-						1496,
-						1466,
-						1462,
-						1475,
-						1505,
-						1464,
-						1488,
-						1487,
-						1500,
-						1509,
-						1477,
-						1476,
-						1502,
-						1470,
-						1472,
-						1504,
-						1484,
-						1489,
-						1468,
-						1465,
-						1497,
-						1518,
-						1517,
-						1516,
-						1508,
-						1491,
-						1507,
 						1506,
-						1501,
-						1499,
-						1513,
-						1469,
-						1471,
-						1463,
-						1481,
-						1514,
-						1511,
-						1467,
-						1474,
-						1479,
+						1527,
+						1510,
 						1480,
+						1476,
+						1489,
+						1520,
 						1478,
-						1473,
-						1482,
-						1515,
+						1502,
+						1501,
+						1514,
+						1524,
+						1491,
 						1490,
-						1461
+						1517,
+						1484,
+						1486,
+						1519,
+						1498,
+						1503,
+						1482,
+						1479,
+						1511,
+						1533,
+						1532,
+						1531,
+						1523,
+						1505,
+						1522,
+						1521,
+						1516,
+						1515,
+						1513,
+						1528,
+						1483,
+						1485,
+						1477,
+						1495,
+						1529,
+						1526,
+						1481,
+						1488,
+						1493,
+						1494,
+						1492,
+						1487,
+						1496,
+						1530,
+						1504,
+						1475
 					]
 				}
 			],
@@ -54932,13 +55358,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1557,
+					"id": 1572,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1543,
+			"id": 1558,
 			"name": "SpotterShareConversationConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -54958,7 +55384,7 @@
 			},
 			"children": [
 				{
-					"id": 1544,
+					"id": 1559,
 					"name": "enableShareConversation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54991,7 +55417,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1564,
 					"name": "spotterShareAddUsersLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55020,7 +55446,7 @@
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1563,
 					"name": "spotterShareCancelLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55053,7 +55479,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1562,
 					"name": "spotterShareConfirmLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55086,7 +55512,7 @@
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1566,
 					"name": "spotterShareEmptySubtitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55115,7 +55541,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1565,
 					"name": "spotterShareEmptyTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55144,7 +55570,7 @@
 					}
 				},
 				{
-					"id": 1552,
+					"id": 1567,
 					"name": "spotterShareIncludeNewMessagesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55173,7 +55599,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1560,
 					"name": "spotterShareLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55206,7 +55632,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1561,
 					"name": "spotterShareModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55235,7 +55661,7 @@
 					}
 				},
 				{
-					"id": 1554,
+					"id": 1569,
 					"name": "spotterShareStaleInfoLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55264,7 +55690,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1568,
 					"name": "spotterShareUpToCurrentLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55293,7 +55719,7 @@
 					}
 				},
 				{
-					"id": 1555,
+					"id": 1570,
 					"name": "spotterSharedConversationBannerMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55322,7 +55748,7 @@
 					}
 				},
 				{
-					"id": 1556,
+					"id": 1571,
 					"name": "spotterSharedConversationExitLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55360,19 +55786,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1544,
-						1549,
-						1548,
-						1547,
-						1551,
-						1550,
-						1552,
-						1545,
-						1546,
-						1554,
-						1553,
-						1555,
-						1556
+						1559,
+						1564,
+						1563,
+						1562,
+						1566,
+						1565,
+						1567,
+						1560,
+						1561,
+						1569,
+						1568,
+						1570,
+						1571
 					]
 				}
 			],
@@ -55385,7 +55811,7 @@
 			]
 		},
 		{
-			"id": 1525,
+			"id": 1540,
 			"name": "SpotterSidebarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55405,7 +55831,7 @@
 			},
 			"children": [
 				{
-					"id": 1526,
+					"id": 1541,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55438,7 +55864,7 @@
 					}
 				},
 				{
-					"id": 1538,
+					"id": 1553,
 					"name": "spotterAnalystLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55471,7 +55897,7 @@
 					}
 				},
 				{
-					"id": 1539,
+					"id": 1554,
 					"name": "spotterAnalystsLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55504,7 +55930,7 @@
 					}
 				},
 				{
-					"id": 1535,
+					"id": 1550,
 					"name": "spotterBestPracticesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55533,7 +55959,7 @@
 					}
 				},
 				{
-					"id": 1530,
+					"id": 1545,
 					"name": "spotterChatDeleteLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55562,7 +55988,7 @@
 					}
 				},
 				{
-					"id": 1531,
+					"id": 1546,
 					"name": "spotterChatPinConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55591,7 +56017,7 @@
 					}
 				},
 				{
-					"id": 1529,
+					"id": 1544,
 					"name": "spotterChatRenameLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55620,7 +56046,7 @@
 					}
 				},
 				{
-					"id": 1536,
+					"id": 1551,
 					"name": "spotterConversationsBatchSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55653,7 +56079,7 @@
 					}
 				},
 				{
-					"id": 1532,
+					"id": 1547,
 					"name": "spotterDeleteConversationModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55682,7 +56108,7 @@
 					}
 				},
 				{
-					"id": 1534,
+					"id": 1549,
 					"name": "spotterDocumentationUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55711,7 +56137,7 @@
 					}
 				},
 				{
-					"id": 1537,
+					"id": 1552,
 					"name": "spotterNewChatButtonTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55740,7 +56166,7 @@
 					}
 				},
 				{
-					"id": 1533,
+					"id": 1548,
 					"name": "spotterPastConversationAlertMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55769,7 +56195,7 @@
 					}
 				},
 				{
-					"id": 1528,
+					"id": 1543,
 					"name": "spotterSidebarDefaultExpanded",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55802,7 +56228,7 @@
 					}
 				},
 				{
-					"id": 1527,
+					"id": 1542,
 					"name": "spotterSidebarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55836,20 +56262,20 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1526,
-						1538,
-						1539,
-						1535,
-						1530,
-						1531,
-						1529,
-						1536,
-						1532,
-						1534,
-						1537,
-						1533,
-						1528,
-						1527
+						1541,
+						1553,
+						1554,
+						1550,
+						1545,
+						1546,
+						1544,
+						1551,
+						1547,
+						1549,
+						1552,
+						1548,
+						1543,
+						1542
 					]
 				}
 			],
@@ -55862,7 +56288,7 @@
 			]
 		},
 		{
-			"id": 2698,
+			"id": 2719,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55886,7 +56312,7 @@
 			},
 			"children": [
 				{
-					"id": 2700,
+					"id": 2721,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55919,7 +56345,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2720,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55952,7 +56378,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2723,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55979,13 +56405,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2712,
+							"id": 2733,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2724,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56014,7 +56440,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2722,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56047,7 +56473,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2725,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56076,7 +56502,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2730,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56109,7 +56535,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2732,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56138,7 +56564,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2731,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56167,7 +56593,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2728,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56200,7 +56626,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2726,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56229,7 +56655,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2727,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56256,13 +56682,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2716,
+							"id": 2737,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2729,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56300,19 +56726,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2700,
-						2699,
-						2702,
-						2703,
-						2701,
-						2704,
-						2709,
-						2711,
-						2710,
-						2707,
-						2705,
-						2706,
-						2708
+						2721,
+						2720,
+						2723,
+						2724,
+						2722,
+						2725,
+						2730,
+						2732,
+						2731,
+						2728,
+						2726,
+						2727,
+						2729
 					]
 				}
 			],
@@ -56325,7 +56751,7 @@
 			]
 		},
 		{
-			"id": 2716,
+			"id": 2737,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56345,7 +56771,7 @@
 			},
 			"children": [
 				{
-					"id": 2717,
+					"id": 2738,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56366,7 +56792,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2739,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56392,8 +56818,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2717,
-						2718
+						2738,
+						2739
 					]
 				}
 			],
@@ -56406,7 +56832,7 @@
 			]
 		},
 		{
-			"id": 2712,
+			"id": 2733,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56426,7 +56852,7 @@
 			},
 			"children": [
 				{
-					"id": 2714,
+					"id": 2735,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56447,7 +56873,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2736,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56468,7 +56894,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2734,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56494,9 +56920,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2714,
-						2715,
-						2713
+						2735,
+						2736,
+						2734
 					]
 				}
 			],
@@ -56509,14 +56935,14 @@
 			]
 		},
 		{
-			"id": 1956,
+			"id": 1974,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1957,
+					"id": 1975,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56534,7 +56960,7 @@
 					}
 				},
 				{
-					"id": 1958,
+					"id": 1976,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56557,8 +56983,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1957,
-						1958
+						1975,
+						1976
 					]
 				}
 			],
@@ -56571,7 +56997,7 @@
 			]
 		},
 		{
-			"id": 3285,
+			"id": 3308,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56591,7 +57017,7 @@
 			},
 			"children": [
 				{
-					"id": 3286,
+					"id": 3309,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56604,7 +57030,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9685,
+							"line": 9765,
 							"character": 4
 						}
 					],
@@ -56614,7 +57040,7 @@
 					}
 				},
 				{
-					"id": 3287,
+					"id": 3310,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56627,7 +57053,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9687,
+							"line": 9767,
 							"character": 4
 						}
 					],
@@ -56642,28 +57068,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3286,
-						3287
+						3309,
+						3310
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9683,
+					"line": 9763,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3190,
+			"id": 3213,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3191,
+					"id": 3214,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56671,7 +57097,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8677,
+							"line": 8757,
 							"character": 4
 						}
 					],
@@ -56684,7 +57110,7 @@
 					}
 				},
 				{
-					"id": 3192,
+					"id": 3215,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56692,7 +57118,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8678,
+							"line": 8758,
 							"character": 4
 						}
 					],
@@ -56710,21 +57136,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3191,
-						3192
+						3214,
+						3215
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8676,
+					"line": 8756,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2895,
+			"id": 2917,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56734,7 +57160,7 @@
 			},
 			"children": [
 				{
-					"id": 2897,
+					"id": 2919,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56764,20 +57190,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2898,
+							"id": 2920,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2899,
+								"id": 2921,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2900,
+										"id": 2922,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -56790,7 +57216,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2901,
+										"id": 2923,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -56803,14 +57229,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2902,
+											"id": 2924,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2903,
+													"id": 2925,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -56832,7 +57258,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2918,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56851,7 +57277,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2904,
+						"id": 2926,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -56861,8 +57287,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2897,
-						2896
+						2919,
+						2918
 					]
 				}
 			],
@@ -57167,7 +57593,7 @@
 			]
 		},
 		{
-			"id": 3284,
+			"id": 3307,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57179,7 +57605,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1580,
+					"line": 1660,
 					"character": 12
 				}
 			],
@@ -57224,7 +57650,7 @@
 			}
 		},
 		{
-			"id": 2865,
+			"id": 2887,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57251,7 +57677,7 @@
 			}
 		},
 		{
-			"id": 2869,
+			"id": 2891,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57259,14 +57685,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2184,
+					"line": 2264,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2870,
+					"id": 2892,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -57283,13 +57709,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2184,
+							"line": 2264,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2871,
+							"id": 2893,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -57299,19 +57725,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2872,
+									"id": 2894,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2877,
+										"id": 2899,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2873,
+									"id": 2895,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -57321,7 +57747,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2874,
+											"id": 2896,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -57329,13 +57755,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2191,
+													"line": 2271,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2875,
+													"id": 2897,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -57345,7 +57771,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2876,
+															"id": 2898,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -57376,7 +57802,7 @@
 			}
 		},
 		{
-			"id": 2866,
+			"id": 2888,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57393,21 +57819,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2173,
+					"line": 2253,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2867,
+					"id": 2889,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2868,
+							"id": 2890,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57420,7 +57846,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2178,
+									"line": 2258,
 									"character": 4
 								}
 							],
@@ -57435,14 +57861,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2868
+								2890
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2173,
+							"line": 2253,
 							"character": 29
 						}
 					]
@@ -57450,7 +57876,7 @@
 			}
 		},
 		{
-			"id": 2877,
+			"id": 2899,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57467,21 +57893,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2160,
+					"line": 2240,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2878,
+					"id": 2900,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2880,
+							"id": 2902,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57489,7 +57915,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2164,
+									"line": 2244,
 									"character": 4
 								}
 							],
@@ -57499,7 +57925,7 @@
 							}
 						},
 						{
-							"id": 2881,
+							"id": 2903,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57509,7 +57935,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2166,
+									"line": 2246,
 									"character": 4
 								}
 							],
@@ -57519,7 +57945,7 @@
 							}
 						},
 						{
-							"id": 2879,
+							"id": 2901,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57527,7 +57953,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2162,
+									"line": 2242,
 									"character": 4
 								}
 							],
@@ -57542,16 +57968,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2880,
-								2881,
-								2879
+								2902,
+								2903,
+								2901
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2160,
+							"line": 2240,
 							"character": 29
 						}
 					]
@@ -57609,7 +58035,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1872,
+									"id": 1890,
 									"name": "AnswerService"
 								}
 							}
@@ -57871,7 +58297,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1872,
+												"id": 1890,
 												"name": "AnswerService"
 											}
 										},
@@ -57958,7 +58384,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2429,
+						"id": 2447,
 						"name": "EmbedConfig"
 					}
 				}
@@ -58029,7 +58455,7 @@
 					"kindString": "Call signature",
 					"flags": {},
 					"comment": {
-						"shortText": "Initializes the Visual Embed SDK globally and perform\nauthentication if applicable. This function needs to be called before any ThoughtSpot\ncomponent like Liveboard etc can be embedded. But need not wait for AuthEvent.SUCCESS\nto actually embed. That is handled internally.",
+						"shortText": "Initializes the Visual Embed SDK globally and perform\nauthentication if applicable. This function needs to be called before any ThoughtSpot\ncomponent like Liveboard etc can be embedded. But need not wait for AuthStatus.SUCCESS\nto actually embed. That is handled internally.",
 						"returns": "{@link AuthEventEmitter} event emitter which emits events on authentication success,\n     failure and logout. See {@link AuthStatus}",
 						"tags": [
 							{
@@ -58058,14 +58484,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2429,
+								"id": 2447,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1819,
+						"id": 1837,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -58205,7 +58631,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2835,
+									"id": 2857,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -58333,7 +58759,7 @@
 			]
 		},
 		{
-			"id": 3330,
+			"id": 3353,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -58349,7 +58775,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3331,
+					"id": 3354,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58379,7 +58805,7 @@
 			]
 		},
 		{
-			"id": 3332,
+			"id": 3355,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -58393,7 +58819,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3333,
+					"id": 3356,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58415,7 +58841,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3334,
+							"id": 3357,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58425,7 +58851,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3284,
+								"id": 3307,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -58603,7 +59029,7 @@
 			]
 		},
 		{
-			"id": 3157,
+			"id": 3180,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -58617,7 +59043,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3158,
+					"id": 3181,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58627,7 +59053,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3159,
+							"id": 3182,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58639,7 +59065,7 @@
 							}
 						},
 						{
-							"id": 3160,
+							"id": 3183,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58650,7 +59076,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3161,
+									"id": 3184,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -58673,92 +59099,92 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2233,
-				1817,
-				1802,
-				1809,
-				1969,
-				3293,
-				3296,
-				3300,
-				2425,
-				2223,
-				3247,
-				3243,
+				2251,
+				1835,
+				1820,
+				1827,
+				1987,
 				3316,
-				3239,
-				2229,
-				3256,
-				2001,
-				3280,
-				2846,
-				3183,
-				3177,
-				2858,
-				2130,
-				3252,
-				3288,
-				3187,
-				3231,
-				3150,
-				1959,
-				2835,
-				3181,
-				1985,
-				1540,
-				3327,
+				3319,
 				3323,
-				3213
+				2443,
+				2241,
+				3270,
+				3266,
+				3339,
+				3262,
+				2247,
+				3279,
+				2019,
+				3303,
+				2868,
+				3206,
+				3200,
+				2880,
+				2148,
+				3275,
+				3311,
+				3210,
+				3254,
+				3173,
+				1977,
+				2857,
+				3204,
+				2003,
+				1555,
+				3350,
+				3346,
+				3236
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1872,
-				903,
-				1243,
-				1616,
-				655,
-				254,
+				1890,
+				911,
+				1255,
+				1632,
+				661,
+				256,
 				58,
-				1135,
-				1274
+				1145,
+				1286
 			]
 		},
 		{
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2719,
-				1819,
-				1205,
-				1557,
-				3193,
+				2740,
+				1837,
+				1216,
+				1572,
+				3216,
+				2926,
+				2914,
 				2904,
-				2892,
-				2882,
-				2429,
-				3274,
-				2840,
-				2597,
-				1981,
-				3147,
-				2545,
-				2480,
-				1949,
-				1167,
-				1519,
-				1460,
-				1543,
-				1525,
-				2698,
-				2716,
-				2712,
-				1956,
-				3285,
-				3190,
-				2895,
+				2447,
+				3297,
+				2862,
+				2617,
+				1999,
+				3170,
+				2564,
+				2498,
+				1967,
+				1177,
+				1534,
+				1474,
+				1558,
+				1540,
+				2719,
+				2737,
+				2733,
+				1974,
+				3308,
+				3213,
+				2917,
 				21,
 				28
 			]
@@ -58767,11 +59193,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3284,
-				2865,
-				2869,
-				2866,
-				2877
+				3307,
+				2887,
+				2891,
+				2888,
+				2899
 			]
 		},
 		{
@@ -58788,10 +59214,10 @@
 				4,
 				7,
 				25,
-				3330,
-				3332,
+				3353,
+				3355,
 				40,
-				3157
+				3180
 			]
 		}
 	],


### PR DESCRIPTION
## Summary

Adds a new supported customCSS variable to style the unsaved filter indicator dot in the Liveboard filter modal. Includes regenerated typedoc.json.