### PR TITLE
SCAL-331020: Add Spotter analyst list/default actions and analystId config

### DIFF
--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -537,13 +537,15 @@ describe('ConversationEmbed', () => {
         );
     });
 
-    it('should render the conversation embed with analystId in the url', async () => {
+    it('should render the conversation embed with spotterAnalystConfig.analystId in the url', async () => {
         const viewConfig: SpotterEmbedViewConfig = {
             worksheetId: 'worksheetId',
             searchOptions: {
                 searchQuery: 'searchQuery',
             },
-            analystId: 'analyst-id-1234',
+            spotterAnalystConfig: {
+                analystId: 'analyst-id-1234',
+            },
         };
         const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
         await conversationEmbed.render();
@@ -553,12 +555,25 @@ describe('ConversationEmbed', () => {
         );
     });
 
-    it('should not add analystId to the url when not provided', async () => {
+    it('should not add analystId to the url when spotterAnalystConfig is not provided', async () => {
         const viewConfig: SpotterEmbedViewConfig = {
             worksheetId: 'worksheetId',
             searchOptions: {
                 searchQuery: 'searchQuery',
             },
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expect(getIFrameSrc()).not.toContain('analystId');
+    });
+
+    it('should not add analystId to the url when spotterAnalystConfig is empty', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+            spotterAnalystConfig: {},
         };
         const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
         await conversationEmbed.render();

--- a/src/embed/conversation.spec.ts
+++ b/src/embed/conversation.spec.ts
@@ -537,6 +537,34 @@ describe('ConversationEmbed', () => {
         );
     });
 
+    it('should render the conversation embed with analystId in the url', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+            analystId: 'analyst-id-1234',
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expectUrlMatchesWithParams(
+            getIFrameSrc(),
+            `http://${thoughtSpotHost}/v2/?${defaultParams}&isSpotterExperienceEnabled=true&analystId=analyst-id-1234#/embed/insights/conv-assist?worksheet=worksheetId&query=searchQuery`,
+        );
+    });
+
+    it('should not add analystId to the url when not provided', async () => {
+        const viewConfig: SpotterEmbedViewConfig = {
+            worksheetId: 'worksheetId',
+            searchOptions: {
+                searchQuery: 'searchQuery',
+            },
+        };
+        const conversationEmbed = new SpotterEmbed(getRootEl(), viewConfig);
+        await conversationEmbed.render();
+        expect(getIFrameSrc()).not.toContain('analystId');
+    });
+
     describe('spotter chat hiddenActions', () => {
         it.each([
             ['SpotterChatConnectorResources', Action.SpotterChatConnectorResources],
@@ -548,6 +576,8 @@ describe('ConversationEmbed', () => {
             ['SpotterAnalystDelete', Action.SpotterAnalystDelete],
             ['SpotterAnalystMakeACopy', Action.SpotterAnalystMakeACopy],
             ['SpotterAnalystSidebar', Action.SpotterAnalystSidebar],
+            ['SpotterAnalystList', Action.SpotterAnalystList],
+            ['SpotterDefaultAnalyst', Action.SpotterDefaultAnalyst],
         ])('should render with hiddenActions for %s', async (_, action) => {
             const viewConfig: SpotterEmbedViewConfig = {
                 worksheetId: 'worksheetId',
@@ -592,6 +622,8 @@ describe('ConversationEmbed', () => {
             ['SpotterAnalystDelete', Action.SpotterAnalystDelete],
             ['SpotterAnalystMakeACopy', Action.SpotterAnalystMakeACopy],
             ['SpotterAnalystSidebar', Action.SpotterAnalystSidebar],
+            ['SpotterAnalystList', Action.SpotterAnalystList],
+            ['SpotterDefaultAnalyst', Action.SpotterDefaultAnalyst],
         ])('should render with disabledActions for %s', async (_, action) => {
             const disabledReason = 'testing disabled reason';
             const viewConfig: SpotterEmbedViewConfig = {

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -304,6 +304,21 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      */
     dataSources?: string[];
     /**
+     * Pins the embed to a single spotter analyst. Implies no default Spotter
+     * and no "Show all".
+     *
+     * Supported embed types: `SpotterEmbed`
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * const embed = new SpotterEmbed('#tsEmbed', {
+     *    ... //other embed view config
+     *    analystId: 'analyst-id-1234',
+     * })
+     * ```
+     */
+    analystId?: string;
+    /**
      * Ability to pass a starting search query to the conversation.
      */
     searchOptions?: SearchOptions;
@@ -695,6 +710,7 @@ export class SpotterEmbed extends TsEmbed {
             defaultQueryMode,
             enableStopAnswerGenerationEmbed,
             spotterChatConfig,
+            analystId,
         } = this.viewConfig;
 
         const queryParams = this.getBaseQueryParams();
@@ -710,6 +726,7 @@ export class SpotterEmbed extends TsEmbed {
         setParamIfDefined(queryParams, Param.ShowSpotterRadiance, showSpotterRadiance, true);
         setParamIfDefined(queryParams, Param.DefaultQueryMode, defaultQueryMode);
         setParamIfDefined(queryParams, Param.EnableStopAnswerGenerationEmbed, enableStopAnswerGenerationEmbed, true);
+        setParamIfDefined(queryParams, Param.AnalystId, analystId);
 
         // Handle spotterChatConfig params
         if (spotterChatConfig) {

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -275,6 +275,30 @@ export interface SpotterChatViewConfig {
 }
 
 /**
+ * Configuration for the Spotter Analyst experience.
+ * Can be used in SpotterEmbed.
+ * @group Embed components
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+ * @example
+ * ```js
+ * const embed = new SpotterEmbed('#tsEmbed', {
+ *    ... //other embed view config
+ *    spotterAnalystConfig: {
+ *        analystId: 'analyst-id-1234',
+ *    },
+ * })
+ * ```
+ */
+export interface SpotterAnalystConfig {
+    /**
+     * Pins the embed to a single spotter analyst. Implies no default Spotter
+     * and no "Show all".
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     */
+    analystId?: string;
+}
+
+/**
  * The configuration for the embedded spotterEmbed options.
  * @group Embed components
  */
@@ -304,8 +328,7 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      */
     dataSources?: string[];
     /**
-     * Pins the embed to a single spotter analyst. Implies no default Spotter
-     * and no "Show all".
+     * Configuration for the Spotter Analyst experience.
      *
      * Supported embed types: `SpotterEmbed`
      * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
@@ -313,11 +336,13 @@ export interface SpotterEmbedViewConfig extends Omit<BaseViewConfig, 'primaryAct
      * ```js
      * const embed = new SpotterEmbed('#tsEmbed', {
      *    ... //other embed view config
-     *    analystId: 'analyst-id-1234',
+     *    spotterAnalystConfig: {
+     *        analystId: 'analyst-id-1234',
+     *    },
      * })
      * ```
      */
-    analystId?: string;
+    spotterAnalystConfig?: SpotterAnalystConfig;
     /**
      * Ability to pass a starting search query to the conversation.
      */
@@ -710,7 +735,7 @@ export class SpotterEmbed extends TsEmbed {
             defaultQueryMode,
             enableStopAnswerGenerationEmbed,
             spotterChatConfig,
-            analystId,
+            spotterAnalystConfig,
         } = this.viewConfig;
 
         const queryParams = this.getBaseQueryParams();
@@ -726,7 +751,7 @@ export class SpotterEmbed extends TsEmbed {
         setParamIfDefined(queryParams, Param.ShowSpotterRadiance, showSpotterRadiance, true);
         setParamIfDefined(queryParams, Param.DefaultQueryMode, defaultQueryMode);
         setParamIfDefined(queryParams, Param.EnableStopAnswerGenerationEmbed, enableStopAnswerGenerationEmbed, true);
-        setParamIfDefined(queryParams, Param.AnalystId, analystId);
+        setParamIfDefined(queryParams, Param.AnalystId, spotterAnalystConfig?.analystId);
 
         // Handle spotterChatConfig params
         if (spotterChatConfig) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { PinboardEmbed, LiveboardViewConfig, LiveboardEmbed } from './embed/live
 import { SearchEmbed, SearchViewConfig } from './embed/search';
 import { SearchBarEmbed, SearchBarViewConfig } from './embed/search-bar';
 import { SpotterAgentEmbed, SpotterAgentEmbedViewConfig, BodylessConversation, BodylessConversationViewConfig} from './embed/bodyless-conversation';
-import { SpotterEmbed, SpotterEmbedViewConfig, SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterQueryMode, SpotterShareConversationConfig, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
+import { SpotterEmbed, SpotterEmbedViewConfig, SpotterChatViewConfig, SpotterSidebarViewConfig, SpotterAnalystConfig, SpotterQueryMode, SpotterShareConversationConfig, ConversationEmbed, ConversationViewConfig } from './embed/conversation';
 import { SpotterVizConfig, SpotterVizStarterPrompt, SpotterVizLoaderTip } from './embed/spotter-viz-utils';
 import {
     AuthFailureType, AuthStatus, AuthEvent, AuthEventEmitter,
@@ -117,6 +117,7 @@ export {
     SpotterEmbedViewConfig,
     SpotterChatViewConfig,
     SpotterSidebarViewConfig,
+    SpotterAnalystConfig,
     SpotterQueryMode,
     SpotterShareConversationConfig,
     ConversationViewConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6770,6 +6770,7 @@ export enum Param {
     IsStarterPromptsEnabled = 'enableStarterPrompts',
     UpdatedSpotterExperience = 'updatedSpotterExperience',
     SpotterDataSources = 'spotterDataSources',
+    AnalystId = 'analystId',
 }
 
 /**
@@ -6784,9 +6785,10 @@ export type SpotterFileUploadFileTypes = {
  * ThoughtSpot application pages include actions and menu commands
  * for various user-initiated operations. These actions are represented
  * as enumeration members in the SDK. To control actions in the embedded view:
- * - disabledActions — the action is grayed out and still visible, but non-interactive (user can see but not click).
- * - hiddenActions — the action is completely removed from the UI (user cannot see it at all).
- * - visibleActions — allowlist, only these actions are shown; all others are hidden.
+ * - disabledActions — the action is grayed out and still visible, but non-interactive
+ * (user can see but not click). - hiddenActions — the action is completely removed from
+ * the UI (user cannot see it at all). - visibleActions — allowlist, only these actions
+ * are shown; all others are hidden.
  *
  * Use disabledActions to disable (gray out) an action.
  * Use hiddenActions to hide (fully remove) an action.
@@ -8712,6 +8714,28 @@ export enum Action {
      * ```
      */
     SpotterAnalystSidebar = 'spotterAnalystSidebar',
+    /**
+     * Controls visibility and disable state of the analyst list
+     * ("Show all") in the Spotter Analyst interface.
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterAnalystList]
+     * disabledActions: [Action.SpotterAnalystList]
+     * ```
+     */
+    SpotterAnalystList = 'spotterAnalystList',
+    /**
+     * Controls visibility and disable state of the default Spotter analyst
+     * entry in the Spotter Analyst interface.
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterDefaultAnalyst]
+     * disabledActions: [Action.SpotterDefaultAnalyst]
+     * ```
+     */
+    SpotterDefaultAnalyst = 'spotterDefaultAnalyst',
 }
 export interface AnswerServiceType {
     getAnswer?: (offset: number, batchSize: number) => any;

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,13 +7,13 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2233,
+			"id": 2253,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"comment": {
-				"shortText": "ThoughtSpot application pages include actions and menu commands\nfor various user-initiated operations. These actions are represented\nas enumeration members in the SDK. To control actions in the embedded view:\n- disabledActions — the action is grayed out and still visible, but non-interactive (user can see but not click).\n- hiddenActions — the action is completely removed from the UI (user cannot see it at all).\n- visibleActions — allowlist, only these actions are shown; all others are hidden.",
+				"shortText": "ThoughtSpot application pages include actions and menu commands\nfor various user-initiated operations. These actions are represented\nas enumeration members in the SDK. To control actions in the embedded view:\n- disabledActions — the action is grayed out and still visible, but non-interactive\n(user can see but not click). - hiddenActions — the action is completely removed from\nthe UI (user cannot see it at all). - visibleActions — allowlist, only these actions\nare shown; all others are hidden.",
 				"text": "Use disabledActions to disable (gray out) an action.\nUse hiddenActions to hide (fully remove) an action.\nUse visibleActions to show only specific actions.",
 				"tags": [
 					{
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2356,
+					"id": 2376,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -49,14 +49,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7883,
+							"line": 7965,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2253,
+					"id": 2273,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -77,14 +77,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6916,
+							"line": 6998,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2246,
+					"id": 2266,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -105,14 +105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6845,
+							"line": 6927,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2245,
+					"id": 2265,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -129,14 +129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6834,
+							"line": 6916,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2251,
+					"id": 2271,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -153,14 +153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6897,
+							"line": 6979,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2252,
+					"id": 2272,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -177,14 +177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6906,
+							"line": 6988,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2254,
+					"id": 2274,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -205,14 +205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6926,
+							"line": 7008,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2336,
+					"id": 2356,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -233,14 +233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7651,
+							"line": 7733,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2306,
+					"id": 2326,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -261,14 +261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7344,
+							"line": 7426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2352,
+					"id": 2372,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -289,14 +289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7836,
+							"line": 7918,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2366,
+					"id": 2386,
 					"name": "AllLiveboardFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -317,14 +317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7995,
+							"line": 8077,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"allLiveboardFilters\""
 				},
 				{
-					"id": 2305,
+					"id": 2325,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -345,14 +345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7332,
+							"line": 7414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2304,
+					"id": 2324,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7320,
+							"line": 7402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2351,
+					"id": 2371,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -402,14 +402,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7825,
+							"line": 7907,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2318,
+					"id": 2338,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -430,14 +430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7466,
+							"line": 7548,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2330,
+					"id": 2350,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -458,14 +458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7597,
+							"line": 7679,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2321,
+					"id": 2341,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -486,14 +486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7500,
+							"line": 7582,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2326,
+					"id": 2346,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -514,14 +514,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7555,
+							"line": 7637,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2320,
+					"id": 2340,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -542,14 +542,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7489,
+							"line": 7571,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2323,
+					"id": 2343,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -570,14 +570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7523,
+							"line": 7605,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2331,
+					"id": 2351,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -598,14 +598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7607,
+							"line": 7689,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2327,
+					"id": 2347,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -626,14 +626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7565,
+							"line": 7647,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2324,
+					"id": 2344,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -654,14 +654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7534,
+							"line": 7616,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2329,
+					"id": 2349,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -682,14 +682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7587,
+							"line": 7669,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2325,
+					"id": 2345,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -710,14 +710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7544,
+							"line": 7626,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2322,
+					"id": 2342,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -738,14 +738,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7511,
+							"line": 7593,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2328,
+					"id": 2348,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -766,14 +766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7575,
+							"line": 7657,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2319,
+					"id": 2339,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -794,14 +794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7477,
+							"line": 7559,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2365,
+					"id": 2385,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -822,14 +822,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7981,
+							"line": 8063,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2250,
+					"id": 2270,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -846,14 +846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6888,
+							"line": 6970,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2249,
+					"id": 2269,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -874,14 +874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6879,
+							"line": 6961,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2248,
+					"id": 2268,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -902,14 +902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6867,
+							"line": 6949,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2374,
+					"id": 2394,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -930,14 +930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8083,
+							"line": 8165,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2247,
+					"id": 2267,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -954,14 +954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6856,
+							"line": 6938,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2297,
+					"id": 2317,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -969,14 +969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7269,
+							"line": 7351,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2240,
+					"id": 2260,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -993,14 +993,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6793,
+							"line": 6875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2296,
+					"id": 2316,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1017,14 +1017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7268,
+							"line": 7350,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2375,
+					"id": 2395,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1045,14 +1045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8093,
+							"line": 8175,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2389,
+					"id": 2409,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1073,14 +1073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8257,
+							"line": 8339,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2349,
+					"id": 2369,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1101,14 +1101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7800,
+							"line": 7882,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2309,
+					"id": 2329,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1129,14 +1129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7374,
+							"line": 7456,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2314,
+					"id": 2334,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1157,14 +1157,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7424,
+							"line": 7506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2367,
+					"id": 2387,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1185,14 +1185,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8007,
+							"line": 8089,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2372,
+					"id": 2392,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1213,14 +1213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8064,
+							"line": 8146,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2362,
+					"id": 2382,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1241,14 +1241,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7950,
+							"line": 8032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2364,
+					"id": 2384,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1269,14 +1269,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7969,
+							"line": 8051,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2262,
+					"id": 2282,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1293,14 +1293,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6976,
+							"line": 7058,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2265,
+					"id": 2285,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1317,14 +1317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7009,
+							"line": 7091,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2264,
+					"id": 2284,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1342,14 +1342,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6999,
+							"line": 7081,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2263,
+					"id": 2283,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1366,14 +1366,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6986,
+							"line": 7068,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2266,
+					"id": 2286,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1390,14 +1390,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7019,
+							"line": 7101,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2267,
+					"id": 2287,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1418,14 +1418,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7029,
+							"line": 7111,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2269,
+					"id": 2289,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1446,14 +1446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7053,
+							"line": 7135,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2268,
+					"id": 2288,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1474,14 +1474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7039,
+							"line": 7121,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2271,
+					"id": 2291,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1502,14 +1502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7073,
+							"line": 7155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2270,
+					"id": 2290,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1530,14 +1530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7063,
+							"line": 7145,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2301,
+					"id": 2321,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1554,14 +1554,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7285,
+							"line": 7367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2295,
+					"id": 2315,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1578,14 +1578,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7258,
+							"line": 7340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2294,
+					"id": 2314,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1602,14 +1602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7249,
+							"line": 7331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2279,
+					"id": 2299,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1626,14 +1626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7149,
+							"line": 7231,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2239,
+					"id": 2259,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1650,14 +1650,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6784,
+							"line": 6866,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2308,
+					"id": 2328,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1678,14 +1678,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7363,
+							"line": 7445,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2299,
+					"id": 2319,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1693,14 +1693,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7274,
+							"line": 7356,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2371,
+					"id": 2391,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1721,14 +1721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8053,
+							"line": 8135,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2340,
+					"id": 2360,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1749,14 +1749,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7695,
+							"line": 7777,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2357,
+					"id": 2377,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1777,14 +1777,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7896,
+							"line": 7978,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2276,
+					"id": 2296,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1801,14 +1801,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7117,
+							"line": 7199,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2280,
+					"id": 2300,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1825,14 +1825,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7157,
+							"line": 7239,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2373,
+					"id": 2393,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1853,14 +1853,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8074,
+							"line": 8156,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2337,
+					"id": 2357,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1881,14 +1881,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7661,
+							"line": 7743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2338,
+					"id": 2358,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1909,14 +1909,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7672,
+							"line": 7754,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2293,
+					"id": 2313,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1933,14 +1933,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7238,
+							"line": 7320,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2273,
+					"id": 2293,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1958,14 +1958,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7089,
+							"line": 7171,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2274,
+					"id": 2294,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1982,14 +1982,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7099,
+							"line": 7181,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2376,
+					"id": 2396,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2011,14 +2011,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8112,
+							"line": 8194,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2412,
+					"id": 2432,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2039,14 +2039,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8495,
+							"line": 8577,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2363,
+					"id": 2383,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2067,14 +2067,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7960,
+							"line": 8042,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2287,
+					"id": 2307,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2091,14 +2091,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7199,
+							"line": 7281,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2382,
+					"id": 2402,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2119,14 +2119,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8178,
+							"line": 8260,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2347,
+					"id": 2367,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2147,14 +2147,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7768,
+							"line": 7850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2238,
+					"id": 2258,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2171,14 +2171,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6775,
+							"line": 6857,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2344,
+					"id": 2364,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2195,14 +2195,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7736,
+							"line": 7818,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2313,
+					"id": 2333,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,14 +2223,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7414,
+							"line": 7496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2384,
+					"id": 2404,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,14 +2251,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8204,
+							"line": 8286,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2361,
+					"id": 2381,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,14 +2279,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7939,
+							"line": 8021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2335,
+					"id": 2355,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,14 +2307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7641,
+							"line": 7723,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2342,
+					"id": 2362,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2334,14 +2334,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7716,
+							"line": 7798,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2388,
+					"id": 2408,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2362,14 +2362,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8247,
+							"line": 8329,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2387,
+					"id": 2407,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2390,14 +2390,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8237,
+							"line": 8319,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2343,
+					"id": 2363,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2414,14 +2414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7725,
+							"line": 7807,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2354,
+					"id": 2374,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2446,14 +2446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7860,
+							"line": 7942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2355,
+					"id": 2375,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2474,14 +2474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7872,
+							"line": 7954,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2386,
+					"id": 2406,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2502,14 +2502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8227,
+							"line": 8309,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2358,
+					"id": 2378,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2530,14 +2530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7907,
+							"line": 7989,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2345,
+					"id": 2365,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2562,14 +2562,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7748,
+							"line": 7830,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2346,
+					"id": 2366,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2590,14 +2590,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7758,
+							"line": 7840,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2290,
+					"id": 2310,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2614,14 +2614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7216,
+							"line": 7298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2380,
+					"id": 2400,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2638,14 +2638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8156,
+							"line": 8238,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2277,
+					"id": 2297,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2662,14 +2662,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7127,
+							"line": 7209,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2368,
+					"id": 2388,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2690,14 +2690,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8019,
+							"line": 8101,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2383,
+					"id": 2403,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2718,14 +2718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8191,
+							"line": 8273,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2303,
+					"id": 2323,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2743,14 +2743,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7310,
+							"line": 7392,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2418,
+					"id": 2438,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2771,14 +2771,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8568,
+							"line": 8650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2281,
+					"id": 2301,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2795,14 +2795,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7167,
+							"line": 7249,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2381,
+					"id": 2401,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2823,14 +2823,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8168,
+							"line": 8250,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2317,
+					"id": 2337,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2851,14 +2851,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7455,
+							"line": 7537,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2307,
+					"id": 2327,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2879,14 +2879,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7354,
+							"line": 7436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2353,
+					"id": 2373,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2907,14 +2907,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7847,
+							"line": 7929,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2333,
+					"id": 2353,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2935,14 +2935,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7621,
+							"line": 7703,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2310,
+					"id": 2330,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2966,14 +2966,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7383,
+							"line": 7465,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2302,
+					"id": 2322,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2990,14 +2990,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7294,
+							"line": 7376,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2334,
+					"id": 2354,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3018,14 +3018,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7631,
+							"line": 7713,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2369,
+					"id": 2389,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3046,14 +3046,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8031,
+							"line": 8113,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2341,
+					"id": 2361,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3074,14 +3074,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7707,
+							"line": 7789,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2234,
+					"id": 2254,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3098,14 +3098,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6744,
+							"line": 6826,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2237,
+					"id": 2257,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3122,14 +3122,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6762,
+							"line": 6844,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2242,
+					"id": 2262,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3146,14 +3146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6807,
+							"line": 6889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2243,
+					"id": 2263,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3170,14 +3170,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6816,
+							"line": 6898,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2413,
+					"id": 2433,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3198,14 +3198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8507,
+							"line": 8589,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2300,
+					"id": 2320,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3213,14 +3213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7275,
+							"line": 7357,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2244,
+					"id": 2264,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3237,14 +3237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6825,
+							"line": 6907,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2259,
+					"id": 2279,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3255,14 +3255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6951,
+							"line": 7033,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2339,
+					"id": 2359,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3283,14 +3283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7682,
+							"line": 7764,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2261,
+					"id": 2281,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3307,14 +3307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6966,
+							"line": 7048,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2256,
+					"id": 2276,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3331,14 +3331,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6939,
+							"line": 7021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2421,
+					"id": 2441,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3359,14 +3359,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8601,
+							"line": 8683,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2422,
+					"id": 2442,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3387,14 +3387,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8612,
+							"line": 8694,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2420,
+					"id": 2440,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3415,14 +3415,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8590,
+							"line": 8672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2423,
+					"id": 2445,
+					"name": "SpotterAnalystList",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the analyst list\n(\"Show all\") in the Spotter Analyst interface.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterAnalystList]\ndisabledActions: [Action.SpotterAnalystList]\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8727,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterAnalystList\""
+				},
+				{
+					"id": 2443,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3443,14 +3471,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8623,
+							"line": 8705,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2419,
+					"id": 2439,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3471,14 +3499,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8579,
+							"line": 8661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2424,
+					"id": 2444,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3499,14 +3527,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8634,
+							"line": 8716,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2409,
+					"id": 2429,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3527,14 +3555,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8461,
+							"line": 8543,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2410,
+					"id": 2430,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3555,14 +3583,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8472,
+							"line": 8554,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2406,
+					"id": 2426,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3583,14 +3611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8430,
+							"line": 8512,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2396,
+					"id": 2416,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3611,14 +3639,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8327,
+							"line": 8409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2411,
+					"id": 2431,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3639,14 +3667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8483,
+							"line": 8565,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2407,
+					"id": 2427,
 					"name": "SpotterChatPin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3667,14 +3695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8440,
+							"line": 8522,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatPin\""
 				},
 				{
-					"id": 2397,
+					"id": 2417,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3695,14 +3723,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8337,
+							"line": 8419,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2408,
+					"id": 2446,
+					"name": "SpotterDefaultAnalyst",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the default Spotter analyst\nentry in the Spotter Analyst interface.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterDefaultAnalyst]\ndisabledActions: [Action.SpotterDefaultAnalyst]\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8738,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterDefaultAnalyst\""
+				},
+				{
+					"id": 2428,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3723,14 +3779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8450,
+							"line": 8532,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2370,
+					"id": 2390,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3751,14 +3807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8042,
+							"line": 8124,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2394,
+					"id": 2414,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3779,14 +3835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8307,
+							"line": 8389,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2395,
+					"id": 2415,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3807,14 +3863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8317,
+							"line": 8399,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2398,
+					"id": 2418,
 					"name": "SpotterShareConversationButtonHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3835,14 +3891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8348,
+							"line": 8430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeader\""
 				},
 				{
-					"id": 2399,
+					"id": 2419,
 					"name": "SpotterShareConversationMenuItemSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3863,14 +3919,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8359,
+							"line": 8441,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebar\""
 				},
 				{
-					"id": 2404,
+					"id": 2424,
 					"name": "SpotterShareIncludeNewMessagesCheckbox",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3891,14 +3947,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8410,
+							"line": 8492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckbox\""
 				},
 				{
-					"id": 2405,
+					"id": 2425,
 					"name": "SpotterShareStaleInfoBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3919,14 +3975,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8420,
+							"line": 8502,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissButton\""
 				},
 				{
-					"id": 2403,
+					"id": 2423,
 					"name": "SpotterShareUpToCurrentInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3947,14 +4003,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8400,
+							"line": 8482,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareUpToCurrentInfo\""
 				},
 				{
-					"id": 2400,
+					"id": 2420,
 					"name": "SpotterSharedConversationBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3975,14 +4031,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8369,
+							"line": 8451,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBanner\""
 				},
 				{
-					"id": 2401,
+					"id": 2421,
 					"name": "SpotterSharedConversationBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4003,14 +4059,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8379,
+							"line": 8461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBannerDismissButton\""
 				},
 				{
-					"id": 2402,
+					"id": 2422,
 					"name": "SpotterSharedConversationExitButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,14 +4087,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8390,
+							"line": 8472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButton\""
 				},
 				{
-					"id": 2392,
+					"id": 2412,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4059,14 +4115,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8287,
+							"line": 8369,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2391,
+					"id": 2411,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4087,14 +4143,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8277,
+							"line": 8359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2393,
+					"id": 2413,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4115,14 +4171,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8297,
+							"line": 8379,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2379,
+					"id": 2399,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4143,14 +4199,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8145,
+							"line": 8227,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2416,
+					"id": 2436,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4171,14 +4227,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8543,
+							"line": 8625,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2415,
+					"id": 2435,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4199,14 +4255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8531,
+							"line": 8613,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2414,
+					"id": 2434,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4227,14 +4283,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8519,
+							"line": 8601,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2417,
+					"id": 2437,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4255,14 +4311,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8557,
+							"line": 8639,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2377,
+					"id": 2397,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4283,14 +4339,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8123,
+							"line": 8205,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2378,
+					"id": 2398,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4311,14 +4367,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8134,
+							"line": 8216,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2292,
+					"id": 2312,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4335,14 +4391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7230,
+							"line": 7312,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2312,
+					"id": 2332,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4363,14 +4419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7404,
+							"line": 7486,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2311,
+					"id": 2331,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4391,14 +4447,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7393,
+							"line": 7475,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2315,
+					"id": 2335,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4419,14 +4475,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7434,
+							"line": 7516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2316,
+					"id": 2336,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4447,14 +4503,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7444,
+							"line": 7526,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2348,
+					"id": 2368,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4479,14 +4535,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7787,
+							"line": 7869,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2278,
+					"id": 2298,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4503,14 +4559,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7139,
+							"line": 7221,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2390,
+					"id": 2410,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4531,14 +4587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8267,
+							"line": 8349,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2385,
+					"id": 2405,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4559,14 +4615,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8216,
+							"line": 8298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2360,
+					"id": 2380,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4587,14 +4643,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7929,
+							"line": 8011,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2275,
+					"id": 2295,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4611,14 +4667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7108,
+							"line": 7190,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2350,
+					"id": 2370,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4639,14 +4695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7811,
+							"line": 7893,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2359,
+					"id": 2379,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4667,7 +4723,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7918,
+							"line": 8000,
 							"character": 4
 						}
 					],
@@ -4679,192 +4735,194 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2356,
-						2253,
-						2246,
-						2245,
-						2251,
-						2252,
-						2254,
-						2336,
-						2306,
-						2352,
-						2366,
-						2305,
-						2304,
-						2351,
-						2318,
-						2330,
-						2321,
-						2326,
-						2320,
-						2323,
-						2331,
-						2327,
-						2324,
-						2329,
-						2325,
-						2322,
-						2328,
-						2319,
-						2365,
-						2250,
-						2249,
-						2248,
-						2374,
-						2247,
-						2297,
-						2240,
-						2296,
-						2375,
-						2389,
-						2349,
-						2309,
-						2314,
-						2367,
-						2372,
-						2362,
-						2364,
-						2262,
-						2265,
-						2264,
-						2263,
+						2376,
+						2273,
 						2266,
-						2267,
+						2265,
+						2271,
+						2272,
+						2274,
+						2356,
+						2326,
+						2372,
+						2386,
+						2325,
+						2324,
+						2371,
+						2338,
+						2350,
+						2341,
+						2346,
+						2340,
+						2343,
+						2351,
+						2347,
+						2344,
+						2349,
+						2345,
+						2342,
+						2348,
+						2339,
+						2385,
+						2270,
 						2269,
 						2268,
-						2271,
-						2270,
-						2301,
-						2295,
-						2294,
-						2279,
-						2239,
-						2308,
-						2299,
-						2371,
-						2340,
-						2357,
-						2276,
-						2280,
-						2373,
-						2337,
-						2338,
-						2293,
-						2273,
-						2274,
-						2376,
-						2412,
-						2363,
-						2287,
-						2382,
-						2347,
-						2238,
-						2344,
-						2313,
-						2384,
-						2361,
-						2335,
-						2342,
-						2388,
-						2387,
-						2343,
-						2354,
-						2355,
-						2386,
-						2358,
-						2345,
-						2346,
-						2290,
-						2380,
-						2277,
-						2368,
-						2383,
-						2303,
-						2418,
-						2281,
-						2381,
+						2394,
+						2267,
 						2317,
-						2307,
-						2353,
-						2333,
-						2310,
-						2302,
-						2334,
+						2260,
+						2316,
+						2395,
+						2409,
 						2369,
-						2341,
-						2234,
-						2237,
-						2242,
-						2243,
-						2413,
-						2300,
-						2244,
+						2329,
+						2334,
+						2387,
+						2392,
+						2382,
+						2384,
+						2282,
+						2285,
+						2284,
+						2283,
+						2286,
+						2287,
+						2289,
+						2288,
+						2291,
+						2290,
+						2321,
+						2315,
+						2314,
+						2299,
 						2259,
-						2339,
-						2261,
-						2256,
-						2421,
-						2422,
-						2420,
-						2423,
+						2328,
+						2319,
+						2391,
+						2360,
+						2377,
+						2296,
+						2300,
+						2393,
+						2357,
+						2358,
+						2313,
+						2293,
+						2294,
+						2396,
+						2432,
+						2383,
+						2307,
+						2402,
+						2367,
+						2258,
+						2364,
+						2333,
+						2404,
+						2381,
+						2355,
+						2362,
+						2408,
+						2407,
+						2363,
+						2374,
+						2375,
+						2406,
+						2378,
+						2365,
+						2366,
+						2310,
+						2400,
+						2297,
+						2388,
+						2403,
+						2323,
+						2438,
+						2301,
+						2401,
+						2337,
+						2327,
+						2373,
+						2353,
+						2330,
+						2322,
+						2354,
+						2389,
+						2361,
+						2254,
+						2257,
+						2262,
+						2263,
+						2433,
+						2320,
+						2264,
+						2279,
+						2359,
+						2281,
+						2276,
+						2441,
+						2442,
+						2440,
+						2445,
+						2443,
+						2439,
+						2444,
+						2429,
+						2430,
+						2426,
+						2416,
+						2431,
+						2427,
+						2417,
+						2446,
+						2428,
+						2390,
+						2414,
+						2415,
+						2418,
 						2419,
 						2424,
-						2409,
-						2410,
-						2406,
-						2396,
+						2425,
+						2423,
+						2420,
+						2421,
+						2422,
+						2412,
 						2411,
-						2407,
-						2397,
-						2408,
-						2370,
-						2394,
-						2395,
-						2398,
+						2413,
 						2399,
-						2404,
-						2405,
-						2403,
-						2400,
-						2401,
-						2402,
-						2392,
-						2391,
-						2393,
-						2379,
-						2416,
-						2415,
-						2414,
-						2417,
-						2377,
-						2378,
-						2292,
+						2436,
+						2435,
+						2434,
+						2437,
+						2397,
+						2398,
 						2312,
-						2311,
-						2315,
-						2316,
-						2348,
-						2278,
-						2390,
-						2385,
-						2360,
-						2275,
-						2350,
-						2359
+						2332,
+						2331,
+						2335,
+						2336,
+						2368,
+						2298,
+						2410,
+						2405,
+						2380,
+						2295,
+						2370,
+						2379
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6735,
+					"line": 6817,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1817,
+			"id": 1837,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4880,7 +4938,7 @@
 			},
 			"children": [
 				{
-					"id": 1818,
+					"id": 1838,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4903,7 +4961,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1818
+						1838
 					]
 				}
 			],
@@ -4916,7 +4974,7 @@
 			]
 		},
 		{
-			"id": 1802,
+			"id": 1822,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4932,7 +4990,7 @@
 			},
 			"children": [
 				{
-					"id": 1805,
+					"id": 1825,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4951,7 +5009,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1807,
+					"id": 1827,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4970,7 +5028,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1804,
+					"id": 1824,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4989,7 +5047,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1806,
+					"id": 1826,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5008,7 +5066,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1803,
+					"id": 1823,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5027,7 +5085,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1808,
+					"id": 1828,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5051,12 +5109,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1805,
-						1807,
-						1804,
-						1806,
-						1803,
-						1808
+						1825,
+						1827,
+						1824,
+						1826,
+						1823,
+						1828
 					]
 				}
 			],
@@ -5069,7 +5127,7 @@
 			]
 		},
 		{
-			"id": 1809,
+			"id": 1829,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5085,7 +5143,7 @@
 			},
 			"children": [
 				{
-					"id": 1810,
+					"id": 1830,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5103,7 +5161,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1814,
+					"id": 1834,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5121,7 +5179,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1816,
+					"id": 1836,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5139,7 +5197,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1811,
+					"id": 1831,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5163,7 +5221,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1813,
+					"id": 1833,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5196,7 +5254,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1815,
+					"id": 1835,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5225,12 +5283,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1810,
-						1814,
-						1816,
-						1811,
-						1813,
-						1815
+						1830,
+						1834,
+						1836,
+						1831,
+						1833,
+						1835
 					]
 				}
 			],
@@ -5243,7 +5301,7 @@
 			]
 		},
 		{
-			"id": 1969,
+			"id": 1989,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5259,7 +5317,7 @@
 			},
 			"children": [
 				{
-					"id": 1980,
+					"id": 2000,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5278,7 +5336,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1971,
+					"id": 1991,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5307,7 +5365,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1970,
+					"id": 1990,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5331,7 +5389,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1976,
+					"id": 1996,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5349,7 +5407,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1974,
+					"id": 1994,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5382,7 +5440,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1978,
+					"id": 1998,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5406,7 +5464,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1979,
+					"id": 1999,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5439,13 +5497,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1980,
-						1971,
-						1970,
-						1976,
-						1974,
-						1978,
-						1979
+						2000,
+						1991,
+						1990,
+						1996,
+						1994,
+						1998,
+						1999
 					]
 				}
 			],
@@ -5458,7 +5516,7 @@
 			]
 		},
 		{
-			"id": 3293,
+			"id": 3319,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5474,7 +5532,7 @@
 			},
 			"children": [
 				{
-					"id": 3295,
+					"id": 3321,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5485,14 +5543,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9339,
+							"line": 9443,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3294,
+					"id": 3320,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5503,7 +5561,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9337,
+							"line": 9441,
 							"character": 4
 						}
 					],
@@ -5515,21 +5573,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3295,
-						3294
+						3321,
+						3320
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9335,
+					"line": 9439,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3296,
+			"id": 3322,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5545,7 +5603,7 @@
 			},
 			"children": [
 				{
-					"id": 3298,
+					"id": 3324,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5556,14 +5614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9350,
+							"line": 9454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3299,
+					"id": 3325,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5574,14 +5632,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9352,
+							"line": 9456,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3297,
+					"id": 3323,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5592,7 +5650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9348,
+							"line": 9452,
 							"character": 4
 						}
 					],
@@ -5604,22 +5662,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3298,
-						3299,
-						3297
+						3324,
+						3325,
+						3323
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9346,
+					"line": 9450,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3300,
+			"id": 3326,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5635,7 +5693,7 @@
 			},
 			"children": [
 				{
-					"id": 3303,
+					"id": 3329,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5646,14 +5704,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9304,
+							"line": 9408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3304,
+					"id": 3330,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5664,14 +5722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9410,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3306,
+					"id": 3332,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5682,14 +5740,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9310,
+							"line": 9414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3311,
+					"id": 3337,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5700,14 +5758,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9320,
+							"line": 9424,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3307,
+					"id": 3333,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5718,14 +5776,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9312,
+							"line": 9416,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3309,
+					"id": 3335,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5736,14 +5794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9316,
+							"line": 9420,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3301,
+					"id": 3327,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5754,14 +5812,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9300,
+							"line": 9404,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3313,
+					"id": 3339,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5772,14 +5830,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9324,
+							"line": 9428,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3302,
+					"id": 3328,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5790,14 +5848,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9302,
+							"line": 9406,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3315,
+					"id": 3341,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5808,14 +5866,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9328,
+							"line": 9432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3314,
+					"id": 3340,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5826,14 +5884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9326,
+							"line": 9430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3308,
+					"id": 3334,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5844,14 +5902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9314,
+							"line": 9418,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3310,
+					"id": 3336,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5862,14 +5920,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9318,
+							"line": 9422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3312,
+					"id": 3338,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5880,14 +5938,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9322,
+							"line": 9426,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3305,
+					"id": 3331,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5898,7 +5956,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9308,
+							"line": 9412,
 							"character": 4
 						}
 					],
@@ -5910,34 +5968,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3303,
-						3304,
-						3306,
-						3311,
-						3307,
-						3309,
-						3301,
-						3313,
-						3302,
-						3315,
-						3314,
-						3308,
-						3310,
-						3312,
-						3305
+						3329,
+						3330,
+						3332,
+						3337,
+						3333,
+						3335,
+						3327,
+						3339,
+						3328,
+						3341,
+						3340,
+						3334,
+						3336,
+						3338,
+						3331
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9298,
+					"line": 9402,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2425,
+			"id": 2447,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5947,7 +6005,7 @@
 			},
 			"children": [
 				{
-					"id": 2428,
+					"id": 2450,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5955,14 +6013,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8654,
+							"line": 8758,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2426,
+					"id": 2448,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5970,14 +6028,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8652,
+							"line": 8756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2427,
+					"id": 2449,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5985,7 +6043,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8653,
+							"line": 8757,
 							"character": 4
 						}
 					],
@@ -5997,22 +6055,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2428,
-						2426,
-						2427
+						2450,
+						2448,
+						2449
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8651,
+					"line": 8755,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2223,
+			"id": 2243,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6036,7 +6094,7 @@
 			},
 			"children": [
 				{
-					"id": 2226,
+					"id": 2246,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6047,14 +6105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9102,
+							"line": 9206,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2225,
+					"id": 2245,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6065,14 +6123,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9098,
+							"line": 9202,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2228,
+					"id": 2248,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6083,14 +6141,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9111,
+							"line": 9215,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2224,
+					"id": 2244,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6101,14 +6159,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9094,
+							"line": 9198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2227,
+					"id": 2247,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6119,7 +6177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9106,
+							"line": 9210,
 							"character": 4
 						}
 					],
@@ -6131,24 +6189,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2226,
-						2225,
-						2228,
-						2224,
-						2227
+						2246,
+						2245,
+						2248,
+						2244,
+						2247
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9090,
+					"line": 9194,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3247,
+			"id": 3273,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6158,7 +6216,7 @@
 			},
 			"children": [
 				{
-					"id": 3250,
+					"id": 3276,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6169,14 +6227,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8791,
+							"line": 8895,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3248,
+					"id": 3274,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6187,14 +6245,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8764,
+							"line": 8868,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3251,
+					"id": 3277,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6205,14 +6263,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8802,
+							"line": 8906,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3249,
+					"id": 3275,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6223,7 +6281,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8778,
+							"line": 8882,
 							"character": 4
 						}
 					],
@@ -6235,23 +6293,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3250,
-						3248,
-						3251,
-						3249
+						3276,
+						3274,
+						3277,
+						3275
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8754,
+					"line": 8858,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3243,
+			"id": 3269,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6261,7 +6319,7 @@
 			},
 			"children": [
 				{
-					"id": 3246,
+					"id": 3272,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6272,14 +6330,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8745,
+							"line": 8849,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3245,
+					"id": 3271,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6290,14 +6348,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8737,
+							"line": 8841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3244,
+					"id": 3270,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6308,7 +6366,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8732,
+							"line": 8836,
 							"character": 4
 						}
 					],
@@ -6320,22 +6378,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3246,
-						3245,
-						3244
+						3272,
+						3271,
+						3270
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8727,
+					"line": 8831,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3316,
+			"id": 3342,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6351,7 +6409,7 @@
 			},
 			"children": [
 				{
-					"id": 3321,
+					"id": 3347,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6362,14 +6420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9393,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3317,
+					"id": 3343,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6380,14 +6438,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9281,
+							"line": 9385,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3319,
+					"id": 3345,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6398,14 +6456,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9285,
+							"line": 9389,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3318,
+					"id": 3344,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6416,14 +6474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9283,
+							"line": 9387,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3320,
+					"id": 3346,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6434,14 +6492,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9287,
+							"line": 9391,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3322,
+					"id": 3348,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6452,7 +6510,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9291,
+							"line": 9395,
 							"character": 4
 						}
 					],
@@ -6464,25 +6522,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3321,
-						3317,
-						3319,
-						3318,
-						3320,
-						3322
+						3347,
+						3343,
+						3345,
+						3344,
+						3346,
+						3348
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9279,
+					"line": 9383,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3239,
+			"id": 3265,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6492,7 +6550,7 @@
 			},
 			"children": [
 				{
-					"id": 3241,
+					"id": 3267,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6510,7 +6568,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3240,
+					"id": 3266,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6528,7 +6586,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3242,
+					"id": 3268,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6551,9 +6609,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3241,
-						3240,
-						3242
+						3267,
+						3266,
+						3268
 					]
 				}
 			],
@@ -6566,7 +6624,7 @@
 			]
 		},
 		{
-			"id": 2229,
+			"id": 2249,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6576,7 +6634,7 @@
 			},
 			"children": [
 				{
-					"id": 2231,
+					"id": 2251,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6587,14 +6645,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6520,
+							"line": 6600,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2232,
+					"id": 2252,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6605,14 +6663,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6524,
+							"line": 6604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2230,
+					"id": 2250,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6623,7 +6681,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6516,
+							"line": 6596,
 							"character": 4
 						}
 					],
@@ -6635,22 +6693,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2231,
-						2232,
-						2230
+						2251,
+						2252,
+						2250
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6512,
+					"line": 6592,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3256,
+			"id": 3282,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6674,7 +6732,7 @@
 			},
 			"children": [
 				{
-					"id": 3259,
+					"id": 3285,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6685,14 +6743,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8968,
+							"line": 9072,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3260,
+					"id": 3286,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6703,14 +6761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8971,
+							"line": 9075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3263,
+					"id": 3289,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6721,14 +6779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8980,
+							"line": 9084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3272,
+					"id": 3298,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6739,14 +6797,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9007,
+							"line": 9111,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3266,
+					"id": 3292,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6757,14 +6815,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8989,
+							"line": 9093,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3270,
+					"id": 3296,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6775,14 +6833,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9001,
+							"line": 9105,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3261,
+					"id": 3287,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6793,14 +6851,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8974,
+							"line": 9078,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3269,
+					"id": 3295,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6811,14 +6869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8998,
+							"line": 9102,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3258,
+					"id": 3284,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6829,14 +6887,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8965,
+							"line": 9069,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3264,
+					"id": 3290,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6847,14 +6905,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8983,
+							"line": 9087,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3262,
+					"id": 3288,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6865,14 +6923,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8977,
+							"line": 9081,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3267,
+					"id": 3293,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6883,14 +6941,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8992,
+							"line": 9096,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3265,
+					"id": 3291,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6901,14 +6959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8986,
+							"line": 9090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3271,
+					"id": 3297,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6919,14 +6977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9004,
+							"line": 9108,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3273,
+					"id": 3299,
 					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6937,14 +6995,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9010,
+							"line": 9114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3268,
+					"id": 3294,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6955,14 +7013,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8995,
+							"line": 9099,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3257,
+					"id": 3283,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6973,7 +7031,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8962,
+							"line": 9066,
 							"character": 4
 						}
 					],
@@ -6985,36 +7043,36 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3259,
-						3260,
-						3263,
-						3272,
-						3266,
-						3270,
-						3261,
-						3269,
-						3258,
-						3264,
-						3262,
-						3267,
-						3265,
-						3271,
-						3273,
-						3268,
-						3257
+						3285,
+						3286,
+						3289,
+						3298,
+						3292,
+						3296,
+						3287,
+						3295,
+						3284,
+						3290,
+						3288,
+						3293,
+						3291,
+						3297,
+						3299,
+						3294,
+						3283
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8960,
+					"line": 9064,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2001,
+			"id": 2021,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7039,7 +7097,7 @@
 			},
 			"children": [
 				{
-					"id": 2038,
+					"id": 2058,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7060,14 +7118,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2942,
+							"line": 3022,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2029,
+					"id": 2049,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7088,14 +7146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2805,
+							"line": 2885,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2009,
+					"id": 2029,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7120,14 +7178,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2553,
+							"line": 2633,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2091,
+					"id": 2111,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7148,14 +7206,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3608,
+							"line": 3688,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2055,
+					"id": 2075,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7176,14 +7234,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3155,
+							"line": 3235,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2014,
+					"id": 2034,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7208,14 +7266,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2663,
+							"line": 2743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2051,
+					"id": 2071,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7236,14 +7294,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3123,
+							"line": 3203,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2037,
+					"id": 2057,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7264,14 +7322,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2931,
+							"line": 3011,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2101,
+					"id": 2121,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7293,14 +7351,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3774,
+							"line": 3854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2080,
+					"id": 2100,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7333,14 +7391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3412,
+							"line": 3492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2015,
+					"id": 2035,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7361,14 +7419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2676,
+							"line": 2756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2003,
+					"id": 2023,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7393,14 +7451,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2455,
+							"line": 2535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2062,
+					"id": 2082,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7421,14 +7479,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3231,
+							"line": 3311,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2078,
+					"id": 2098,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7465,14 +7523,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3398,
+							"line": 3478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2049,
+					"id": 2069,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7493,14 +7551,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3101,
+							"line": 3181,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2064,
+					"id": 2084,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7521,14 +7579,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3251,
+							"line": 3331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2044,
+					"id": 2064,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7549,14 +7607,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3034,
+							"line": 3114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2070,
+					"id": 2090,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7573,14 +7631,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3310,
+							"line": 3390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2085,
+					"id": 2105,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7598,14 +7656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3558,
+							"line": 3638,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2086,
+					"id": 2106,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7622,14 +7680,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3563,
+							"line": 3643,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2079,
+					"id": 2099,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7646,14 +7704,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3403,
+							"line": 3483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2065,
+					"id": 2085,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7674,14 +7732,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3262,
+							"line": 3342,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2010,
+					"id": 2030,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7703,21 +7761,21 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nappEmbed.on(EmbedEvent.customAction, payload => {\n    const data = payload.data;\n    if (data.id === 'insert Custom Action ID here') {\n        console.log('Custom Action event:', data.embedAnswerData);\n    }\n})\n```\n"
+								"text": "\n```js\nappEmbed.on(EmbedEvent.CustomAction, payload => {\n    const data = payload.data;\n    if (data.id === 'insert Custom Action ID here') {\n        console.log('Custom Action event:', data.embedAnswerData);\n    }\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2570,
+							"line": 2650,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2005,
+					"id": 2025,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7746,14 +7804,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2483,
+							"line": 2563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2092,
+					"id": 2112,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7774,14 +7832,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3619,
+							"line": 3699,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2008,
+					"id": 2028,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7806,14 +7864,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2541,
+							"line": 2621,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2060,
+					"id": 2080,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7834,14 +7892,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3213,
+							"line": 3293,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2076,
+					"id": 2096,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7870,14 +7928,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3370,
+							"line": 3450,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2077,
+					"id": 2097,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7902,14 +7960,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3377,
+							"line": 3457,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2027,
+					"id": 2047,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7930,14 +7988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2772,
+							"line": 2852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2026,
+					"id": 2046,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7958,21 +8016,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2761,
+							"line": 2841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2031,
+					"id": 2051,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
 						"shortText": "Emitted when the download action is triggered on an Answer.",
-						"text": "**Note**: This event is deprecated in v1.21.0.\nTo fire an event when a download action is initiated on a chart or table,\nuse `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPDF`,\n`EmbedEvent.DownloadAsCSV`, or `EmbedEvent.DownloadAsXLSX`",
+						"text": "**Note**: This event is deprecated in v1.21.0.\nTo fire an event when a download action is initiated on a chart or table,\nuse `EmbedEvent.DownloadAsPng`, `EmbedEvent.DownloadAsPdf`,\n`EmbedEvent.DownloadAsCsv`, or `EmbedEvent.DownloadAsXlsx`",
 						"tags": [
 							{
 								"tag": "version",
@@ -7987,14 +8045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2840,
+							"line": 2920,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2034,
+					"id": 2054,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8008,21 +8066,21 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n//emit when action starts\nsearchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {\n  console.log('download CSV', payload)}, {start: true })\n//emit when action ends\nsearchEmbed.on(EmbedEvent.DownloadAsCSV, payload => {\n   console.log('download CSV', payload)})\n```\n"
+								"text": "\n```js\n//emit when action starts\nsearchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {\n  console.log('download CSV', payload)}, {start: true })\n//emit when action ends\nsearchEmbed.on(EmbedEvent.DownloadAsCsv, payload => {\n   console.log('download CSV', payload)})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2888,
+							"line": 2968,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2033,
+					"id": 2053,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8043,14 +8101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2872,
+							"line": 2952,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2032,
+					"id": 2052,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8071,14 +8129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2856,
+							"line": 2936,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2035,
+					"id": 2055,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8099,14 +8157,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2904,
+							"line": 2984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2036,
+					"id": 2056,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8127,14 +8185,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2915,
+							"line": 2995,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2043,
+					"id": 2063,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8155,14 +8213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3023,
+							"line": 3103,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2042,
+					"id": 2062,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8183,14 +8241,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3011,
+							"line": 3091,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2007,
+					"id": 2027,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8216,7 +8274,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nsearchEmbed.on(EmbedEvent.DrillDown, {\n   points: {\n       clickedPoint,\n       selectedPoints: selectedPoint\n   },\n   autoDrillDown: true,\n})\n```\nIn this example, `VizPointDoubleClick` event is used for\ntriggering the `DrillDown` event when an area or specific\ndata point on a table or chart is double-clicked."
+								"text": "\n```js\nsearchEmbed.on(EmbedEvent.Drilldown, {\n   points: {\n       clickedPoint,\n       selectedPoints: selectedPoint\n   },\n   autoDrillDown: true,\n})\n```\nIn this example, `VizPointDoubleClick` event is used for\ntriggering the `DrillDown` event when an area or specific\ndata point on a table or chart is double-clicked."
 							},
 							{
 								"tag": "example",
@@ -8227,14 +8285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2529,
+							"line": 2609,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2057,
+					"id": 2077,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8255,14 +8313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3177,
+							"line": 3257,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2046,
+					"id": 2066,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8283,14 +8341,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3057,
+							"line": 3137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2119,
+					"id": 2139,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8311,14 +8369,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4012,
+							"line": 4092,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 2013,
+					"id": 2033,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8348,14 +8406,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2653,
+							"line": 2733,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2063,
+					"id": 2083,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8376,14 +8434,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3241,
+							"line": 3321,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2047,
+					"id": 2067,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8404,14 +8462,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3074,
+							"line": 3154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2068,
+					"id": 2088,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8432,14 +8490,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3300,
+							"line": 3380,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2021,
+					"id": 2041,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8460,14 +8518,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2718,
+							"line": 2798,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2002,
+					"id": 2022,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8488,14 +8546,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2443,
+							"line": 2523,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2095,
+					"id": 2115,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8516,14 +8574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3652,
+							"line": 3732,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2094,
+					"id": 2114,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8544,14 +8602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3641,
+							"line": 3721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2054,
+					"id": 2074,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8572,14 +8630,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3144,
+							"line": 3224,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2028,
+					"id": 2048,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8604,14 +8662,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2794,
+							"line": 2874,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2004,
+					"id": 2024,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8636,14 +8694,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2469,
+							"line": 2549,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2058,
+					"id": 2078,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8664,14 +8722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3188,
+							"line": 3268,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2024,
+					"id": 2044,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8692,14 +8750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2744,
+							"line": 2824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2082,
+					"id": 2102,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8730,14 +8788,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3483,
+							"line": 3563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2100,
+					"id": 2120,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8758,14 +8816,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3708,
+							"line": 3788,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2083,
+					"id": 2103,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8782,14 +8840,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3502,
+							"line": 3582,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2039,
+					"id": 2059,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8810,14 +8868,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2963,
+							"line": 3043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2059,
+					"id": 2079,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8842,14 +8900,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3203,
+							"line": 3283,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2090,
+					"id": 2110,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8870,14 +8928,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3597,
+							"line": 3677,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2006,
+					"id": 2026,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8898,14 +8956,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2492,
+							"line": 2572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2129,
+					"id": 2149,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8926,14 +8984,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4154,
+							"line": 4234,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2081,
+					"id": 2101,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8950,14 +9008,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3417,
+							"line": 3497,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2075,
+					"id": 2095,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8990,14 +9048,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3361,
+							"line": 3441,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2096,
+					"id": 2116,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9018,14 +9076,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3663,
+							"line": 3743,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2022,
+					"id": 2042,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9046,14 +9104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2728,
+							"line": 2808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2030,
+					"id": 2050,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9074,14 +9132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2824,
+							"line": 2904,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2048,
+					"id": 2068,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9102,14 +9160,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3085,
+							"line": 3165,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2073,
+					"id": 2093,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9146,14 +9204,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3343,
+							"line": 3423,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2074,
+					"id": 2094,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9186,14 +9244,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3352,
+							"line": 3432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2056,
+					"id": 2076,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9214,14 +9272,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3166,
+							"line": 3246,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2061,
+					"id": 2081,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9242,14 +9300,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3222,
+							"line": 3302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2121,
+					"id": 2141,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9270,14 +9328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4051,
+							"line": 4131,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2041,
+					"id": 2061,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9298,14 +9356,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2999,
+							"line": 3079,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2050,
+					"id": 2070,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9326,14 +9384,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3112,
+							"line": 3192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2040,
+					"id": 2060,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9354,14 +9412,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2981,
+							"line": 3061,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2103,
+					"id": 2123,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9382,14 +9440,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3798,
+							"line": 3878,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2114,
+					"id": 2134,
 					"name": "SpotterConversationPinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9410,14 +9468,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3938,
+							"line": 4018,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationPinned\""
 				},
 				{
-					"id": 2102,
+					"id": 2122,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9438,14 +9496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3786,
+							"line": 3866,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2116,
+					"id": 2136,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9466,14 +9524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3962,
+							"line": 4042,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2107,
+					"id": 2127,
 					"name": "SpotterConversationShareRevoked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9494,14 +9552,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3853,
+							"line": 3933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShareRevoked\""
 				},
 				{
-					"id": 2106,
+					"id": 2126,
 					"name": "SpotterConversationShared",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9522,14 +9580,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3839,
+							"line": 3919,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShared\""
 				},
 				{
-					"id": 2115,
+					"id": 2135,
 					"name": "SpotterConversationUnpinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9550,14 +9608,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3950,
+							"line": 4030,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationUnpinned\""
 				},
 				{
-					"id": 2089,
+					"id": 2109,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9578,14 +9636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3586,
+							"line": 3666,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2097,
+					"id": 2117,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9606,14 +9664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3674,
+							"line": 3754,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2098,
+					"id": 2118,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9634,14 +9692,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3685,
+							"line": 3765,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2093,
+					"id": 2113,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9662,14 +9720,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3630,
+							"line": 3710,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2117,
+					"id": 2137,
 					"name": "SpotterResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9695,14 +9753,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3987,
+							"line": 4067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterResponseComplete\""
 				},
 				{
-					"id": 2104,
+					"id": 2124,
 					"name": "SpotterShareConversationButtonHeaderClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9723,14 +9781,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3811,
+							"line": 3891,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeaderClicked\""
 				},
 				{
-					"id": 2105,
+					"id": 2125,
 					"name": "SpotterShareConversationMenuItemSidebarClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9751,14 +9809,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3823,
+							"line": 3903,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebarClicked\""
 				},
 				{
-					"id": 2109,
+					"id": 2129,
 					"name": "SpotterShareIncludeNewMessagesCheckboxToggled",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9779,14 +9837,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3878,
+							"line": 3958,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckboxToggled\""
 				},
 				{
-					"id": 2112,
+					"id": 2132,
 					"name": "SpotterShareModalCancelButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9807,14 +9865,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3914,
+							"line": 3994,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalCancelButtonClicked\""
 				},
 				{
-					"id": 2111,
+					"id": 2131,
 					"name": "SpotterShareModalConfirmButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9835,14 +9893,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3903,
+							"line": 3983,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalConfirmButtonClicked\""
 				},
 				{
-					"id": 2110,
+					"id": 2130,
 					"name": "SpotterShareStaleInfoBannerDismissed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9863,14 +9921,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3890,
+							"line": 3970,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissed\""
 				},
 				{
-					"id": 2113,
+					"id": 2133,
 					"name": "SpotterSharedConversationExitButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9891,14 +9949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3926,
+							"line": 4006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButtonClicked\""
 				},
 				{
-					"id": 2108,
+					"id": 2128,
 					"name": "SpotterSharedConversationViewed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9919,14 +9977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3866,
+							"line": 3946,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationViewed\""
 				},
 				{
-					"id": 2125,
+					"id": 2145,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9947,14 +10005,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4103,
+							"line": 4183,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2126,
+					"id": 2146,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9975,14 +10033,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4116,
+							"line": 4196,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2128,
+					"id": 2148,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10003,14 +10061,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4140,
+							"line": 4220,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2127,
+					"id": 2147,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10031,14 +10089,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4128,
+							"line": 4208,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2122,
+					"id": 2142,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10059,14 +10117,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4064,
+							"line": 4144,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2123,
+					"id": 2143,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10087,14 +10145,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4077,
+							"line": 4157,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2124,
+					"id": 2144,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10115,14 +10173,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4090,
+							"line": 4170,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2120,
+					"id": 2140,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10148,14 +10206,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4036,
+							"line": 4116,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2084,
+					"id": 2104,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10177,14 +10235,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3545,
+							"line": 3625,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2069,
+					"id": 2089,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10201,14 +10259,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3305,
+							"line": 3385,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2071,
+					"id": 2091,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10245,14 +10303,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3322,
+							"line": 3402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2072,
+					"id": 2092,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10285,14 +10343,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3332,
+							"line": 3412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2045,
+					"id": 2065,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10313,14 +10371,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3045,
+							"line": 3125,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2012,
+					"id": 2032,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10349,14 +10407,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2601,
+							"line": 2681,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2011,
+					"id": 2031,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10381,14 +10439,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2582,
+							"line": 2662,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2066,
+					"id": 2086,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10409,7 +10467,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3273,
+							"line": 3353,
 							"character": 4
 						}
 					],
@@ -10421,133 +10479,133 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2038,
-						2029,
-						2009,
-						2091,
-						2055,
-						2014,
-						2051,
-						2037,
-						2101,
-						2080,
-						2015,
-						2003,
-						2062,
-						2078,
-						2049,
-						2064,
-						2044,
-						2070,
-						2085,
-						2086,
-						2079,
-						2065,
-						2010,
-						2005,
-						2092,
-						2008,
-						2060,
-						2076,
-						2077,
-						2027,
-						2026,
-						2031,
-						2034,
-						2033,
-						2032,
-						2035,
-						2036,
-						2043,
-						2042,
-						2007,
-						2057,
-						2046,
-						2119,
-						2013,
-						2063,
-						2047,
-						2068,
-						2021,
-						2002,
-						2095,
-						2094,
-						2054,
-						2028,
-						2004,
 						2058,
-						2024,
-						2082,
-						2100,
-						2083,
-						2039,
-						2059,
-						2090,
-						2006,
-						2129,
-						2081,
-						2075,
-						2096,
-						2022,
-						2030,
-						2048,
-						2073,
-						2074,
-						2056,
-						2061,
-						2121,
-						2041,
-						2050,
-						2040,
-						2103,
-						2114,
-						2102,
-						2116,
-						2107,
-						2106,
-						2115,
-						2089,
-						2097,
-						2098,
-						2093,
-						2117,
-						2104,
-						2105,
-						2109,
-						2112,
+						2049,
+						2029,
 						2111,
-						2110,
-						2113,
-						2108,
-						2125,
-						2126,
-						2128,
-						2127,
-						2122,
-						2123,
-						2124,
-						2120,
-						2084,
-						2069,
+						2075,
+						2034,
 						2071,
-						2072,
-						2045,
-						2012,
-						2011,
-						2066
+						2057,
+						2121,
+						2100,
+						2035,
+						2023,
+						2082,
+						2098,
+						2069,
+						2084,
+						2064,
+						2090,
+						2105,
+						2106,
+						2099,
+						2085,
+						2030,
+						2025,
+						2112,
+						2028,
+						2080,
+						2096,
+						2097,
+						2047,
+						2046,
+						2051,
+						2054,
+						2053,
+						2052,
+						2055,
+						2056,
+						2063,
+						2062,
+						2027,
+						2077,
+						2066,
+						2139,
+						2033,
+						2083,
+						2067,
+						2088,
+						2041,
+						2022,
+						2115,
+						2114,
+						2074,
+						2048,
+						2024,
+						2078,
+						2044,
+						2102,
+						2120,
+						2103,
+						2059,
+						2079,
+						2110,
+						2026,
+						2149,
+						2101,
+						2095,
+						2116,
+						2042,
+						2050,
+						2068,
+						2093,
+						2094,
+						2076,
+						2081,
+						2141,
+						2061,
+						2070,
+						2060,
+						2123,
+						2134,
+						2122,
+						2136,
+						2127,
+						2126,
+						2135,
+						2109,
+						2117,
+						2118,
+						2113,
+						2137,
+						2124,
+						2125,
+						2129,
+						2132,
+						2131,
+						2130,
+						2133,
+						2128,
+						2145,
+						2146,
+						2148,
+						2147,
+						2142,
+						2143,
+						2144,
+						2140,
+						2104,
+						2089,
+						2091,
+						2092,
+						2065,
+						2032,
+						2031,
+						2086
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2430,
+					"line": 2510,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3280,
+			"id": 3306,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10572,7 +10630,7 @@
 			},
 			"children": [
 				{
-					"id": 3281,
+					"id": 3307,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10583,14 +10641,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8922,
+							"line": 9026,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3283,
+					"id": 3309,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10601,14 +10659,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8926,
+							"line": 9030,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3282,
+					"id": 3308,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10619,7 +10677,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8924,
+							"line": 9028,
 							"character": 4
 						}
 					],
@@ -10631,22 +10689,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3281,
-						3283,
-						3282
+						3307,
+						3309,
+						3308
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8920,
+					"line": 9024,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2846,
+			"id": 2872,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10656,7 +10714,7 @@
 			},
 			"children": [
 				{
-					"id": 2850,
+					"id": 2876,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10680,7 +10738,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2857,
+					"id": 2883,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10704,7 +10762,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 2854,
+					"id": 2880,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10728,7 +10786,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2856,
+					"id": 2882,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10752,7 +10810,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2848,
+					"id": 2874,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10776,7 +10834,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2853,
+					"id": 2879,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10800,7 +10858,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2849,
+					"id": 2875,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10824,7 +10882,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2851,
+					"id": 2877,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10848,7 +10906,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2847,
+					"id": 2873,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10872,7 +10930,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2852,
+					"id": 2878,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10896,7 +10954,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2855,
+					"id": 2881,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10925,17 +10983,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2850,
-						2857,
-						2854,
-						2856,
-						2848,
-						2853,
-						2849,
-						2851,
-						2847,
-						2852,
-						2855
+						2876,
+						2883,
+						2880,
+						2882,
+						2874,
+						2879,
+						2875,
+						2877,
+						2873,
+						2878,
+						2881
 					]
 				}
 			],
@@ -10948,7 +11006,7 @@
 			]
 		},
 		{
-			"id": 3183,
+			"id": 3209,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10964,7 +11022,7 @@
 			},
 			"children": [
 				{
-					"id": 3186,
+					"id": 3212,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10988,7 +11046,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3184,
+					"id": 3210,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11012,7 +11070,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3185,
+					"id": 3211,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11035,9 +11093,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3186,
-						3184,
-						3185
+						3212,
+						3210,
+						3211
 					]
 				}
 			],
@@ -11050,14 +11108,14 @@
 			]
 		},
 		{
-			"id": 3177,
+			"id": 3203,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3179,
+					"id": 3205,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11072,7 +11130,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3180,
+					"id": 3206,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11087,7 +11145,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3178,
+					"id": 3204,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11107,9 +11165,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3179,
-						3180,
-						3178
+						3205,
+						3206,
+						3204
 					]
 				}
 			],
@@ -11122,7 +11180,7 @@
 			]
 		},
 		{
-			"id": 2858,
+			"id": 2884,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11139,7 +11197,7 @@
 			},
 			"children": [
 				{
-					"id": 2861,
+					"id": 2887,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11150,14 +11208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2302,
+							"line": 2382,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2864,
+					"id": 2890,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11168,14 +11226,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2314,
+							"line": 2394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2862,
+					"id": 2888,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11186,14 +11244,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2306,
+							"line": 2386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2859,
+					"id": 2885,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11204,14 +11262,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2294,
+							"line": 2374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2863,
+					"id": 2889,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11222,14 +11280,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2310,
+							"line": 2390,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2860,
+					"id": 2886,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11240,7 +11298,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2298,
+							"line": 2378,
 							"character": 4
 						}
 					],
@@ -11252,25 +11310,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2861,
-						2864,
-						2862,
-						2859,
-						2863,
-						2860
+						2887,
+						2890,
+						2888,
+						2885,
+						2889,
+						2886
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2290,
+					"line": 2370,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2130,
+			"id": 2150,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11303,7 +11361,7 @@
 			},
 			"children": [
 				{
-					"id": 2154,
+					"id": 2174,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11324,14 +11382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4871,
+							"line": 4951,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2142,
+					"id": 2162,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11361,14 +11419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4569,
+							"line": 4649,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2200,
+					"id": 2220,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11394,14 +11452,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6237,
+							"line": 6317,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2207,
+					"id": 2227,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11427,14 +11485,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6309,
+							"line": 6389,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2184,
+					"id": 2204,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11455,14 +11513,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5893,
+							"line": 5973,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2210,
+					"id": 2230,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11488,14 +11546,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6347,
+							"line": 6427,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2204,
+					"id": 2224,
 					"name": "CloseSpotterShareConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11516,14 +11574,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6276,
+							"line": 6356,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterShareConversation\""
 				},
 				{
-					"id": 2221,
+					"id": 2241,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11544,14 +11602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6493,
+							"line": 6573,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2161,
+					"id": 2181,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11593,14 +11651,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5104,
+							"line": 5184,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2158,
+					"id": 2178,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11638,14 +11696,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4979,
+							"line": 5059,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2201,
+					"id": 2221,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11666,14 +11724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6246,
+							"line": 6326,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2165,
+					"id": 2185,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11707,14 +11765,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5257,
+							"line": 5337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2206,
+					"id": 2226,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11735,14 +11793,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6294,
+							"line": 6374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2212,
+					"id": 2232,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11763,14 +11821,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6367,
+							"line": 6447,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2167,
+					"id": 2187,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11800,14 +11858,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5319,
+							"line": 5399,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2169,
+					"id": 2189,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11841,14 +11899,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5389,
+							"line": 5469,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2152,
+					"id": 2172,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11886,14 +11944,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4849,
+							"line": 4929,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2168,
+					"id": 2188,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11918,14 +11976,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5350,
+							"line": 5430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2170,
+					"id": 2190,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11959,14 +12017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5428,
+							"line": 5508,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2153,
+					"id": 2173,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11987,14 +12045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4861,
+							"line": 4941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2132,
+					"id": 2152,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12032,14 +12090,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4329,
+							"line": 4409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2160,
+					"id": 2180,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12078,14 +12136,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5059,
+							"line": 5139,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2198,
+					"id": 2218,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12115,14 +12173,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6211,
+							"line": 6291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2150,
+					"id": 2170,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12151,14 +12209,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4795,
+							"line": 4875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2205,
+					"id": 2225,
 					"name": "ExitSpotterSharedConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12179,14 +12237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6285,
+							"line": 6365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ExitSpotterSharedConversation\""
 				},
 				{
-					"id": 2157,
+					"id": 2177,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12216,14 +12274,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4948,
+							"line": 5028,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2149,
+					"id": 2169,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12252,14 +12310,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4773,
+							"line": 4853,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2183,
+					"id": 2203,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12285,14 +12343,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5883,
+							"line": 5963,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2177,
+					"id": 2197,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12317,14 +12375,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5638,
+							"line": 5718,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2180,
+					"id": 2200,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12349,14 +12407,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5809,
+							"line": 5889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 2135,
+					"id": 2155,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12381,14 +12439,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4356,
+							"line": 4436,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2189,
+					"id": 2209,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12414,14 +12472,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6016,
+							"line": 6096,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2163,
+					"id": 2183,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12458,14 +12516,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5195,
+							"line": 5275,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2179,
+					"id": 2199,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12490,14 +12548,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5787,
+							"line": 5867,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2219,
+					"id": 2239,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12518,14 +12576,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6473,
+							"line": 6553,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2146,
+					"id": 2166,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12550,14 +12608,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4721,
+							"line": 4801,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2155,
+					"id": 2175,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12602,14 +12660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4916,
+							"line": 4996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2159,
+					"id": 2179,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12651,14 +12709,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5014,
+							"line": 5094,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2175,
+					"id": 2195,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12692,14 +12750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5594,
+							"line": 5674,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2139,
+					"id": 2159,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12726,14 +12784,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4472,
+							"line": 4552,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2140,
+					"id": 2160,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12771,14 +12829,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4519,
+							"line": 4599,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2141,
+					"id": 2161,
 					"name": "OpenParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12808,14 +12866,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4551,
+							"line": 4631,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openParameter\""
 				},
 				{
-					"id": 2220,
+					"id": 2240,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12836,14 +12894,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6483,
+							"line": 6563,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2145,
+					"id": 2165,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12897,14 +12955,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4705,
+							"line": 4785,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2214,
+					"id": 2234,
 					"name": "PinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12926,14 +12984,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6400,
+							"line": 6480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinSpotterConversation\""
 				},
 				{
-					"id": 2162,
+					"id": 2182,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12975,14 +13033,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5149,
+							"line": 5229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2199,
+					"id": 2219,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13007,14 +13065,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6226,
+							"line": 6306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2222,
+					"id": 2242,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13035,14 +13093,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6504,
+							"line": 6584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2156,
+					"id": 2176,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13071,14 +13129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4930,
+							"line": 5010,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2143,
+					"id": 2163,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13108,14 +13166,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4587,
+							"line": 4667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2186,
+					"id": 2206,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13140,14 +13198,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5920,
+							"line": 6000,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2187,
+					"id": 2207,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13168,14 +13226,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5929,
+							"line": 6009,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2176,
+					"id": 2196,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13200,14 +13258,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5612,
+							"line": 5692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2202,
+					"id": 2222,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13228,14 +13286,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6255,
+							"line": 6335,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2172,
+					"id": 2192,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13269,14 +13327,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5505,
+							"line": 5585,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2194,
+					"id": 2214,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13318,14 +13376,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6145,
+							"line": 6225,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2147,
+					"id": 2167,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13350,14 +13408,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4736,
+							"line": 4816,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2148,
+					"id": 2168,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13367,11 +13425,11 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\n liveboardEmbed.trigger(HostEvent.ScheduleList)\n```"
+								"text": "\n```js\n liveboardEmbed.trigger(HostEvent.SchedulesList)\n```"
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Manage schedules from liveboard context\nimport { ContextType } from '@thoughtspot/visual-embed-sdk';\nliveboardEmbed.trigger(HostEvent.ScheduleList, {}, ContextType.Liveboard);\n```"
+								"text": "\n```js\n// Manage schedules from liveboard context\nimport { ContextType } from '@thoughtspot/visual-embed-sdk';\nliveboardEmbed.trigger(HostEvent.SchedulesList, {}, ContextType.Liveboard);\n```"
 							},
 							{
 								"tag": "version",
@@ -13382,14 +13440,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4751,
+							"line": 4831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2131,
+					"id": 2151,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13415,14 +13473,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4260,
+							"line": 4340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2192,
+					"id": 2212,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13451,14 +13509,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6075,
+							"line": 6155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2217,
+					"id": 2237,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13483,14 +13541,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6450,
+							"line": 6530,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2137,
+					"id": 2157,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13520,14 +13578,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4398,
+							"line": 4478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2182,
+					"id": 2202,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13557,14 +13615,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5853,
+							"line": 5933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2181,
+					"id": 2201,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13594,14 +13652,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5831,
+							"line": 5911,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2136,
+					"id": 2156,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13631,14 +13689,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4378,
+							"line": 4458,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2171,
+					"id": 2191,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13667,14 +13725,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5453,
+							"line": 5533,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2203,
+					"id": 2223,
 					"name": "ShareSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13695,14 +13753,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6267,
+							"line": 6347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ShareSpotterConversation\""
 				},
 				{
-					"id": 2164,
+					"id": 2184,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13736,14 +13794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5228,
+							"line": 5308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2166,
+					"id": 2186,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13777,14 +13835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5291,
+							"line": 5371,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2197,
+					"id": 2217,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13814,14 +13872,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6195,
+							"line": 6275,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2218,
+					"id": 2238,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13847,14 +13905,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6463,
+							"line": 6543,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2213,
+					"id": 2233,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13876,14 +13934,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6381,
+							"line": 6461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2174,
+					"id": 2194,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13917,14 +13975,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5564,
+							"line": 5644,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2173,
+					"id": 2193,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13958,14 +14016,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5534,
+							"line": 5614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2196,
+					"id": 2216,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13991,14 +14049,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6170,
+							"line": 6250,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2215,
+					"id": 2235,
 					"name": "UnpinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14020,14 +14078,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6418,
+							"line": 6498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UnpinSpotterConversation\""
 				},
 				{
-					"id": 2185,
+					"id": 2205,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14048,14 +14106,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5909,
+							"line": 5989,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2178,
+					"id": 2198,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14101,14 +14159,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5766,
+							"line": 5846,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2188,
+					"id": 2208,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14142,14 +14200,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5979,
+							"line": 6059,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2190,
+					"id": 2210,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14174,14 +14232,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6034,
+							"line": 6114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2191,
+					"id": 2211,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14198,14 +14256,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6042,
+							"line": 6122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2138,
+					"id": 2158,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14240,14 +14298,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4441,
+							"line": 4521,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2151,
+					"id": 2171,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14272,14 +14330,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4810,
+							"line": 4890,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2144,
+					"id": 2164,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14300,7 +14358,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4603,
+							"line": 4683,
 							"character": 4
 						}
 					],
@@ -14312,103 +14370,103 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2154,
-						2142,
-						2200,
-						2207,
-						2184,
-						2210,
-						2204,
-						2221,
-						2161,
-						2158,
-						2201,
-						2165,
-						2206,
-						2212,
-						2167,
-						2169,
-						2152,
-						2168,
-						2170,
-						2153,
-						2132,
-						2160,
-						2198,
-						2150,
-						2205,
-						2157,
-						2149,
-						2183,
-						2177,
-						2180,
-						2135,
-						2189,
-						2163,
-						2179,
-						2219,
-						2146,
-						2155,
-						2159,
-						2175,
-						2139,
-						2140,
-						2141,
-						2220,
-						2145,
-						2214,
-						2162,
-						2199,
-						2222,
-						2156,
-						2143,
-						2186,
-						2187,
-						2176,
-						2202,
-						2172,
-						2194,
-						2147,
-						2148,
-						2131,
-						2192,
-						2217,
-						2137,
-						2182,
-						2181,
-						2136,
-						2171,
-						2203,
-						2164,
-						2166,
-						2197,
-						2218,
-						2213,
 						2174,
-						2173,
-						2196,
-						2215,
-						2185,
+						2162,
+						2220,
+						2227,
+						2204,
+						2230,
+						2224,
+						2241,
+						2181,
 						2178,
+						2221,
+						2185,
+						2226,
+						2232,
+						2187,
+						2189,
+						2172,
 						2188,
 						2190,
-						2191,
-						2138,
+						2173,
+						2152,
+						2180,
+						2218,
+						2170,
+						2225,
+						2177,
+						2169,
+						2203,
+						2197,
+						2200,
+						2155,
+						2209,
+						2183,
+						2199,
+						2239,
+						2166,
+						2175,
+						2179,
+						2195,
+						2159,
+						2160,
+						2161,
+						2240,
+						2165,
+						2234,
+						2182,
+						2219,
+						2242,
+						2176,
+						2163,
+						2206,
+						2207,
+						2196,
+						2222,
+						2192,
+						2214,
+						2167,
+						2168,
 						2151,
-						2144
+						2212,
+						2237,
+						2157,
+						2202,
+						2201,
+						2156,
+						2191,
+						2223,
+						2184,
+						2186,
+						2217,
+						2238,
+						2233,
+						2194,
+						2193,
+						2216,
+						2235,
+						2205,
+						2198,
+						2208,
+						2210,
+						2211,
+						2158,
+						2171,
+						2164
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4230,
+					"line": 4310,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3252,
+			"id": 3278,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14418,7 +14476,7 @@
 			},
 			"children": [
 				{
-					"id": 3254,
+					"id": 3280,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14429,14 +14487,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9144,
+							"line": 9248,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3253,
+					"id": 3279,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14447,14 +14505,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9140,
+							"line": 9244,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3255,
+					"id": 3281,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14465,7 +14523,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9148,
+							"line": 9252,
 							"character": 4
 						}
 					],
@@ -14477,22 +14535,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3254,
-						3253,
-						3255
+						3280,
+						3279,
+						3281
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9136,
+					"line": 9240,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3288,
+			"id": 3314,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14508,7 +14566,7 @@
 			},
 			"children": [
 				{
-					"id": 3290,
+					"id": 3316,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14519,14 +14577,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9414,
+							"line": 9518,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3291,
+					"id": 3317,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14537,14 +14595,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9416,
+							"line": 9520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3292,
+					"id": 3318,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14555,14 +14613,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9418,
+							"line": 9522,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3289,
+					"id": 3315,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14573,7 +14631,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9412,
+							"line": 9516,
 							"character": 4
 						}
 					],
@@ -14585,23 +14643,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3290,
-						3291,
-						3292,
-						3289
+						3316,
+						3317,
+						3318,
+						3315
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9410,
+					"line": 9514,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3187,
+			"id": 3213,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14617,7 +14675,7 @@
 			},
 			"children": [
 				{
-					"id": 3188,
+					"id": 3214,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14635,7 +14693,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3189,
+					"id": 3215,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14658,8 +14716,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3188,
-						3189
+						3214,
+						3215
 					]
 				}
 			],
@@ -14672,7 +14730,7 @@
 			]
 		},
 		{
-			"id": 3231,
+			"id": 3257,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14688,7 +14746,7 @@
 			},
 			"children": [
 				{
-					"id": 3235,
+					"id": 3261,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14699,14 +14757,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2340,
+							"line": 2420,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3236,
+					"id": 3262,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14717,14 +14775,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2344,
+							"line": 2424,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3232,
+					"id": 3258,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14735,14 +14793,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2327,
+							"line": 2407,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3233,
+					"id": 3259,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14759,14 +14817,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2332,
+							"line": 2412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3237,
+					"id": 3263,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14777,14 +14835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2348,
+							"line": 2428,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3234,
+					"id": 3260,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14795,14 +14853,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2336,
+							"line": 2416,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3238,
+					"id": 3264,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14813,7 +14871,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2352,
+							"line": 2432,
 							"character": 4
 						}
 					],
@@ -14825,26 +14883,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3235,
-						3236,
-						3232,
-						3233,
-						3237,
-						3234,
-						3238
+						3261,
+						3262,
+						3258,
+						3259,
+						3263,
+						3260,
+						3264
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2323,
+					"line": 2403,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3150,
+			"id": 3176,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14854,7 +14912,7 @@
 			},
 			"children": [
 				{
-					"id": 3155,
+					"id": 3181,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14875,14 +14933,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8876,
+							"line": 8980,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3152,
+					"id": 3178,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14903,14 +14961,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8837,
+							"line": 8941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3154,
+					"id": 3180,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14931,14 +14989,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8862,
+							"line": 8966,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3151,
+					"id": 3177,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14959,14 +15017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8825,
+							"line": 8929,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3156,
+					"id": 3182,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14987,14 +15045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8888,
+							"line": 8992,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3153,
+					"id": 3179,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15015,7 +15073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8849,
+							"line": 8953,
 							"character": 4
 						}
 					],
@@ -15027,25 +15085,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3155,
-						3152,
-						3154,
-						3151,
-						3156,
-						3153
+						3181,
+						3178,
+						3180,
+						3177,
+						3182,
+						3179
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8812,
+					"line": 8916,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1959,
+			"id": 1979,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15055,7 +15113,7 @@
 			},
 			"children": [
 				{
-					"id": 1962,
+					"id": 1982,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15073,7 +15131,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1968,
+					"id": 1988,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15091,7 +15149,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 1965,
+					"id": 1985,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15109,7 +15167,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1960,
+					"id": 1980,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15127,7 +15185,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1963,
+					"id": 1983,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15145,7 +15203,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1967,
+					"id": 1987,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15163,7 +15221,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1961,
+					"id": 1981,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15181,7 +15239,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1966,
+					"id": 1986,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15204,14 +15262,14 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1962,
-						1968,
-						1965,
-						1960,
-						1963,
-						1967,
-						1961,
-						1966
+						1982,
+						1988,
+						1985,
+						1980,
+						1983,
+						1987,
+						1981,
+						1986
 					]
 				}
 			],
@@ -15224,14 +15282,14 @@
 			]
 		},
 		{
-			"id": 2835,
+			"id": 2861,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2836,
+					"id": 2862,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15239,14 +15297,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8641,
+							"line": 8745,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2838,
+					"id": 2864,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15254,14 +15312,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8643,
+							"line": 8747,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2837,
+					"id": 2863,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15269,14 +15327,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8642,
+							"line": 8746,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2839,
+					"id": 2865,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15284,7 +15342,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8644,
+							"line": 8748,
 							"character": 4
 						}
 					],
@@ -15296,23 +15354,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2836,
-						2838,
-						2837,
-						2839
+						2862,
+						2864,
+						2863,
+						2865
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8640,
+					"line": 8744,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3181,
+			"id": 3207,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15328,7 +15386,7 @@
 			},
 			"children": [
 				{
-					"id": 3182,
+					"id": 3208,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15351,7 +15409,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3182
+						3208
 					]
 				}
 			],
@@ -15364,7 +15422,7 @@
 			]
 		},
 		{
-			"id": 1985,
+			"id": 2005,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15374,7 +15432,7 @@
 			},
 			"children": [
 				{
-					"id": 1993,
+					"id": 2013,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15385,14 +15443,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2248,
+							"line": 2328,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 1998,
+					"id": 2018,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15403,14 +15461,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2268,
+							"line": 2348,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 1997,
+					"id": 2017,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15421,14 +15479,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2264,
+							"line": 2344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 1995,
+					"id": 2015,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15439,14 +15497,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2256,
+							"line": 2336,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 1996,
+					"id": 2016,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15457,14 +15515,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2260,
+							"line": 2340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 1992,
+					"id": 2012,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15475,14 +15533,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2244,
+							"line": 2324,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 1994,
+					"id": 2014,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15493,14 +15551,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2252,
+							"line": 2332,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 1986,
+					"id": 2006,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15511,14 +15569,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2220,
+							"line": 2300,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 1991,
+					"id": 2011,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15529,14 +15587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2240,
+							"line": 2320,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 1990,
+					"id": 2010,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15547,14 +15605,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2236,
+							"line": 2316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 1999,
+					"id": 2019,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15565,14 +15623,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2272,
+							"line": 2352,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 1989,
+					"id": 2009,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15583,14 +15641,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2232,
+							"line": 2312,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 1988,
+					"id": 2008,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15601,14 +15659,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2228,
+							"line": 2308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 1987,
+					"id": 2007,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15619,14 +15677,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2224,
+							"line": 2304,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2000,
+					"id": 2020,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15637,7 +15695,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2276,
+							"line": 2356,
 							"character": 4
 						}
 					],
@@ -15649,34 +15707,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1993,
-						1998,
-						1997,
-						1995,
-						1996,
-						1992,
-						1994,
-						1986,
-						1991,
-						1990,
-						1999,
-						1989,
-						1988,
-						1987,
-						2000
+						2013,
+						2018,
+						2017,
+						2015,
+						2016,
+						2012,
+						2014,
+						2006,
+						2011,
+						2010,
+						2019,
+						2009,
+						2008,
+						2007,
+						2020
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2216,
+					"line": 2296,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1540,
+			"id": 1556,
 			"name": "SpotterQueryMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15692,7 +15750,7 @@
 			},
 			"children": [
 				{
-					"id": 1541,
+					"id": 1557,
 					"name": "FAST_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15707,7 +15765,7 @@
 					"defaultValue": "\"fastSearch\""
 				},
 				{
-					"id": 1542,
+					"id": 1558,
 					"name": "RESEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15727,8 +15785,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1541,
-						1542
+						1557,
+						1558
 					]
 				}
 			],
@@ -15741,7 +15799,7 @@
 			]
 		},
 		{
-			"id": 3327,
+			"id": 3353,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15757,7 +15815,7 @@
 			},
 			"children": [
 				{
-					"id": 3329,
+					"id": 3355,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15768,14 +15826,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9442,
+							"line": 9546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3328,
+					"id": 3354,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15786,7 +15844,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9440,
+							"line": 9544,
 							"character": 4
 						}
 					],
@@ -15798,21 +15856,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3329,
-						3328
+						3355,
+						3354
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9438,
+					"line": 9542,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3323,
+			"id": 3349,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15828,7 +15886,7 @@
 			},
 			"children": [
 				{
-					"id": 3324,
+					"id": 3350,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15839,14 +15897,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9427,
+							"line": 9531,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3325,
+					"id": 3351,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15857,14 +15915,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9429,
+							"line": 9533,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3326,
+					"id": 3352,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15875,7 +15933,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9431,
+							"line": 9535,
 							"character": 4
 						}
 					],
@@ -15887,29 +15945,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3324,
-						3325,
-						3326
+						3350,
+						3351,
+						3352
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9425,
+					"line": 9529,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3213,
+			"id": 3239,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3222,
+					"id": 3248,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15924,7 +15982,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3218,
+					"id": 3244,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15939,7 +15997,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3223,
+					"id": 3249,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15954,7 +16012,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3217,
+					"id": 3243,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15969,7 +16027,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3216,
+					"id": 3242,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15984,7 +16042,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3230,
+					"id": 3256,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15999,7 +16057,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3224,
+					"id": 3250,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16014,7 +16072,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3229,
+					"id": 3255,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16029,7 +16087,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 3225,
+					"id": 3251,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16044,7 +16102,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3219,
+					"id": 3245,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16059,7 +16117,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3226,
+					"id": 3252,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16074,7 +16132,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3227,
+					"id": 3253,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16089,7 +16147,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3228,
+					"id": 3254,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16104,7 +16162,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3220,
+					"id": 3246,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16119,7 +16177,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3214,
+					"id": 3240,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16134,7 +16192,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3215,
+					"id": 3241,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16149,7 +16207,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3221,
+					"id": 3247,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16169,23 +16227,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3222,
-						3218,
-						3223,
-						3217,
-						3216,
-						3230,
-						3224,
-						3229,
-						3225,
-						3219,
-						3226,
-						3227,
-						3228,
-						3220,
-						3214,
-						3215,
-						3221
+						3248,
+						3244,
+						3249,
+						3243,
+						3242,
+						3256,
+						3250,
+						3255,
+						3251,
+						3245,
+						3252,
+						3253,
+						3254,
+						3246,
+						3240,
+						3241,
+						3247
 					]
 				}
 			],
@@ -16198,7 +16256,7 @@
 			]
 		},
 		{
-			"id": 1872,
+			"id": 1892,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -16227,7 +16285,7 @@
 			},
 			"children": [
 				{
-					"id": 1873,
+					"id": 1893,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16244,7 +16302,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1874,
+							"id": 1894,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -16254,7 +16312,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1875,
+									"id": 1895,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16262,12 +16320,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1949,
+										"id": 1969,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1876,
+									"id": 1896,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16279,7 +16337,7 @@
 									}
 								},
 								{
-									"id": 1877,
+									"id": 1897,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16291,7 +16349,7 @@
 									}
 								},
 								{
-									"id": 1878,
+									"id": 1898,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16305,7 +16363,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3190,
+											"id": 3216,
 											"name": "VizPoint"
 										}
 									}
@@ -16313,14 +16371,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1872,
+								"id": 1892,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1887,
+					"id": 1907,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16336,7 +16394,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1888,
+							"id": 1908,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16347,7 +16405,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1889,
+									"id": 1909,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16376,7 +16434,7 @@
 					]
 				},
 				{
-					"id": 1890,
+					"id": 1910,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16392,7 +16450,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1891,
+							"id": 1911,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16408,7 +16466,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1892,
+									"id": 1912,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16437,7 +16495,7 @@
 					]
 				},
 				{
-					"id": 1943,
+					"id": 1963,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16453,14 +16511,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1944,
+							"id": 1964,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1945,
+									"id": 1965,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16485,7 +16543,7 @@
 					]
 				},
 				{
-					"id": 1893,
+					"id": 1913,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16501,7 +16559,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1894,
+							"id": 1914,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16512,7 +16570,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1895,
+									"id": 1915,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16524,7 +16582,7 @@
 									}
 								},
 								{
-									"id": 1896,
+									"id": 1916,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16532,12 +16590,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1985,
+										"id": 2005,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1897,
+									"id": 1917,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16583,7 +16641,7 @@
 					]
 				},
 				{
-					"id": 1933,
+					"id": 1953,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16599,7 +16657,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1934,
+							"id": 1954,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16610,7 +16668,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1935,
+									"id": 1955,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16624,7 +16682,7 @@
 									}
 								},
 								{
-									"id": 1936,
+									"id": 1956,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16652,7 +16710,7 @@
 					]
 				},
 				{
-					"id": 1911,
+					"id": 1931,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16668,7 +16726,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1912,
+							"id": 1932,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16679,7 +16737,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1913,
+									"id": 1933,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16692,7 +16750,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1914,
+									"id": 1934,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16721,7 +16779,7 @@
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1924,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16737,7 +16795,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1925,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16748,7 +16806,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1906,
+									"id": 1926,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16761,7 +16819,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1907,
+									"id": 1927,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16780,14 +16838,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1908,
+											"id": 1928,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1909,
+													"id": 1929,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16798,7 +16856,7 @@
 													}
 												},
 												{
-													"id": 1910,
+													"id": 1930,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16814,8 +16872,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1909,
-														1910
+														1929,
+														1930
 													]
 												}
 											]
@@ -16828,7 +16886,7 @@
 					]
 				},
 				{
-					"id": 1915,
+					"id": 1935,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16844,7 +16902,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1916,
+							"id": 1936,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16855,7 +16913,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1917,
+									"id": 1937,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16868,7 +16926,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1918,
+									"id": 1938,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16883,7 +16941,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1919,
+									"id": 1939,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16912,7 +16970,7 @@
 					]
 				},
 				{
-					"id": 1939,
+					"id": 1959,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16928,7 +16986,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1940,
+							"id": 1960,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16947,7 +17005,7 @@
 					]
 				},
 				{
-					"id": 1920,
+					"id": 1940,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16963,7 +17021,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1941,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16974,7 +17032,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1942,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16987,7 +17045,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1923,
+									"id": 1943,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17008,7 +17066,7 @@
 					]
 				},
 				{
-					"id": 1924,
+					"id": 1944,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17024,7 +17082,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1925,
+							"id": 1945,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17034,7 +17092,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1926,
+									"id": 1946,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17047,7 +17105,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1927,
+									"id": 1947,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17060,7 +17118,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1928,
+									"id": 1948,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17083,7 +17141,7 @@
 					]
 				},
 				{
-					"id": 1901,
+					"id": 1921,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17099,14 +17157,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1902,
+							"id": 1922,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1903,
+									"id": 1923,
 									"name": "fetchSQLWithAllColumns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17132,7 +17190,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1957,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17148,7 +17206,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1958,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17159,14 +17217,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1949,
+								"id": 1969,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1882,
+					"id": 1902,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17182,7 +17240,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1883,
+							"id": 1903,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17204,7 +17262,7 @@
 					]
 				},
 				{
-					"id": 1941,
+					"id": 1961,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17220,7 +17278,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1942,
+							"id": 1962,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17239,7 +17297,7 @@
 					]
 				},
 				{
-					"id": 1929,
+					"id": 1949,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17255,7 +17313,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1930,
+							"id": 1950,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17275,7 +17333,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1931,
+									"id": 1951,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17290,7 +17348,7 @@
 									}
 								},
 								{
-									"id": 1932,
+									"id": 1952,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17302,7 +17360,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1956,
+											"id": 1976,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -17313,7 +17371,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -17323,7 +17381,7 @@
 					]
 				},
 				{
-					"id": 1884,
+					"id": 1904,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17339,7 +17397,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1885,
+							"id": 1905,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17350,7 +17408,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1886,
+									"id": 1906,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17379,7 +17437,7 @@
 					]
 				},
 				{
-					"id": 1946,
+					"id": 1966,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17395,14 +17453,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1947,
+							"id": 1967,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1948,
+									"id": 1968,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17421,7 +17479,7 @@
 					]
 				},
 				{
-					"id": 1898,
+					"id": 1918,
 					"name": "updateDisplayMode",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17437,14 +17495,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1899,
+							"id": 1919,
 							"name": "updateDisplayMode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1900,
+									"id": 1920,
 									"name": "displayMode",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17475,32 +17533,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1873
+						1893
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1887,
-						1890,
-						1943,
-						1893,
-						1933,
-						1911,
-						1904,
-						1915,
-						1939,
-						1920,
+						1907,
+						1910,
+						1963,
+						1913,
+						1953,
+						1931,
 						1924,
-						1901,
-						1937,
-						1882,
-						1941,
-						1929,
-						1884,
-						1946,
-						1898
+						1935,
+						1959,
+						1940,
+						1944,
+						1921,
+						1957,
+						1902,
+						1961,
+						1949,
+						1904,
+						1966,
+						1918
 					]
 				}
 			],
@@ -17513,7 +17571,7 @@
 			]
 		},
 		{
-			"id": 903,
+			"id": 911,
 			"name": "AppEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -17529,7 +17587,7 @@
 			},
 			"children": [
 				{
-					"id": 904,
+					"id": 912,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -17543,40 +17601,40 @@
 					],
 					"signatures": [
 						{
-							"id": 905,
+							"id": 913,
 							"name": "new AppEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 906,
+									"id": 914,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2891,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 907,
+									"id": 915,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2719,
+										"id": 2744,
 										"name": "AppViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 903,
+								"id": 911,
 								"name": "AppEmbed"
 							},
 							"overwrites": {
@@ -17591,7 +17649,7 @@
 					}
 				},
 				{
-					"id": 947,
+					"id": 955,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17607,7 +17665,7 @@
 					],
 					"signatures": [
 						{
-							"id": 948,
+							"id": 956,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17637,7 +17695,7 @@
 					}
 				},
 				{
-					"id": 1132,
+					"id": 1142,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17647,13 +17705,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1133,
+							"id": 1143,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17669,7 +17727,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1134,
+									"id": 1144,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17690,7 +17748,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -17708,7 +17766,7 @@
 					}
 				},
 				{
-					"id": 1097,
+					"id": 1107,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17718,13 +17776,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1098,
+							"id": 1108,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17765,7 +17823,7 @@
 					}
 				},
 				{
-					"id": 924,
+					"id": 932,
 					"name": "getIFrameSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17781,7 +17839,7 @@
 					],
 					"signatures": [
 						{
-							"id": 925,
+							"id": 933,
 							"name": "getIFrameSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17797,7 +17855,7 @@
 					]
 				},
 				{
-					"id": 1093,
+					"id": 1103,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17807,13 +17865,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1094,
+							"id": 1104,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17834,7 +17892,7 @@
 					}
 				},
 				{
-					"id": 1126,
+					"id": 1136,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17844,13 +17902,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1127,
+							"id": 1137,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17872,14 +17930,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1128,
+									"id": 1138,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1130,
+											"id": 1140,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17891,7 +17949,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1131,
+											"id": 1141,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17903,7 +17961,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1129,
+											"id": 1139,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -17920,9 +17978,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1130,
-												1131,
-												1129
+												1140,
+												1141,
+												1139
 											]
 										}
 									]
@@ -17940,7 +17998,7 @@
 					}
 				},
 				{
-					"id": 1106,
+					"id": 1116,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17950,13 +18008,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1107,
+							"id": 1117,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17972,7 +18030,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1108,
+									"id": 1118,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17980,20 +18038,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1109,
+											"id": 1119,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1110,
+												"id": 1120,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1111,
+														"id": 1121,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -18038,7 +18096,7 @@
 					}
 				},
 				{
-					"id": 1112,
+					"id": 1122,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18048,13 +18106,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1113,
+							"id": 1123,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18075,7 +18133,7 @@
 					}
 				},
 				{
-					"id": 1124,
+					"id": 1134,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18085,13 +18143,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1125,
+							"id": 1135,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18115,7 +18173,7 @@
 					}
 				},
 				{
-					"id": 943,
+					"id": 951,
 					"name": "navigateToPage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18131,7 +18189,7 @@
 					],
 					"signatures": [
 						{
-							"id": 944,
+							"id": 952,
 							"name": "navigateToPage",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18147,7 +18205,7 @@
 							},
 							"parameters": [
 								{
-									"id": 945,
+									"id": 953,
 									"name": "path",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18170,7 +18228,7 @@
 									}
 								},
 								{
-									"id": 946,
+									"id": 954,
 									"name": "noReload",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18193,7 +18251,7 @@
 					]
 				},
 				{
-					"id": 1062,
+					"id": 1072,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18203,13 +18261,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1063,
+							"id": 1073,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18225,7 +18283,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1064,
+									"id": 1074,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18235,12 +18293,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1065,
+									"id": 1075,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18250,7 +18308,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -18271,7 +18329,7 @@
 					}
 				},
 				{
-					"id": 962,
+					"id": 970,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18281,13 +18339,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2284,
+							"line": 2304,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 963,
+							"id": 971,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18310,38 +18368,38 @@
 							},
 							"parameters": [
 								{
-									"id": 964,
+									"id": 972,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 965,
+									"id": 973,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 966,
+									"id": 974,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18363,7 +18421,7 @@
 					}
 				},
 				{
-					"id": 1102,
+					"id": 1112,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18373,13 +18431,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1103,
+							"id": 1113,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18389,7 +18447,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1104,
+									"id": 1114,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18404,7 +18462,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1105,
+									"id": 1115,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18438,7 +18496,7 @@
 					}
 				},
 				{
-					"id": 1114,
+					"id": 1124,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18448,13 +18506,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1115,
+							"id": 1125,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18491,7 +18549,7 @@
 					}
 				},
 				{
-					"id": 955,
+					"id": 963,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18507,7 +18565,7 @@
 					],
 					"signatures": [
 						{
-							"id": 956,
+							"id": 964,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18520,7 +18578,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 903,
+										"id": 911,
 										"name": "AppEmbed"
 									}
 								],
@@ -18538,7 +18596,7 @@
 					}
 				},
 				{
-					"id": 1118,
+					"id": 1128,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18548,13 +18606,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1119,
+							"id": 1129,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18584,7 +18642,7 @@
 					}
 				},
 				{
-					"id": 1099,
+					"id": 1109,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18594,13 +18652,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1100,
+							"id": 1110,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18618,7 +18676,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1101,
+									"id": 1111,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18631,12 +18689,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -18659,7 +18717,7 @@
 					}
 				},
 				{
-					"id": 1122,
+					"id": 1132,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18669,13 +18727,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1123,
+							"id": 1133,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18705,7 +18763,7 @@
 					}
 				},
 				{
-					"id": 1080,
+					"id": 1090,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18715,13 +18773,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1081,
+							"id": 1091,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18742,40 +18800,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1082,
+									"id": 1092,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1083,
+									"id": 1093,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1084,
+									"id": 1094,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1085,
+									"id": 1095,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18789,7 +18847,7 @@
 									}
 								},
 								{
-									"id": 1086,
+									"id": 1096,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18814,7 +18872,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1087,
+									"id": 1097,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18866,7 +18924,7 @@
 					}
 				},
 				{
-					"id": 1088,
+					"id": 1098,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -18876,13 +18934,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1089,
+							"id": 1099,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -18893,21 +18951,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1090,
+									"id": 1100,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1091,
+									"id": 1101,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18921,7 +18979,7 @@
 									}
 								},
 								{
-									"id": 1092,
+									"id": 1102,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -18974,33 +19032,33 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						904
+						912
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						947,
-						1132,
-						1097,
-						924,
-						1093,
-						1126,
-						1106,
+						955,
+						1142,
+						1107,
+						932,
+						1103,
+						1136,
+						1116,
+						1122,
+						1134,
+						951,
+						1072,
+						970,
 						1112,
 						1124,
-						943,
-						1062,
-						962,
-						1102,
-						1114,
-						955,
-						1118,
-						1099,
-						1122,
-						1080,
-						1088
+						963,
+						1128,
+						1109,
+						1132,
+						1090,
+						1098
 					]
 				}
 			],
@@ -19019,7 +19077,7 @@
 			]
 		},
 		{
-			"id": 1243,
+			"id": 1255,
 			"name": "BodylessConversation",
 			"kind": 128,
 			"kindString": "Class",
@@ -19043,7 +19101,7 @@
 			},
 			"children": [
 				{
-					"id": 1244,
+					"id": 1256,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19057,45 +19115,45 @@
 					],
 					"signatures": [
 						{
-							"id": 1245,
+							"id": 1257,
 							"name": "new BodylessConversation",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1246,
+									"id": 1258,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1205,
+										"id": 1216,
 										"name": "BodylessConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1243,
+								"id": 1255,
 								"name": "BodylessConversation"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1137,
+								"id": 1147,
 								"name": "SpotterAgentEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1136,
+						"id": 1146,
 						"name": "SpotterAgentEmbed.constructor"
 					}
 				},
 				{
-					"id": 1247,
+					"id": 1259,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19111,14 +19169,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1248,
+							"id": 1260,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1249,
+									"id": 1261,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19138,14 +19196,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1250,
+													"id": 1262,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1252,
+															"id": 1264,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19156,7 +19214,7 @@
 															}
 														},
 														{
-															"id": 1251,
+															"id": 1263,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19167,7 +19225,7 @@
 															}
 														},
 														{
-															"id": 1253,
+															"id": 1265,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19184,9 +19242,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1252,
-																1251,
-																1253
+																1264,
+																1263,
+																1265
 															]
 														}
 													]
@@ -19195,14 +19253,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1254,
+													"id": 1266,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1255,
+															"id": 1267,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19213,7 +19271,7 @@
 															}
 														},
 														{
-															"id": 1257,
+															"id": 1269,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19224,7 +19282,7 @@
 															}
 														},
 														{
-															"id": 1256,
+															"id": 1268,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19241,9 +19299,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1255,
-																1257,
-																1256
+																1267,
+																1269,
+																1268
 															]
 														}
 													]
@@ -19256,19 +19314,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1141,
+								"id": 1151,
 								"name": "SpotterAgentEmbed.sendMessage"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1140,
+						"id": 1150,
 						"name": "SpotterAgentEmbed.sendMessage"
 					}
 				},
 				{
-					"id": 1258,
+					"id": 1270,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19284,7 +19342,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1259,
+							"id": 1271,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19295,7 +19353,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1260,
+									"id": 1272,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19318,14 +19376,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1261,
+													"id": 1273,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1263,
+															"id": 1275,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19337,7 +19395,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1262,
+															"id": 1274,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19353,8 +19411,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1263,
-																1262
+																1275,
+																1274
 															]
 														}
 													]
@@ -19363,14 +19421,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1264,
+													"id": 1276,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1265,
+															"id": 1277,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19378,14 +19436,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1266,
+																	"id": 1278,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1272,
+																			"id": 1284,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19397,7 +19455,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1271,
+																			"id": 1283,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19409,7 +19467,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1267,
+																			"id": 1279,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19421,7 +19479,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1270,
+																			"id": 1282,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19433,7 +19491,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1268,
+																			"id": 1280,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19445,7 +19503,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1269,
+																			"id": 1281,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -19462,12 +19520,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1272,
-																				1271,
-																				1267,
-																				1270,
-																				1268,
-																				1269
+																				1284,
+																				1283,
+																				1279,
+																				1282,
+																				1280,
+																				1281
 																			]
 																		}
 																	]
@@ -19476,7 +19534,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1273,
+															"id": 1285,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -19492,8 +19550,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1265,
-																1273
+																1277,
+																1285
 															]
 														}
 													]
@@ -19506,14 +19564,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1152,
+								"id": 1162,
 								"name": "SpotterAgentEmbed.sendMessageData"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1151,
+						"id": 1161,
 						"name": "SpotterAgentEmbed.sendMessageData"
 					}
 				}
@@ -19523,15 +19581,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1244
+						1256
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1247,
-						1258
+						1259,
+						1270
 					]
 				}
 			],
@@ -19545,13 +19603,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1135,
+					"id": 1145,
 					"name": "SpotterAgentEmbed"
 				}
 			]
 		},
 		{
-			"id": 1616,
+			"id": 1634,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19579,7 +19637,7 @@
 			},
 			"children": [
 				{
-					"id": 1617,
+					"id": 1635,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19587,20 +19645,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 812,
+							"line": 829,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1618,
+							"id": 1636,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1619,
+									"id": 1637,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19611,38 +19669,38 @@
 									}
 								},
 								{
-									"id": 1620,
+									"id": 1638,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1557,
+										"id": 1573,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1616,
+								"id": 1634,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
 								"type": "reference",
-								"id": 1276,
+								"id": 1288,
 								"name": "SpotterEmbed.constructor"
 							}
 						}
 					],
 					"overwrites": {
 						"type": "reference",
-						"id": 1275,
+						"id": 1287,
 						"name": "SpotterEmbed.constructor"
 					}
 				},
 				{
-					"id": 1777,
+					"id": 1797,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19652,13 +19710,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1798,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19678,19 +19736,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1436,
+								"id": 1450,
 								"name": "SpotterEmbed.destroy"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1435,
+						"id": 1449,
 						"name": "SpotterEmbed.destroy"
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1819,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19700,13 +19758,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1820,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19722,7 +19780,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1801,
+									"id": 1821,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19743,7 +19801,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -19751,19 +19809,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1458,
+								"id": 1472,
 								"name": "SpotterEmbed.getAnswerService"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1457,
+						"id": 1471,
 						"name": "SpotterEmbed.getAnswerService"
 					}
 				},
 				{
-					"id": 1762,
+					"id": 1782,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19773,13 +19831,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1763,
+							"id": 1783,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19810,19 +19868,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1421,
+								"id": 1435,
 								"name": "SpotterEmbed.getCurrentContext"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1420,
+						"id": 1434,
 						"name": "SpotterEmbed.getCurrentContext"
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1644,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19832,13 +19890,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 738,
+							"line": 755,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1627,
+							"id": 1645,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19849,19 +19907,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1285,
+								"id": 1297,
 								"name": "SpotterEmbed.getIframeSrc"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1284,
+						"id": 1296,
 						"name": "SpotterEmbed.getIframeSrc"
 					}
 				},
 				{
-					"id": 1793,
+					"id": 1813,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19871,13 +19929,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1794,
+							"id": 1814,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19899,14 +19957,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1795,
+									"id": 1815,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1797,
+											"id": 1817,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19918,7 +19976,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1798,
+											"id": 1818,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19930,7 +19988,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1796,
+											"id": 1816,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19947,9 +20005,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1797,
-												1798,
-												1796
+												1817,
+												1818,
+												1816
 											]
 										}
 									]
@@ -19957,19 +20015,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1452,
+								"id": 1466,
 								"name": "SpotterEmbed.getPreRenderIds"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1451,
+						"id": 1465,
 						"name": "SpotterEmbed.getPreRenderIds"
 					}
 				},
 				{
-					"id": 1771,
+					"id": 1791,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19979,13 +20037,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1772,
+							"id": 1792,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20001,7 +20059,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1773,
+									"id": 1793,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20009,20 +20067,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1774,
+											"id": 1794,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1775,
+												"id": 1795,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1776,
+														"id": 1796,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -20057,19 +20115,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1430,
+								"id": 1444,
 								"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1429,
+						"id": 1443,
 						"name": "SpotterEmbed.getThoughtSpotPostUrlParams"
 					}
 				},
 				{
-					"id": 1779,
+					"id": 1799,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20079,13 +20137,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1780,
+							"id": 1800,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20096,19 +20154,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1438,
+								"id": 1452,
 								"name": "SpotterEmbed.getUnderlyingFrameElement"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1437,
+						"id": 1451,
 						"name": "SpotterEmbed.getUnderlyingFrameElement"
 					}
 				},
 				{
-					"id": 1791,
+					"id": 1811,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20118,13 +20176,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1792,
+							"id": 1812,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20138,19 +20196,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1450,
+								"id": 1464,
 								"name": "SpotterEmbed.hidePreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1449,
+						"id": 1463,
 						"name": "SpotterEmbed.hidePreRender"
 					}
 				},
 				{
-					"id": 1729,
+					"id": 1749,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20160,13 +20218,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1730,
+							"id": 1750,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20182,7 +20240,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1731,
+									"id": 1751,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20192,12 +20250,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1732,
+									"id": 1752,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20207,7 +20265,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -20218,19 +20276,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1388,
+								"id": 1402,
 								"name": "SpotterEmbed.off"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1387,
+						"id": 1401,
 						"name": "SpotterEmbed.off"
 					}
 				},
 				{
-					"id": 1723,
+					"id": 1743,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20240,13 +20298,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1724,
+							"id": 1744,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20266,7 +20324,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1725,
+									"id": 1745,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20276,12 +20334,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1726,
+									"id": 1746,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20291,12 +20349,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1727,
+									"id": 1747,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20306,13 +20364,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1728,
+									"id": 1748,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20331,19 +20389,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1382,
+								"id": 1396,
 								"name": "SpotterEmbed.on"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1381,
+						"id": 1395,
 						"name": "SpotterEmbed.on"
 					}
 				},
 				{
-					"id": 1767,
+					"id": 1787,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20353,13 +20411,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1768,
+							"id": 1788,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20369,7 +20427,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1769,
+									"id": 1789,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20384,7 +20442,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1770,
+									"id": 1790,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20408,19 +20466,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1426,
+								"id": 1440,
 								"name": "SpotterEmbed.preRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1425,
+						"id": 1439,
 						"name": "SpotterEmbed.preRender"
 					}
 				},
 				{
-					"id": 1781,
+					"id": 1801,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20430,13 +20488,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1782,
+							"id": 1802,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20463,19 +20521,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1440,
+								"id": 1454,
 								"name": "SpotterEmbed.prerenderGeneric"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1439,
+						"id": 1453,
 						"name": "SpotterEmbed.prerenderGeneric"
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1646,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20485,13 +20543,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 785,
+							"line": 802,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1629,
+							"id": 1647,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20501,7 +20559,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1274,
+										"id": 1286,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -20509,19 +20567,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1287,
+								"id": 1299,
 								"name": "SpotterEmbed.render"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1286,
+						"id": 1298,
 						"name": "SpotterEmbed.render"
 					}
 				},
 				{
-					"id": 1785,
+					"id": 1805,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20531,13 +20589,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1786,
+							"id": 1806,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20557,19 +20615,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1444,
+								"id": 1458,
 								"name": "SpotterEmbed.showPreRender"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1443,
+						"id": 1457,
 						"name": "SpotterEmbed.showPreRender"
 					}
 				},
 				{
-					"id": 1764,
+					"id": 1784,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20579,13 +20637,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1765,
+							"id": 1785,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20603,7 +20661,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1766,
+									"id": 1786,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20616,12 +20674,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -20634,19 +20692,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1423,
+								"id": 1437,
 								"name": "SpotterEmbed.subscribedEvent"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1422,
+						"id": 1436,
 						"name": "SpotterEmbed.subscribedEvent"
 					}
 				},
 				{
-					"id": 1789,
+					"id": 1809,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20656,13 +20714,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1790,
+							"id": 1810,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20682,19 +20740,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1448,
+								"id": 1462,
 								"name": "SpotterEmbed.syncPreRenderStyle"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1447,
+						"id": 1461,
 						"name": "SpotterEmbed.syncPreRenderStyle"
 					}
 				},
 				{
-					"id": 1747,
+					"id": 1767,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20704,13 +20762,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1748,
+							"id": 1768,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20731,40 +20789,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1749,
+									"id": 1769,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1750,
+									"id": 1770,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1751,
+									"id": 1771,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1752,
+									"id": 1772,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20778,7 +20836,7 @@
 									}
 								},
 								{
-									"id": 1753,
+									"id": 1773,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20803,7 +20861,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1754,
+									"id": 1774,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20845,19 +20903,19 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1406,
+								"id": 1420,
 								"name": "SpotterEmbed.trigger"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1405,
+						"id": 1419,
 						"name": "SpotterEmbed.trigger"
 					}
 				},
 				{
-					"id": 1755,
+					"id": 1775,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20867,13 +20925,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1756,
+							"id": 1776,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20884,21 +20942,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1757,
+									"id": 1777,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1758,
+									"id": 1778,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20912,7 +20970,7 @@
 									}
 								},
 								{
-									"id": 1759,
+									"id": 1779,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20950,14 +21008,14 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"id": 1414,
+								"id": 1428,
 								"name": "SpotterEmbed.triggerUIPassThrough"
 							}
 						}
 					],
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1413,
+						"id": 1427,
 						"name": "SpotterEmbed.triggerUIPassThrough"
 					}
 				}
@@ -20967,51 +21025,51 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1617
+						1635
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1777,
-						1799,
-						1762,
-						1626,
-						1793,
-						1771,
-						1779,
+						1797,
+						1819,
+						1782,
+						1644,
+						1813,
 						1791,
-						1729,
-						1723,
+						1799,
+						1811,
+						1749,
+						1743,
+						1787,
+						1801,
+						1646,
+						1805,
+						1784,
+						1809,
 						1767,
-						1781,
-						1628,
-						1785,
-						1764,
-						1789,
-						1747,
-						1755
+						1775
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 811,
+					"line": 828,
 					"character": 13
 				}
 			],
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1274,
+					"id": 1286,
 					"name": "SpotterEmbed"
 				}
 			]
 		},
 		{
-			"id": 655,
+			"id": 661,
 			"name": "LiveboardEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -21031,7 +21089,7 @@
 			},
 			"children": [
 				{
-					"id": 656,
+					"id": 662,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -21045,40 +21103,40 @@
 					],
 					"signatures": [
 						{
-							"id": 657,
+							"id": 663,
 							"name": "new LiveboardEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 658,
+									"id": 664,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2891,
 										"name": "DOMSelector"
 									}
 								},
 								{
-									"id": 659,
+									"id": 665,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2597,
+										"id": 2621,
 										"name": "LiveboardViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 655,
+								"id": 661,
 								"name": "LiveboardEmbed"
 							},
 							"overwrites": {
@@ -21093,7 +21151,7 @@
 					}
 				},
 				{
-					"id": 719,
+					"id": 725,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21109,7 +21167,7 @@
 					],
 					"signatures": [
 						{
-							"id": 720,
+							"id": 726,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21139,7 +21197,7 @@
 					}
 				},
 				{
-					"id": 900,
+					"id": 908,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21149,13 +21207,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 901,
+							"id": 909,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21171,7 +21229,7 @@
 							},
 							"parameters": [
 								{
-									"id": 902,
+									"id": 910,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21192,7 +21250,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -21210,7 +21268,7 @@
 					}
 				},
 				{
-					"id": 867,
+					"id": 875,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21220,13 +21278,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 868,
+							"id": 876,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21267,7 +21325,7 @@
 					}
 				},
 				{
-					"id": 865,
+					"id": 873,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21277,13 +21335,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 866,
+							"id": 874,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21304,7 +21362,7 @@
 					}
 				},
 				{
-					"id": 735,
+					"id": 741,
 					"name": "getLiveboardUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21320,7 +21378,7 @@
 					],
 					"signatures": [
 						{
-							"id": 736,
+							"id": 742,
 							"name": "getLiveboardUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21337,7 +21395,7 @@
 					]
 				},
 				{
-					"id": 894,
+					"id": 902,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21347,13 +21405,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 895,
+							"id": 903,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21375,14 +21433,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 896,
+									"id": 904,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 898,
+											"id": 906,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21394,7 +21452,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 899,
+											"id": 907,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21406,7 +21464,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 897,
+											"id": 905,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -21423,9 +21481,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												898,
-												899,
-												897
+												906,
+												907,
+												905
 											]
 										}
 									]
@@ -21443,7 +21501,7 @@
 					}
 				},
 				{
-					"id": 876,
+					"id": 884,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21453,13 +21511,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 877,
+							"id": 885,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21475,7 +21533,7 @@
 							},
 							"parameters": [
 								{
-									"id": 878,
+									"id": 886,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21483,20 +21541,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 879,
+											"id": 887,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 880,
+												"id": 888,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 881,
+														"id": 889,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -21541,7 +21599,7 @@
 					}
 				},
 				{
-					"id": 882,
+					"id": 890,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21551,13 +21609,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 883,
+							"id": 891,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21578,7 +21636,7 @@
 					}
 				},
 				{
-					"id": 892,
+					"id": 900,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21588,13 +21646,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 893,
+							"id": 901,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21618,7 +21676,7 @@
 					}
 				},
 				{
-					"id": 729,
+					"id": 735,
 					"name": "navigateToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21634,14 +21692,14 @@
 					],
 					"signatures": [
 						{
-							"id": 730,
+							"id": 736,
 							"name": "navigateToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 731,
+									"id": 737,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21652,7 +21710,7 @@
 									}
 								},
 								{
-									"id": 732,
+									"id": 738,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21665,7 +21723,7 @@
 									}
 								},
 								{
-									"id": 733,
+									"id": 739,
 									"name": "activeTabId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21678,7 +21736,7 @@
 									}
 								},
 								{
-									"id": 734,
+									"id": 740,
 									"name": "personalizedViewId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21699,7 +21757,7 @@
 					]
 				},
 				{
-					"id": 842,
+					"id": 850,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21709,13 +21767,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 843,
+							"id": 851,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21731,7 +21789,7 @@
 							},
 							"parameters": [
 								{
-									"id": 844,
+									"id": 852,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21741,12 +21799,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 845,
+									"id": 853,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21756,7 +21814,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -21777,7 +21835,7 @@
 					}
 				},
 				{
-					"id": 742,
+					"id": 748,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21787,13 +21845,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2284,
+							"line": 2304,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 743,
+							"id": 749,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21816,38 +21874,38 @@
 							},
 							"parameters": [
 								{
-									"id": 744,
+									"id": 750,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 745,
+									"id": 751,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 746,
+									"id": 752,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -21869,7 +21927,7 @@
 					}
 				},
 				{
-					"id": 872,
+					"id": 880,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21879,13 +21937,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 873,
+							"id": 881,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21895,7 +21953,7 @@
 							},
 							"parameters": [
 								{
-									"id": 874,
+									"id": 882,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21910,7 +21968,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 875,
+									"id": 883,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21944,7 +22002,7 @@
 					}
 				},
 				{
-					"id": 884,
+					"id": 892,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -21954,13 +22012,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 885,
+							"id": 893,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -21997,7 +22055,7 @@
 					}
 				},
 				{
-					"id": 727,
+					"id": 733,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22013,7 +22071,7 @@
 					],
 					"signatures": [
 						{
-							"id": 728,
+							"id": 734,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22026,7 +22084,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 655,
+										"id": 661,
 										"name": "LiveboardEmbed"
 									}
 								],
@@ -22044,7 +22102,7 @@
 					}
 				},
 				{
-					"id": 886,
+					"id": 894,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22054,13 +22112,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 887,
+							"id": 895,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22090,7 +22148,7 @@
 					}
 				},
 				{
-					"id": 869,
+					"id": 877,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22100,13 +22158,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 870,
+							"id": 878,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22124,7 +22182,7 @@
 							},
 							"parameters": [
 								{
-									"id": 871,
+									"id": 879,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22137,12 +22195,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -22165,7 +22223,7 @@
 					}
 				},
 				{
-					"id": 890,
+					"id": 898,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22175,13 +22233,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 891,
+							"id": 899,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22211,7 +22269,7 @@
 					}
 				},
 				{
-					"id": 711,
+					"id": 717,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22227,7 +22285,7 @@
 					],
 					"signatures": [
 						{
-							"id": 712,
+							"id": 718,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22238,40 +22296,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 713,
+									"id": 719,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 714,
+									"id": 720,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 715,
+									"id": 721,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 716,
+									"id": 722,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22285,7 +22343,7 @@
 									}
 								},
 								{
-									"id": 717,
+									"id": 723,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22310,7 +22368,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 718,
+									"id": 724,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22359,7 +22417,7 @@
 					}
 				},
 				{
-					"id": 860,
+					"id": 868,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22369,13 +22427,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 861,
+							"id": 869,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22386,21 +22444,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 862,
+									"id": 870,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 863,
+									"id": 871,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22414,7 +22472,7 @@
 									}
 								},
 								{
-									"id": 864,
+									"id": 872,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22467,33 +22525,33 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						656
+						662
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						719,
-						900,
-						867,
-						865,
-						735,
-						894,
-						876,
-						882,
-						892,
-						729,
-						842,
-						742,
-						872,
+						725,
+						908,
+						875,
+						873,
+						741,
+						902,
 						884,
-						727,
-						886,
-						869,
 						890,
-						711,
-						860
+						900,
+						735,
+						850,
+						748,
+						880,
+						892,
+						733,
+						894,
+						877,
+						898,
+						717,
+						868
 					]
 				}
 			],
@@ -22512,7 +22570,7 @@
 			]
 		},
 		{
-			"id": 254,
+			"id": 256,
 			"name": "SearchBarEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -22532,7 +22590,7 @@
 			},
 			"children": [
 				{
-					"id": 255,
+					"id": 257,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -22546,14 +22604,14 @@
 					],
 					"signatures": [
 						{
-							"id": 256,
+							"id": 258,
 							"name": "new SearchBarEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 257,
+									"id": 259,
 									"name": "domSelector",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22564,21 +22622,21 @@
 									}
 								},
 								{
-									"id": 258,
+									"id": 260,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2545,
+										"id": 2568,
 										"name": "SearchBarViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 254,
+								"id": 256,
 								"name": "SearchBarEmbed"
 							},
 							"overwrites": {
@@ -22593,7 +22651,7 @@
 					}
 				},
 				{
-					"id": 422,
+					"id": 426,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22603,13 +22661,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 423,
+							"id": 427,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22639,7 +22697,7 @@
 					}
 				},
 				{
-					"id": 444,
+					"id": 448,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22649,13 +22707,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 445,
+							"id": 449,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22671,7 +22729,7 @@
 							},
 							"parameters": [
 								{
-									"id": 446,
+									"id": 450,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22692,7 +22750,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -22710,7 +22768,7 @@
 					}
 				},
 				{
-					"id": 407,
+					"id": 411,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22720,13 +22778,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 408,
+							"id": 412,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22767,7 +22825,7 @@
 					}
 				},
 				{
-					"id": 403,
+					"id": 407,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22777,13 +22835,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 404,
+							"id": 408,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22804,7 +22862,7 @@
 					}
 				},
 				{
-					"id": 438,
+					"id": 442,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22814,13 +22872,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 439,
+							"id": 443,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22842,14 +22900,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 440,
+									"id": 444,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 442,
+											"id": 446,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22861,7 +22919,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 443,
+											"id": 447,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22873,7 +22931,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 441,
+											"id": 445,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -22890,9 +22948,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												442,
-												443,
-												441
+												446,
+												447,
+												445
 											]
 										}
 									]
@@ -22910,7 +22968,7 @@
 					}
 				},
 				{
-					"id": 416,
+					"id": 420,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -22920,13 +22978,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 417,
+							"id": 421,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -22942,7 +23000,7 @@
 							},
 							"parameters": [
 								{
-									"id": 418,
+									"id": 422,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -22950,20 +23008,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 419,
+											"id": 423,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 420,
+												"id": 424,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 421,
+														"id": 425,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -23008,7 +23066,7 @@
 					}
 				},
 				{
-					"id": 424,
+					"id": 428,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23018,13 +23076,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 425,
+							"id": 429,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23045,7 +23103,7 @@
 					}
 				},
 				{
-					"id": 436,
+					"id": 440,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23055,13 +23113,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 437,
+							"id": 441,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23085,7 +23143,7 @@
 					}
 				},
 				{
-					"id": 372,
+					"id": 376,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23095,13 +23153,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 373,
+							"id": 377,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23117,7 +23175,7 @@
 							},
 							"parameters": [
 								{
-									"id": 374,
+									"id": 378,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23127,12 +23185,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 375,
+									"id": 379,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23142,7 +23200,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -23163,7 +23221,7 @@
 					}
 				},
 				{
-					"id": 366,
+					"id": 370,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23173,13 +23231,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 367,
+							"id": 371,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23199,7 +23257,7 @@
 							},
 							"parameters": [
 								{
-									"id": 368,
+									"id": 372,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23209,12 +23267,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 369,
+									"id": 373,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23224,12 +23282,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 370,
+									"id": 374,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23239,13 +23297,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 371,
+									"id": 375,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23274,7 +23332,7 @@
 					}
 				},
 				{
-					"id": 412,
+					"id": 416,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23284,13 +23342,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 413,
+							"id": 417,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23300,7 +23358,7 @@
 							},
 							"parameters": [
 								{
-									"id": 414,
+									"id": 418,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23315,7 +23373,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 415,
+									"id": 419,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23349,7 +23407,7 @@
 					}
 				},
 				{
-					"id": 426,
+					"id": 430,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23359,13 +23417,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 427,
+							"id": 431,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23402,7 +23460,7 @@
 					}
 				},
 				{
-					"id": 265,
+					"id": 267,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23418,7 +23476,7 @@
 					],
 					"signatures": [
 						{
-							"id": 266,
+							"id": 268,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23431,7 +23489,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 254,
+										"id": 256,
 										"name": "SearchBarEmbed"
 									}
 								],
@@ -23449,7 +23507,7 @@
 					}
 				},
 				{
-					"id": 430,
+					"id": 434,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23459,13 +23517,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 431,
+							"id": 435,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23495,7 +23553,7 @@
 					}
 				},
 				{
-					"id": 409,
+					"id": 413,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23505,13 +23563,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 410,
+							"id": 414,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23529,7 +23587,7 @@
 							},
 							"parameters": [
 								{
-									"id": 411,
+									"id": 415,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23542,12 +23600,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -23570,7 +23628,7 @@
 					}
 				},
 				{
-					"id": 434,
+					"id": 438,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23580,13 +23638,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 435,
+							"id": 439,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23616,7 +23674,7 @@
 					}
 				},
 				{
-					"id": 390,
+					"id": 394,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23626,13 +23684,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 391,
+							"id": 395,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23653,40 +23711,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 392,
+									"id": 396,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 393,
+									"id": 397,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 394,
+									"id": 398,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 395,
+									"id": 399,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23700,7 +23758,7 @@
 									}
 								},
 								{
-									"id": 396,
+									"id": 400,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23725,7 +23783,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 397,
+									"id": 401,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23777,7 +23835,7 @@
 					}
 				},
 				{
-					"id": 398,
+					"id": 402,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -23787,13 +23845,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 399,
+							"id": 403,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -23804,21 +23862,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 400,
+									"id": 404,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 401,
+									"id": 405,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23832,7 +23890,7 @@
 									}
 								},
 								{
-									"id": 402,
+									"id": 406,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -23885,31 +23943,31 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						255
+						257
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						422,
-						444,
-						407,
-						403,
-						438,
-						416,
-						424,
-						436,
-						372,
-						366,
-						412,
 						426,
-						265,
+						448,
+						411,
+						407,
+						442,
+						420,
+						428,
+						440,
+						376,
+						370,
+						416,
 						430,
-						409,
+						267,
 						434,
-						390,
-						398
+						413,
+						438,
+						394,
+						402
 					]
 				}
 			],
@@ -23972,7 +24030,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2865,
+										"id": 2891,
 										"name": "DOMSelector"
 									}
 								},
@@ -23984,7 +24042,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2480,
+										"id": 2502,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -24006,7 +24064,7 @@
 					}
 				},
 				{
-					"id": 229,
+					"id": 231,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24016,13 +24074,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 230,
+							"id": 232,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24052,7 +24110,7 @@
 					}
 				},
 				{
-					"id": 251,
+					"id": 253,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24062,13 +24120,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 252,
+							"id": 254,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24084,7 +24142,7 @@
 							},
 							"parameters": [
 								{
-									"id": 253,
+									"id": 255,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24105,7 +24163,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -24123,7 +24181,7 @@
 					}
 				},
 				{
-					"id": 214,
+					"id": 216,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24133,13 +24191,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 215,
+							"id": 217,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24212,7 +24270,7 @@
 					]
 				},
 				{
-					"id": 210,
+					"id": 212,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24222,13 +24280,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1725,
+							"line": 1743,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 211,
+							"id": 213,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24249,7 +24307,7 @@
 					}
 				},
 				{
-					"id": 245,
+					"id": 247,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24259,13 +24317,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 246,
+							"id": 248,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24287,14 +24345,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 247,
+									"id": 249,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 249,
+											"id": 251,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24306,7 +24364,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 250,
+											"id": 252,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24318,7 +24376,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 248,
+											"id": 250,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -24335,9 +24393,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												249,
-												250,
-												248
+												251,
+												252,
+												250
 											]
 										}
 									]
@@ -24355,7 +24413,7 @@
 					}
 				},
 				{
-					"id": 223,
+					"id": 225,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24365,13 +24423,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 224,
+							"id": 226,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24387,7 +24445,7 @@
 							},
 							"parameters": [
 								{
-									"id": 225,
+									"id": 227,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24395,20 +24453,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 226,
+											"id": 228,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 227,
+												"id": 229,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 228,
+														"id": 230,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -24453,7 +24511,7 @@
 					}
 				},
 				{
-					"id": 231,
+					"id": 233,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24463,13 +24521,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 232,
+							"id": 234,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24490,7 +24548,7 @@
 					}
 				},
 				{
-					"id": 243,
+					"id": 245,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24500,13 +24558,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 244,
+							"id": 246,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24530,7 +24588,7 @@
 					}
 				},
 				{
-					"id": 179,
+					"id": 181,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24540,13 +24598,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 180,
+							"id": 182,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24562,7 +24620,7 @@
 							},
 							"parameters": [
 								{
-									"id": 181,
+									"id": 183,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24572,12 +24630,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 182,
+									"id": 184,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24587,7 +24645,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -24608,7 +24666,7 @@
 					}
 				},
 				{
-					"id": 173,
+					"id": 175,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24618,13 +24676,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 174,
+							"id": 176,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24644,7 +24702,7 @@
 							},
 							"parameters": [
 								{
-									"id": 175,
+									"id": 177,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24654,12 +24712,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 176,
+									"id": 178,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24669,12 +24727,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 177,
+									"id": 179,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24684,13 +24742,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 178,
+									"id": 180,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24719,7 +24777,7 @@
 					}
 				},
 				{
-					"id": 219,
+					"id": 221,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24729,13 +24787,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 220,
+							"id": 222,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24745,7 +24803,7 @@
 							},
 							"parameters": [
 								{
-									"id": 221,
+									"id": 223,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24760,7 +24818,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 222,
+									"id": 224,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24794,7 +24852,7 @@
 					}
 				},
 				{
-					"id": 233,
+					"id": 235,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24804,13 +24862,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 234,
+							"id": 236,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24894,7 +24952,7 @@
 					}
 				},
 				{
-					"id": 237,
+					"id": 239,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24904,13 +24962,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 238,
+							"id": 240,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24940,7 +24998,7 @@
 					}
 				},
 				{
-					"id": 216,
+					"id": 218,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -24950,13 +25008,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 217,
+							"id": 219,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -24974,7 +25032,7 @@
 							},
 							"parameters": [
 								{
-									"id": 218,
+									"id": 220,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -24987,12 +25045,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -25015,7 +25073,7 @@
 					}
 				},
 				{
-					"id": 241,
+					"id": 243,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25025,13 +25083,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 242,
+							"id": 244,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25061,7 +25119,7 @@
 					}
 				},
 				{
-					"id": 197,
+					"id": 199,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25071,13 +25129,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 198,
+							"id": 200,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25098,40 +25156,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 199,
+									"id": 201,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 200,
+									"id": 202,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 201,
+									"id": 203,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 202,
+									"id": 204,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25145,7 +25203,7 @@
 									}
 								},
 								{
-									"id": 203,
+									"id": 205,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25170,7 +25228,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 204,
+									"id": 206,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25222,7 +25280,7 @@
 					}
 				},
 				{
-					"id": 205,
+					"id": 207,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25232,13 +25290,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 206,
+							"id": 208,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25249,21 +25307,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 207,
+									"id": 209,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 208,
+									"id": 210,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25277,7 +25335,7 @@
 									}
 								},
 								{
-									"id": 209,
+									"id": 211,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25337,25 +25395,25 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						229,
-						251,
-						214,
-						78,
-						210,
-						245,
-						223,
 						231,
-						243,
-						179,
-						173,
-						219,
-						233,
-						80,
-						237,
+						253,
 						216,
-						241,
-						197,
-						205
+						78,
+						212,
+						247,
+						225,
+						233,
+						245,
+						181,
+						175,
+						221,
+						235,
+						80,
+						239,
+						218,
+						243,
+						199,
+						207
 					]
 				}
 			],
@@ -25374,7 +25432,7 @@
 			]
 		},
 		{
-			"id": 1135,
+			"id": 1145,
 			"name": "SpotterAgentEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -25398,7 +25456,7 @@
 			},
 			"children": [
 				{
-					"id": 1136,
+					"id": 1146,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -25412,35 +25470,35 @@
 					],
 					"signatures": [
 						{
-							"id": 1137,
+							"id": 1147,
 							"name": "new SpotterAgentEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1138,
+									"id": 1148,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1167,
+										"id": 1177,
 										"name": "SpotterAgentEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1135,
+								"id": 1145,
 								"name": "SpotterAgentEmbed"
 							}
 						}
 					]
 				},
 				{
-					"id": 1140,
+					"id": 1150,
 					"name": "sendMessage",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25456,14 +25514,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1141,
+							"id": 1151,
 							"name": "sendMessage",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1142,
+									"id": 1152,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25483,14 +25541,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1143,
+													"id": 1153,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1145,
+															"id": 1155,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25501,7 +25559,7 @@
 															}
 														},
 														{
-															"id": 1144,
+															"id": 1154,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25512,7 +25570,7 @@
 															}
 														},
 														{
-															"id": 1146,
+															"id": 1156,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25529,9 +25587,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1145,
-																1144,
-																1146
+																1155,
+																1154,
+																1156
 															]
 														}
 													]
@@ -25540,14 +25598,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1147,
+													"id": 1157,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1148,
+															"id": 1158,
 															"name": "container",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25558,7 +25616,7 @@
 															}
 														},
 														{
-															"id": 1150,
+															"id": 1160,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25569,7 +25627,7 @@
 															}
 														},
 														{
-															"id": 1149,
+															"id": 1159,
 															"name": "viz",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25586,9 +25644,9 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1148,
-																1150,
-																1149
+																1158,
+																1160,
+																1159
 															]
 														}
 													]
@@ -25603,7 +25661,7 @@
 					]
 				},
 				{
-					"id": 1151,
+					"id": 1161,
 					"name": "sendMessageData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25619,7 +25677,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1152,
+							"id": 1162,
 							"name": "sendMessageData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -25630,7 +25688,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1153,
+									"id": 1163,
 									"name": "userMessage",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25653,14 +25711,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1154,
+													"id": 1164,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1156,
+															"id": 1166,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25672,7 +25730,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1155,
+															"id": 1165,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25688,8 +25746,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1156,
-																1155
+																1166,
+																1165
 															]
 														}
 													]
@@ -25698,14 +25756,14 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 1157,
+													"id": 1167,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
 													"flags": {},
 													"children": [
 														{
-															"id": 1158,
+															"id": 1168,
 															"name": "data",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25713,14 +25771,14 @@
 															"type": {
 																"type": "reflection",
 																"declaration": {
-																	"id": 1159,
+																	"id": 1169,
 																	"name": "__type",
 																	"kind": 65536,
 																	"kindString": "Type literal",
 																	"flags": {},
 																	"children": [
 																		{
-																			"id": 1165,
+																			"id": 1175,
 																			"name": "acGenNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25732,7 +25790,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1164,
+																			"id": 1174,
 																			"name": "acSessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25744,7 +25802,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1160,
+																			"id": 1170,
 																			"name": "convId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25756,7 +25814,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1163,
+																			"id": 1173,
 																			"name": "genNo",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25768,7 +25826,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1161,
+																			"id": 1171,
 																			"name": "messageId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25780,7 +25838,7 @@
 																			"defaultValue": "..."
 																		},
 																		{
-																			"id": 1162,
+																			"id": 1172,
 																			"name": "sessionId",
 																			"kind": 1024,
 																			"kindString": "Property",
@@ -25797,12 +25855,12 @@
 																			"title": "Properties",
 																			"kind": 1024,
 																			"children": [
-																				1165,
-																				1164,
-																				1160,
-																				1163,
-																				1161,
-																				1162
+																				1175,
+																				1174,
+																				1170,
+																				1173,
+																				1171,
+																				1172
 																			]
 																		}
 																	]
@@ -25811,7 +25869,7 @@
 															"defaultValue": "..."
 														},
 														{
-															"id": 1166,
+															"id": 1176,
 															"name": "error",
 															"kind": 1024,
 															"kindString": "Property",
@@ -25827,8 +25885,8 @@
 															"title": "Properties",
 															"kind": 1024,
 															"children": [
-																1158,
-																1166
+																1168,
+																1176
 															]
 														}
 													]
@@ -25848,15 +25906,15 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1136
+						1146
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1140,
-						1151
+						1150,
+						1161
 					]
 				}
 			],
@@ -25870,13 +25928,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1243,
+					"id": 1255,
 					"name": "BodylessConversation"
 				}
 			]
 		},
 		{
-			"id": 1274,
+			"id": 1286,
 			"name": "SpotterEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -25900,7 +25958,7 @@
 			},
 			"children": [
 				{
-					"id": 1275,
+					"id": 1287,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -25908,20 +25966,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 648,
+							"line": 663,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1276,
+							"id": 1288,
 							"name": "new SpotterEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1277,
+									"id": 1289,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -25932,21 +25990,21 @@
 									}
 								},
 								{
-									"id": 1278,
+									"id": 1290,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1460,
+										"id": 1474,
 										"name": "SpotterEmbedViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1274,
+								"id": 1286,
 								"name": "SpotterEmbed"
 							},
 							"overwrites": {
@@ -25961,7 +26019,7 @@
 					}
 				},
 				{
-					"id": 1435,
+					"id": 1449,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -25971,13 +26029,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1903,
+							"line": 1921,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1436,
+							"id": 1450,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26007,7 +26065,7 @@
 					}
 				},
 				{
-					"id": 1457,
+					"id": 1471,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26017,13 +26075,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2171,
+							"line": 2191,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1458,
+							"id": 1472,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26039,7 +26097,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1459,
+									"id": 1473,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26060,7 +26118,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1872,
+										"id": 1892,
 										"name": "AnswerService"
 									}
 								],
@@ -26078,7 +26136,7 @@
 					}
 				},
 				{
-					"id": 1420,
+					"id": 1434,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26088,13 +26146,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1763,
+							"line": 1781,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1421,
+							"id": 1435,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26135,7 +26193,7 @@
 					}
 				},
 				{
-					"id": 1284,
+					"id": 1296,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26145,13 +26203,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 738,
+							"line": 755,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1285,
+							"id": 1297,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26172,7 +26230,7 @@
 					}
 				},
 				{
-					"id": 1451,
+					"id": 1465,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26182,13 +26240,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2157,
+							"line": 2176,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1452,
+							"id": 1466,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26210,14 +26268,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1453,
+									"id": 1467,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1455,
+											"id": 1469,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26229,7 +26287,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1456,
+											"id": 1470,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26241,7 +26299,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1454,
+											"id": 1468,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -26258,9 +26316,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1455,
-												1456,
-												1454
+												1469,
+												1470,
+												1468
 											]
 										}
 									]
@@ -26278,7 +26336,7 @@
 					}
 				},
 				{
-					"id": 1429,
+					"id": 1443,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26288,13 +26346,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1824,
+							"line": 1842,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1430,
+							"id": 1444,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26310,7 +26368,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1431,
+									"id": 1445,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26318,20 +26376,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1432,
+											"id": 1446,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1433,
+												"id": 1447,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1434,
+														"id": 1448,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -26376,7 +26434,7 @@
 					}
 				},
 				{
-					"id": 1437,
+					"id": 1451,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26386,13 +26444,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1938,
+							"line": 1956,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1438,
+							"id": 1452,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26413,7 +26471,7 @@
 					}
 				},
 				{
-					"id": 1449,
+					"id": 1463,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26423,13 +26481,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2113,
+							"line": 2131,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1450,
+							"id": 1464,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26453,7 +26511,7 @@
 					}
 				},
 				{
-					"id": 1387,
+					"id": 1401,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26463,13 +26521,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1503,
+							"line": 1521,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1388,
+							"id": 1402,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26485,7 +26543,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1389,
+									"id": 1403,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26495,12 +26553,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1390,
+									"id": 1404,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26510,7 +26568,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								}
@@ -26531,7 +26589,7 @@
 					}
 				},
 				{
-					"id": 1381,
+					"id": 1395,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26541,13 +26599,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1474,
+							"line": 1492,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1382,
+							"id": 1396,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26567,7 +26625,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1383,
+									"id": 1397,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26577,12 +26635,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2001,
+										"id": 2021,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1384,
+									"id": 1398,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26592,12 +26650,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2869,
+										"id": 2895,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1385,
+									"id": 1399,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26607,13 +26665,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2866,
+										"id": 2892,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1386,
+									"id": 1400,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26642,7 +26700,7 @@
 					}
 				},
 				{
-					"id": 1425,
+					"id": 1439,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26652,13 +26710,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1792,
+							"line": 1810,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1426,
+							"id": 1440,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26668,7 +26726,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1427,
+									"id": 1441,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26683,7 +26741,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1428,
+									"id": 1442,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26717,7 +26775,7 @@
 					}
 				},
 				{
-					"id": 1439,
+					"id": 1453,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26727,13 +26785,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1949,
+							"line": 1967,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1440,
+							"id": 1454,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26770,7 +26828,7 @@
 					}
 				},
 				{
-					"id": 1286,
+					"id": 1298,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26780,13 +26838,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 785,
+							"line": 802,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1287,
+							"id": 1299,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26796,7 +26854,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1274,
+										"id": 1286,
 										"name": "SpotterEmbed"
 									}
 								],
@@ -26814,7 +26872,7 @@
 					}
 				},
 				{
-					"id": 1443,
+					"id": 1457,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26824,13 +26882,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1987,
+							"line": 2005,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1444,
+							"id": 1458,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26860,7 +26918,7 @@
 					}
 				},
 				{
-					"id": 1422,
+					"id": 1436,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26870,13 +26928,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1783,
+							"line": 1801,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1423,
+							"id": 1437,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26894,7 +26952,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1424,
+									"id": 1438,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -26907,12 +26965,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2233,
+												"id": 2253,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2130,
+												"id": 2150,
 												"name": "HostEvent"
 											}
 										]
@@ -26935,7 +26993,7 @@
 					}
 				},
 				{
-					"id": 1447,
+					"id": 1461,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26945,13 +27003,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 2082,
+							"line": 2100,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1448,
+							"id": 1462,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -26981,7 +27039,7 @@
 					}
 				},
 				{
-					"id": 1405,
+					"id": 1419,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -26991,13 +27049,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1628,
+							"line": 1646,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1406,
+							"id": 1420,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27018,40 +27076,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1407,
+									"id": 1421,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2130,
+										"id": 2150,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1408,
+									"id": 1422,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1409,
+									"id": 1423,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2223,
+										"id": 2243,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1410,
+									"id": 1424,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27065,7 +27123,7 @@
 									}
 								},
 								{
-									"id": 1411,
+									"id": 1425,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27090,7 +27148,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1412,
+									"id": 1426,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27142,7 +27200,7 @@
 					}
 				},
 				{
-					"id": 1413,
+					"id": 1427,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -27152,13 +27210,13 @@
 					"sources": [
 						{
 							"fileName": "embed/ts-embed.ts",
-							"line": 1698,
+							"line": 1716,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1414,
+							"id": 1428,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -27169,21 +27227,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1415,
+									"id": 1429,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3213,
+										"id": 3239,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1416,
+									"id": 1430,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27197,7 +27255,7 @@
 									}
 								},
 								{
-									"id": 1417,
+									"id": 1431,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -27250,38 +27308,38 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1275
+						1287
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1435,
-						1457,
-						1420,
-						1284,
-						1451,
-						1429,
-						1437,
 						1449,
-						1387,
-						1381,
-						1425,
-						1439,
-						1286,
+						1471,
+						1434,
+						1296,
+						1465,
 						1443,
-						1422,
-						1447,
-						1405,
-						1413
+						1451,
+						1463,
+						1401,
+						1395,
+						1439,
+						1453,
+						1298,
+						1457,
+						1436,
+						1461,
+						1419,
+						1427
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 647,
+					"line": 662,
 					"character": 13
 				}
 			],
@@ -27294,13 +27352,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1616,
+					"id": 1634,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2719,
+			"id": 2744,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27316,7 +27374,7 @@
 			},
 			"children": [
 				{
-					"id": 2776,
+					"id": 2801,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27340,27 +27398,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2777,
+							"id": 2802,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2778,
+								"id": 2803,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2779,
+										"id": 2804,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27396,7 +27454,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2835,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27424,7 +27482,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -27438,7 +27496,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2764,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27475,7 +27533,7 @@
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2832,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27499,13 +27557,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2447,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -27514,7 +27572,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2853,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27538,7 +27596,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2030,
+							"line": 2110,
 							"character": 4
 						}
 					],
@@ -27552,7 +27610,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2823,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27584,7 +27642,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -27601,7 +27659,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2805,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27624,13 +27682,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27639,7 +27697,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2765,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27673,12 +27731,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3239,
+						"id": 3265,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2836,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27706,7 +27764,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -27720,7 +27778,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2779,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27754,12 +27812,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1556,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2747,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27797,7 +27855,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2815,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27821,7 +27879,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -27835,7 +27893,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2797,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27859,7 +27917,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -27873,7 +27931,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2796,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27897,7 +27955,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -27905,7 +27963,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -27915,7 +27973,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2763,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27952,7 +28010,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2809,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27971,6 +28029,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -27979,7 +28041,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -27993,7 +28055,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2847,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28021,7 +28083,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 2006,
 							"character": 4
 						}
 					],
@@ -28035,7 +28097,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2852,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28063,7 +28125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2014,
+							"line": 2094,
 							"character": 4
 						}
 					],
@@ -28077,7 +28139,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2837,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28105,7 +28167,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -28119,7 +28181,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2788,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28153,7 +28215,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2819,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28177,7 +28239,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -28191,7 +28253,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2789,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28224,7 +28286,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2780,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28262,7 +28324,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2748,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28300,7 +28362,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2760,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28338,7 +28400,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2786,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28372,7 +28434,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2812,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28396,7 +28458,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -28410,7 +28472,7 @@
 					}
 				},
 				{
-					"id": 2807,
+					"id": 2833,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28434,7 +28496,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -28448,7 +28510,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2834,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28472,7 +28534,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -28486,7 +28548,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2814,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28509,7 +28571,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -28523,7 +28585,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2793,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28547,13 +28609,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28562,7 +28624,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2761,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28596,7 +28658,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2798,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28613,7 +28675,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -28624,7 +28686,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -28632,7 +28694,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -28642,7 +28704,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2842,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28666,7 +28728,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1686,
+							"line": 1766,
 							"character": 4
 						}
 					],
@@ -28674,7 +28736,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2846,
+							"id": 2872,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -28684,7 +28746,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2840,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28708,7 +28770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1639,
+							"line": 1719,
 							"character": 4
 						}
 					],
@@ -28716,7 +28778,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2858,
+							"id": 2884,
 							"name": "HomepageModule"
 						}
 					},
@@ -28726,7 +28788,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2839,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28743,14 +28805,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\nimport { ListPageColumns } from '@thoughtspot/visual-embed-sdk';\n\nconst embed = new AppEmbed('#tsEmbed', {\n   ... //other embed view config\n   hiddenListColumns : [ListPageColumns.Favorite,ListPageColumns.Author],\n})\n```\n"
+								"text": "\n```js\nimport { ListPageColumns } from '@thoughtspot/visual-embed-sdk';\n\nconst embed = new AppEmbed('#tsEmbed', {\n   ... //other embed view config\n   hiddenListColumns : [ListPageColumns.Favorites,ListPageColumns.Author],\n})\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1696,
 							"character": 4
 						}
 					],
@@ -28758,7 +28820,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3231,
+							"id": 3257,
 							"name": "ListPageColumns"
 						}
 					},
@@ -28768,7 +28830,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2752,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28806,7 +28868,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2749,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28844,7 +28906,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2746,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28882,7 +28944,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2850,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28910,7 +28972,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1981,
+							"line": 2061,
 							"character": 4
 						}
 					],
@@ -28924,7 +28986,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2843,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28952,7 +29014,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1862,
+							"line": 1942,
 							"character": 4
 						}
 					],
@@ -28966,7 +29028,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2751,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29004,7 +29066,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2750,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29042,7 +29104,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2758,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29079,7 +29141,7 @@
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2753,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29117,7 +29179,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2757,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29151,7 +29213,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2766,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29177,12 +29239,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3177,
+						"id": 3203,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2806,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29206,7 +29268,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -29220,7 +29282,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2829,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29243,7 +29305,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -29257,7 +29319,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2828,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29269,7 +29331,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -29280,7 +29342,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -29297,7 +29359,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2854,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29325,7 +29387,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2049,
+							"line": 2129,
 							"character": 4
 						}
 					],
@@ -29339,7 +29401,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2771,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29377,7 +29439,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2857,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29401,7 +29463,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2099,
+							"line": 2179,
 							"character": 4
 						}
 					],
@@ -29415,7 +29477,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2773,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29453,7 +29515,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2856,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29477,7 +29539,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2082,
+							"line": 2162,
 							"character": 4
 						}
 					],
@@ -29491,7 +29553,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2848,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29519,7 +29581,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1943,
+							"line": 2023,
 							"character": 4
 						}
 					],
@@ -29533,7 +29595,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2846,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29557,7 +29619,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1909,
+							"line": 1989,
 							"character": 4
 						}
 					],
@@ -29571,7 +29633,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2859,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29599,7 +29661,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2131,
+							"line": 2211,
 							"character": 4
 						}
 					],
@@ -29613,7 +29675,7 @@
 					}
 				},
 				{
-					"id": 2744,
+					"id": 2769,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29650,7 +29712,7 @@
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2772,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29688,7 +29750,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2827,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29708,7 +29770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -29722,7 +29784,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2770,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29756,7 +29818,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2855,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29780,7 +29842,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2067,
+							"line": 2147,
 							"character": 4
 						}
 					],
@@ -29794,7 +29856,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2838,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29818,7 +29880,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -29832,7 +29894,7 @@
 					}
 				},
 				{
-					"id": 2742,
+					"id": 2767,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29870,7 +29932,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2774,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29907,7 +29969,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2776,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29941,7 +30003,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2818,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29965,7 +30027,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -29979,7 +30041,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2800,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30003,7 +30065,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -30017,7 +30079,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2787,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30054,7 +30116,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2762,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30095,7 +30157,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2860,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30123,7 +30185,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2147,
+							"line": 2227,
 							"character": 4
 						}
 					],
@@ -30137,7 +30199,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2768,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30175,7 +30237,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2817,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30199,7 +30261,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -30213,7 +30275,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2816,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30237,7 +30299,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -30251,7 +30313,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2755,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30281,12 +30343,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1959,
+						"id": 1979,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2754,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30320,7 +30382,44 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2811,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "AllEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2810,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30336,6 +30435,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -30344,7 +30447,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -30367,7 +30470,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2808,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30383,6 +30486,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -30391,7 +30498,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -30405,7 +30512,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2820,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30429,7 +30536,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -30443,7 +30550,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2824,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30470,7 +30577,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -30484,7 +30591,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2841,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30508,7 +30615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1663,
+							"line": 1743,
 							"character": 4
 						}
 					],
@@ -30516,7 +30623,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2858,
+							"id": 2884,
 							"name": "HomepageModule"
 						}
 					},
@@ -30526,7 +30633,7 @@
 					}
 				},
 				{
-					"id": 2804,
+					"id": 2830,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30550,7 +30657,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -30558,7 +30665,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30568,7 +30675,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2831,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30592,7 +30699,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -30600,7 +30707,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30610,7 +30717,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2825,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30637,7 +30744,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -30651,7 +30758,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2822,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30674,7 +30781,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -30688,7 +30795,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2845,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30716,7 +30823,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1894,
+							"line": 1974,
 							"character": 4
 						}
 					],
@@ -30730,7 +30837,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2851,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30758,7 +30865,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1998,
+							"line": 2078,
 							"character": 4
 						}
 					],
@@ -30772,7 +30879,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2844,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30800,7 +30907,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1878,
+							"line": 1958,
 							"character": 4
 						}
 					],
@@ -30814,7 +30921,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2849,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30842,7 +30949,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1960,
+							"line": 2040,
 							"character": 4
 						}
 					],
@@ -30856,7 +30963,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2858,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30884,7 +30991,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2115,
+							"line": 2195,
 							"character": 4
 						}
 					],
@@ -30898,7 +31005,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2745,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30936,7 +31043,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2778,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30974,7 +31081,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2782,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31004,12 +31111,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1535,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2784,
 					"name": "spotterDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31046,7 +31153,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2783,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31076,12 +31183,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1559,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2781,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31111,12 +31218,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1541,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2785,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31146,12 +31253,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2698,
+						"id": 2723,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2756,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31185,7 +31292,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2777,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31223,7 +31330,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2791,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31261,7 +31368,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2826,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31288,7 +31395,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -31302,7 +31409,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2799,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31323,14 +31430,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -31338,7 +31445,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -31348,7 +31455,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2790,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31373,7 +31480,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3285,
+						"id": 3311,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -31383,110 +31490,111 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2776,
-						2809,
-						2739,
-						2806,
-						2827,
-						2797,
-						2780,
-						2740,
-						2810,
-						2754,
-						2722,
-						2789,
-						2772,
-						2771,
-						2738,
-						2784,
-						2821,
-						2826,
-						2811,
-						2763,
-						2793,
-						2764,
-						2755,
-						2723,
-						2735,
-						2761,
-						2786,
-						2807,
-						2808,
-						2788,
-						2768,
-						2736,
-						2773,
-						2816,
-						2814,
-						2813,
-						2727,
-						2724,
-						2721,
-						2824,
-						2817,
-						2726,
-						2725,
-						2733,
-						2728,
-						2732,
-						2741,
-						2781,
-						2803,
-						2802,
-						2828,
-						2746,
-						2831,
-						2748,
-						2830,
-						2822,
-						2820,
-						2833,
-						2744,
-						2747,
 						2801,
-						2745,
-						2829,
-						2812,
-						2742,
-						2749,
-						2751,
-						2792,
-						2775,
-						2762,
-						2737,
-						2834,
-						2743,
-						2791,
-						2790,
-						2730,
-						2729,
-						2785,
-						2783,
-						2794,
-						2798,
-						2815,
-						2804,
-						2805,
-						2799,
-						2796,
-						2819,
-						2825,
-						2818,
-						2823,
+						2835,
+						2764,
 						2832,
-						2720,
+						2853,
+						2823,
+						2805,
+						2765,
+						2836,
+						2779,
+						2747,
+						2815,
+						2797,
+						2796,
+						2763,
+						2809,
+						2847,
+						2852,
+						2837,
+						2788,
+						2819,
+						2789,
+						2780,
+						2748,
+						2760,
+						2786,
+						2812,
+						2833,
+						2834,
+						2814,
+						2793,
+						2761,
+						2798,
+						2842,
+						2840,
+						2839,
+						2752,
+						2749,
+						2746,
+						2850,
+						2843,
+						2751,
+						2750,
+						2758,
 						2753,
 						2757,
-						2759,
-						2758,
-						2756,
-						2760,
-						2731,
-						2752,
 						2766,
-						2800,
+						2806,
+						2829,
+						2828,
+						2854,
+						2771,
+						2857,
+						2773,
+						2856,
+						2848,
+						2846,
+						2859,
+						2769,
+						2772,
+						2827,
+						2770,
+						2855,
+						2838,
+						2767,
 						2774,
-						2765
+						2776,
+						2818,
+						2800,
+						2787,
+						2762,
+						2860,
+						2768,
+						2817,
+						2816,
+						2755,
+						2754,
+						2811,
+						2810,
+						2808,
+						2820,
+						2824,
+						2841,
+						2830,
+						2831,
+						2825,
+						2822,
+						2845,
+						2851,
+						2844,
+						2849,
+						2858,
+						2745,
+						2778,
+						2782,
+						2784,
+						2783,
+						2781,
+						2785,
+						2756,
+						2777,
+						2791,
+						2826,
+						2799,
+						2790
 					]
 				}
 			],
@@ -31505,7 +31613,7 @@
 			]
 		},
 		{
-			"id": 1819,
+			"id": 1839,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31521,14 +31629,14 @@
 			},
 			"children": [
 				{
-					"id": 1856,
+					"id": 1876,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1857,
+							"id": 1877,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31538,19 +31646,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1858,
+									"id": 1878,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1818,
+										"id": 1838,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1859,
+									"id": 1879,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31574,14 +31682,14 @@
 					]
 				},
 				{
-					"id": 1860,
+					"id": 1880,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1861,
+							"id": 1881,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31591,7 +31699,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1862,
+									"id": 1882,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31599,12 +31707,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1829,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1863,
+									"id": 1883,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31613,21 +31721,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1864,
+											"id": 1884,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1865,
+													"id": 1885,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1866,
+															"id": 1886,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31653,7 +31761,7 @@
 									}
 								},
 								{
-									"id": 1867,
+									"id": 1887,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31665,7 +31773,7 @@
 									}
 								},
 								{
-									"id": 1868,
+									"id": 1888,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31681,21 +31789,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1820,
+					"id": 1840,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1821,
+							"id": 1841,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31705,7 +31813,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1822,
+									"id": 1842,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31713,12 +31821,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1830,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1823,
+									"id": 1843,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31729,28 +31837,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1824,
+											"id": 1844,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1825,
+													"id": 1845,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1826,
+															"id": 1846,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1802,
+																"id": 1822,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31767,12 +31875,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1827,
+							"id": 1847,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31782,7 +31890,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1828,
+									"id": 1848,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31793,29 +31901,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1831,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1814,
+												"id": 1834,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1815,
+												"id": 1835,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1816,
+												"id": 1836,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1829,
+									"id": 1849,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31826,14 +31934,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1830,
+											"id": 1850,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1831,
+													"id": 1851,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -31850,31 +31958,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1832,
+							"id": 1852,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1833,
+									"id": 1853,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1813,
+										"id": 1833,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1834,
+									"id": 1854,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31882,21 +31990,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1835,
+											"id": 1855,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1836,
+													"id": 1856,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1837,
+															"id": 1857,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31919,40 +32027,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1838,
+					"id": 1858,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1839,
+							"id": 1859,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1840,
+									"id": 1860,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1810,
+										"id": 1830,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1841,
+									"id": 1861,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31960,28 +32068,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1842,
+											"id": 1862,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1843,
+													"id": 1863,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1844,
+															"id": 1864,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1802,
+																"id": 1822,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31998,19 +32106,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1845,
+							"id": 1865,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1846,
+									"id": 1866,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32020,29 +32128,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1811,
+												"id": 1831,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1814,
+												"id": 1834,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1815,
+												"id": 1835,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1816,
+												"id": 1836,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1847,
+									"id": 1867,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32050,14 +32158,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1848,
+											"id": 1868,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1849,
+													"id": 1869,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -32074,31 +32182,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1850,
+							"id": 1870,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1851,
+									"id": 1871,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1813,
+										"id": 1833,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1852,
+									"id": 1872,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32106,21 +32214,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1853,
+											"id": 1873,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1854,
+													"id": 1874,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1855,
+															"id": 1875,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32143,21 +32251,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1869,
+					"id": 1889,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1870,
+							"id": 1890,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -32167,7 +32275,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1871,
+									"id": 1891,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32177,14 +32285,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1809,
+										"id": 1829,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1819,
+								"id": 1839,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -32196,11 +32304,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1856,
-						1860,
-						1820,
-						1838,
-						1869
+						1876,
+						1880,
+						1840,
+						1858,
+						1889
 					]
 				}
 			],
@@ -32213,7 +32321,7 @@
 			]
 		},
 		{
-			"id": 1205,
+			"id": 1216,
 			"name": "BodylessConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -32233,7 +32341,7 @@
 			},
 			"children": [
 				{
-					"id": 1216,
+					"id": 1227,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32257,27 +32365,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1217,
+							"id": 1228,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1218,
+								"id": 1229,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1219,
+										"id": 1230,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -32309,12 +32417,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1178,
+						"id": 1188,
 						"name": "SpotterAgentEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1236,
+					"id": 1248,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32346,7 +32454,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -32359,12 +32467,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1198,
+						"id": 1209,
 						"name": "SpotterAgentEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1220,
+					"id": 1231,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32387,23 +32495,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1182,
+						"id": 1192,
 						"name": "SpotterAgentEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1229,
+					"id": 1241,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32427,7 +32535,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -32437,12 +32545,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1191,
+						"id": 1202,
 						"name": "SpotterAgentEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1212,
+					"id": 1223,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32466,7 +32574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -32476,12 +32584,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1174,
+						"id": 1184,
 						"name": "SpotterAgentEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1211,
+					"id": 1222,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32505,7 +32613,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -32513,18 +32621,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1173,
+						"id": 1183,
 						"name": "SpotterAgentEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1224,
+					"id": 1235,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32543,6 +32651,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -32551,7 +32663,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -32561,12 +32673,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1186,
+						"id": 1196,
 						"name": "SpotterAgentEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1233,
+					"id": 1245,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32590,7 +32702,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -32600,12 +32712,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1195,
+						"id": 1206,
 						"name": "SpotterAgentEmbedViewConfig.enableLinkOverridesV2"
 					}
 				},
 				{
-					"id": 1226,
+					"id": 1238,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32629,7 +32741,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -32639,12 +32751,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1188,
+						"id": 1199,
 						"name": "SpotterAgentEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1228,
+					"id": 1240,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32667,7 +32779,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -32677,12 +32789,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1190,
+						"id": 1201,
 						"name": "SpotterAgentEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1208,
+					"id": 1219,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32706,23 +32818,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1170,
+						"id": 1180,
 						"name": "SpotterAgentEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1213,
+					"id": 1224,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32739,7 +32851,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -32750,7 +32862,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -32758,18 +32870,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1175,
+						"id": 1185,
 						"name": "SpotterAgentEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1221,
+					"id": 1232,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32793,7 +32905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -32803,12 +32915,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1183,
+						"id": 1193,
 						"name": "SpotterAgentEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1242,
+					"id": 1254,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32831,7 +32943,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -32841,12 +32953,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1204,
+						"id": 1215,
 						"name": "SpotterAgentEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1241,
+					"id": 1253,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32858,7 +32970,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -32869,7 +32981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -32882,12 +32994,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1203,
+						"id": 1214,
 						"name": "SpotterAgentEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1240,
+					"id": 1252,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32907,7 +33019,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -32917,12 +33029,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1202,
+						"id": 1213,
 						"name": "SpotterAgentEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1232,
+					"id": 1244,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32946,7 +33058,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -32956,12 +33068,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1194,
+						"id": 1205,
 						"name": "SpotterAgentEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1215,
+					"id": 1226,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -32985,7 +33097,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -32995,12 +33107,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1177,
+						"id": 1187,
 						"name": "SpotterAgentEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1231,
+					"id": 1243,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33024,7 +33136,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -33034,12 +33146,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1193,
+						"id": 1204,
 						"name": "SpotterAgentEmbedViewConfig.overrideHistoryState"
 					}
 				},
 				{
-					"id": 1230,
+					"id": 1242,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33063,7 +33175,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -33073,12 +33185,50 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1192,
+						"id": 1203,
 						"name": "SpotterAgentEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1225,
+					"id": 1237,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1198,
+						"name": "SpotterAgentEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 1236,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33094,6 +33244,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -33102,7 +33256,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -33121,12 +33275,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1187,
+						"id": 1197,
 						"name": "SpotterAgentEmbedViewConfig.preRenderContainer"
 					}
 				},
 				{
-					"id": 1223,
+					"id": 1234,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33142,6 +33296,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -33150,7 +33308,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -33160,12 +33318,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1185,
+						"id": 1195,
 						"name": "SpotterAgentEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1237,
+					"id": 1249,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33192,7 +33350,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -33202,12 +33360,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1199,
+						"id": 1210,
 						"name": "SpotterAgentEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1238,
+					"id": 1250,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33234,7 +33392,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -33244,12 +33402,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1200,
+						"id": 1211,
 						"name": "SpotterAgentEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1235,
+					"id": 1247,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33272,7 +33430,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -33282,12 +33440,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1197,
+						"id": 1208,
 						"name": "SpotterAgentEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1239,
+					"id": 1251,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33314,7 +33472,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -33324,12 +33482,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1201,
+						"id": 1212,
 						"name": "SpotterAgentEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1214,
+					"id": 1225,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33350,14 +33508,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -33365,18 +33523,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1176,
+						"id": 1186,
 						"name": "SpotterAgentEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1206,
+					"id": 1217,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33397,7 +33555,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1168,
+						"id": 1178,
 						"name": "SpotterAgentEmbedViewConfig.worksheetId"
 					}
 				}
@@ -33407,34 +33565,35 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1216,
-						1236,
-						1220,
-						1229,
-						1212,
-						1211,
-						1224,
-						1233,
-						1226,
-						1228,
-						1208,
-						1213,
-						1221,
-						1242,
-						1241,
-						1240,
-						1232,
-						1215,
+						1227,
+						1248,
 						1231,
-						1230,
-						1225,
+						1241,
 						1223,
-						1237,
-						1238,
+						1222,
 						1235,
-						1239,
-						1214,
-						1206
+						1245,
+						1238,
+						1240,
+						1219,
+						1224,
+						1232,
+						1254,
+						1253,
+						1252,
+						1244,
+						1226,
+						1243,
+						1242,
+						1237,
+						1236,
+						1234,
+						1249,
+						1250,
+						1247,
+						1251,
+						1225,
+						1217
 					]
 				}
 			],
@@ -33448,13 +33607,13 @@
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1167,
+					"id": 1177,
 					"name": "SpotterAgentEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1557,
+			"id": 1573,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33474,7 +33633,7 @@
 			},
 			"children": [
 				{
-					"id": 1589,
+					"id": 1606,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33498,27 +33657,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1590,
+							"id": 1607,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1591,
+								"id": 1608,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1592,
+										"id": 1609,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33550,12 +33709,51 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1492,
+						"id": 1507,
 						"name": "SpotterEmbedViewConfig.additionalFlags"
 					}
 				},
 				{
-					"id": 1609,
+					"id": 1576,
+					"name": "analystId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Pins the embed to a single spotter analyst. Implies no default Spotter\nand no \"Show all\".",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   analystId: 'analyst-id-1234',\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 320,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1477,
+						"name": "SpotterEmbedViewConfig.analystId"
+					}
+				},
+				{
+					"id": 1627,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33587,7 +33785,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -33600,12 +33798,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1512,
+						"id": 1528,
 						"name": "SpotterEmbedViewConfig.customActions"
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1610,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33628,23 +33826,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1496,
+						"id": 1511,
 						"name": "SpotterEmbedViewConfig.customizations"
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1580,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33672,7 +33870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 354,
+							"line": 369,
 							"character": 4
 						}
 					],
@@ -33682,12 +33880,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1466,
+						"id": 1481,
 						"name": "SpotterEmbedViewConfig.dataPanelV2"
 					}
 				},
 				{
-					"id": 1559,
+					"id": 1575,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33724,12 +33922,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1462,
+						"id": 1476,
 						"name": "SpotterEmbedViewConfig.dataSources"
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1589,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33757,23 +33955,23 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 497,
+							"line": 512,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1556,
 						"name": "SpotterQueryMode"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1475,
+						"id": 1490,
 						"name": "SpotterEmbedViewConfig.defaultQueryMode"
 					}
 				},
 				{
-					"id": 1602,
+					"id": 1620,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33797,7 +33995,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -33807,12 +34005,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1505,
+						"id": 1521,
 						"name": "SpotterEmbedViewConfig.disableRedirectionLinksInNewTab"
 					}
 				},
 				{
-					"id": 1561,
+					"id": 1578,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33836,7 +34034,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 324,
+							"line": 339,
 							"character": 4
 						}
 					],
@@ -33846,12 +34044,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1464,
+						"id": 1479,
 						"name": "SpotterEmbedViewConfig.disableSourceSelection"
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1602,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33875,7 +34073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -33885,12 +34083,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1488,
+						"id": 1503,
 						"name": "SpotterEmbedViewConfig.disabledActionReason"
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1601,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33914,7 +34112,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -33922,18 +34120,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1487,
+						"id": 1502,
 						"name": "SpotterEmbedViewConfig.disabledActions"
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1614,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33952,6 +34150,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -33960,7 +34162,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -33970,12 +34172,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1500,
+						"id": 1515,
 						"name": "SpotterEmbedViewConfig.doNotTrackPreRenderSize"
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1624,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33999,7 +34201,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -34009,12 +34211,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1509,
+						"id": 1525,
 						"name": "SpotterEmbedViewConfig.enableLinkOverridesV2"
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1591,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34042,7 +34244,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 516,
+							"line": 531,
 							"character": 4
 						}
 					],
@@ -34052,12 +34254,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1477,
+						"id": 1492,
 						"name": "SpotterEmbedViewConfig.enablePastConversationsSidebar"
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1590,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34081,7 +34283,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 506,
+							"line": 521,
 							"character": 4
 						}
 					],
@@ -34091,12 +34293,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1476,
+						"id": 1491,
 						"name": "SpotterEmbedViewConfig.enableStopAnswerGenerationEmbed"
 					}
 				},
 				{
-					"id": 1599,
+					"id": 1617,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34120,7 +34322,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -34130,12 +34332,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1502,
+						"id": 1518,
 						"name": "SpotterEmbedViewConfig.enableV2Shell_experimental"
 					}
 				},
 				{
-					"id": 1567,
+					"id": 1584,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34159,7 +34361,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 418,
+							"line": 433,
 							"character": 4
 						}
 					],
@@ -34169,12 +34371,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1470,
+						"id": 1485,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeFiltersfromURL"
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1586,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34198,7 +34400,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 449,
+							"line": 464,
 							"character": 4
 						}
 					],
@@ -34208,12 +34410,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1472,
+						"id": 1487,
 						"name": "SpotterEmbedViewConfig.excludeRuntimeParametersfromURL"
 					}
 				},
 				{
-					"id": 1601,
+					"id": 1619,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34236,7 +34438,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -34246,12 +34448,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1504,
+						"id": 1520,
 						"name": "SpotterEmbedViewConfig.exposeTranslationIDs"
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1598,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34275,23 +34477,23 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1484,
+						"id": 1499,
 						"name": "SpotterEmbedViewConfig.frameParams"
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1603,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34308,7 +34510,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -34319,7 +34521,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -34327,18 +34529,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1489,
+						"id": 1504,
 						"name": "SpotterEmbedViewConfig.hiddenActions"
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1582,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34362,7 +34564,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 385,
+							"line": 400,
 							"character": 4
 						}
 					],
@@ -34372,12 +34574,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1468,
+						"id": 1483,
 						"name": "SpotterEmbedViewConfig.hideSampleQuestions"
 					}
 				},
 				{
-					"id": 1562,
+					"id": 1579,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34401,7 +34603,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 338,
+							"line": 353,
 							"character": 4
 						}
 					],
@@ -34411,12 +34613,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1465,
+						"id": 1480,
 						"name": "SpotterEmbedViewConfig.hideSourceSelection"
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1611,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34440,7 +34642,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -34450,12 +34652,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1497,
+						"id": 1512,
 						"name": "SpotterEmbedViewConfig.insertAsSibling"
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1633,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34478,7 +34680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -34488,12 +34690,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1518,
+						"id": 1534,
 						"name": "SpotterEmbedViewConfig.interceptTimeout"
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1632,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34505,7 +34707,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -34516,7 +34718,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -34529,12 +34731,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1517,
+						"id": 1533,
 						"name": "SpotterEmbedViewConfig.interceptUrls"
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1631,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34554,7 +34756,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -34564,12 +34766,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1516,
+						"id": 1532,
 						"name": "SpotterEmbedViewConfig.isOnBeforeGetVizDataInterceptEnabled"
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1623,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34593,7 +34795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -34603,12 +34805,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1508,
+						"id": 1524,
 						"name": "SpotterEmbedViewConfig.linkOverride"
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1605,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34632,7 +34834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -34642,12 +34844,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1491,
+						"id": 1506,
 						"name": "SpotterEmbedViewConfig.locale"
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1622,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34671,7 +34873,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -34681,12 +34883,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1507,
+						"id": 1523,
 						"name": "SpotterEmbedViewConfig.overrideHistoryState"
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1621,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34710,7 +34912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -34720,12 +34922,50 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1506,
+						"id": 1522,
 						"name": "SpotterEmbedViewConfig.overrideOrgId"
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1616,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1517,
+						"name": "SpotterEmbedViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 1615,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34741,6 +34981,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -34749,7 +34993,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -34768,12 +35012,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1501,
+						"id": 1516,
 						"name": "SpotterEmbedViewConfig.preRenderContainer"
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1613,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34789,6 +35033,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -34797,7 +35045,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -34807,12 +35055,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1499,
+						"id": 1514,
 						"name": "SpotterEmbedViewConfig.preRenderId"
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1628,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34839,7 +35087,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -34849,12 +35097,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1513,
+						"id": 1529,
 						"name": "SpotterEmbedViewConfig.refreshAuthTokenOnNearExpiry"
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1583,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34878,7 +35126,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 406,
+							"line": 421,
 							"character": 4
 						}
 					],
@@ -34886,18 +35134,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1469,
+						"id": 1484,
 						"name": "SpotterEmbedViewConfig.runtimeFilters"
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1585,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34921,7 +35169,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 437,
+							"line": 452,
 							"character": 4
 						}
 					],
@@ -34929,18 +35177,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1471,
+						"id": 1486,
 						"name": "SpotterEmbedViewConfig.runtimeParameters"
 					}
 				},
 				{
-					"id": 1560,
+					"id": 1577,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34953,7 +35201,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 309,
+							"line": 324,
 							"character": 4
 						}
 					],
@@ -34963,12 +35211,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1463,
+						"id": 1478,
 						"name": "SpotterEmbedViewConfig.searchOptions"
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1595,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34992,7 +35240,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 593,
+							"line": 608,
 							"character": 4
 						}
 					],
@@ -35002,12 +35250,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1481,
+						"id": 1496,
 						"name": "SpotterEmbedViewConfig.sharedConversationId"
 					}
 				},
 				{
-					"id": 1611,
+					"id": 1629,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35034,7 +35282,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -35044,12 +35292,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1514,
+						"id": 1530,
 						"name": "SpotterEmbedViewConfig.shouldBypassPayloadValidation"
 					}
 				},
 				{
-					"id": 1608,
+					"id": 1626,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35072,7 +35320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -35082,12 +35330,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1511,
+						"id": 1527,
 						"name": "SpotterEmbedViewConfig.showAlerts"
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1581,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35111,7 +35359,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 370,
+							"line": 385,
 							"character": 4
 						}
 					],
@@ -35121,12 +35369,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1467,
+						"id": 1482,
 						"name": "SpotterEmbedViewConfig.showSpotterLimitations"
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1588,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35154,7 +35402,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 479,
+							"line": 494,
 							"character": 4
 						}
 					],
@@ -35164,12 +35412,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1474,
+						"id": 1489,
 						"name": "SpotterEmbedViewConfig.showSpotterRadiance"
 					}
 				},
 				{
-					"id": 1576,
+					"id": 1593,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35193,23 +35441,23 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 555,
+							"line": 570,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1535,
 						"name": "SpotterChatViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1479,
+						"id": 1494,
 						"name": "SpotterEmbedViewConfig.spotterChatConfig"
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1594,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35233,23 +35481,23 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 571,
+							"line": 586,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1559,
 						"name": "SpotterShareConversationConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1480,
+						"id": 1495,
 						"name": "SpotterEmbedViewConfig.spotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1592,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35273,23 +35521,23 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 552,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1541,
 						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1478,
+						"id": 1493,
 						"name": "SpotterEmbedViewConfig.spotterSidebarConfig"
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1587,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35317,7 +35565,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 464,
+							"line": 479,
 							"character": 4
 						}
 					],
@@ -35327,12 +35575,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1473,
+						"id": 1488,
 						"name": "SpotterEmbedViewConfig.updatedSpotterChatPrompt"
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1596,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35360,7 +35608,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 608,
+							"line": 623,
 							"character": 4
 						}
 					],
@@ -35370,12 +35618,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1482,
+						"id": 1497,
 						"name": "SpotterEmbedViewConfig.updatedSpotterExperience"
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1630,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35402,7 +35650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -35412,12 +35660,12 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1515,
+						"id": 1531,
 						"name": "SpotterEmbedViewConfig.useHostEventsV2"
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1604,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35438,14 +35686,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -35453,18 +35701,18 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1490,
+						"id": 1505,
 						"name": "SpotterEmbedViewConfig.visibleActions"
 					}
 				},
 				{
-					"id": 1558,
+					"id": 1574,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35487,7 +35735,7 @@
 					},
 					"inheritedFrom": {
 						"type": "reference",
-						"id": 1461,
+						"id": 1475,
 						"name": "SpotterEmbedViewConfig.worksheetId"
 					}
 				}
@@ -35497,75 +35745,77 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1589,
-						1609,
-						1593,
-						1563,
-						1559,
-						1572,
-						1602,
-						1561,
-						1585,
-						1584,
-						1597,
 						1606,
-						1574,
-						1573,
-						1599,
-						1567,
-						1569,
-						1601,
-						1581,
-						1586,
-						1565,
-						1562,
-						1594,
-						1615,
-						1614,
-						1613,
-						1605,
-						1588,
-						1604,
-						1603,
-						1598,
-						1596,
-						1610,
-						1566,
-						1568,
-						1560,
-						1578,
-						1611,
-						1608,
-						1564,
-						1571,
 						1576,
-						1577,
+						1627,
+						1610,
+						1580,
 						1575,
-						1570,
+						1589,
+						1620,
+						1578,
+						1602,
+						1601,
+						1614,
+						1624,
+						1591,
+						1590,
+						1617,
+						1584,
+						1586,
+						1619,
+						1598,
+						1603,
+						1582,
 						1579,
-						1612,
+						1611,
+						1633,
+						1632,
+						1631,
+						1623,
+						1605,
+						1622,
+						1621,
+						1616,
+						1615,
+						1613,
+						1628,
+						1583,
+						1585,
+						1577,
+						1595,
+						1629,
+						1626,
+						1581,
+						1588,
+						1593,
+						1594,
+						1592,
 						1587,
-						1558
+						1596,
+						1630,
+						1604,
+						1574
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 618,
+					"line": 633,
 					"character": 17
 				}
 			],
 			"extendedTypes": [
 				{
 					"type": "reference",
-					"id": 1460,
+					"id": 1474,
 					"name": "SpotterEmbedViewConfig"
 				}
 			]
 		},
 		{
-			"id": 3193,
+			"id": 3219,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35580,7 +35830,7 @@
 			},
 			"children": [
 				{
-					"id": 3194,
+					"id": 3220,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35590,21 +35840,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8685,
+							"line": 8789,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3195,
+							"id": 3221,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3196,
+									"id": 3222,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35612,18 +35862,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8686,
+											"line": 8790,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3190,
+										"id": 3216,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3197,
+									"id": 3223,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35631,7 +35881,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8687,
+											"line": 8791,
 											"character": 8
 										}
 									],
@@ -35639,7 +35889,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3190,
+											"id": 3216,
 											"name": "VizPoint"
 										}
 									}
@@ -35650,8 +35900,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3196,
-										3197
+										3222,
+										3223
 									]
 								}
 							]
@@ -35659,7 +35909,7 @@
 					}
 				},
 				{
-					"id": 3198,
+					"id": 3224,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35667,21 +35917,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8689,
+							"line": 8793,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3199,
+							"id": 3225,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3207,
+									"id": 3233,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35689,7 +35939,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8697,
+											"line": 8801,
 											"character": 8
 										}
 									],
@@ -35702,7 +35952,7 @@
 									}
 								},
 								{
-									"id": 3208,
+									"id": 3234,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35710,7 +35960,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8698,
+											"line": 8802,
 											"character": 8
 										}
 									],
@@ -35723,7 +35973,7 @@
 									}
 								},
 								{
-									"id": 3201,
+									"id": 3227,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35731,7 +35981,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8691,
+											"line": 8795,
 											"character": 8
 										}
 									],
@@ -35741,7 +35991,7 @@
 									}
 								},
 								{
-									"id": 3200,
+									"id": 3226,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35749,7 +35999,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8690,
+											"line": 8794,
 											"character": 8
 										}
 									],
@@ -35759,7 +36009,7 @@
 									}
 								},
 								{
-									"id": 3202,
+									"id": 3228,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35767,21 +36017,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8692,
+											"line": 8796,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3203,
+											"id": 3229,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3204,
+													"id": 3230,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -35789,21 +36039,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8693,
+															"line": 8797,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3205,
+															"id": 3231,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3206,
+																	"id": 3232,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -35811,7 +36061,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8694,
+																			"line": 8798,
 																			"character": 16
 																		}
 																	],
@@ -35826,7 +36076,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3206
+																		3232
 																	]
 																}
 															]
@@ -35839,7 +36089,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3204
+														3230
 													]
 												}
 											]
@@ -35852,23 +36102,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3207,
-										3208,
-										3201,
-										3200,
-										3202
+										3233,
+										3234,
+										3227,
+										3226,
+										3228
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3209,
+								"id": 3235,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3210,
+										"id": 3236,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -35887,7 +36137,7 @@
 					}
 				},
 				{
-					"id": 3211,
+					"id": 3237,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35895,18 +36145,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8701,
+							"line": 8805,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1949,
+						"id": 1969,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3212,
+					"id": 3238,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35916,7 +36166,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8702,
+							"line": 8806,
 							"character": 4
 						}
 					],
@@ -35931,23 +36181,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3194,
-						3198,
-						3211,
-						3212
+						3220,
+						3224,
+						3237,
+						3238
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8684,
+					"line": 8788,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2904,
+			"id": 2930,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35957,7 +36207,7 @@
 			},
 			"children": [
 				{
-					"id": 2967,
+					"id": 2993,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35980,7 +36230,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2992,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36003,7 +36253,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2962,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36026,7 +36276,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2963,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36049,7 +36299,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2965,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36072,7 +36322,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2964,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36095,7 +36345,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2935,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36118,7 +36368,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 3005,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36141,7 +36391,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 3006,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36164,7 +36414,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 3003,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36187,7 +36437,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 3004,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36210,7 +36460,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2967,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36233,7 +36483,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2972,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36256,7 +36506,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2969,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36279,7 +36529,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2971,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36302,7 +36552,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2970,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36325,7 +36575,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2968,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36348,7 +36598,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2977,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36371,7 +36621,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2974,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36394,7 +36644,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2976,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36417,7 +36667,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2975,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36440,7 +36690,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2973,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36463,7 +36713,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2981,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36486,7 +36736,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2980,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36509,7 +36759,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2979,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36532,7 +36782,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2978,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36555,7 +36805,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2966,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36578,7 +36828,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3101,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36601,7 +36851,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3096,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36624,7 +36874,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3091,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36647,7 +36897,7 @@
 					}
 				},
 				{
-					"id": 3064,
+					"id": 3090,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36670,7 +36920,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3093,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36693,7 +36943,7 @@
 					}
 				},
 				{
-					"id": 3066,
+					"id": 3092,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36716,7 +36966,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3028,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36739,7 +36989,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3031,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,7 +37012,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3026,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36785,7 +37035,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3029,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36808,7 +37058,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3030,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36831,7 +37081,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3025,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36854,7 +37104,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3027,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36877,7 +37127,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2998,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36900,7 +37150,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2997,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36923,7 +37173,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 3000,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36946,7 +37196,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2999,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36969,7 +37219,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2996,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36992,7 +37242,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2994,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37015,7 +37265,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2995,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37038,7 +37288,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 3001,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37061,7 +37311,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 3002,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37084,7 +37334,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 3013,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37107,7 +37357,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 3014,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37130,7 +37380,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 3017,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37153,7 +37403,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 3015,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37176,7 +37426,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 3016,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37199,7 +37449,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3024,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37222,7 +37472,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3023,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37245,7 +37495,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 3022,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37268,7 +37518,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3021,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37291,7 +37541,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3089,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37314,7 +37564,7 @@
 					}
 				},
 				{
-					"id": 3062,
+					"id": 3088,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37337,7 +37587,7 @@
 					}
 				},
 				{
-					"id": 3061,
+					"id": 3087,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37360,7 +37610,7 @@
 					}
 				},
 				{
-					"id": 3069,
+					"id": 3095,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37383,7 +37633,7 @@
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3094,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37406,7 +37656,7 @@
 					}
 				},
 				{
-					"id": 2913,
+					"id": 2939,
 					"name": "--ts-var-left-nav-active-tab-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37429,7 +37679,7 @@
 					}
 				},
 				{
-					"id": 2914,
+					"id": 2940,
 					"name": "--ts-var-left-nav-active-tab-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37452,7 +37702,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2938,
 					"name": "--ts-var-left-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,7 +37725,7 @@
 					}
 				},
 				{
-					"id": 2916,
+					"id": 2942,
 					"name": "--ts-var-left-nav-item-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37498,7 +37748,7 @@
 					}
 				},
 				{
-					"id": 2918,
+					"id": 2944,
 					"name": "--ts-var-left-nav-item-selection-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37521,7 +37771,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2943,
 					"name": "--ts-var-left-nav-item-selection-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37544,7 +37794,7 @@
 					}
 				},
 				{
-					"id": 2915,
+					"id": 2941,
 					"name": "--ts-var-left-nav-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37567,7 +37817,7 @@
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2945,
 					"name": "--ts-var-left-nav-tab-icon-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37590,7 +37840,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2946,
 					"name": "--ts-var-left-nav-tab-icon-inactive-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37613,7 +37863,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 3019,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37636,7 +37886,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 3018,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37659,7 +37909,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3048,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37682,7 +37932,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3061,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37706,7 +37956,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3060,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37730,7 +37980,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3058,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37754,7 +38004,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3059,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37778,7 +38028,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3066,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37801,7 +38051,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3064,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37824,7 +38074,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3063,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37847,7 +38097,7 @@
 					}
 				},
 				{
-					"id": 3124,
+					"id": 3150,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37870,7 +38120,7 @@
 					}
 				},
 				{
-					"id": 3128,
+					"id": 3154,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37893,7 +38143,7 @@
 					}
 				},
 				{
-					"id": 3129,
+					"id": 3155,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37916,7 +38166,7 @@
 					}
 				},
 				{
-					"id": 3125,
+					"id": 3151,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37939,7 +38189,7 @@
 					}
 				},
 				{
-					"id": 3126,
+					"id": 3152,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37962,7 +38212,7 @@
 					}
 				},
 				{
-					"id": 3127,
+					"id": 3153,
 					"name": "--ts-var-liveboard-edit-toolbar-text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37985,7 +38235,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3049,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38009,7 +38259,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3050,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38033,7 +38283,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3054,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38057,7 +38307,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3042,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38081,7 +38331,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3057,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38105,7 +38355,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3056,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38129,7 +38379,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3047,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38153,7 +38403,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3055,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38177,7 +38427,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3045,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38201,7 +38451,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3046,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38225,7 +38475,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3053,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38249,7 +38499,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3043,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38273,7 +38523,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3044,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38297,7 +38547,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3080,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38320,7 +38570,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3077,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38343,7 +38593,7 @@
 					}
 				},
 				{
-					"id": 3052,
+					"id": 3078,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38366,7 +38616,7 @@
 					}
 				},
 				{
-					"id": 3053,
+					"id": 3079,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38389,7 +38639,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3033,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38412,7 +38662,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3086,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38435,7 +38685,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3081,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38458,7 +38708,7 @@
 					}
 				},
 				{
-					"id": 3056,
+					"id": 3082,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38481,7 +38731,7 @@
 					}
 				},
 				{
-					"id": 3059,
+					"id": 3085,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38504,7 +38754,7 @@
 					}
 				},
 				{
-					"id": 3057,
+					"id": 3083,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38527,7 +38777,7 @@
 					}
 				},
 				{
-					"id": 3058,
+					"id": 3084,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38550,7 +38800,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3034,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38573,7 +38823,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3038,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38596,7 +38846,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3037,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38619,7 +38869,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3032,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38642,7 +38892,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3052,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38665,7 +38915,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3051,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38688,7 +38938,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3065,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38711,7 +38961,7 @@
 					}
 				},
 				{
-					"id": 3094,
+					"id": 3120,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38734,7 +38984,7 @@
 					}
 				},
 				{
-					"id": 3091,
+					"id": 3117,
 					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38757,7 +39007,7 @@
 					}
 				},
 				{
-					"id": 3093,
+					"id": 3119,
 					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38780,7 +39030,7 @@
 					}
 				},
 				{
-					"id": 3095,
+					"id": 3121,
 					"name": "--ts-var-liveboard-styling-button-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38803,7 +39053,7 @@
 					}
 				},
 				{
-					"id": 3096,
+					"id": 3122,
 					"name": "--ts-var-liveboard-styling-button-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38826,7 +39076,7 @@
 					}
 				},
 				{
-					"id": 3092,
+					"id": 3118,
 					"name": "--ts-var-liveboard-styling-button-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38849,7 +39099,7 @@
 					}
 				},
 				{
-					"id": 3097,
+					"id": 3123,
 					"name": "--ts-var-liveboard-styling-color-palette-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38872,7 +39122,7 @@
 					}
 				},
 				{
-					"id": 3090,
+					"id": 3116,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38895,7 +39145,7 @@
 					}
 				},
 				{
-					"id": 3089,
+					"id": 3115,
 					"name": "--ts-var-liveboard-styling-panel-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38918,7 +39168,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3067,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38941,7 +39191,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3068,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38964,7 +39214,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3036,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38987,7 +39237,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3035,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39010,7 +39260,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3039,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39033,7 +39283,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3040,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39056,7 +39306,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3041,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39079,7 +39329,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3069,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39102,7 +39352,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3070,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39125,7 +39375,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 3011,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39148,7 +39398,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 3008,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39171,7 +39421,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 3007,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39194,7 +39444,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 3009,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39217,7 +39467,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 3012,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39240,7 +39490,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 3010,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39263,7 +39513,7 @@
 					}
 				},
 				{
-					"id": 2910,
+					"id": 2936,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39286,7 +39536,7 @@
 					}
 				},
 				{
-					"id": 2911,
+					"id": 2937,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39309,7 +39559,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3075,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39332,7 +39582,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3076,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39355,7 +39605,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3071,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39378,7 +39628,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3073,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39401,7 +39651,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3074,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39424,7 +39674,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3072,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39447,7 +39697,7 @@
 					}
 				},
 				{
-					"id": 2905,
+					"id": 2931,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39470,7 +39720,7 @@
 					}
 				},
 				{
-					"id": 2906,
+					"id": 2932,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39493,7 +39743,7 @@
 					}
 				},
 				{
-					"id": 2907,
+					"id": 2933,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39516,7 +39766,7 @@
 					}
 				},
 				{
-					"id": 2908,
+					"id": 2934,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39539,7 +39789,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3104,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39562,7 +39812,7 @@
 					}
 				},
 				{
-					"id": 3077,
+					"id": 3103,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39585,7 +39835,7 @@
 					}
 				},
 				{
-					"id": 3082,
+					"id": 3108,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39608,7 +39858,7 @@
 					}
 				},
 				{
-					"id": 3083,
+					"id": 3109,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39631,7 +39881,7 @@
 					}
 				},
 				{
-					"id": 3086,
+					"id": 3112,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39654,7 +39904,7 @@
 					}
 				},
 				{
-					"id": 3085,
+					"id": 3111,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39677,7 +39927,7 @@
 					}
 				},
 				{
-					"id": 3084,
+					"id": 3110,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39700,7 +39950,7 @@
 					}
 				},
 				{
-					"id": 3087,
+					"id": 3113,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39723,7 +39973,7 @@
 					}
 				},
 				{
-					"id": 3080,
+					"id": 3106,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39746,7 +39996,7 @@
 					}
 				},
 				{
-					"id": 3088,
+					"id": 3114,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39769,7 +40019,7 @@
 					}
 				},
 				{
-					"id": 3079,
+					"id": 3105,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39792,7 +40042,7 @@
 					}
 				},
 				{
-					"id": 3081,
+					"id": 3107,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39815,7 +40065,7 @@
 					}
 				},
 				{
-					"id": 2928,
+					"id": 2954,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39838,7 +40088,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2958,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39861,7 +40111,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2959,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39884,7 +40134,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2957,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39907,7 +40157,7 @@
 					}
 				},
 				{
-					"id": 2927,
+					"id": 2953,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39930,7 +40180,7 @@
 					}
 				},
 				{
-					"id": 2930,
+					"id": 2956,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39953,7 +40203,7 @@
 					}
 				},
 				{
-					"id": 2924,
+					"id": 2950,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39976,7 +40226,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2951,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39999,7 +40249,7 @@
 					}
 				},
 				{
-					"id": 2926,
+					"id": 2952,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40022,7 +40272,7 @@
 					}
 				},
 				{
-					"id": 2921,
+					"id": 2947,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40045,7 +40295,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2948,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40068,7 +40318,7 @@
 					}
 				},
 				{
-					"id": 2923,
+					"id": 2949,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40091,7 +40341,7 @@
 					}
 				},
 				{
-					"id": 2929,
+					"id": 2955,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40114,7 +40364,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3020,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40137,7 +40387,7 @@
 					}
 				},
 				{
-					"id": 3140,
+					"id": 3166,
 					"name": "--ts-var-share-chat-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40160,7 +40410,7 @@
 					}
 				},
 				{
-					"id": 3139,
+					"id": 3165,
 					"name": "--ts-var-share-chat-header-container-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40183,7 +40433,7 @@
 					}
 				},
 				{
-					"id": 3143,
+					"id": 3169,
 					"name": "--ts-var-share-chat-header-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40206,7 +40456,7 @@
 					}
 				},
 				{
-					"id": 3144,
+					"id": 3170,
 					"name": "--ts-var-share-chat-header-input-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40229,7 +40479,7 @@
 					}
 				},
 				{
-					"id": 3142,
+					"id": 3168,
 					"name": "--ts-var-share-chat-header-input-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40252,7 +40502,7 @@
 					}
 				},
 				{
-					"id": 3141,
+					"id": 3167,
 					"name": "--ts-var-share-chat-header-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40275,7 +40525,7 @@
 					}
 				},
 				{
-					"id": 3136,
+					"id": 3162,
 					"name": "--ts-var-shared-conv-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40298,7 +40548,7 @@
 					}
 				},
 				{
-					"id": 3137,
+					"id": 3163,
 					"name": "--ts-var-shared-conv-header-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40321,7 +40571,7 @@
 					}
 				},
 				{
-					"id": 3138,
+					"id": 3164,
 					"name": "--ts-var-shared-conv-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40344,7 +40594,7 @@
 					}
 				},
 				{
-					"id": 3145,
+					"id": 3171,
 					"name": "--ts-var-shimmer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40367,7 +40617,7 @@
 					}
 				},
 				{
-					"id": 3146,
+					"id": 3172,
 					"name": "--ts-var-shimmer-sweep-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40390,7 +40640,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3062,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40413,7 +40663,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3100,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40436,7 +40686,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3097,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40459,7 +40709,7 @@
 					}
 				},
 				{
-					"id": 3072,
+					"id": 3098,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40482,7 +40732,7 @@
 					}
 				},
 				{
-					"id": 3073,
+					"id": 3099,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40505,7 +40755,7 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3102,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40528,7 +40778,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2960,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40551,7 +40801,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2961,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40574,7 +40824,7 @@
 					}
 				},
 				{
-					"id": 3131,
+					"id": 3157,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40597,7 +40847,7 @@
 					}
 				},
 				{
-					"id": 3103,
+					"id": 3129,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40620,7 +40870,7 @@
 					}
 				},
 				{
-					"id": 3132,
+					"id": 3158,
 					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40643,7 +40893,7 @@
 					}
 				},
 				{
-					"id": 3130,
+					"id": 3156,
 					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40666,7 +40916,7 @@
 					}
 				},
 				{
-					"id": 3099,
+					"id": 3125,
 					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40689,7 +40939,7 @@
 					}
 				},
 				{
-					"id": 3101,
+					"id": 3127,
 					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40712,7 +40962,7 @@
 					}
 				},
 				{
-					"id": 3102,
+					"id": 3128,
 					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40735,7 +40985,7 @@
 					}
 				},
 				{
-					"id": 3100,
+					"id": 3126,
 					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40758,7 +41008,7 @@
 					}
 				},
 				{
-					"id": 3122,
+					"id": 3148,
 					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40781,7 +41031,7 @@
 					}
 				},
 				{
-					"id": 3123,
+					"id": 3149,
 					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40804,7 +41054,7 @@
 					}
 				},
 				{
-					"id": 3108,
+					"id": 3134,
 					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40827,7 +41077,7 @@
 					}
 				},
 				{
-					"id": 3098,
+					"id": 3124,
 					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40850,7 +41100,7 @@
 					}
 				},
 				{
-					"id": 3104,
+					"id": 3130,
 					"name": "--ts-var-spotterviz-prompt-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40873,7 +41123,7 @@
 					}
 				},
 				{
-					"id": 3105,
+					"id": 3131,
 					"name": "--ts-var-spotterviz-prompt-card-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40896,7 +41146,7 @@
 					}
 				},
 				{
-					"id": 3133,
+					"id": 3159,
 					"name": "--ts-var-spotterviz-reference-icon-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40919,7 +41169,7 @@
 					}
 				},
 				{
-					"id": 3135,
+					"id": 3161,
 					"name": "--ts-var-spotterviz-reference-icon-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40942,7 +41192,7 @@
 					}
 				},
 				{
-					"id": 3134,
+					"id": 3160,
 					"name": "--ts-var-spotterviz-reference-icon-selected-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40965,7 +41215,7 @@
 					}
 				},
 				{
-					"id": 3106,
+					"id": 3132,
 					"name": "--ts-var-spotterviz-text-primary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40988,7 +41238,7 @@
 					}
 				},
 				{
-					"id": 3107,
+					"id": 3133,
 					"name": "--ts-var-spotterviz-text-secondary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41011,7 +41261,7 @@
 					}
 				},
 				{
-					"id": 3112,
+					"id": 3138,
 					"name": "--ts-var-spotterviz-thinking-completed-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41034,7 +41284,7 @@
 					}
 				},
 				{
-					"id": 3114,
+					"id": 3140,
 					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41057,7 +41307,7 @@
 					}
 				},
 				{
-					"id": 3111,
+					"id": 3137,
 					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41080,7 +41330,7 @@
 					}
 				},
 				{
-					"id": 3113,
+					"id": 3139,
 					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41103,7 +41353,7 @@
 					}
 				},
 				{
-					"id": 3117,
+					"id": 3143,
 					"name": "--ts-var-spotterviz-tool-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41126,7 +41376,7 @@
 					}
 				},
 				{
-					"id": 3115,
+					"id": 3141,
 					"name": "--ts-var-spotterviz-tool-call-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41149,7 +41399,7 @@
 					}
 				},
 				{
-					"id": 3119,
+					"id": 3145,
 					"name": "--ts-var-spotterviz-tool-feedback-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41172,7 +41422,7 @@
 					}
 				},
 				{
-					"id": 3120,
+					"id": 3146,
 					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41195,7 +41445,7 @@
 					}
 				},
 				{
-					"id": 3118,
+					"id": 3144,
 					"name": "--ts-var-spotterviz-tool-json-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41218,7 +41468,7 @@
 					}
 				},
 				{
-					"id": 3121,
+					"id": 3147,
 					"name": "--ts-var-spotterviz-tool-json-input-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41241,7 +41491,7 @@
 					}
 				},
 				{
-					"id": 3116,
+					"id": 3142,
 					"name": "--ts-var-spotterviz-tool-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41264,7 +41514,7 @@
 					}
 				},
 				{
-					"id": 3110,
+					"id": 3136,
 					"name": "--ts-var-spotterviz-usermessage-icon-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41287,7 +41537,7 @@
 					}
 				},
 				{
-					"id": 3109,
+					"id": 3135,
 					"name": "--ts-var-spotterviz-usermessage-icon-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41310,7 +41560,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2990,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41333,7 +41583,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2988,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41356,7 +41606,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2989,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41379,7 +41629,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2985,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41402,7 +41652,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2986,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41425,7 +41675,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2987,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41448,7 +41698,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2991,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41471,7 +41721,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2982,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41494,7 +41744,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2983,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41517,7 +41767,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2984,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41545,248 +41795,248 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2967,
-						2966,
-						2936,
-						2937,
-						2939,
-						2938,
-						2909,
-						2979,
-						2980,
-						2977,
-						2978,
-						2941,
-						2946,
-						2943,
-						2945,
-						2944,
-						2942,
-						2951,
-						2948,
-						2950,
-						2949,
-						2947,
-						2955,
-						2954,
-						2953,
-						2952,
-						2940,
-						3075,
-						3070,
-						3065,
-						3064,
-						3067,
-						3066,
-						3002,
-						3005,
-						3000,
-						3003,
-						3004,
-						2999,
-						3001,
-						2972,
-						2971,
-						2974,
-						2973,
-						2970,
-						2968,
-						2969,
-						2975,
-						2976,
-						2987,
-						2988,
-						2991,
-						2989,
-						2990,
-						2998,
-						2997,
-						2996,
-						2995,
-						3063,
-						3062,
-						3061,
-						3069,
-						3068,
-						2913,
-						2914,
-						2912,
-						2916,
-						2918,
-						2917,
-						2915,
-						2919,
-						2920,
 						2993,
 						2992,
-						3022,
-						3035,
-						3034,
-						3032,
-						3033,
-						3040,
-						3038,
-						3037,
-						3124,
-						3128,
-						3129,
-						3125,
-						3126,
-						3127,
-						3023,
-						3024,
-						3028,
-						3016,
-						3031,
-						3030,
-						3021,
-						3029,
-						3019,
-						3020,
-						3027,
-						3017,
-						3018,
-						3054,
-						3051,
-						3052,
-						3053,
-						3007,
-						3060,
-						3055,
-						3056,
-						3059,
-						3057,
-						3058,
-						3008,
-						3012,
-						3011,
-						3006,
-						3026,
-						3025,
-						3039,
-						3094,
-						3091,
-						3093,
-						3095,
-						3096,
-						3092,
-						3097,
-						3090,
-						3089,
-						3041,
-						3042,
-						3010,
-						3009,
-						3013,
-						3014,
-						3015,
-						3043,
-						3044,
-						2985,
-						2982,
-						2981,
-						2983,
-						2986,
-						2984,
-						2910,
-						2911,
-						3049,
-						3050,
-						3045,
-						3047,
-						3048,
-						3046,
-						2905,
-						2906,
-						2907,
-						2908,
-						3078,
-						3077,
-						3082,
-						3083,
-						3086,
-						3085,
-						3084,
-						3087,
-						3080,
-						3088,
-						3079,
-						3081,
-						2928,
-						2932,
-						2933,
-						2931,
-						2927,
-						2930,
-						2924,
-						2925,
-						2926,
-						2921,
-						2922,
-						2923,
-						2929,
-						2994,
-						3140,
-						3139,
-						3143,
-						3144,
-						3142,
-						3141,
-						3136,
-						3137,
-						3138,
-						3145,
-						3146,
-						3036,
-						3074,
-						3071,
-						3072,
-						3073,
-						3076,
-						2934,
-						2935,
-						3131,
-						3103,
-						3132,
-						3130,
-						3099,
-						3101,
-						3102,
-						3100,
-						3122,
-						3123,
-						3108,
-						3098,
-						3104,
-						3105,
-						3133,
-						3135,
-						3134,
-						3106,
-						3107,
-						3112,
-						3114,
-						3111,
-						3113,
-						3117,
-						3115,
-						3119,
-						3120,
-						3118,
-						3121,
-						3116,
-						3110,
-						3109,
-						2964,
 						2962,
 						2963,
+						2965,
+						2964,
+						2935,
+						3005,
+						3006,
+						3003,
+						3004,
+						2967,
+						2972,
+						2969,
+						2971,
+						2970,
+						2968,
+						2977,
+						2974,
+						2976,
+						2975,
+						2973,
+						2981,
+						2980,
+						2979,
+						2978,
+						2966,
+						3101,
+						3096,
+						3091,
+						3090,
+						3093,
+						3092,
+						3028,
+						3031,
+						3026,
+						3029,
+						3030,
+						3025,
+						3027,
+						2998,
+						2997,
+						3000,
+						2999,
+						2996,
+						2994,
+						2995,
+						3001,
+						3002,
+						3013,
+						3014,
+						3017,
+						3015,
+						3016,
+						3024,
+						3023,
+						3022,
+						3021,
+						3089,
+						3088,
+						3087,
+						3095,
+						3094,
+						2939,
+						2940,
+						2938,
+						2942,
+						2944,
+						2943,
+						2941,
+						2945,
+						2946,
+						3019,
+						3018,
+						3048,
+						3061,
+						3060,
+						3058,
+						3059,
+						3066,
+						3064,
+						3063,
+						3150,
+						3154,
+						3155,
+						3151,
+						3152,
+						3153,
+						3049,
+						3050,
+						3054,
+						3042,
+						3057,
+						3056,
+						3047,
+						3055,
+						3045,
+						3046,
+						3053,
+						3043,
+						3044,
+						3080,
+						3077,
+						3078,
+						3079,
+						3033,
+						3086,
+						3081,
+						3082,
+						3085,
+						3083,
+						3084,
+						3034,
+						3038,
+						3037,
+						3032,
+						3052,
+						3051,
+						3065,
+						3120,
+						3117,
+						3119,
+						3121,
+						3122,
+						3118,
+						3123,
+						3116,
+						3115,
+						3067,
+						3068,
+						3036,
+						3035,
+						3039,
+						3040,
+						3041,
+						3069,
+						3070,
+						3011,
+						3008,
+						3007,
+						3009,
+						3012,
+						3010,
+						2936,
+						2937,
+						3075,
+						3076,
+						3071,
+						3073,
+						3074,
+						3072,
+						2931,
+						2932,
+						2933,
+						2934,
+						3104,
+						3103,
+						3108,
+						3109,
+						3112,
+						3111,
+						3110,
+						3113,
+						3106,
+						3114,
+						3105,
+						3107,
+						2954,
+						2958,
 						2959,
+						2957,
+						2953,
+						2956,
+						2950,
+						2951,
+						2952,
+						2947,
+						2948,
+						2949,
+						2955,
+						3020,
+						3166,
+						3165,
+						3169,
+						3170,
+						3168,
+						3167,
+						3162,
+						3163,
+						3164,
+						3171,
+						3172,
+						3062,
+						3100,
+						3097,
+						3098,
+						3099,
+						3102,
 						2960,
 						2961,
-						2965,
-						2956,
-						2957,
-						2958
+						3157,
+						3129,
+						3158,
+						3156,
+						3125,
+						3127,
+						3128,
+						3126,
+						3148,
+						3149,
+						3134,
+						3124,
+						3130,
+						3131,
+						3159,
+						3161,
+						3160,
+						3132,
+						3133,
+						3138,
+						3140,
+						3137,
+						3139,
+						3143,
+						3141,
+						3145,
+						3146,
+						3144,
+						3147,
+						3142,
+						3136,
+						3135,
+						2990,
+						2988,
+						2989,
+						2985,
+						2986,
+						2987,
+						2991,
+						2982,
+						2983,
+						2984
 					]
 				}
 			],
@@ -41799,7 +42049,7 @@
 			]
 		},
 		{
-			"id": 2892,
+			"id": 2918,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41809,7 +42059,7 @@
 			},
 			"children": [
 				{
-					"id": 2894,
+					"id": 2920,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41825,12 +42075,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2895,
+						"id": 2921,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2893,
+					"id": 2919,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41855,8 +42105,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2894,
-						2893
+						2920,
+						2919
 					]
 				}
 			],
@@ -41869,7 +42119,7 @@
 			]
 		},
 		{
-			"id": 2882,
+			"id": 2908,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -41885,7 +42135,7 @@
 			},
 			"children": [
 				{
-					"id": 2884,
+					"id": 2910,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41902,14 +42152,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2885,
+							"id": 2911,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2887,
+									"id": 2913,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -41939,7 +42189,7 @@
 									}
 								},
 								{
-									"id": 2888,
+									"id": 2914,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -41959,7 +42209,7 @@
 									}
 								},
 								{
-									"id": 2886,
+									"id": 2912,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42002,21 +42252,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2887,
-										2888,
-										2886
+										2913,
+										2914,
+										2912
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2889,
+								"id": 2915,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2890,
+										"id": 2916,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42035,7 +42285,7 @@
 					}
 				},
 				{
-					"id": 2891,
+					"id": 2917,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42055,7 +42305,7 @@
 					}
 				},
 				{
-					"id": 2883,
+					"id": 2909,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42071,7 +42321,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2892,
+						"id": 2918,
 						"name": "CustomStyles"
 					}
 				}
@@ -42081,9 +42331,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2884,
-						2891,
-						2883
+						2910,
+						2917,
+						2909
 					]
 				}
 			],
@@ -42096,7 +42346,7 @@
 			]
 		},
 		{
-			"id": 2429,
+			"id": 2451,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42112,7 +42362,7 @@
 			},
 			"children": [
 				{
-					"id": 2470,
+					"id": 2492,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42142,20 +42392,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2471,
+							"id": 2493,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2472,
+								"id": 2494,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2473,
+										"id": 2495,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42187,7 +42437,7 @@
 					}
 				},
 				{
-					"id": 2432,
+					"id": 2454,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42210,7 +42460,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2474,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42252,7 +42502,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2476,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42281,7 +42531,7 @@
 					}
 				},
 				{
-					"id": 2431,
+					"id": 2453,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42298,12 +42548,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1969,
+						"id": 1989,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2444,
+					"id": 2466,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42332,7 +42582,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2477,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42365,7 +42615,7 @@
 					}
 				},
 				{
-					"id": 2447,
+					"id": 2469,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42394,7 +42644,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2501,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42427,7 +42677,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2489,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42456,7 +42706,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2499,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42500,7 +42750,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2496,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42543,7 +42793,7 @@
 					}
 				},
 				{
-					"id": 2451,
+					"id": 2473,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42568,12 +42818,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2487,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42602,7 +42852,7 @@
 					}
 				},
 				{
-					"id": 2449,
+					"id": 2471,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42632,7 +42882,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2498,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42669,7 +42919,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2491,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42698,7 +42948,7 @@
 					}
 				},
 				{
-					"id": 2445,
+					"id": 2467,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42731,7 +42981,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2497,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42751,7 +43001,7 @@
 					}
 				},
 				{
-					"id": 2443,
+					"id": 2465,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42780,7 +43030,7 @@
 					}
 				},
 				{
-					"id": 2438,
+					"id": 2460,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42814,7 +43064,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2485,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42847,12 +43097,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3150,
+						"id": 3176,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2446,
+					"id": 2468,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42881,7 +43131,7 @@
 					}
 				},
 				{
-					"id": 2437,
+					"id": 2459,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42914,7 +43164,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2488,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42943,7 +43193,7 @@
 					}
 				},
 				{
-					"id": 2436,
+					"id": 2458,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42967,7 +43217,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2483,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42996,7 +43246,7 @@
 					}
 				},
 				{
-					"id": 2448,
+					"id": 2470,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43029,7 +43279,7 @@
 					}
 				},
 				{
-					"id": 2439,
+					"id": 2461,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43059,7 +43309,7 @@
 					}
 				},
 				{
-					"id": 2441,
+					"id": 2463,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43088,7 +43338,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2484,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43117,7 +43367,7 @@
 					}
 				},
 				{
-					"id": 2442,
+					"id": 2464,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43146,7 +43396,7 @@
 					}
 				},
 				{
-					"id": 2450,
+					"id": 2472,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43175,7 +43425,7 @@
 					}
 				},
 				{
-					"id": 2430,
+					"id": 2452,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43196,7 +43446,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2475,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43219,7 +43469,7 @@
 					}
 				},
 				{
-					"id": 2435,
+					"id": 2457,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43242,7 +43492,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2500,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43275,7 +43525,7 @@
 					}
 				},
 				{
-					"id": 2433,
+					"id": 2455,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -43291,7 +43541,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2434,
+							"id": 2456,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -43319,50 +43569,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2470,
-						2432,
-						2452,
+						2492,
 						2454,
-						2431,
-						2444,
-						2455,
-						2447,
-						2479,
-						2467,
-						2477,
 						2474,
-						2451,
-						2465,
-						2449,
 						2476,
-						2469,
-						2445,
-						2475,
-						2443,
-						2438,
-						2463,
-						2446,
-						2437,
-						2466,
-						2436,
-						2461,
-						2448,
-						2439,
-						2441,
-						2462,
-						2442,
-						2450,
-						2430,
 						2453,
-						2435,
-						2478
+						2466,
+						2477,
+						2469,
+						2501,
+						2489,
+						2499,
+						2496,
+						2473,
+						2487,
+						2471,
+						2498,
+						2491,
+						2467,
+						2497,
+						2465,
+						2460,
+						2485,
+						2468,
+						2459,
+						2488,
+						2458,
+						2483,
+						2470,
+						2461,
+						2463,
+						2484,
+						2464,
+						2472,
+						2452,
+						2475,
+						2457,
+						2500
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2433
+						2455
 					]
 				}
 			],
@@ -43375,7 +43625,7 @@
 			]
 		},
 		{
-			"id": 3274,
+			"id": 3300,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43404,7 +43654,7 @@
 			},
 			"children": [
 				{
-					"id": 3277,
+					"id": 3303,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43415,18 +43665,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9069,
+							"line": 9173,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3256,
+						"id": 3282,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3275,
+					"id": 3301,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43437,18 +43687,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9065,
+							"line": 9169,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3280,
+						"id": 3306,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3276,
+					"id": 3302,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43459,7 +43709,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9067,
+							"line": 9171,
 							"character": 4
 						}
 					],
@@ -43486,21 +43736,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3277,
-						3275,
-						3276
+						3303,
+						3301,
+						3302
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9063,
+					"line": 9167,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3278,
+				"id": 3304,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43510,7 +43760,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3279,
+						"id": 3305,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43527,7 +43777,7 @@
 			}
 		},
 		{
-			"id": 2840,
+			"id": 2866,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43543,7 +43793,7 @@
 			},
 			"children": [
 				{
-					"id": 2842,
+					"id": 2868,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43575,7 +43825,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2869,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43611,7 +43861,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2867,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43648,9 +43898,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2842,
-						2843,
-						2841
+						2868,
+						2869,
+						2867
 					]
 				}
 			],
@@ -43662,7 +43912,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2844,
+				"id": 2870,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43672,7 +43922,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2845,
+						"id": 2871,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43706,7 +43956,7 @@
 			}
 		},
 		{
-			"id": 2597,
+			"id": 2621,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43722,7 +43972,7 @@
 			},
 			"children": [
 				{
-					"id": 2609,
+					"id": 2633,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43756,7 +44006,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2667,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43780,27 +44030,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2644,
+							"id": 2668,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2645,
+								"id": 2669,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2646,
+										"id": 2670,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -43836,7 +44086,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2701,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43864,7 +44114,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -43878,7 +44128,7 @@
 					}
 				},
 				{
-					"id": 2673,
+					"id": 2698,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43902,13 +44152,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2447,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -43917,7 +44167,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2715,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43941,7 +44191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2030,
+							"line": 2110,
 							"character": 4
 						}
 					],
@@ -43955,7 +44205,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2689,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43987,7 +44237,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -44004,7 +44254,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2671,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44027,13 +44277,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44042,7 +44292,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2702,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44070,7 +44320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -44084,7 +44334,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2623,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44126,7 +44376,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2681,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44150,7 +44400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -44164,7 +44414,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2663,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44188,7 +44438,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -44202,7 +44452,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2662,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44226,7 +44476,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -44234,7 +44484,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -44244,7 +44494,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2675,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44263,6 +44513,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -44271,7 +44525,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -44285,7 +44539,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2709,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44313,7 +44567,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1926,
+							"line": 2006,
 							"character": 4
 						}
 					],
@@ -44327,7 +44581,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2714,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44355,7 +44609,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2014,
+							"line": 2094,
 							"character": 4
 						}
 					],
@@ -44369,7 +44623,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2703,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44397,7 +44651,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -44411,7 +44665,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2685,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44435,7 +44689,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -44449,7 +44703,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2656,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44482,7 +44736,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2648,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44512,7 +44766,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2653,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44546,7 +44800,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2678,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44570,7 +44824,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -44584,7 +44838,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2625,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44621,7 +44875,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2699,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44645,7 +44899,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -44659,7 +44913,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2700,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44683,7 +44937,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -44697,7 +44951,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2680,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44720,7 +44974,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -44734,7 +44988,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2659,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44758,13 +45012,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -44773,7 +45027,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2622,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44807,7 +45061,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2664,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44824,7 +45078,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -44835,7 +45089,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -44843,7 +45097,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -44853,7 +45107,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2640,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44890,7 +45144,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2712,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44918,7 +45172,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1981,
+							"line": 2061,
 							"character": 4
 						}
 					],
@@ -44932,7 +45186,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2705,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44960,7 +45214,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1862,
+							"line": 1942,
 							"character": 4
 						}
 					],
@@ -44974,7 +45228,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2635,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45008,7 +45262,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2672,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45032,7 +45286,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -45046,7 +45300,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2695,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45069,7 +45323,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -45083,7 +45337,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2694,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45095,7 +45349,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -45106,7 +45360,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -45123,7 +45377,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2716,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45151,7 +45405,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2049,
+							"line": 2129,
 							"character": 4
 						}
 					],
@@ -45165,7 +45419,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2644,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45203,7 +45457,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2719,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45227,7 +45481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2099,
+							"line": 2179,
 							"character": 4
 						}
 					],
@@ -45241,7 +45495,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2646,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45279,7 +45533,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2718,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45303,7 +45557,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2082,
+							"line": 2162,
 							"character": 4
 						}
 					],
@@ -45317,7 +45571,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2710,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45345,7 +45599,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1943,
+							"line": 2023,
 							"character": 4
 						}
 					],
@@ -45359,7 +45613,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2708,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45383,7 +45637,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1909,
+							"line": 1989,
 							"character": 4
 						}
 					],
@@ -45397,7 +45651,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2721,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45425,7 +45679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2131,
+							"line": 2211,
 							"character": 4
 						}
 					],
@@ -45439,7 +45693,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2642,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45476,7 +45730,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2645,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45514,7 +45768,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2693,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45534,7 +45788,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -45548,7 +45802,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2643,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45582,7 +45836,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2717,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45606,7 +45860,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2067,
+							"line": 2147,
 							"character": 4
 						}
 					],
@@ -45620,7 +45874,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2704,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45644,7 +45898,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -45658,7 +45912,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2647,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45695,7 +45949,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2649,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45729,7 +45983,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2684,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45753,7 +46007,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -45767,7 +46021,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2626,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45801,7 +46055,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2632,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45835,7 +46089,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2666,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45859,7 +46113,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -45873,7 +46127,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2624,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45910,7 +46164,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2722,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45938,7 +46192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2147,
+							"line": 2227,
 							"character": 4
 						}
 					],
@@ -45952,7 +46206,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2683,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45976,7 +46230,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -45990,7 +46244,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2682,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46014,7 +46268,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -46028,7 +46282,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2634,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46062,7 +46316,44 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2677,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2676,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46078,6 +46369,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -46086,7 +46381,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -46109,7 +46404,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2674,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46125,6 +46420,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -46133,7 +46432,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -46147,7 +46446,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2629,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46181,7 +46480,7 @@
 					}
 				},
 				{
-					"id": 2661,
+					"id": 2686,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46205,7 +46504,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -46219,7 +46518,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2690,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46246,7 +46545,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -46260,7 +46559,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2696,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46284,7 +46583,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -46292,7 +46591,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46302,7 +46601,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2697,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46326,7 +46625,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -46334,7 +46633,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46344,7 +46643,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2691,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46371,7 +46670,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -46385,7 +46684,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2688,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46408,7 +46707,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -46422,7 +46721,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2707,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46450,7 +46749,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1894,
+							"line": 1974,
 							"character": 4
 						}
 					],
@@ -46464,7 +46763,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2713,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46492,7 +46791,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1998,
+							"line": 2078,
 							"character": 4
 						}
 					],
@@ -46506,7 +46805,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2706,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46534,7 +46833,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1878,
+							"line": 1958,
 							"character": 4
 						}
 					],
@@ -46548,7 +46847,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2711,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46576,7 +46875,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1960,
+							"line": 2040,
 							"character": 4
 						}
 					],
@@ -46590,7 +46889,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2720,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46618,7 +46917,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2115,
+							"line": 2195,
 							"character": 4
 						}
 					],
@@ -46632,7 +46931,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2636,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46666,7 +46965,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2650,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46699,7 +46998,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2652,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46737,7 +47036,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2654,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46767,12 +47066,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1535,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2655,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46802,12 +47101,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2698,
+						"id": 2723,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2651,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46845,7 +47144,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2657,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46883,7 +47182,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2692,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46910,7 +47209,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -46924,7 +47223,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2665,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46945,14 +47244,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -46960,7 +47259,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -46970,7 +47269,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2641,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47007,7 +47306,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2630,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47044,7 +47343,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2628,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47083,92 +47382,93 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2609,
-						2643,
-						2676,
-						2673,
-						2690,
-						2664,
-						2647,
-						2677,
-						2599,
-						2656,
-						2639,
-						2638,
-						2651,
-						2684,
-						2689,
-						2678,
-						2660,
-						2632,
-						2624,
-						2629,
-						2653,
-						2601,
-						2674,
-						2675,
-						2655,
-						2635,
-						2598,
-						2640,
-						2616,
-						2687,
-						2680,
-						2611,
-						2648,
-						2670,
-						2669,
-						2691,
-						2620,
-						2694,
-						2622,
-						2693,
-						2685,
-						2683,
-						2696,
-						2618,
-						2621,
-						2668,
-						2619,
-						2692,
-						2679,
-						2623,
-						2625,
-						2659,
-						2602,
-						2608,
-						2642,
-						2600,
-						2697,
-						2658,
-						2657,
-						2610,
-						2652,
-						2650,
-						2605,
-						2661,
-						2665,
-						2671,
-						2672,
-						2666,
-						2663,
-						2682,
-						2688,
-						2681,
-						2686,
-						2695,
-						2612,
-						2626,
-						2628,
-						2630,
-						2631,
-						2627,
 						2633,
 						2667,
+						2701,
+						2698,
+						2715,
+						2689,
+						2671,
+						2702,
+						2623,
+						2681,
+						2663,
+						2662,
+						2675,
+						2709,
+						2714,
+						2703,
+						2685,
+						2656,
+						2648,
+						2653,
+						2678,
+						2625,
+						2699,
+						2700,
+						2680,
+						2659,
+						2622,
+						2664,
+						2640,
+						2712,
+						2705,
+						2635,
+						2672,
+						2695,
+						2694,
+						2716,
+						2644,
+						2719,
+						2646,
+						2718,
+						2710,
+						2708,
+						2721,
+						2642,
+						2645,
+						2693,
+						2643,
+						2717,
+						2704,
+						2647,
+						2649,
+						2684,
+						2626,
+						2632,
+						2666,
+						2624,
+						2722,
+						2683,
+						2682,
+						2634,
+						2677,
+						2676,
+						2674,
+						2629,
+						2686,
+						2690,
+						2696,
+						2697,
+						2691,
+						2688,
+						2707,
+						2713,
+						2706,
+						2711,
+						2720,
+						2636,
+						2650,
+						2652,
+						2654,
+						2655,
+						2651,
+						2657,
+						2692,
+						2665,
 						2641,
-						2617,
-						2606,
-						2604
+						2630,
+						2628
 					]
 				}
 			],
@@ -47195,7 +47495,7 @@
 			]
 		},
 		{
-			"id": 1981,
+			"id": 2001,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47205,7 +47505,7 @@
 			},
 			"children": [
 				{
-					"id": 1982,
+					"id": 2002,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47216,7 +47516,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2363,
+							"line": 2443,
 							"character": 4
 						}
 					],
@@ -47226,7 +47526,7 @@
 					}
 				},
 				{
-					"id": 1983,
+					"id": 2003,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47237,18 +47537,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2367,
+							"line": 2447,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1985,
+						"id": 2005,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 1984,
+					"id": 2004,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47259,7 +47559,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2373,
+							"line": 2453,
 							"character": 4
 						}
 					],
@@ -47294,22 +47594,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1982,
-						1983,
-						1984
+						2002,
+						2003,
+						2004
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2359,
+					"line": 2439,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3147,
+			"id": 3173,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47319,7 +47619,7 @@
 			},
 			"children": [
 				{
-					"id": 3148,
+					"id": 3174,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47330,7 +47630,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2383,
+							"line": 2463,
 							"character": 4
 						}
 					],
@@ -47340,7 +47640,7 @@
 					}
 				},
 				{
-					"id": 3149,
+					"id": 3175,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47351,7 +47651,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2387,
+							"line": 2467,
 							"character": 4
 						}
 					],
@@ -47379,21 +47679,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3148,
-						3149
+						3174,
+						3175
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2379,
+					"line": 2459,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2545,
+			"id": 2568,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47408,7 +47708,7 @@
 			},
 			"children": [
 				{
-					"id": 2560,
+					"id": 2583,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47432,27 +47732,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2561,
+							"id": 2584,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2562,
+								"id": 2585,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2563,
+										"id": 2586,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47488,7 +47788,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2617,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47516,7 +47816,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -47530,7 +47830,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2614,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47554,13 +47854,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2447,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47569,7 +47869,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2605,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47601,7 +47901,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -47618,7 +47918,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2587,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47641,13 +47941,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47656,7 +47956,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2618,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47684,7 +47984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -47698,7 +47998,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2570,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47732,7 +48032,7 @@
 					}
 				},
 				{
-					"id": 2546,
+					"id": 2569,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47773,7 +48073,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2597,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47797,7 +48097,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -47811,7 +48111,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2579,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47835,7 +48135,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -47849,7 +48149,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2578,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47873,7 +48173,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -47881,7 +48181,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -47891,7 +48191,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2591,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47910,6 +48210,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -47918,7 +48222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -47932,7 +48236,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2619,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47960,7 +48264,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -47974,7 +48278,7 @@
 					}
 				},
 				{
-					"id": 2577,
+					"id": 2601,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47998,7 +48302,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -48012,7 +48316,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2594,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48036,7 +48340,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -48050,7 +48354,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2615,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48074,7 +48378,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -48088,7 +48392,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2616,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48112,7 +48416,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -48126,7 +48430,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2573,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48160,7 +48464,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2596,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48183,7 +48487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -48197,7 +48501,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2575,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48221,13 +48525,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48236,7 +48540,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2580,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48253,7 +48557,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -48264,7 +48568,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -48272,7 +48576,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -48282,7 +48586,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2588,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48306,7 +48610,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -48320,7 +48624,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2611,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48343,7 +48647,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -48357,7 +48661,7 @@
 					}
 				},
 				{
-					"id": 2586,
+					"id": 2610,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48369,7 +48673,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -48380,7 +48684,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -48397,7 +48701,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2609,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48417,7 +48721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -48431,7 +48735,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2620,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48455,7 +48759,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -48469,7 +48773,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2600,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48493,7 +48797,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -48507,7 +48811,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2582,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48531,7 +48835,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -48545,7 +48849,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2599,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48569,7 +48873,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -48583,7 +48887,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2598,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48607,7 +48911,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -48621,7 +48925,44 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2593,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "BaseViewConfig.preRenderConfig"
+					}
+				},
+				{
+					"id": 2592,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48637,6 +48978,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -48645,7 +48990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -48668,7 +49013,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2590,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48684,6 +49029,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -48692,7 +49041,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -48706,7 +49055,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2602,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48730,7 +49079,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1323,
+							"line": 1403,
 							"character": 4
 						}
 					],
@@ -48744,7 +49093,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2606,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48771,7 +49120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -48785,7 +49134,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2612,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48809,7 +49158,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -48817,7 +49166,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -48827,7 +49176,7 @@
 					}
 				},
 				{
-					"id": 2589,
+					"id": 2613,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48851,7 +49200,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -48859,7 +49208,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -48869,7 +49218,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2572,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48903,7 +49252,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2607,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48930,7 +49279,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -48944,7 +49293,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2604,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48967,7 +49316,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -48981,7 +49330,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2608,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49008,7 +49357,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -49022,7 +49371,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2571,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49056,7 +49405,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2581,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49077,14 +49426,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -49092,7 +49441,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -49107,48 +49456,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2560,
-						2593,
-						2590,
-						2581,
-						2564,
-						2594,
-						2547,
-						2546,
-						2573,
-						2556,
-						2555,
-						2568,
-						2595,
-						2577,
-						2570,
-						2591,
-						2592,
-						2550,
-						2572,
-						2552,
-						2557,
-						2565,
-						2587,
-						2586,
-						2585,
-						2596,
-						2576,
-						2559,
-						2575,
-						2574,
-						2569,
-						2567,
-						2578,
-						2582,
-						2588,
-						2589,
-						2549,
 						2583,
+						2617,
+						2614,
+						2605,
+						2587,
+						2618,
+						2570,
+						2569,
+						2597,
+						2579,
+						2578,
+						2591,
+						2619,
+						2601,
+						2594,
+						2615,
+						2616,
+						2573,
+						2596,
+						2575,
 						2580,
-						2584,
-						2548,
-						2558
+						2588,
+						2611,
+						2610,
+						2609,
+						2620,
+						2600,
+						2582,
+						2599,
+						2598,
+						2593,
+						2592,
+						2590,
+						2602,
+						2606,
+						2612,
+						2613,
+						2572,
+						2607,
+						2604,
+						2608,
+						2571,
+						2581
 					]
 				}
 			],
@@ -49171,7 +49521,7 @@
 			]
 		},
 		{
-			"id": 2480,
+			"id": 2502,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49187,7 +49537,7 @@
 			},
 			"children": [
 				{
-					"id": 2518,
+					"id": 2540,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49211,27 +49561,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2519,
+							"id": 2541,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2520,
+								"id": 2542,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2521,
+										"id": 2543,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -49267,7 +49617,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2514,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49301,7 +49651,7 @@
 					}
 				},
 				{
-					"id": 2482,
+					"id": 2504,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49335,7 +49685,7 @@
 					}
 				},
 				{
-					"id": 2481,
+					"id": 2503,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49369,7 +49719,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2527,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49397,7 +49747,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1792,
+							"line": 1872,
 							"character": 4
 						}
 					],
@@ -49411,7 +49761,7 @@
 					}
 				},
 				{
-					"id": 2495,
+					"id": 2517,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49448,7 +49798,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2524,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49472,13 +49822,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1750,
+							"line": 1830,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2425,
+						"id": 2447,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -49487,7 +49837,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2561,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49519,7 +49869,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -49536,7 +49886,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2544,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49559,13 +49909,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49574,7 +49924,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2518,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49612,7 +49962,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2528,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49640,7 +49990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1808,
+							"line": 1888,
 							"character": 4
 						}
 					],
@@ -49654,7 +50004,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2510,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49688,7 +50038,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2509,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49724,7 +50074,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2554,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49748,7 +50098,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -49762,7 +50112,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2536,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49786,7 +50136,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -49800,7 +50150,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2535,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49824,7 +50174,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -49832,7 +50182,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -49842,7 +50192,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2548,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49861,6 +50211,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -49869,7 +50223,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -49883,7 +50237,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2529,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49911,7 +50265,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1824,
+							"line": 1904,
 							"character": 4
 						}
 					],
@@ -49925,7 +50279,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2558,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49949,7 +50303,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -49963,7 +50317,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2507,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49997,7 +50351,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2551,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50021,7 +50375,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -50035,7 +50389,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2525,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50059,7 +50413,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1763,
+							"line": 1843,
 							"character": 4
 						}
 					],
@@ -50073,7 +50427,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2526,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50097,7 +50451,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1776,
+							"line": 1856,
 							"character": 4
 						}
 					],
@@ -50111,7 +50465,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2513,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50145,7 +50499,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2553,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50168,7 +50522,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -50182,7 +50536,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2519,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50220,7 +50574,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2508,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50254,7 +50608,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2532,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50278,13 +50632,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50293,7 +50647,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2537,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50310,7 +50664,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -50321,7 +50675,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -50329,7 +50683,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -50339,7 +50693,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2505,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50373,7 +50727,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2506,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50407,7 +50761,7 @@
 					}
 				},
 				{
-					"id": 2493,
+					"id": 2515,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50441,7 +50795,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2545,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50465,7 +50819,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -50479,7 +50833,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2567,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50502,7 +50856,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -50516,7 +50870,7 @@
 					}
 				},
 				{
-					"id": 2543,
+					"id": 2566,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50528,7 +50882,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -50539,7 +50893,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -50556,7 +50910,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2565,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50576,7 +50930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -50590,7 +50944,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2530,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50614,7 +50968,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1840,
+							"line": 1920,
 							"character": 4
 						}
 					],
@@ -50628,7 +50982,7 @@
 					}
 				},
 				{
-					"id": 2534,
+					"id": 2557,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50652,7 +51006,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -50666,7 +51020,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2539,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50690,7 +51044,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -50704,7 +51058,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2520,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50742,7 +51096,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2556,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50766,7 +51120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -50780,7 +51134,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2555,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50804,7 +51158,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -50818,7 +51172,44 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2550,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 2549,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50834,6 +51225,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -50842,7 +51237,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -50865,7 +51260,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2547,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50881,6 +51276,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -50889,7 +51288,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -50903,7 +51302,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2562,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50930,7 +51329,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -50944,7 +51343,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2522,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50968,7 +51367,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1714,
+							"line": 1794,
 							"character": 4
 						}
 					],
@@ -50976,7 +51375,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -50986,7 +51385,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2523,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51010,7 +51409,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1735,
+							"line": 1815,
 							"character": 4
 						}
 					],
@@ -51018,7 +51417,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -51028,7 +51427,7 @@
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2512,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51058,7 +51457,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2511,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51087,7 +51486,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2563,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51114,7 +51513,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -51128,7 +51527,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2560,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51151,7 +51550,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -51165,7 +51564,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2564,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51192,7 +51591,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -51206,7 +51605,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2516,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51236,7 +51635,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2538,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51257,14 +51656,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -51272,7 +51671,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -51282,7 +51681,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2521,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51307,7 +51706,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3285,
+						"id": 3311,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -51317,61 +51716,62 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2518,
-						2492,
-						2482,
-						2481,
-						2505,
-						2495,
-						2502,
-						2538,
-						2522,
-						2496,
-						2506,
-						2488,
-						2487,
-						2531,
-						2514,
-						2513,
-						2526,
-						2507,
-						2535,
-						2485,
-						2528,
-						2503,
-						2504,
-						2491,
-						2530,
-						2497,
-						2486,
-						2510,
-						2515,
-						2483,
-						2484,
-						2493,
-						2523,
-						2544,
-						2543,
-						2542,
-						2508,
-						2534,
-						2517,
-						2498,
-						2533,
-						2532,
-						2527,
-						2525,
-						2539,
-						2500,
-						2501,
-						2490,
-						2489,
 						2540,
+						2514,
+						2504,
+						2503,
+						2527,
+						2517,
+						2524,
+						2561,
+						2544,
+						2518,
+						2528,
+						2510,
+						2509,
+						2554,
+						2536,
+						2535,
+						2548,
+						2529,
+						2558,
+						2507,
+						2551,
+						2525,
+						2526,
+						2513,
+						2553,
+						2519,
+						2508,
+						2532,
 						2537,
-						2541,
-						2494,
+						2505,
+						2506,
+						2515,
+						2545,
+						2567,
+						2566,
+						2565,
+						2530,
+						2557,
+						2539,
+						2520,
+						2556,
+						2555,
+						2550,
+						2549,
+						2547,
+						2562,
+						2522,
+						2523,
+						2512,
+						2511,
+						2563,
+						2560,
+						2564,
 						2516,
-						2499
+						2538,
+						2521
 					]
 				}
 			],
@@ -51404,14 +51804,14 @@
 			]
 		},
 		{
-			"id": 1949,
+			"id": 1969,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1952,
+					"id": 1972,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51426,14 +51826,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1953,
+							"id": 1973,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1955,
+									"id": 1975,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51451,7 +51851,7 @@
 									}
 								},
 								{
-									"id": 1954,
+									"id": 1974,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51474,8 +51874,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1955,
-										1954
+										1975,
+										1974
 									]
 								}
 							]
@@ -51483,7 +51883,7 @@
 					}
 				},
 				{
-					"id": 1951,
+					"id": 1971,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51501,7 +51901,7 @@
 					}
 				},
 				{
-					"id": 1950,
+					"id": 1970,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51524,9 +51924,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1952,
-						1951,
-						1950
+						1972,
+						1971,
+						1970
 					]
 				}
 			],
@@ -51539,7 +51939,7 @@
 			]
 		},
 		{
-			"id": 1167,
+			"id": 1177,
 			"name": "SpotterAgentEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -51555,7 +51955,7 @@
 			},
 			"children": [
 				{
-					"id": 1178,
+					"id": 1188,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51579,27 +51979,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1179,
+							"id": 1189,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1180,
+								"id": 1190,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1181,
+										"id": 1191,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -51635,7 +52035,7 @@
 					}
 				},
 				{
-					"id": 1198,
+					"id": 1209,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51667,7 +52067,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -51684,7 +52084,7 @@
 					}
 				},
 				{
-					"id": 1182,
+					"id": 1192,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51707,13 +52107,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -51722,7 +52122,7 @@
 					}
 				},
 				{
-					"id": 1191,
+					"id": 1202,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51746,7 +52146,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -51760,7 +52160,7 @@
 					}
 				},
 				{
-					"id": 1174,
+					"id": 1184,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51784,7 +52184,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -51798,7 +52198,7 @@
 					}
 				},
 				{
-					"id": 1173,
+					"id": 1183,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51822,7 +52222,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -51830,7 +52230,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -51840,7 +52240,7 @@
 					}
 				},
 				{
-					"id": 1186,
+					"id": 1196,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51859,6 +52259,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -51867,7 +52271,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -51881,7 +52285,7 @@
 					}
 				},
 				{
-					"id": 1195,
+					"id": 1206,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51905,7 +52309,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -51919,7 +52323,7 @@
 					}
 				},
 				{
-					"id": 1188,
+					"id": 1199,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51943,7 +52347,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -51957,7 +52361,7 @@
 					}
 				},
 				{
-					"id": 1190,
+					"id": 1201,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51980,7 +52384,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -51994,7 +52398,7 @@
 					}
 				},
 				{
-					"id": 1170,
+					"id": 1180,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52018,13 +52422,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -52033,7 +52437,7 @@
 					}
 				},
 				{
-					"id": 1175,
+					"id": 1185,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52050,7 +52454,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -52061,7 +52465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -52069,7 +52473,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -52079,7 +52483,7 @@
 					}
 				},
 				{
-					"id": 1183,
+					"id": 1193,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52103,7 +52507,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -52117,7 +52521,7 @@
 					}
 				},
 				{
-					"id": 1204,
+					"id": 1215,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52140,7 +52544,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -52154,7 +52558,7 @@
 					}
 				},
 				{
-					"id": 1203,
+					"id": 1214,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52166,7 +52570,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -52177,7 +52581,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -52194,7 +52598,7 @@
 					}
 				},
 				{
-					"id": 1202,
+					"id": 1213,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52214,7 +52618,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -52228,7 +52632,7 @@
 					}
 				},
 				{
-					"id": 1194,
+					"id": 1205,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52252,7 +52656,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -52266,7 +52670,7 @@
 					}
 				},
 				{
-					"id": 1177,
+					"id": 1187,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52290,7 +52694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -52304,7 +52708,7 @@
 					}
 				},
 				{
-					"id": 1193,
+					"id": 1204,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52328,7 +52732,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -52342,7 +52746,7 @@
 					}
 				},
 				{
-					"id": 1192,
+					"id": 1203,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52366,7 +52770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -52380,7 +52784,44 @@
 					}
 				},
 				{
-					"id": 1187,
+					"id": 1198,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 1197,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52396,6 +52837,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -52404,7 +52849,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -52427,7 +52872,7 @@
 					}
 				},
 				{
-					"id": 1185,
+					"id": 1195,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52443,6 +52888,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -52451,7 +52900,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -52465,7 +52914,7 @@
 					}
 				},
 				{
-					"id": 1199,
+					"id": 1210,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52492,7 +52941,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -52506,7 +52955,7 @@
 					}
 				},
 				{
-					"id": 1200,
+					"id": 1211,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52533,7 +52982,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -52547,7 +52996,7 @@
 					}
 				},
 				{
-					"id": 1197,
+					"id": 1208,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52570,7 +53019,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -52584,7 +53033,7 @@
 					}
 				},
 				{
-					"id": 1201,
+					"id": 1212,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52611,7 +53060,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -52625,7 +53074,7 @@
 					}
 				},
 				{
-					"id": 1176,
+					"id": 1186,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52646,14 +53095,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -52661,7 +53110,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -52671,7 +53120,7 @@
 					}
 				},
 				{
-					"id": 1168,
+					"id": 1178,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52697,34 +53146,35 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1178,
-						1198,
-						1182,
-						1191,
-						1174,
-						1173,
-						1186,
-						1195,
 						1188,
-						1190,
-						1170,
-						1175,
+						1209,
+						1192,
+						1202,
+						1184,
 						1183,
+						1196,
+						1206,
+						1199,
+						1201,
+						1180,
+						1185,
+						1193,
+						1215,
+						1214,
+						1213,
+						1205,
+						1187,
 						1204,
 						1203,
-						1202,
-						1194,
-						1177,
-						1193,
-						1192,
-						1187,
-						1185,
-						1199,
-						1200,
+						1198,
 						1197,
-						1201,
-						1176,
-						1168
+						1195,
+						1210,
+						1211,
+						1208,
+						1212,
+						1186,
+						1178
 					]
 				}
 			],
@@ -52754,13 +53204,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1205,
+					"id": 1216,
 					"name": "BodylessConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1519,
+			"id": 1535,
 			"name": "SpotterChatViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52780,7 +53230,7 @@
 			},
 			"children": [
 				{
-					"id": 1524,
+					"id": 1540,
 					"name": "enableStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52814,7 +53264,7 @@
 					}
 				},
 				{
-					"id": 1520,
+					"id": 1536,
 					"name": "hideToolResponseCardBranding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52843,7 +53293,7 @@
 					}
 				},
 				{
-					"id": 1522,
+					"id": 1538,
 					"name": "spotterFileUploadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52877,7 +53327,7 @@
 					}
 				},
 				{
-					"id": 1523,
+					"id": 1539,
 					"name": "spotterFileUploadFileTypes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52907,7 +53357,7 @@
 					}
 				},
 				{
-					"id": 1521,
+					"id": 1537,
 					"name": "toolResponseCardBrandingLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52935,11 +53385,11 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1524,
-						1520,
-						1522,
-						1523,
-						1521
+						1540,
+						1536,
+						1538,
+						1539,
+						1537
 					]
 				}
 			],
@@ -52952,7 +53402,7 @@
 			]
 		},
 		{
-			"id": 1460,
+			"id": 1474,
 			"name": "SpotterEmbedViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -52968,7 +53418,7 @@
 			},
 			"children": [
 				{
-					"id": 1492,
+					"id": 1507,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -52992,27 +53442,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1050,
+							"line": 1106,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1493,
+							"id": 1508,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1494,
+								"id": 1509,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1495,
+										"id": 1510,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -53048,7 +53498,41 @@
 					}
 				},
 				{
-					"id": 1512,
+					"id": 1477,
+					"name": "analystId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Pins the embed to a single spotter analyst. Implies no default Spotter\nand no \"Show all\".",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   analystId: 'analyst-id-1234',\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 320,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1528,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53080,7 +53564,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1522,
+							"line": 1602,
 							"character": 4
 						}
 					],
@@ -53097,7 +53581,7 @@
 					}
 				},
 				{
-					"id": 1496,
+					"id": 1511,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53120,13 +53604,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1057,
+							"line": 1113,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2882,
+						"id": 2908,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -53135,7 +53619,7 @@
 					}
 				},
 				{
-					"id": 1466,
+					"id": 1481,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53163,7 +53647,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 354,
+							"line": 369,
 							"character": 4
 						}
 					],
@@ -53173,7 +53657,7 @@
 					}
 				},
 				{
-					"id": 1462,
+					"id": 1476,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53210,7 +53694,7 @@
 					}
 				},
 				{
-					"id": 1475,
+					"id": 1490,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53238,18 +53722,18 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 497,
+							"line": 512,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1540,
+						"id": 1556,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 1505,
+					"id": 1521,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53273,7 +53757,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1212,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -53287,7 +53771,7 @@
 					}
 				},
 				{
-					"id": 1464,
+					"id": 1479,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53311,7 +53795,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 324,
+							"line": 339,
 							"character": 4
 						}
 					],
@@ -53321,7 +53805,7 @@
 					}
 				},
 				{
-					"id": 1488,
+					"id": 1503,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53345,7 +53829,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 970,
+							"line": 1026,
 							"character": 4
 						}
 					],
@@ -53359,7 +53843,7 @@
 					}
 				},
 				{
-					"id": 1487,
+					"id": 1502,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53383,7 +53867,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 954,
+							"line": 1010,
 							"character": 4
 						}
 					],
@@ -53391,7 +53875,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -53401,7 +53885,7 @@
 					}
 				},
 				{
-					"id": 1500,
+					"id": 1515,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53420,6 +53904,10 @@
 								"text": "SDK: 1.24.0 | ThoughtSpot: 9.4.0.cl, 9.4.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.doNotTrackPreRenderSize} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Disable tracking PreRender size in the configuration\nconst config = {\n  doNotTrackPreRenderSize: true,\n};\n\n// Instantiate an object with the configuration\nconst myComponent = new MyComponent(config);\n```\n"
 							}
@@ -53428,7 +53916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1121,
+							"line": 1179,
 							"character": 4
 						}
 					],
@@ -53442,7 +53930,7 @@
 					}
 				},
 				{
-					"id": 1509,
+					"id": 1525,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53466,7 +53954,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1307,
+							"line": 1387,
 							"character": 4
 						}
 					],
@@ -53480,7 +53968,7 @@
 					}
 				},
 				{
-					"id": 1477,
+					"id": 1492,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53508,7 +53996,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 516,
+							"line": 531,
 							"character": 4
 						}
 					],
@@ -53518,7 +54006,7 @@
 					}
 				},
 				{
-					"id": 1476,
+					"id": 1491,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53542,7 +54030,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 506,
+							"line": 521,
 							"character": 4
 						}
 					],
@@ -53552,7 +54040,7 @@
 					}
 				},
 				{
-					"id": 1502,
+					"id": 1518,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53576,7 +54064,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1177,
+							"line": 1257,
 							"character": 4
 						}
 					],
@@ -53590,7 +54078,7 @@
 					}
 				},
 				{
-					"id": 1470,
+					"id": 1485,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53614,7 +54102,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 418,
+							"line": 433,
 							"character": 4
 						}
 					],
@@ -53624,7 +54112,7 @@
 					}
 				},
 				{
-					"id": 1472,
+					"id": 1487,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53648,7 +54136,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 449,
+							"line": 464,
 							"character": 4
 						}
 					],
@@ -53658,7 +54146,7 @@
 					}
 				},
 				{
-					"id": 1504,
+					"id": 1520,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53681,7 +54169,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1188,
+							"line": 1268,
 							"character": 4
 						}
 					],
@@ -53695,7 +54183,7 @@
 					}
 				},
 				{
-					"id": 1484,
+					"id": 1499,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53719,13 +54207,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 926,
+							"line": 982,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2840,
+						"id": 2866,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -53734,7 +54222,7 @@
 					}
 				},
 				{
-					"id": 1489,
+					"id": 1504,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53751,7 +54239,7 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.Export],\n});\n```"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   hiddenActions: [Action.Download, Action.ExportTML],\n});\n```"
 							},
 							{
 								"tag": "important",
@@ -53762,7 +54250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 990,
+							"line": 1046,
 							"character": 4
 						}
 					],
@@ -53770,7 +54258,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -53780,7 +54268,7 @@
 					}
 				},
 				{
-					"id": 1468,
+					"id": 1483,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53804,7 +54292,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 385,
+							"line": 400,
 							"character": 4
 						}
 					],
@@ -53814,7 +54302,7 @@
 					}
 				},
 				{
-					"id": 1465,
+					"id": 1480,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53838,7 +54326,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 338,
+							"line": 353,
 							"character": 4
 						}
 					],
@@ -53848,7 +54336,7 @@
 					}
 				},
 				{
-					"id": 1497,
+					"id": 1512,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53872,7 +54360,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1073,
+							"line": 1129,
 							"character": 4
 						}
 					],
@@ -53886,7 +54374,7 @@
 					}
 				},
 				{
-					"id": 1518,
+					"id": 1534,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53909,7 +54397,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9192,
+							"line": 9296,
 							"character": 4
 						}
 					],
@@ -53923,7 +54411,7 @@
 					}
 				},
 				{
-					"id": 1517,
+					"id": 1533,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53935,7 +54423,7 @@
 						"tags": [
 							{
 								"tag": "example",
-								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.DATA],\n})\n```\n"
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#embed', {\n  ...viewConfig,\n  enableApiIntercept: true,\n  interceptUrls: [InterceptedApiType.LiveboardData],\n})\n```\n"
 							},
 							{
 								"tag": "version",
@@ -53946,7 +54434,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9175,
+							"line": 9279,
 							"character": 4
 						}
 					],
@@ -53963,7 +54451,7 @@
 					}
 				},
 				{
-					"id": 1516,
+					"id": 1532,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53983,7 +54471,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9159,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -53997,7 +54485,7 @@
 					}
 				},
 				{
-					"id": 1508,
+					"id": 1524,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54021,7 +54509,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1276,
+							"line": 1356,
 							"character": 4
 						}
 					],
@@ -54035,7 +54523,7 @@
 					}
 				},
 				{
-					"id": 1491,
+					"id": 1506,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54059,7 +54547,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1082,
 							"character": 4
 						}
 					],
@@ -54073,7 +54561,7 @@
 					}
 				},
 				{
-					"id": 1507,
+					"id": 1523,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54097,7 +54585,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1251,
+							"line": 1331,
 							"character": 4
 						}
 					],
@@ -54111,7 +54599,7 @@
 					}
 				},
 				{
-					"id": 1506,
+					"id": 1522,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54135,7 +54623,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1231,
+							"line": 1311,
 							"character": 4
 						}
 					],
@@ -54149,7 +54637,44 @@
 					}
 				},
 				{
-					"id": 1501,
+					"id": 1517,
+					"name": "preRenderConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the pre-render wrapper element.\nAll properties here mirror the top-level preRender properties on\n`BaseViewConfig` and take precedence over them when both are set,\nso existing top-level usage continues to work without any changes.\nSee {@link PreRenderConfig} for available options.",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.51.0"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderConfig: {\n    preRenderId: 'my-liveboard',\n    zIndex: -10,\n  },\n});\nembed.preRender();\nembed.showPreRender();\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 1240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"name": "PreRenderConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"name": "Omit.preRenderConfig"
+					}
+				},
+				{
+					"id": 1516,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54165,6 +54690,10 @@
 								"text": "SDK: 1.49.2 | ThoughtSpot: *"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderContainer} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\nconst embed = new LiveboardEmbed('#tsEmbed', {\n  preRenderId: 'my-liveboard',\n  // Prefer a selector for a stable, scrollable container.\n  preRenderContainer: '#my-scroll-container',\n});\n```\n"
 							}
@@ -54173,7 +54702,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1160,
+							"line": 1219,
 							"character": 4
 						}
 					],
@@ -54196,7 +54725,7 @@
 					}
 				},
 				{
-					"id": 1499,
+					"id": 1514,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54212,6 +54741,10 @@
 								"text": "SDK: 1.25.0 | ThoughtSpot: 9.6.0.cl, 9.8.0.sw"
 							},
 							{
+								"tag": "deprecated",
+								"text": "Use {@link PreRenderConfig.preRenderId} via `preRenderConfig` instead."
+							},
+							{
 								"tag": "example",
 								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n  preRenderId: \"preRenderId-123\",\n});\nembed.showPreRender();\n```\n"
 							}
@@ -54220,7 +54753,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1100,
+							"line": 1157,
 							"character": 4
 						}
 					],
@@ -54234,7 +54767,7 @@
 					}
 				},
 				{
-					"id": 1513,
+					"id": 1529,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54261,7 +54794,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1536,
+							"line": 1616,
 							"character": 4
 						}
 					],
@@ -54275,7 +54808,7 @@
 					}
 				},
 				{
-					"id": 1469,
+					"id": 1484,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54299,7 +54832,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 406,
+							"line": 421,
 							"character": 4
 						}
 					],
@@ -54307,13 +54840,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 1981,
+							"id": 2001,
 							"name": "RuntimeFilter"
 						}
 					}
 				},
 				{
-					"id": 1471,
+					"id": 1486,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54337,7 +54870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 437,
+							"line": 452,
 							"character": 4
 						}
 					],
@@ -54345,13 +54878,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3147,
+							"id": 3173,
 							"name": "RuntimeParameter"
 						}
 					}
 				},
 				{
-					"id": 1463,
+					"id": 1478,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54364,7 +54897,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 309,
+							"line": 324,
 							"character": 4
 						}
 					],
@@ -54374,7 +54907,7 @@
 					}
 				},
 				{
-					"id": 1481,
+					"id": 1496,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54398,7 +54931,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 593,
+							"line": 608,
 							"character": 4
 						}
 					],
@@ -54408,7 +54941,7 @@
 					}
 				},
 				{
-					"id": 1514,
+					"id": 1530,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54435,7 +54968,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1549,
+							"line": 1629,
 							"character": 4
 						}
 					],
@@ -54449,7 +54982,7 @@
 					}
 				},
 				{
-					"id": 1511,
+					"id": 1527,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54472,7 +55005,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1343,
+							"line": 1423,
 							"character": 4
 						}
 					],
@@ -54486,7 +55019,7 @@
 					}
 				},
 				{
-					"id": 1467,
+					"id": 1482,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54510,7 +55043,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 370,
+							"line": 385,
 							"character": 4
 						}
 					],
@@ -54520,7 +55053,7 @@
 					}
 				},
 				{
-					"id": 1474,
+					"id": 1489,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54548,7 +55081,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 479,
+							"line": 494,
 							"character": 4
 						}
 					],
@@ -54558,7 +55091,7 @@
 					}
 				},
 				{
-					"id": 1479,
+					"id": 1494,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54582,18 +55115,18 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 555,
+							"line": 570,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1519,
+						"id": 1535,
 						"name": "SpotterChatViewConfig"
 					}
 				},
 				{
-					"id": 1480,
+					"id": 1495,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54617,18 +55150,18 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 571,
+							"line": 586,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1543,
+						"id": 1559,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 1478,
+					"id": 1493,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54652,18 +55185,18 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 552,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1525,
+						"id": 1541,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 1473,
+					"id": 1488,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54691,7 +55224,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 464,
+							"line": 479,
 							"character": 4
 						}
 					],
@@ -54701,7 +55234,7 @@
 					}
 				},
 				{
-					"id": 1482,
+					"id": 1497,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54729,7 +55262,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 608,
+							"line": 623,
 							"character": 4
 						}
 					],
@@ -54739,7 +55272,7 @@
 					}
 				},
 				{
-					"id": 1515,
+					"id": 1531,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54766,7 +55299,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1563,
+							"line": 1643,
 							"character": 4
 						}
 					],
@@ -54780,7 +55313,7 @@
 					}
 				},
 				{
-					"id": 1490,
+					"id": 1505,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54801,14 +55334,14 @@
 							},
 							{
 								"tag": "example",
-								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.Export],\n});\n```\n"
+								"text": "\n```js\n// Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed\nconst embed = new <EmbedComponent>('#tsEmbed', {\n   ... // other embed view config\n   visibleActions: [Action.Download, Action.ExportTML],\n});\n```\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1011,
+							"line": 1067,
 							"character": 4
 						}
 					],
@@ -54816,7 +55349,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2233,
+							"id": 2253,
 							"name": "Action"
 						}
 					},
@@ -54826,7 +55359,7 @@
 					}
 				},
 				{
-					"id": 1461,
+					"id": 1475,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54854,55 +55387,57 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1492,
-						1512,
-						1496,
-						1466,
-						1462,
-						1475,
-						1505,
-						1464,
-						1488,
-						1487,
-						1500,
-						1509,
+						1507,
 						1477,
+						1528,
+						1511,
+						1481,
 						1476,
+						1490,
+						1521,
+						1479,
+						1503,
 						1502,
-						1470,
-						1472,
-						1504,
-						1484,
-						1489,
-						1468,
-						1465,
-						1497,
+						1515,
+						1525,
+						1492,
+						1491,
 						1518,
+						1485,
+						1487,
+						1520,
+						1499,
+						1504,
+						1483,
+						1480,
+						1512,
+						1534,
+						1533,
+						1532,
+						1524,
+						1506,
+						1523,
+						1522,
 						1517,
 						1516,
-						1508,
-						1491,
-						1507,
-						1506,
-						1501,
-						1499,
-						1513,
-						1469,
-						1471,
-						1463,
-						1481,
 						1514,
-						1511,
-						1467,
-						1474,
-						1479,
-						1480,
+						1529,
+						1484,
+						1486,
 						1478,
-						1473,
+						1496,
+						1530,
+						1527,
 						1482,
-						1515,
-						1490,
-						1461
+						1489,
+						1494,
+						1495,
+						1493,
+						1488,
+						1497,
+						1531,
+						1505,
+						1475
 					]
 				}
 			],
@@ -54932,13 +55467,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1557,
+					"id": 1573,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1543,
+			"id": 1559,
 			"name": "SpotterShareConversationConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -54958,7 +55493,7 @@
 			},
 			"children": [
 				{
-					"id": 1544,
+					"id": 1560,
 					"name": "enableShareConversation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -54991,7 +55526,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1565,
 					"name": "spotterShareAddUsersLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55020,7 +55555,7 @@
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1564,
 					"name": "spotterShareCancelLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55053,7 +55588,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1563,
 					"name": "spotterShareConfirmLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55086,7 +55621,7 @@
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1567,
 					"name": "spotterShareEmptySubtitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55115,7 +55650,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1566,
 					"name": "spotterShareEmptyTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55144,7 +55679,7 @@
 					}
 				},
 				{
-					"id": 1552,
+					"id": 1568,
 					"name": "spotterShareIncludeNewMessagesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55173,7 +55708,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1561,
 					"name": "spotterShareLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55206,7 +55741,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1562,
 					"name": "spotterShareModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55235,7 +55770,7 @@
 					}
 				},
 				{
-					"id": 1554,
+					"id": 1570,
 					"name": "spotterShareStaleInfoLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55264,7 +55799,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1569,
 					"name": "spotterShareUpToCurrentLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55293,7 +55828,7 @@
 					}
 				},
 				{
-					"id": 1555,
+					"id": 1571,
 					"name": "spotterSharedConversationBannerMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55322,7 +55857,7 @@
 					}
 				},
 				{
-					"id": 1556,
+					"id": 1572,
 					"name": "spotterSharedConversationExitLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55360,19 +55895,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1544,
-						1549,
-						1548,
-						1547,
-						1551,
-						1550,
-						1552,
-						1545,
-						1546,
-						1554,
-						1553,
-						1555,
-						1556
+						1560,
+						1565,
+						1564,
+						1563,
+						1567,
+						1566,
+						1568,
+						1561,
+						1562,
+						1570,
+						1569,
+						1571,
+						1572
 					]
 				}
 			],
@@ -55385,7 +55920,7 @@
 			]
 		},
 		{
-			"id": 1525,
+			"id": 1541,
 			"name": "SpotterSidebarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55405,7 +55940,7 @@
 			},
 			"children": [
 				{
-					"id": 1526,
+					"id": 1542,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55438,7 +55973,7 @@
 					}
 				},
 				{
-					"id": 1538,
+					"id": 1554,
 					"name": "spotterAnalystLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55471,7 +56006,7 @@
 					}
 				},
 				{
-					"id": 1539,
+					"id": 1555,
 					"name": "spotterAnalystsLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55504,7 +56039,7 @@
 					}
 				},
 				{
-					"id": 1535,
+					"id": 1551,
 					"name": "spotterBestPracticesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55533,7 +56068,7 @@
 					}
 				},
 				{
-					"id": 1530,
+					"id": 1546,
 					"name": "spotterChatDeleteLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55562,7 +56097,7 @@
 					}
 				},
 				{
-					"id": 1531,
+					"id": 1547,
 					"name": "spotterChatPinConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55591,7 +56126,7 @@
 					}
 				},
 				{
-					"id": 1529,
+					"id": 1545,
 					"name": "spotterChatRenameLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55620,7 +56155,7 @@
 					}
 				},
 				{
-					"id": 1536,
+					"id": 1552,
 					"name": "spotterConversationsBatchSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55653,7 +56188,7 @@
 					}
 				},
 				{
-					"id": 1532,
+					"id": 1548,
 					"name": "spotterDeleteConversationModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55682,7 +56217,7 @@
 					}
 				},
 				{
-					"id": 1534,
+					"id": 1550,
 					"name": "spotterDocumentationUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55711,7 +56246,7 @@
 					}
 				},
 				{
-					"id": 1537,
+					"id": 1553,
 					"name": "spotterNewChatButtonTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55740,7 +56275,7 @@
 					}
 				},
 				{
-					"id": 1533,
+					"id": 1549,
 					"name": "spotterPastConversationAlertMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55769,7 +56304,7 @@
 					}
 				},
 				{
-					"id": 1528,
+					"id": 1544,
 					"name": "spotterSidebarDefaultExpanded",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55802,7 +56337,7 @@
 					}
 				},
 				{
-					"id": 1527,
+					"id": 1543,
 					"name": "spotterSidebarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55836,20 +56371,20 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1526,
-						1538,
-						1539,
-						1535,
-						1530,
-						1531,
-						1529,
-						1536,
-						1532,
-						1534,
-						1537,
-						1533,
-						1528,
-						1527
+						1542,
+						1554,
+						1555,
+						1551,
+						1546,
+						1547,
+						1545,
+						1552,
+						1548,
+						1550,
+						1553,
+						1549,
+						1544,
+						1543
 					]
 				}
 			],
@@ -55862,7 +56397,7 @@
 			]
 		},
 		{
-			"id": 2698,
+			"id": 2723,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55886,7 +56421,7 @@
 			},
 			"children": [
 				{
-					"id": 2700,
+					"id": 2725,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55919,7 +56454,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2724,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55952,7 +56487,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2727,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55979,13 +56514,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2712,
+							"id": 2737,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2728,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56014,7 +56549,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2726,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56047,7 +56582,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2729,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56076,7 +56611,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2734,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56109,7 +56644,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2736,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56138,7 +56673,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2735,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56167,7 +56702,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2732,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56200,7 +56735,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2730,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56229,7 +56764,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2731,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56256,13 +56791,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2716,
+							"id": 2741,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2733,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56300,19 +56835,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2700,
-						2699,
-						2702,
-						2703,
-						2701,
-						2704,
-						2709,
-						2711,
-						2710,
-						2707,
-						2705,
-						2706,
-						2708
+						2725,
+						2724,
+						2727,
+						2728,
+						2726,
+						2729,
+						2734,
+						2736,
+						2735,
+						2732,
+						2730,
+						2731,
+						2733
 					]
 				}
 			],
@@ -56325,7 +56860,7 @@
 			]
 		},
 		{
-			"id": 2716,
+			"id": 2741,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56345,7 +56880,7 @@
 			},
 			"children": [
 				{
-					"id": 2717,
+					"id": 2742,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56366,7 +56901,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2743,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56392,8 +56927,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2717,
-						2718
+						2742,
+						2743
 					]
 				}
 			],
@@ -56406,7 +56941,7 @@
 			]
 		},
 		{
-			"id": 2712,
+			"id": 2737,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56426,7 +56961,7 @@
 			},
 			"children": [
 				{
-					"id": 2714,
+					"id": 2739,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56447,7 +56982,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2740,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56468,7 +57003,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2738,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56494,9 +57029,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2714,
-						2715,
-						2713
+						2739,
+						2740,
+						2738
 					]
 				}
 			],
@@ -56509,14 +57044,14 @@
 			]
 		},
 		{
-			"id": 1956,
+			"id": 1976,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1957,
+					"id": 1977,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56534,7 +57069,7 @@
 					}
 				},
 				{
-					"id": 1958,
+					"id": 1978,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56557,8 +57092,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1957,
-						1958
+						1977,
+						1978
 					]
 				}
 			],
@@ -56571,7 +57106,7 @@
 			]
 		},
 		{
-			"id": 3285,
+			"id": 3311,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56591,7 +57126,7 @@
 			},
 			"children": [
 				{
-					"id": 3286,
+					"id": 3312,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56604,7 +57139,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9685,
+							"line": 9789,
 							"character": 4
 						}
 					],
@@ -56614,7 +57149,7 @@
 					}
 				},
 				{
-					"id": 3287,
+					"id": 3313,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56627,7 +57162,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9687,
+							"line": 9791,
 							"character": 4
 						}
 					],
@@ -56642,28 +57177,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3286,
-						3287
+						3312,
+						3313
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9683,
+					"line": 9787,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3190,
+			"id": 3216,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3191,
+					"id": 3217,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56671,7 +57206,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8677,
+							"line": 8781,
 							"character": 4
 						}
 					],
@@ -56684,7 +57219,7 @@
 					}
 				},
 				{
-					"id": 3192,
+					"id": 3218,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56692,7 +57227,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8678,
+							"line": 8782,
 							"character": 4
 						}
 					],
@@ -56710,21 +57245,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3191,
-						3192
+						3217,
+						3218
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8676,
+					"line": 8780,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2895,
+			"id": 2921,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56734,7 +57269,7 @@
 			},
 			"children": [
 				{
-					"id": 2897,
+					"id": 2923,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56764,20 +57299,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2898,
+							"id": 2924,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2899,
+								"id": 2925,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2900,
+										"id": 2926,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -56790,7 +57325,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2901,
+										"id": 2927,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -56803,14 +57338,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2902,
+											"id": 2928,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2903,
+													"id": 2929,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -56832,7 +57367,7 @@
 					}
 				},
 				{
-					"id": 2896,
+					"id": 2922,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56851,7 +57386,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2904,
+						"id": 2930,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -56861,8 +57396,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2897,
-						2896
+						2923,
+						2922
 					]
 				}
 			],
@@ -57167,7 +57702,7 @@
 			]
 		},
 		{
-			"id": 3284,
+			"id": 3310,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57179,7 +57714,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1580,
+					"line": 1660,
 					"character": 12
 				}
 			],
@@ -57224,7 +57759,7 @@
 			}
 		},
 		{
-			"id": 2865,
+			"id": 2891,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57251,7 +57786,7 @@
 			}
 		},
 		{
-			"id": 2869,
+			"id": 2895,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57259,14 +57794,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2184,
+					"line": 2264,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2870,
+					"id": 2896,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -57283,13 +57818,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2184,
+							"line": 2264,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2871,
+							"id": 2897,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -57299,19 +57834,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2872,
+									"id": 2898,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2877,
+										"id": 2903,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2873,
+									"id": 2899,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -57321,7 +57856,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2874,
+											"id": 2900,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -57329,13 +57864,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2191,
+													"line": 2271,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2875,
+													"id": 2901,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -57345,7 +57880,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2876,
+															"id": 2902,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -57376,7 +57911,7 @@
 			}
 		},
 		{
-			"id": 2866,
+			"id": 2892,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57393,21 +57928,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2173,
+					"line": 2253,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2867,
+					"id": 2893,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2868,
+							"id": 2894,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57420,7 +57955,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2178,
+									"line": 2258,
 									"character": 4
 								}
 							],
@@ -57435,14 +57970,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2868
+								2894
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2173,
+							"line": 2253,
 							"character": 29
 						}
 					]
@@ -57450,7 +57985,7 @@
 			}
 		},
 		{
-			"id": 2877,
+			"id": 2903,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57467,21 +58002,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2160,
+					"line": 2240,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2878,
+					"id": 2904,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2880,
+							"id": 2906,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57489,7 +58024,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2164,
+									"line": 2244,
 									"character": 4
 								}
 							],
@@ -57499,7 +58034,7 @@
 							}
 						},
 						{
-							"id": 2881,
+							"id": 2907,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57509,7 +58044,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2166,
+									"line": 2246,
 									"character": 4
 								}
 							],
@@ -57519,7 +58054,7 @@
 							}
 						},
 						{
-							"id": 2879,
+							"id": 2905,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57527,7 +58062,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2162,
+									"line": 2242,
 									"character": 4
 								}
 							],
@@ -57542,16 +58077,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2880,
-								2881,
-								2879
+								2906,
+								2907,
+								2905
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2160,
+							"line": 2240,
 							"character": 29
 						}
 					]
@@ -57609,7 +58144,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1872,
+									"id": 1892,
 									"name": "AnswerService"
 								}
 							}
@@ -57871,7 +58406,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1872,
+												"id": 1892,
 												"name": "AnswerService"
 											}
 										},
@@ -57958,7 +58493,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2429,
+						"id": 2451,
 						"name": "EmbedConfig"
 					}
 				}
@@ -58029,7 +58564,7 @@
 					"kindString": "Call signature",
 					"flags": {},
 					"comment": {
-						"shortText": "Initializes the Visual Embed SDK globally and perform\nauthentication if applicable. This function needs to be called before any ThoughtSpot\ncomponent like Liveboard etc can be embedded. But need not wait for AuthEvent.SUCCESS\nto actually embed. That is handled internally.",
+						"shortText": "Initializes the Visual Embed SDK globally and perform\nauthentication if applicable. This function needs to be called before any ThoughtSpot\ncomponent like Liveboard etc can be embedded. But need not wait for AuthStatus.SUCCESS\nto actually embed. That is handled internally.",
 						"returns": "{@link AuthEventEmitter} event emitter which emits events on authentication success,\n     failure and logout. See {@link AuthStatus}",
 						"tags": [
 							{
@@ -58058,14 +58593,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2429,
+								"id": 2451,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1819,
+						"id": 1839,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -58205,7 +58740,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2835,
+									"id": 2861,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -58333,7 +58868,7 @@
 			]
 		},
 		{
-			"id": 3330,
+			"id": 3356,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -58349,7 +58884,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3331,
+					"id": 3357,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58379,7 +58914,7 @@
 			]
 		},
 		{
-			"id": 3332,
+			"id": 3358,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -58393,7 +58928,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3333,
+					"id": 3359,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58415,7 +58950,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3334,
+							"id": 3360,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58425,7 +58960,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3284,
+								"id": 3310,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -58603,7 +59138,7 @@
 			]
 		},
 		{
-			"id": 3157,
+			"id": 3183,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -58617,7 +59152,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3158,
+					"id": 3184,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58627,7 +59162,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3159,
+							"id": 3185,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58639,7 +59174,7 @@
 							}
 						},
 						{
-							"id": 3160,
+							"id": 3186,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58650,7 +59185,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3161,
+									"id": 3187,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -58673,92 +59208,92 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2233,
-				1817,
-				1802,
-				1809,
-				1969,
-				3293,
-				3296,
-				3300,
-				2425,
-				2223,
-				3247,
-				3243,
-				3316,
-				3239,
-				2229,
-				3256,
-				2001,
-				3280,
-				2846,
-				3183,
-				3177,
-				2858,
-				2130,
-				3252,
-				3288,
-				3187,
-				3231,
-				3150,
-				1959,
-				2835,
-				3181,
-				1985,
-				1540,
-				3327,
-				3323,
-				3213
+				2253,
+				1837,
+				1822,
+				1829,
+				1989,
+				3319,
+				3322,
+				3326,
+				2447,
+				2243,
+				3273,
+				3269,
+				3342,
+				3265,
+				2249,
+				3282,
+				2021,
+				3306,
+				2872,
+				3209,
+				3203,
+				2884,
+				2150,
+				3278,
+				3314,
+				3213,
+				3257,
+				3176,
+				1979,
+				2861,
+				3207,
+				2005,
+				1556,
+				3353,
+				3349,
+				3239
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1872,
-				903,
-				1243,
-				1616,
-				655,
-				254,
+				1892,
+				911,
+				1255,
+				1634,
+				661,
+				256,
 				58,
-				1135,
-				1274
+				1145,
+				1286
 			]
 		},
 		{
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2719,
-				1819,
-				1205,
-				1557,
-				3193,
-				2904,
-				2892,
-				2882,
-				2429,
-				3274,
-				2840,
-				2597,
-				1981,
-				3147,
-				2545,
-				2480,
-				1949,
-				1167,
-				1519,
-				1460,
-				1543,
-				1525,
-				2698,
-				2716,
-				2712,
-				1956,
-				3285,
-				3190,
-				2895,
+				2744,
+				1839,
+				1216,
+				1573,
+				3219,
+				2930,
+				2918,
+				2908,
+				2451,
+				3300,
+				2866,
+				2621,
+				2001,
+				3173,
+				2568,
+				2502,
+				1969,
+				1177,
+				1535,
+				1474,
+				1559,
+				1541,
+				2723,
+				2741,
+				2737,
+				1976,
+				3311,
+				3216,
+				2921,
 				21,
 				28
 			]
@@ -58767,11 +59302,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3284,
-				2865,
-				2869,
-				2866,
-				2877
+				3310,
+				2891,
+				2895,
+				2892,
+				2903
 			]
 		},
 		{
@@ -58788,10 +59323,10 @@
 				4,
 				7,
 				25,
-				3330,
-				3332,
+				3356,
+				3358,
 				40,
-				3157
+				3183
 			]
 		}
 	],

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2253,
+			"id": 2255,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2376,
+					"id": 2378,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -56,7 +56,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2273,
+					"id": 2275,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -84,7 +84,7 @@
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2266,
+					"id": 2268,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -112,7 +112,7 @@
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2265,
+					"id": 2267,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -136,7 +136,7 @@
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2271,
+					"id": 2273,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -160,7 +160,7 @@
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2272,
+					"id": 2274,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -184,7 +184,7 @@
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2274,
+					"id": 2276,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -212,7 +212,7 @@
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2356,
+					"id": 2358,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -240,7 +240,7 @@
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2326,
+					"id": 2328,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -268,7 +268,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2372,
+					"id": 2374,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -296,7 +296,7 @@
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2386,
+					"id": 2388,
 					"name": "AllLiveboardFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -324,7 +324,7 @@
 					"defaultValue": "\"allLiveboardFilters\""
 				},
 				{
-					"id": 2325,
+					"id": 2327,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -352,7 +352,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2324,
+					"id": 2326,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -380,7 +380,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2371,
+					"id": 2373,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -409,7 +409,7 @@
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2338,
+					"id": 2340,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -437,7 +437,7 @@
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2350,
+					"id": 2352,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -465,7 +465,7 @@
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2341,
+					"id": 2343,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -493,7 +493,7 @@
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2346,
+					"id": 2348,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -521,7 +521,7 @@
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2340,
+					"id": 2342,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -549,7 +549,7 @@
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2343,
+					"id": 2345,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -577,7 +577,7 @@
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2351,
+					"id": 2353,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -605,7 +605,7 @@
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2347,
+					"id": 2349,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -633,7 +633,7 @@
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2344,
+					"id": 2346,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -661,7 +661,7 @@
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2349,
+					"id": 2351,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -689,7 +689,7 @@
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2345,
+					"id": 2347,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -717,7 +717,7 @@
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2342,
+					"id": 2344,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -745,7 +745,7 @@
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2348,
+					"id": 2350,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -773,7 +773,7 @@
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2339,
+					"id": 2341,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -801,7 +801,7 @@
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2385,
+					"id": 2387,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -829,7 +829,7 @@
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2270,
+					"id": 2272,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -853,7 +853,7 @@
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2269,
+					"id": 2271,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -881,7 +881,7 @@
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2268,
+					"id": 2270,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -909,7 +909,7 @@
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2394,
+					"id": 2396,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -937,7 +937,7 @@
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2267,
+					"id": 2269,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -961,7 +961,7 @@
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2317,
+					"id": 2319,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -976,7 +976,7 @@
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2260,
+					"id": 2262,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1000,7 +1000,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2316,
+					"id": 2318,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1024,7 +1024,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2395,
+					"id": 2397,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1052,7 +1052,7 @@
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2409,
+					"id": 2411,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1080,7 +1080,7 @@
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2369,
+					"id": 2371,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1108,7 +1108,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2329,
+					"id": 2331,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1136,7 +1136,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2334,
+					"id": 2336,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1164,7 +1164,7 @@
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2387,
+					"id": 2389,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1192,7 +1192,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2392,
+					"id": 2394,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1220,7 +1220,7 @@
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2382,
+					"id": 2384,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1248,7 +1248,7 @@
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2384,
+					"id": 2386,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1276,7 +1276,7 @@
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2282,
+					"id": 2284,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1300,7 +1300,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2285,
+					"id": 2287,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1324,7 +1324,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2284,
+					"id": 2286,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1349,7 +1349,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2283,
+					"id": 2285,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1373,7 +1373,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2286,
+					"id": 2288,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1397,7 +1397,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2287,
+					"id": 2289,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1425,7 +1425,7 @@
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2289,
+					"id": 2291,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1453,7 +1453,7 @@
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2288,
+					"id": 2290,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1481,7 +1481,7 @@
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2291,
+					"id": 2293,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1509,7 +1509,7 @@
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2290,
+					"id": 2292,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1537,7 +1537,7 @@
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2321,
+					"id": 2323,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1561,7 +1561,7 @@
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2315,
+					"id": 2317,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1585,7 +1585,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2314,
+					"id": 2316,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1609,7 +1609,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2299,
+					"id": 2301,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1633,7 +1633,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2259,
+					"id": 2261,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1657,7 +1657,7 @@
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2328,
+					"id": 2330,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1685,7 +1685,7 @@
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2319,
+					"id": 2321,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1700,7 +1700,7 @@
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2391,
+					"id": 2393,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1728,7 +1728,7 @@
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2360,
+					"id": 2362,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1756,7 +1756,7 @@
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2377,
+					"id": 2379,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1784,7 +1784,7 @@
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2296,
+					"id": 2298,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1808,7 +1808,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2300,
+					"id": 2302,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1832,7 +1832,7 @@
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2393,
+					"id": 2395,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1860,7 +1860,7 @@
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2357,
+					"id": 2359,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1888,7 +1888,7 @@
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2358,
+					"id": 2360,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1916,7 +1916,7 @@
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2313,
+					"id": 2315,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1940,7 +1940,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2293,
+					"id": 2295,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1965,7 +1965,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2294,
+					"id": 2296,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1989,7 +1989,7 @@
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2396,
+					"id": 2398,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2018,7 +2018,7 @@
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2432,
+					"id": 2434,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2046,7 +2046,7 @@
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2383,
+					"id": 2385,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2074,7 +2074,7 @@
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2307,
+					"id": 2309,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2098,7 +2098,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2402,
+					"id": 2404,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2126,7 +2126,7 @@
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2367,
+					"id": 2369,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2154,7 +2154,7 @@
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2258,
+					"id": 2260,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2178,7 +2178,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2364,
+					"id": 2366,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2202,7 +2202,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2333,
+					"id": 2335,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2230,7 +2230,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2404,
+					"id": 2406,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2258,7 +2258,7 @@
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2381,
+					"id": 2383,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2286,7 +2286,7 @@
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2355,
+					"id": 2357,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2314,7 +2314,7 @@
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2362,
+					"id": 2364,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2341,7 +2341,7 @@
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2408,
+					"id": 2410,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2369,7 +2369,7 @@
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2407,
+					"id": 2409,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2397,7 +2397,7 @@
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2363,
+					"id": 2365,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2421,7 +2421,7 @@
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2374,
+					"id": 2376,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2453,7 +2453,7 @@
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2375,
+					"id": 2377,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2481,7 +2481,7 @@
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2406,
+					"id": 2408,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2509,7 +2509,7 @@
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2378,
+					"id": 2380,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2537,7 +2537,7 @@
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2365,
+					"id": 2367,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2569,7 +2569,7 @@
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2366,
+					"id": 2368,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2597,7 +2597,7 @@
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2310,
+					"id": 2312,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2621,7 +2621,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2400,
+					"id": 2402,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2645,7 +2645,7 @@
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2297,
+					"id": 2299,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2669,7 +2669,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2388,
+					"id": 2390,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2697,7 +2697,7 @@
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2403,
+					"id": 2405,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2725,7 +2725,7 @@
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2323,
+					"id": 2325,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2750,7 +2750,7 @@
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2438,
+					"id": 2440,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2778,7 +2778,7 @@
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2301,
+					"id": 2303,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2802,7 +2802,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2401,
+					"id": 2403,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2830,7 +2830,7 @@
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2337,
+					"id": 2339,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2858,7 +2858,7 @@
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2327,
+					"id": 2329,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2886,7 +2886,7 @@
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2373,
+					"id": 2375,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2914,7 +2914,7 @@
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2353,
+					"id": 2355,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2942,7 +2942,7 @@
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2330,
+					"id": 2332,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2973,7 +2973,7 @@
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2322,
+					"id": 2324,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2997,7 +2997,7 @@
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2354,
+					"id": 2356,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3025,7 +3025,7 @@
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2389,
+					"id": 2391,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3053,7 +3053,7 @@
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2361,
+					"id": 2363,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3081,7 +3081,7 @@
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2254,
+					"id": 2256,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3105,7 +3105,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2257,
+					"id": 2259,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3129,7 +3129,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2262,
+					"id": 2264,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3153,7 +3153,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2263,
+					"id": 2265,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3177,7 +3177,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2433,
+					"id": 2435,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3205,7 +3205,7 @@
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2320,
+					"id": 2322,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3220,7 +3220,7 @@
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2264,
+					"id": 2266,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3244,7 +3244,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2279,
+					"id": 2281,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3262,7 +3262,7 @@
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2359,
+					"id": 2361,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3290,7 +3290,7 @@
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2281,
+					"id": 2283,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3314,7 +3314,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2276,
+					"id": 2278,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3338,7 +3338,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2441,
+					"id": 2443,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3366,7 +3366,7 @@
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2442,
+					"id": 2444,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3394,7 +3394,7 @@
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2440,
+					"id": 2442,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3422,7 +3422,7 @@
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2445,
+					"id": 2447,
 					"name": "SpotterAnalystList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3450,7 +3450,7 @@
 					"defaultValue": "\"spotterAnalystList\""
 				},
 				{
-					"id": 2443,
+					"id": 2445,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3478,7 +3478,7 @@
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2439,
+					"id": 2441,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3506,7 +3506,7 @@
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2444,
+					"id": 2446,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3534,7 +3534,7 @@
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2429,
+					"id": 2431,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3562,7 +3562,7 @@
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2430,
+					"id": 2432,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3590,7 +3590,7 @@
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2426,
+					"id": 2428,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3618,7 +3618,7 @@
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2416,
+					"id": 2418,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3646,7 +3646,7 @@
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2431,
+					"id": 2433,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3674,7 +3674,7 @@
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2427,
+					"id": 2429,
 					"name": "SpotterChatPin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3702,7 +3702,7 @@
 					"defaultValue": "\"spotterChatPin\""
 				},
 				{
-					"id": 2417,
+					"id": 2419,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3730,7 +3730,7 @@
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2446,
+					"id": 2448,
 					"name": "SpotterDefaultAnalyst",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3758,7 +3758,7 @@
 					"defaultValue": "\"spotterDefaultAnalyst\""
 				},
 				{
-					"id": 2428,
+					"id": 2430,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3786,7 +3786,7 @@
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2390,
+					"id": 2392,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3814,7 +3814,7 @@
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2414,
+					"id": 2416,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3842,7 +3842,7 @@
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2415,
+					"id": 2417,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3870,7 +3870,7 @@
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2418,
+					"id": 2420,
 					"name": "SpotterShareConversationButtonHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3898,7 +3898,7 @@
 					"defaultValue": "\"spotterShareConversationButtonHeader\""
 				},
 				{
-					"id": 2419,
+					"id": 2421,
 					"name": "SpotterShareConversationMenuItemSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3926,7 +3926,7 @@
 					"defaultValue": "\"spotterShareConversationMenuItemSidebar\""
 				},
 				{
-					"id": 2424,
+					"id": 2426,
 					"name": "SpotterShareIncludeNewMessagesCheckbox",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3954,7 +3954,7 @@
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckbox\""
 				},
 				{
-					"id": 2425,
+					"id": 2427,
 					"name": "SpotterShareStaleInfoBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3982,7 +3982,7 @@
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissButton\""
 				},
 				{
-					"id": 2423,
+					"id": 2425,
 					"name": "SpotterShareUpToCurrentInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4010,7 +4010,7 @@
 					"defaultValue": "\"spotterShareUpToCurrentInfo\""
 				},
 				{
-					"id": 2420,
+					"id": 2422,
 					"name": "SpotterSharedConversationBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4038,7 +4038,7 @@
 					"defaultValue": "\"spotterSharedConversationBanner\""
 				},
 				{
-					"id": 2421,
+					"id": 2423,
 					"name": "SpotterSharedConversationBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4066,7 +4066,7 @@
 					"defaultValue": "\"spotterSharedConversationBannerDismissButton\""
 				},
 				{
-					"id": 2422,
+					"id": 2424,
 					"name": "SpotterSharedConversationExitButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4094,7 +4094,7 @@
 					"defaultValue": "\"spotterSharedConversationExitButton\""
 				},
 				{
-					"id": 2412,
+					"id": 2414,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4122,7 +4122,7 @@
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2411,
+					"id": 2413,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4150,7 +4150,7 @@
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2413,
+					"id": 2415,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4178,7 +4178,7 @@
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2399,
+					"id": 2401,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4206,7 +4206,7 @@
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2436,
+					"id": 2438,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4234,7 +4234,7 @@
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2435,
+					"id": 2437,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4262,7 +4262,7 @@
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2434,
+					"id": 2436,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4290,7 +4290,7 @@
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2437,
+					"id": 2439,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4318,7 +4318,7 @@
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2397,
+					"id": 2399,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4346,7 +4346,7 @@
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2398,
+					"id": 2400,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4374,7 +4374,7 @@
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2312,
+					"id": 2314,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4398,7 +4398,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2332,
+					"id": 2334,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4426,7 +4426,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2331,
+					"id": 2333,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4454,7 +4454,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2335,
+					"id": 2337,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4482,7 +4482,7 @@
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2336,
+					"id": 2338,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4510,7 +4510,7 @@
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2368,
+					"id": 2370,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4542,7 +4542,7 @@
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2298,
+					"id": 2300,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4566,7 +4566,7 @@
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2410,
+					"id": 2412,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4594,7 +4594,7 @@
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2405,
+					"id": 2407,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4622,7 +4622,7 @@
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2380,
+					"id": 2382,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4650,7 +4650,7 @@
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2295,
+					"id": 2297,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4674,7 +4674,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2370,
+					"id": 2372,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4702,7 +4702,7 @@
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2379,
+					"id": 2381,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4735,181 +4735,181 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2376,
+						2378,
+						2275,
+						2268,
+						2267,
 						2273,
-						2266,
-						2265,
-						2271,
-						2272,
 						2274,
-						2356,
+						2276,
+						2358,
+						2328,
+						2374,
+						2388,
+						2327,
 						2326,
-						2372,
-						2386,
-						2325,
-						2324,
-						2371,
-						2338,
-						2350,
-						2341,
-						2346,
+						2373,
 						2340,
+						2352,
 						2343,
+						2348,
+						2342,
+						2345,
+						2353,
+						2349,
+						2346,
 						2351,
 						2347,
 						2344,
-						2349,
-						2345,
-						2342,
-						2348,
-						2339,
-						2385,
-						2270,
-						2269,
-						2268,
-						2394,
-						2267,
-						2317,
-						2260,
-						2316,
-						2395,
-						2409,
-						2369,
-						2329,
-						2334,
+						2350,
+						2341,
 						2387,
-						2392,
-						2382,
+						2272,
+						2271,
+						2270,
+						2396,
+						2269,
+						2319,
+						2262,
+						2318,
+						2397,
+						2411,
+						2371,
+						2331,
+						2336,
+						2389,
+						2394,
 						2384,
-						2282,
-						2285,
+						2386,
 						2284,
-						2283,
-						2286,
 						2287,
-						2289,
+						2286,
+						2285,
 						2288,
+						2289,
 						2291,
 						2290,
-						2321,
-						2315,
-						2314,
-						2299,
-						2259,
-						2328,
-						2319,
-						2391,
-						2360,
-						2377,
-						2296,
-						2300,
-						2393,
-						2357,
-						2358,
-						2313,
 						2293,
-						2294,
-						2396,
-						2432,
-						2383,
-						2307,
-						2402,
-						2367,
-						2258,
-						2364,
-						2333,
-						2404,
-						2381,
-						2355,
-						2362,
-						2408,
-						2407,
-						2363,
-						2374,
-						2375,
-						2406,
-						2378,
-						2365,
-						2366,
-						2310,
-						2400,
-						2297,
-						2388,
-						2403,
+						2292,
 						2323,
-						2438,
+						2317,
+						2316,
 						2301,
-						2401,
-						2337,
-						2327,
-						2373,
-						2353,
+						2261,
 						2330,
-						2322,
-						2354,
-						2389,
-						2361,
-						2254,
-						2257,
-						2262,
-						2263,
-						2433,
-						2320,
-						2264,
-						2279,
+						2321,
+						2393,
+						2362,
+						2379,
+						2298,
+						2302,
+						2395,
 						2359,
-						2281,
-						2276,
-						2441,
-						2442,
-						2440,
-						2445,
-						2443,
-						2439,
-						2444,
-						2429,
-						2430,
-						2426,
-						2416,
-						2431,
-						2427,
-						2417,
-						2446,
-						2428,
+						2360,
+						2315,
+						2295,
+						2296,
+						2398,
+						2434,
+						2385,
+						2309,
+						2404,
+						2369,
+						2260,
+						2366,
+						2335,
+						2406,
+						2383,
+						2357,
+						2364,
+						2410,
+						2409,
+						2365,
+						2376,
+						2377,
+						2408,
+						2380,
+						2367,
+						2368,
+						2312,
+						2402,
+						2299,
 						2390,
-						2414,
-						2415,
+						2405,
+						2325,
+						2440,
+						2303,
+						2403,
+						2339,
+						2329,
+						2375,
+						2355,
+						2332,
+						2324,
+						2356,
+						2391,
+						2363,
+						2256,
+						2259,
+						2264,
+						2265,
+						2435,
+						2322,
+						2266,
+						2281,
+						2361,
+						2283,
+						2278,
+						2443,
+						2444,
+						2442,
+						2447,
+						2445,
+						2441,
+						2446,
+						2431,
+						2432,
+						2428,
 						2418,
+						2433,
+						2429,
 						2419,
-						2424,
-						2425,
-						2423,
+						2448,
+						2430,
+						2392,
+						2416,
+						2417,
 						2420,
 						2421,
+						2426,
+						2427,
+						2425,
 						2422,
-						2412,
-						2411,
+						2423,
+						2424,
+						2414,
 						2413,
-						2399,
-						2436,
-						2435,
-						2434,
+						2415,
+						2401,
+						2438,
 						2437,
-						2397,
-						2398,
-						2312,
-						2332,
-						2331,
-						2335,
-						2336,
-						2368,
-						2298,
-						2410,
-						2405,
-						2380,
-						2295,
+						2436,
+						2439,
+						2399,
+						2400,
+						2314,
+						2334,
+						2333,
+						2337,
+						2338,
 						2370,
-						2379
+						2300,
+						2412,
+						2407,
+						2382,
+						2297,
+						2372,
+						2381
 					]
 				}
 			],
@@ -4922,7 +4922,7 @@
 			]
 		},
 		{
-			"id": 1837,
+			"id": 1839,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4938,7 +4938,7 @@
 			},
 			"children": [
 				{
-					"id": 1838,
+					"id": 1840,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4961,7 +4961,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1838
+						1840
 					]
 				}
 			],
@@ -4974,7 +4974,7 @@
 			]
 		},
 		{
-			"id": 1822,
+			"id": 1824,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4990,7 +4990,7 @@
 			},
 			"children": [
 				{
-					"id": 1825,
+					"id": 1827,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5009,7 +5009,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1827,
+					"id": 1829,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5028,7 +5028,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1824,
+					"id": 1826,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5047,7 +5047,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1826,
+					"id": 1828,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5066,7 +5066,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1823,
+					"id": 1825,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5085,7 +5085,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1828,
+					"id": 1830,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5109,12 +5109,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1825,
 						1827,
-						1824,
+						1829,
 						1826,
-						1823,
-						1828
+						1828,
+						1825,
+						1830
 					]
 				}
 			],
@@ -5127,7 +5127,7 @@
 			]
 		},
 		{
-			"id": 1829,
+			"id": 1831,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5143,7 +5143,7 @@
 			},
 			"children": [
 				{
-					"id": 1830,
+					"id": 1832,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5161,7 +5161,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1834,
+					"id": 1836,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5179,7 +5179,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1836,
+					"id": 1838,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5197,7 +5197,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1831,
+					"id": 1833,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5221,7 +5221,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1833,
+					"id": 1835,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5254,7 +5254,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1835,
+					"id": 1837,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5283,12 +5283,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1830,
-						1834,
+						1832,
 						1836,
-						1831,
+						1838,
 						1833,
-						1835
+						1835,
+						1837
 					]
 				}
 			],
@@ -5301,7 +5301,7 @@
 			]
 		},
 		{
-			"id": 1989,
+			"id": 1991,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5317,7 +5317,7 @@
 			},
 			"children": [
 				{
-					"id": 2000,
+					"id": 2002,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5336,7 +5336,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1991,
+					"id": 1993,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5365,7 +5365,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1990,
+					"id": 1992,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5389,7 +5389,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1996,
+					"id": 1998,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5407,7 +5407,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1994,
+					"id": 1996,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5440,7 +5440,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 1998,
+					"id": 2000,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5464,7 +5464,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 1999,
+					"id": 2001,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5497,13 +5497,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2000,
-						1991,
-						1990,
-						1996,
-						1994,
+						2002,
+						1993,
+						1992,
 						1998,
-						1999
+						1996,
+						2000,
+						2001
 					]
 				}
 			],
@@ -5516,7 +5516,7 @@
 			]
 		},
 		{
-			"id": 3319,
+			"id": 3321,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5532,7 +5532,7 @@
 			},
 			"children": [
 				{
-					"id": 3321,
+					"id": 3323,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5550,7 +5550,7 @@
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3320,
+					"id": 3322,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5573,8 +5573,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3321,
-						3320
+						3323,
+						3322
 					]
 				}
 			],
@@ -5587,7 +5587,7 @@
 			]
 		},
 		{
-			"id": 3322,
+			"id": 3324,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5603,7 +5603,7 @@
 			},
 			"children": [
 				{
-					"id": 3324,
+					"id": 3326,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5621,7 +5621,7 @@
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3325,
+					"id": 3327,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5639,7 +5639,7 @@
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3323,
+					"id": 3325,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5662,9 +5662,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3324,
-						3325,
-						3323
+						3326,
+						3327,
+						3325
 					]
 				}
 			],
@@ -5677,7 +5677,7 @@
 			]
 		},
 		{
-			"id": 3326,
+			"id": 3328,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5693,7 +5693,7 @@
 			},
 			"children": [
 				{
-					"id": 3329,
+					"id": 3331,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5711,7 +5711,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3330,
+					"id": 3332,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5729,7 +5729,7 @@
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3332,
+					"id": 3334,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5747,7 +5747,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3337,
+					"id": 3339,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5765,7 +5765,7 @@
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3333,
+					"id": 3335,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5783,7 +5783,7 @@
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3335,
+					"id": 3337,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5801,7 +5801,7 @@
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3327,
+					"id": 3329,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5819,7 +5819,7 @@
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3339,
+					"id": 3341,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5837,7 +5837,7 @@
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3328,
+					"id": 3330,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5855,7 +5855,7 @@
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3341,
+					"id": 3343,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5873,7 +5873,7 @@
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3340,
+					"id": 3342,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5891,7 +5891,7 @@
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3334,
+					"id": 3336,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5909,7 +5909,7 @@
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3336,
+					"id": 3338,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5927,7 +5927,7 @@
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3338,
+					"id": 3340,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5945,7 +5945,7 @@
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3331,
+					"id": 3333,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5968,21 +5968,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3329,
-						3330,
+						3331,
 						3332,
-						3337,
-						3333,
-						3335,
-						3327,
-						3339,
-						3328,
-						3341,
-						3340,
 						3334,
+						3339,
+						3335,
+						3337,
+						3329,
+						3341,
+						3330,
+						3343,
+						3342,
 						3336,
 						3338,
-						3331
+						3340,
+						3333
 					]
 				}
 			],
@@ -5995,7 +5995,7 @@
 			]
 		},
 		{
-			"id": 2447,
+			"id": 2449,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6005,7 +6005,7 @@
 			},
 			"children": [
 				{
-					"id": 2450,
+					"id": 2452,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6020,7 +6020,7 @@
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2448,
+					"id": 2450,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6035,7 +6035,7 @@
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2449,
+					"id": 2451,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6055,9 +6055,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						2452,
 						2450,
-						2448,
-						2449
+						2451
 					]
 				}
 			],
@@ -6070,7 +6070,7 @@
 			]
 		},
 		{
-			"id": 2243,
+			"id": 2245,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6094,7 +6094,7 @@
 			},
 			"children": [
 				{
-					"id": 2246,
+					"id": 2248,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6112,7 +6112,7 @@
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2245,
+					"id": 2247,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6130,7 +6130,7 @@
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2248,
+					"id": 2250,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6148,7 +6148,7 @@
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2244,
+					"id": 2246,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6166,7 +6166,7 @@
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2247,
+					"id": 2249,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6189,11 +6189,11 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2246,
-						2245,
 						2248,
-						2244,
-						2247
+						2247,
+						2250,
+						2246,
+						2249
 					]
 				}
 			],
@@ -6206,7 +6206,7 @@
 			]
 		},
 		{
-			"id": 3273,
+			"id": 3275,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6216,7 +6216,7 @@
 			},
 			"children": [
 				{
-					"id": 3276,
+					"id": 3278,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6234,7 +6234,7 @@
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3274,
+					"id": 3276,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6252,7 +6252,7 @@
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3277,
+					"id": 3279,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6270,7 +6270,7 @@
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3275,
+					"id": 3277,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6293,10 +6293,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						3278,
 						3276,
-						3274,
-						3277,
-						3275
+						3279,
+						3277
 					]
 				}
 			],
@@ -6309,7 +6309,7 @@
 			]
 		},
 		{
-			"id": 3269,
+			"id": 3271,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6319,7 +6319,7 @@
 			},
 			"children": [
 				{
-					"id": 3272,
+					"id": 3274,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6337,7 +6337,7 @@
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3271,
+					"id": 3273,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6355,7 +6355,7 @@
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3270,
+					"id": 3272,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6378,9 +6378,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3272,
-						3271,
-						3270
+						3274,
+						3273,
+						3272
 					]
 				}
 			],
@@ -6393,7 +6393,7 @@
 			]
 		},
 		{
-			"id": 3342,
+			"id": 3344,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6409,7 +6409,7 @@
 			},
 			"children": [
 				{
-					"id": 3347,
+					"id": 3349,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6427,7 +6427,7 @@
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3343,
+					"id": 3345,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6445,7 +6445,7 @@
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3345,
+					"id": 3347,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6463,7 +6463,7 @@
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3344,
+					"id": 3346,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6481,7 +6481,7 @@
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3346,
+					"id": 3348,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6499,7 +6499,7 @@
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3348,
+					"id": 3350,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6522,12 +6522,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3347,
-						3343,
+						3349,
 						3345,
-						3344,
+						3347,
 						3346,
-						3348
+						3348,
+						3350
 					]
 				}
 			],
@@ -6540,7 +6540,7 @@
 			]
 		},
 		{
-			"id": 3265,
+			"id": 3267,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6550,7 +6550,7 @@
 			},
 			"children": [
 				{
-					"id": 3267,
+					"id": 3269,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6568,7 +6568,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3266,
+					"id": 3268,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6586,7 +6586,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3268,
+					"id": 3270,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6609,9 +6609,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3267,
-						3266,
-						3268
+						3269,
+						3268,
+						3270
 					]
 				}
 			],
@@ -6624,7 +6624,7 @@
 			]
 		},
 		{
-			"id": 2249,
+			"id": 2251,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6634,7 +6634,7 @@
 			},
 			"children": [
 				{
-					"id": 2251,
+					"id": 2253,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6652,7 +6652,7 @@
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2252,
+					"id": 2254,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6670,7 +6670,7 @@
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2250,
+					"id": 2252,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6693,9 +6693,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2251,
-						2252,
-						2250
+						2253,
+						2254,
+						2252
 					]
 				}
 			],
@@ -6708,7 +6708,7 @@
 			]
 		},
 		{
-			"id": 3282,
+			"id": 3284,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6732,7 +6732,7 @@
 			},
 			"children": [
 				{
-					"id": 3285,
+					"id": 3287,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6750,7 +6750,7 @@
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3286,
+					"id": 3288,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6768,7 +6768,7 @@
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3289,
+					"id": 3291,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6786,7 +6786,7 @@
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3298,
+					"id": 3300,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6804,7 +6804,7 @@
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3292,
+					"id": 3294,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6822,7 +6822,7 @@
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3296,
+					"id": 3298,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6840,7 +6840,7 @@
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3287,
+					"id": 3289,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6858,7 +6858,7 @@
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3295,
+					"id": 3297,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6876,7 +6876,7 @@
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3284,
+					"id": 3286,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6894,7 +6894,7 @@
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3290,
+					"id": 3292,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6912,7 +6912,7 @@
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3288,
+					"id": 3290,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6930,7 +6930,7 @@
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3293,
+					"id": 3295,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6948,7 +6948,7 @@
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3291,
+					"id": 3293,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6966,7 +6966,7 @@
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3297,
+					"id": 3299,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6984,7 +6984,7 @@
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3299,
+					"id": 3301,
 					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7002,7 +7002,7 @@
 					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3294,
+					"id": 3296,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7020,7 +7020,7 @@
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3283,
+					"id": 3285,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7043,23 +7043,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3285,
-						3286,
-						3289,
-						3298,
-						3292,
-						3296,
 						3287,
-						3295,
-						3284,
-						3290,
 						3288,
-						3293,
 						3291,
-						3297,
-						3299,
+						3300,
 						3294,
-						3283
+						3298,
+						3289,
+						3297,
+						3286,
+						3292,
+						3290,
+						3295,
+						3293,
+						3299,
+						3301,
+						3296,
+						3285
 					]
 				}
 			],
@@ -7072,7 +7072,7 @@
 			]
 		},
 		{
-			"id": 2021,
+			"id": 2023,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7097,7 +7097,7 @@
 			},
 			"children": [
 				{
-					"id": 2058,
+					"id": 2060,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7125,7 +7125,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2049,
+					"id": 2051,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7153,7 +7153,7 @@
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2029,
+					"id": 2031,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7185,7 +7185,7 @@
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2111,
+					"id": 2113,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7213,7 +7213,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2075,
+					"id": 2077,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7241,7 +7241,7 @@
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2034,
+					"id": 2036,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7273,7 +7273,7 @@
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2071,
+					"id": 2073,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7301,7 +7301,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2057,
+					"id": 2059,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7329,7 +7329,7 @@
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2121,
+					"id": 2123,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7358,7 +7358,7 @@
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2100,
+					"id": 2102,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7398,7 +7398,7 @@
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2035,
+					"id": 2037,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7426,7 +7426,7 @@
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2023,
+					"id": 2025,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7458,7 +7458,7 @@
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2082,
+					"id": 2084,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7486,7 +7486,7 @@
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2098,
+					"id": 2100,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7530,7 +7530,7 @@
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2069,
+					"id": 2071,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7558,7 +7558,7 @@
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2084,
+					"id": 2086,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7586,7 +7586,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2064,
+					"id": 2066,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7614,7 +7614,7 @@
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2090,
+					"id": 2092,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7638,7 +7638,7 @@
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2105,
+					"id": 2107,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7663,7 +7663,7 @@
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2106,
+					"id": 2108,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7687,7 +7687,7 @@
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2099,
+					"id": 2101,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7711,7 +7711,7 @@
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2085,
+					"id": 2087,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7739,7 +7739,7 @@
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2030,
+					"id": 2032,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7775,7 +7775,7 @@
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2025,
+					"id": 2027,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7811,7 +7811,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2112,
+					"id": 2114,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7839,7 +7839,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2028,
+					"id": 2030,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7871,7 +7871,7 @@
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2080,
+					"id": 2082,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7899,7 +7899,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2096,
+					"id": 2098,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7935,7 +7935,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2097,
+					"id": 2099,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7967,7 +7967,7 @@
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2047,
+					"id": 2049,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7995,7 +7995,7 @@
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2046,
+					"id": 2048,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8023,7 +8023,7 @@
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2051,
+					"id": 2053,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8052,7 +8052,7 @@
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2054,
+					"id": 2056,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8080,7 +8080,7 @@
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2053,
+					"id": 2055,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8108,7 +8108,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2052,
+					"id": 2054,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8136,7 +8136,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2055,
+					"id": 2057,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8164,7 +8164,7 @@
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2056,
+					"id": 2058,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8192,7 +8192,7 @@
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2063,
+					"id": 2065,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8220,7 +8220,7 @@
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2062,
+					"id": 2064,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8248,7 +8248,7 @@
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2027,
+					"id": 2029,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8292,7 +8292,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2077,
+					"id": 2079,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8320,7 +8320,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2066,
+					"id": 2068,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8348,7 +8348,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2139,
+					"id": 2141,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8376,7 +8376,7 @@
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 2033,
+					"id": 2035,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8413,7 +8413,7 @@
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2083,
+					"id": 2085,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8441,7 +8441,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2067,
+					"id": 2069,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8469,7 +8469,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2088,
+					"id": 2090,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8497,7 +8497,7 @@
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2041,
+					"id": 2043,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8525,7 +8525,7 @@
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2022,
+					"id": 2024,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8553,7 +8553,7 @@
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2115,
+					"id": 2117,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8581,7 +8581,7 @@
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2114,
+					"id": 2116,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8609,7 +8609,7 @@
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2074,
+					"id": 2076,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8637,7 +8637,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2048,
+					"id": 2050,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8669,7 +8669,7 @@
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2024,
+					"id": 2026,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8701,7 +8701,7 @@
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2078,
+					"id": 2080,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8729,7 +8729,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2044,
+					"id": 2046,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8757,7 +8757,7 @@
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2102,
+					"id": 2104,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8795,7 +8795,7 @@
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2120,
+					"id": 2122,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8823,7 +8823,7 @@
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2103,
+					"id": 2105,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8847,7 +8847,7 @@
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2059,
+					"id": 2061,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8875,7 +8875,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2079,
+					"id": 2081,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8907,7 +8907,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2110,
+					"id": 2112,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8935,7 +8935,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2026,
+					"id": 2028,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8963,7 +8963,7 @@
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2149,
+					"id": 2151,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8991,7 +8991,7 @@
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2101,
+					"id": 2103,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9015,7 +9015,7 @@
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2095,
+					"id": 2097,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9055,7 +9055,7 @@
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2116,
+					"id": 2118,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9083,7 +9083,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2042,
+					"id": 2044,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9111,7 +9111,7 @@
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2050,
+					"id": 2052,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9139,7 +9139,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2068,
+					"id": 2070,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9167,7 +9167,7 @@
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2093,
+					"id": 2095,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9211,7 +9211,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2094,
+					"id": 2096,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9251,7 +9251,7 @@
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2076,
+					"id": 2078,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9279,7 +9279,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2081,
+					"id": 2083,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9307,7 +9307,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2141,
+					"id": 2143,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9335,7 +9335,7 @@
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2061,
+					"id": 2063,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9363,7 +9363,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2070,
+					"id": 2072,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9391,7 +9391,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2060,
+					"id": 2062,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9419,7 +9419,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2123,
+					"id": 2125,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9447,7 +9447,7 @@
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2134,
+					"id": 2136,
 					"name": "SpotterConversationPinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9475,7 +9475,7 @@
 					"defaultValue": "\"spotterConversationPinned\""
 				},
 				{
-					"id": 2122,
+					"id": 2124,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9503,7 +9503,7 @@
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2136,
+					"id": 2138,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9531,7 +9531,7 @@
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2127,
+					"id": 2129,
 					"name": "SpotterConversationShareRevoked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9559,7 +9559,7 @@
 					"defaultValue": "\"spotterConversationShareRevoked\""
 				},
 				{
-					"id": 2126,
+					"id": 2128,
 					"name": "SpotterConversationShared",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9587,7 +9587,7 @@
 					"defaultValue": "\"spotterConversationShared\""
 				},
 				{
-					"id": 2135,
+					"id": 2137,
 					"name": "SpotterConversationUnpinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9615,7 +9615,7 @@
 					"defaultValue": "\"spotterConversationUnpinned\""
 				},
 				{
-					"id": 2109,
+					"id": 2111,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9643,7 +9643,7 @@
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2117,
+					"id": 2119,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9671,7 +9671,7 @@
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2118,
+					"id": 2120,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9699,7 +9699,7 @@
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2113,
+					"id": 2115,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9727,7 +9727,7 @@
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2137,
+					"id": 2139,
 					"name": "SpotterResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9760,7 +9760,7 @@
 					"defaultValue": "\"spotterResponseComplete\""
 				},
 				{
-					"id": 2124,
+					"id": 2126,
 					"name": "SpotterShareConversationButtonHeaderClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9788,7 +9788,7 @@
 					"defaultValue": "\"spotterShareConversationButtonHeaderClicked\""
 				},
 				{
-					"id": 2125,
+					"id": 2127,
 					"name": "SpotterShareConversationMenuItemSidebarClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9816,7 +9816,7 @@
 					"defaultValue": "\"spotterShareConversationMenuItemSidebarClicked\""
 				},
 				{
-					"id": 2129,
+					"id": 2131,
 					"name": "SpotterShareIncludeNewMessagesCheckboxToggled",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9844,7 +9844,7 @@
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckboxToggled\""
 				},
 				{
-					"id": 2132,
+					"id": 2134,
 					"name": "SpotterShareModalCancelButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9872,7 +9872,7 @@
 					"defaultValue": "\"spotterShareModalCancelButtonClicked\""
 				},
 				{
-					"id": 2131,
+					"id": 2133,
 					"name": "SpotterShareModalConfirmButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9900,7 +9900,7 @@
 					"defaultValue": "\"spotterShareModalConfirmButtonClicked\""
 				},
 				{
-					"id": 2130,
+					"id": 2132,
 					"name": "SpotterShareStaleInfoBannerDismissed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9928,7 +9928,7 @@
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissed\""
 				},
 				{
-					"id": 2133,
+					"id": 2135,
 					"name": "SpotterSharedConversationExitButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9956,7 +9956,7 @@
 					"defaultValue": "\"spotterSharedConversationExitButtonClicked\""
 				},
 				{
-					"id": 2128,
+					"id": 2130,
 					"name": "SpotterSharedConversationViewed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9984,7 +9984,7 @@
 					"defaultValue": "\"spotterSharedConversationViewed\""
 				},
 				{
-					"id": 2145,
+					"id": 2147,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10012,7 +10012,7 @@
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2146,
+					"id": 2148,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10040,7 +10040,7 @@
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2148,
+					"id": 2150,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10068,7 +10068,7 @@
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2147,
+					"id": 2149,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10096,7 +10096,7 @@
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2142,
+					"id": 2144,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10124,7 +10124,7 @@
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2143,
+					"id": 2145,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10152,7 +10152,7 @@
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2144,
+					"id": 2146,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10180,7 +10180,7 @@
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2140,
+					"id": 2142,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10213,7 +10213,7 @@
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2104,
+					"id": 2106,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10242,7 +10242,7 @@
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2089,
+					"id": 2091,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10266,7 +10266,7 @@
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2091,
+					"id": 2093,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10310,7 +10310,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2092,
+					"id": 2094,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10350,7 +10350,7 @@
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2065,
+					"id": 2067,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10378,7 +10378,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2032,
+					"id": 2034,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10414,7 +10414,7 @@
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2031,
+					"id": 2033,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10446,7 +10446,7 @@
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2086,
+					"id": 2088,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10479,120 +10479,120 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2058,
-						2049,
-						2029,
-						2111,
-						2075,
-						2034,
-						2071,
-						2057,
-						2121,
+						2060,
+						2051,
+						2031,
+						2113,
+						2077,
+						2036,
+						2073,
+						2059,
+						2123,
+						2102,
+						2037,
+						2025,
+						2084,
 						2100,
-						2035,
-						2023,
+						2071,
+						2086,
+						2066,
+						2092,
+						2107,
+						2108,
+						2101,
+						2087,
+						2032,
+						2027,
+						2114,
+						2030,
 						2082,
 						2098,
-						2069,
-						2084,
-						2064,
-						2090,
-						2105,
-						2106,
 						2099,
+						2049,
+						2048,
+						2053,
+						2056,
+						2055,
+						2054,
+						2057,
+						2058,
+						2065,
+						2064,
+						2029,
+						2079,
+						2068,
+						2141,
+						2035,
 						2085,
-						2030,
-						2025,
+						2069,
+						2090,
+						2043,
+						2024,
+						2117,
+						2116,
+						2076,
+						2050,
+						2026,
+						2080,
+						2046,
+						2104,
+						2122,
+						2105,
+						2061,
+						2081,
 						2112,
 						2028,
-						2080,
-						2096,
-						2097,
-						2047,
-						2046,
-						2051,
-						2054,
-						2053,
-						2052,
-						2055,
-						2056,
-						2063,
-						2062,
-						2027,
-						2077,
-						2066,
-						2139,
-						2033,
-						2083,
-						2067,
-						2088,
-						2041,
-						2022,
-						2115,
-						2114,
-						2074,
-						2048,
-						2024,
-						2078,
-						2044,
-						2102,
-						2120,
+						2151,
 						2103,
-						2059,
-						2079,
-						2110,
-						2026,
-						2149,
-						2101,
-						2095,
-						2116,
-						2042,
-						2050,
-						2068,
-						2093,
-						2094,
-						2076,
-						2081,
-						2141,
-						2061,
-						2070,
-						2060,
-						2123,
-						2134,
-						2122,
-						2136,
-						2127,
-						2126,
-						2135,
-						2109,
-						2117,
+						2097,
 						2118,
-						2113,
-						2137,
-						2124,
+						2044,
+						2052,
+						2070,
+						2095,
+						2096,
+						2078,
+						2083,
+						2143,
+						2063,
+						2072,
+						2062,
 						2125,
+						2136,
+						2124,
+						2138,
 						2129,
-						2132,
-						2131,
-						2130,
-						2133,
 						2128,
+						2137,
+						2111,
+						2119,
+						2120,
+						2115,
+						2139,
+						2126,
+						2127,
+						2131,
+						2134,
+						2133,
+						2132,
+						2135,
+						2130,
+						2147,
+						2148,
+						2150,
+						2149,
+						2144,
 						2145,
 						2146,
-						2148,
-						2147,
 						2142,
-						2143,
-						2144,
-						2140,
-						2104,
-						2089,
+						2106,
 						2091,
-						2092,
-						2065,
-						2032,
-						2031,
-						2086
+						2093,
+						2094,
+						2067,
+						2034,
+						2033,
+						2088
 					]
 				}
 			],
@@ -10605,7 +10605,7 @@
 			]
 		},
 		{
-			"id": 3306,
+			"id": 3308,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10630,7 +10630,7 @@
 			},
 			"children": [
 				{
-					"id": 3307,
+					"id": 3309,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10648,7 +10648,7 @@
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3309,
+					"id": 3311,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10666,7 +10666,7 @@
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3308,
+					"id": 3310,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10689,9 +10689,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3307,
 						3309,
-						3308
+						3311,
+						3310
 					]
 				}
 			],
@@ -10704,7 +10704,7 @@
 			]
 		},
 		{
-			"id": 2872,
+			"id": 2874,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10714,7 +10714,7 @@
 			},
 			"children": [
 				{
-					"id": 2876,
+					"id": 2878,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10738,7 +10738,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2883,
+					"id": 2885,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10762,7 +10762,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 2880,
+					"id": 2882,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10786,7 +10786,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2882,
+					"id": 2884,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10810,7 +10810,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2874,
+					"id": 2876,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10834,7 +10834,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2879,
+					"id": 2881,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10858,7 +10858,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2875,
+					"id": 2877,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10882,7 +10882,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2877,
+					"id": 2879,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10906,7 +10906,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2873,
+					"id": 2875,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10930,7 +10930,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2878,
+					"id": 2880,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10954,7 +10954,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2881,
+					"id": 2883,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10983,17 +10983,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2876,
-						2883,
-						2880,
+						2878,
+						2885,
 						2882,
-						2874,
+						2884,
+						2876,
+						2881,
+						2877,
 						2879,
 						2875,
-						2877,
-						2873,
-						2878,
-						2881
+						2880,
+						2883
 					]
 				}
 			],
@@ -11006,7 +11006,7 @@
 			]
 		},
 		{
-			"id": 3209,
+			"id": 3211,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11022,7 +11022,7 @@
 			},
 			"children": [
 				{
-					"id": 3212,
+					"id": 3214,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11046,7 +11046,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3210,
+					"id": 3212,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11070,7 +11070,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3211,
+					"id": 3213,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11093,9 +11093,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
+						3214,
 						3212,
-						3210,
-						3211
+						3213
 					]
 				}
 			],
@@ -11108,14 +11108,14 @@
 			]
 		},
 		{
-			"id": 3203,
+			"id": 3205,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3205,
+					"id": 3207,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11130,7 +11130,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3206,
+					"id": 3208,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11145,7 +11145,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3204,
+					"id": 3206,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11165,9 +11165,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3205,
-						3206,
-						3204
+						3207,
+						3208,
+						3206
 					]
 				}
 			],
@@ -11180,7 +11180,7 @@
 			]
 		},
 		{
-			"id": 2884,
+			"id": 2886,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11197,7 +11197,7 @@
 			},
 			"children": [
 				{
-					"id": 2887,
+					"id": 2889,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11215,7 +11215,7 @@
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2890,
+					"id": 2892,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11233,7 +11233,7 @@
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2888,
+					"id": 2890,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11251,7 +11251,7 @@
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2885,
+					"id": 2887,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11269,7 +11269,7 @@
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2889,
+					"id": 2891,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11287,7 +11287,7 @@
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2886,
+					"id": 2888,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11310,12 +11310,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2887,
-						2890,
-						2888,
-						2885,
 						2889,
-						2886
+						2892,
+						2890,
+						2887,
+						2891,
+						2888
 					]
 				}
 			],
@@ -11328,7 +11328,7 @@
 			]
 		},
 		{
-			"id": 2150,
+			"id": 2152,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11361,7 +11361,7 @@
 			},
 			"children": [
 				{
-					"id": 2174,
+					"id": 2176,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11389,7 +11389,7 @@
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2162,
+					"id": 2164,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11426,7 +11426,7 @@
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2220,
+					"id": 2222,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11459,7 +11459,7 @@
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2227,
+					"id": 2229,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11492,7 +11492,7 @@
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2204,
+					"id": 2206,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11520,7 +11520,7 @@
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2230,
+					"id": 2232,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11553,7 +11553,7 @@
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2224,
+					"id": 2226,
 					"name": "CloseSpotterShareConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11581,7 +11581,7 @@
 					"defaultValue": "\"CloseSpotterShareConversation\""
 				},
 				{
-					"id": 2241,
+					"id": 2243,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11609,7 +11609,7 @@
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2181,
+					"id": 2183,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11658,7 +11658,7 @@
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2178,
+					"id": 2180,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11703,7 +11703,7 @@
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2221,
+					"id": 2223,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11731,7 +11731,7 @@
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2185,
+					"id": 2187,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11772,7 +11772,7 @@
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2226,
+					"id": 2228,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11800,7 +11800,7 @@
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2232,
+					"id": 2234,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11828,7 +11828,7 @@
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2187,
+					"id": 2189,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11865,7 +11865,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2189,
+					"id": 2191,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11906,7 +11906,7 @@
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2172,
+					"id": 2174,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11951,7 +11951,7 @@
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2188,
+					"id": 2190,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11983,7 +11983,7 @@
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2190,
+					"id": 2192,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12024,7 +12024,7 @@
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2173,
+					"id": 2175,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12052,7 +12052,7 @@
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2152,
+					"id": 2154,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12097,7 +12097,7 @@
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2180,
+					"id": 2182,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12143,7 +12143,7 @@
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2218,
+					"id": 2220,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12180,7 +12180,7 @@
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2170,
+					"id": 2172,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12216,7 +12216,7 @@
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2225,
+					"id": 2227,
 					"name": "ExitSpotterSharedConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12244,7 +12244,7 @@
 					"defaultValue": "\"ExitSpotterSharedConversation\""
 				},
 				{
-					"id": 2177,
+					"id": 2179,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12281,7 +12281,7 @@
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2169,
+					"id": 2171,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12317,7 +12317,7 @@
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2203,
+					"id": 2205,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12350,7 +12350,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2197,
+					"id": 2199,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12382,7 +12382,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2200,
+					"id": 2202,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12414,7 +12414,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 2155,
+					"id": 2157,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12446,7 +12446,7 @@
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2209,
+					"id": 2211,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12479,7 +12479,7 @@
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2183,
+					"id": 2185,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12523,7 +12523,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2199,
+					"id": 2201,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12555,7 +12555,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2239,
+					"id": 2241,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12583,7 +12583,7 @@
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2166,
+					"id": 2168,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12615,7 +12615,7 @@
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2175,
+					"id": 2177,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12667,7 +12667,7 @@
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2179,
+					"id": 2181,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12716,7 +12716,7 @@
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2195,
+					"id": 2197,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12757,7 +12757,7 @@
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2159,
+					"id": 2161,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12791,7 +12791,7 @@
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2160,
+					"id": 2162,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12836,7 +12836,7 @@
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2161,
+					"id": 2163,
 					"name": "OpenParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12873,7 +12873,7 @@
 					"defaultValue": "\"openParameter\""
 				},
 				{
-					"id": 2240,
+					"id": 2242,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12901,7 +12901,7 @@
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2165,
+					"id": 2167,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12962,7 +12962,7 @@
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2234,
+					"id": 2236,
 					"name": "PinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12991,7 +12991,7 @@
 					"defaultValue": "\"PinSpotterConversation\""
 				},
 				{
-					"id": 2182,
+					"id": 2184,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13040,7 +13040,7 @@
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2219,
+					"id": 2221,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13072,7 +13072,7 @@
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2242,
+					"id": 2244,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13100,7 +13100,7 @@
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2176,
+					"id": 2178,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13136,7 +13136,7 @@
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2163,
+					"id": 2165,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13173,7 +13173,7 @@
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2206,
+					"id": 2208,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13205,7 +13205,7 @@
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2207,
+					"id": 2209,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13233,7 +13233,7 @@
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2196,
+					"id": 2198,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13265,7 +13265,7 @@
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2222,
+					"id": 2224,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13293,7 +13293,7 @@
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2192,
+					"id": 2194,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13334,7 +13334,7 @@
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2214,
+					"id": 2216,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13383,7 +13383,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2167,
+					"id": 2169,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13415,7 +13415,7 @@
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2168,
+					"id": 2170,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13447,7 +13447,7 @@
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2151,
+					"id": 2153,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13480,7 +13480,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2212,
+					"id": 2214,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13516,7 +13516,7 @@
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2237,
+					"id": 2239,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13548,7 +13548,7 @@
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2157,
+					"id": 2159,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13585,7 +13585,7 @@
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2202,
+					"id": 2204,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13622,7 +13622,7 @@
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2201,
+					"id": 2203,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13659,7 +13659,7 @@
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2156,
+					"id": 2158,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13696,7 +13696,7 @@
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2191,
+					"id": 2193,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13732,7 +13732,7 @@
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2223,
+					"id": 2225,
 					"name": "ShareSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13760,7 +13760,7 @@
 					"defaultValue": "\"ShareSpotterConversation\""
 				},
 				{
-					"id": 2184,
+					"id": 2186,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13801,7 +13801,7 @@
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2186,
+					"id": 2188,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13842,7 +13842,7 @@
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2217,
+					"id": 2219,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13879,7 +13879,7 @@
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2238,
+					"id": 2240,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13912,7 +13912,7 @@
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2233,
+					"id": 2235,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13941,7 +13941,7 @@
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2194,
+					"id": 2196,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13982,7 +13982,7 @@
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2193,
+					"id": 2195,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14023,7 +14023,7 @@
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2216,
+					"id": 2218,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14056,7 +14056,7 @@
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2235,
+					"id": 2237,
 					"name": "UnpinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14085,7 +14085,7 @@
 					"defaultValue": "\"UnpinSpotterConversation\""
 				},
 				{
-					"id": 2205,
+					"id": 2207,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14113,7 +14113,7 @@
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2198,
+					"id": 2200,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14166,7 +14166,7 @@
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2208,
+					"id": 2210,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14207,7 +14207,7 @@
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2210,
+					"id": 2212,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14239,7 +14239,7 @@
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2211,
+					"id": 2213,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14263,7 +14263,7 @@
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2158,
+					"id": 2160,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14305,7 +14305,7 @@
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2171,
+					"id": 2173,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14337,7 +14337,7 @@
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2164,
+					"id": 2166,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14370,90 +14370,90 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2174,
-						2162,
-						2220,
-						2227,
-						2204,
-						2230,
-						2224,
-						2241,
-						2181,
-						2178,
-						2221,
-						2185,
-						2226,
-						2232,
-						2187,
-						2189,
-						2172,
-						2188,
-						2190,
-						2173,
-						2152,
-						2180,
-						2218,
-						2170,
-						2225,
-						2177,
-						2169,
-						2203,
-						2197,
-						2200,
-						2155,
-						2209,
-						2183,
-						2199,
-						2239,
-						2166,
-						2175,
-						2179,
-						2195,
-						2159,
-						2160,
-						2161,
-						2240,
-						2165,
-						2234,
-						2182,
-						2219,
-						2242,
 						2176,
-						2163,
-						2206,
-						2207,
-						2196,
+						2164,
 						2222,
-						2192,
-						2214,
-						2167,
-						2168,
-						2151,
-						2212,
-						2237,
-						2157,
-						2202,
-						2201,
-						2156,
-						2191,
+						2229,
+						2206,
+						2232,
+						2226,
+						2243,
+						2183,
+						2180,
 						2223,
-						2184,
-						2186,
-						2217,
-						2238,
-						2233,
-						2194,
-						2193,
-						2216,
-						2235,
-						2205,
-						2198,
-						2208,
-						2210,
-						2211,
-						2158,
+						2187,
+						2228,
+						2234,
+						2189,
+						2191,
+						2174,
+						2190,
+						2192,
+						2175,
+						2154,
+						2182,
+						2220,
+						2172,
+						2227,
+						2179,
 						2171,
-						2164
+						2205,
+						2199,
+						2202,
+						2157,
+						2211,
+						2185,
+						2201,
+						2241,
+						2168,
+						2177,
+						2181,
+						2197,
+						2161,
+						2162,
+						2163,
+						2242,
+						2167,
+						2236,
+						2184,
+						2221,
+						2244,
+						2178,
+						2165,
+						2208,
+						2209,
+						2198,
+						2224,
+						2194,
+						2216,
+						2169,
+						2170,
+						2153,
+						2214,
+						2239,
+						2159,
+						2204,
+						2203,
+						2158,
+						2193,
+						2225,
+						2186,
+						2188,
+						2219,
+						2240,
+						2235,
+						2196,
+						2195,
+						2218,
+						2237,
+						2207,
+						2200,
+						2210,
+						2212,
+						2213,
+						2160,
+						2173,
+						2166
 					]
 				}
 			],
@@ -14466,7 +14466,7 @@
 			]
 		},
 		{
-			"id": 3278,
+			"id": 3280,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14476,7 +14476,7 @@
 			},
 			"children": [
 				{
-					"id": 3280,
+					"id": 3282,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14494,7 +14494,7 @@
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3279,
+					"id": 3281,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14512,7 +14512,7 @@
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3281,
+					"id": 3283,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14535,9 +14535,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3280,
-						3279,
-						3281
+						3282,
+						3281,
+						3283
 					]
 				}
 			],
@@ -14550,7 +14550,7 @@
 			]
 		},
 		{
-			"id": 3314,
+			"id": 3316,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14566,7 +14566,7 @@
 			},
 			"children": [
 				{
-					"id": 3316,
+					"id": 3318,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14584,7 +14584,7 @@
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3317,
+					"id": 3319,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14602,7 +14602,7 @@
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3318,
+					"id": 3320,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14620,7 +14620,7 @@
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3315,
+					"id": 3317,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14643,10 +14643,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3316,
-						3317,
 						3318,
-						3315
+						3319,
+						3320,
+						3317
 					]
 				}
 			],
@@ -14659,7 +14659,7 @@
 			]
 		},
 		{
-			"id": 3213,
+			"id": 3215,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14675,7 +14675,7 @@
 			},
 			"children": [
 				{
-					"id": 3214,
+					"id": 3216,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14693,7 +14693,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3215,
+					"id": 3217,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14716,8 +14716,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3214,
-						3215
+						3216,
+						3217
 					]
 				}
 			],
@@ -14730,7 +14730,7 @@
 			]
 		},
 		{
-			"id": 3257,
+			"id": 3259,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14746,7 +14746,7 @@
 			},
 			"children": [
 				{
-					"id": 3261,
+					"id": 3263,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14764,7 +14764,7 @@
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3262,
+					"id": 3264,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14782,7 +14782,7 @@
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3258,
+					"id": 3260,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14800,7 +14800,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3259,
+					"id": 3261,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14824,7 +14824,7 @@
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3263,
+					"id": 3265,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14842,7 +14842,7 @@
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3260,
+					"id": 3262,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14860,7 +14860,7 @@
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3264,
+					"id": 3266,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14883,13 +14883,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3261,
-						3262,
-						3258,
-						3259,
 						3263,
+						3264,
 						3260,
-						3264
+						3261,
+						3265,
+						3262,
+						3266
 					]
 				}
 			],
@@ -14902,7 +14902,7 @@
 			]
 		},
 		{
-			"id": 3176,
+			"id": 3178,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14912,7 +14912,7 @@
 			},
 			"children": [
 				{
-					"id": 3181,
+					"id": 3183,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14940,7 +14940,7 @@
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3178,
+					"id": 3180,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14968,7 +14968,7 @@
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3180,
+					"id": 3182,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14996,7 +14996,7 @@
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3177,
+					"id": 3179,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15024,7 +15024,7 @@
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3182,
+					"id": 3184,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15052,7 +15052,7 @@
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3179,
+					"id": 3181,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15085,12 +15085,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3181,
-						3178,
+						3183,
 						3180,
-						3177,
 						3182,
-						3179
+						3179,
+						3184,
+						3181
 					]
 				}
 			],
@@ -15103,7 +15103,7 @@
 			]
 		},
 		{
-			"id": 1979,
+			"id": 1981,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15113,7 +15113,7 @@
 			},
 			"children": [
 				{
-					"id": 1982,
+					"id": 1984,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15131,7 +15131,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1988,
+					"id": 1990,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15149,7 +15149,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 1985,
+					"id": 1987,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15167,7 +15167,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1980,
+					"id": 1982,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15185,7 +15185,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1983,
+					"id": 1985,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15203,7 +15203,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1987,
+					"id": 1989,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15221,7 +15221,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1981,
+					"id": 1983,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15239,7 +15239,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1986,
+					"id": 1988,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15262,14 +15262,14 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1982,
-						1988,
-						1985,
-						1980,
-						1983,
+						1984,
+						1990,
 						1987,
-						1981,
-						1986
+						1982,
+						1985,
+						1989,
+						1983,
+						1988
 					]
 				}
 			],
@@ -15282,14 +15282,14 @@
 			]
 		},
 		{
-			"id": 2861,
+			"id": 2863,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2862,
+					"id": 2864,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15304,7 +15304,7 @@
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2864,
+					"id": 2866,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15319,7 +15319,7 @@
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2863,
+					"id": 2865,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15334,7 +15334,7 @@
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2865,
+					"id": 2867,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15354,10 +15354,10 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2862,
 						2864,
-						2863,
-						2865
+						2866,
+						2865,
+						2867
 					]
 				}
 			],
@@ -15370,7 +15370,7 @@
 			]
 		},
 		{
-			"id": 3207,
+			"id": 3209,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15386,7 +15386,7 @@
 			},
 			"children": [
 				{
-					"id": 3208,
+					"id": 3210,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15409,7 +15409,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3208
+						3210
 					]
 				}
 			],
@@ -15422,7 +15422,7 @@
 			]
 		},
 		{
-			"id": 2005,
+			"id": 2007,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15432,7 +15432,7 @@
 			},
 			"children": [
 				{
-					"id": 2013,
+					"id": 2015,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15450,7 +15450,7 @@
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2018,
+					"id": 2020,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15468,7 +15468,7 @@
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2017,
+					"id": 2019,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15486,7 +15486,7 @@
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2015,
+					"id": 2017,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15504,7 +15504,7 @@
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2016,
+					"id": 2018,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15522,7 +15522,7 @@
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2012,
+					"id": 2014,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15540,7 +15540,7 @@
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2014,
+					"id": 2016,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15558,7 +15558,7 @@
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2006,
+					"id": 2008,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15576,7 +15576,7 @@
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2011,
+					"id": 2013,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15594,7 +15594,7 @@
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2010,
+					"id": 2012,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15612,7 +15612,7 @@
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2019,
+					"id": 2021,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15630,7 +15630,7 @@
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2009,
+					"id": 2011,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15648,7 +15648,7 @@
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2008,
+					"id": 2010,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15666,7 +15666,7 @@
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2007,
+					"id": 2009,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15684,7 +15684,7 @@
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2020,
+					"id": 2022,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15707,21 +15707,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2013,
-						2018,
-						2017,
 						2015,
-						2016,
-						2012,
+						2020,
+						2019,
+						2017,
+						2018,
 						2014,
-						2006,
+						2016,
+						2008,
+						2013,
+						2012,
+						2021,
 						2011,
 						2010,
-						2019,
 						2009,
-						2008,
-						2007,
-						2020
+						2022
 					]
 				}
 			],
@@ -15734,7 +15734,7 @@
 			]
 		},
 		{
-			"id": 1556,
+			"id": 1558,
 			"name": "SpotterQueryMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15750,7 +15750,7 @@
 			},
 			"children": [
 				{
-					"id": 1557,
+					"id": 1559,
 					"name": "FAST_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15765,7 +15765,7 @@
 					"defaultValue": "\"fastSearch\""
 				},
 				{
-					"id": 1558,
+					"id": 1560,
 					"name": "RESEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15785,8 +15785,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1557,
-						1558
+						1559,
+						1560
 					]
 				}
 			],
@@ -15799,7 +15799,7 @@
 			]
 		},
 		{
-			"id": 3353,
+			"id": 3355,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15815,7 +15815,7 @@
 			},
 			"children": [
 				{
-					"id": 3355,
+					"id": 3357,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15833,7 +15833,7 @@
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3354,
+					"id": 3356,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15856,8 +15856,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3355,
-						3354
+						3357,
+						3356
 					]
 				}
 			],
@@ -15870,7 +15870,7 @@
 			]
 		},
 		{
-			"id": 3349,
+			"id": 3351,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15886,7 +15886,7 @@
 			},
 			"children": [
 				{
-					"id": 3350,
+					"id": 3352,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15904,7 +15904,7 @@
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3351,
+					"id": 3353,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15922,7 +15922,7 @@
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3352,
+					"id": 3354,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15945,9 +15945,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3350,
-						3351,
-						3352
+						3352,
+						3353,
+						3354
 					]
 				}
 			],
@@ -15960,14 +15960,14 @@
 			]
 		},
 		{
-			"id": 3239,
+			"id": 3241,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3248,
+					"id": 3250,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15982,7 +15982,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3244,
+					"id": 3246,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15997,7 +15997,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3249,
+					"id": 3251,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16012,7 +16012,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3243,
+					"id": 3245,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16027,7 +16027,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3242,
+					"id": 3244,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16042,7 +16042,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3256,
+					"id": 3258,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16057,7 +16057,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3250,
+					"id": 3252,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16072,7 +16072,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3255,
+					"id": 3257,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16087,7 +16087,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 3251,
+					"id": 3253,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16102,7 +16102,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3245,
+					"id": 3247,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16117,7 +16117,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3252,
+					"id": 3254,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16132,7 +16132,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3253,
+					"id": 3255,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16147,7 +16147,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3254,
+					"id": 3256,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16162,7 +16162,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3246,
+					"id": 3248,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16177,7 +16177,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3240,
+					"id": 3242,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16192,7 +16192,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3241,
+					"id": 3243,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16207,7 +16207,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3247,
+					"id": 3249,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16227,23 +16227,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3248,
-						3244,
-						3249,
-						3243,
-						3242,
-						3256,
 						3250,
-						3255,
+						3246,
 						3251,
 						3245,
+						3244,
+						3258,
 						3252,
+						3257,
 						3253,
+						3247,
 						3254,
-						3246,
-						3240,
-						3241,
-						3247
+						3255,
+						3256,
+						3248,
+						3242,
+						3243,
+						3249
 					]
 				}
 			],
@@ -16256,7 +16256,7 @@
 			]
 		},
 		{
-			"id": 1892,
+			"id": 1894,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -16285,7 +16285,7 @@
 			},
 			"children": [
 				{
-					"id": 1893,
+					"id": 1895,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16302,7 +16302,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1894,
+							"id": 1896,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -16312,7 +16312,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1895,
+									"id": 1897,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16320,12 +16320,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1969,
+										"id": 1971,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1896,
+									"id": 1898,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16337,7 +16337,7 @@
 									}
 								},
 								{
-									"id": 1897,
+									"id": 1899,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16349,7 +16349,7 @@
 									}
 								},
 								{
-									"id": 1898,
+									"id": 1900,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16363,7 +16363,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3216,
+											"id": 3218,
 											"name": "VizPoint"
 										}
 									}
@@ -16371,14 +16371,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1892,
+								"id": 1894,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1907,
+					"id": 1909,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16394,7 +16394,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1908,
+							"id": 1910,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16405,7 +16405,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1909,
+									"id": 1911,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16434,7 +16434,7 @@
 					]
 				},
 				{
-					"id": 1910,
+					"id": 1912,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16450,7 +16450,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1911,
+							"id": 1913,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16466,7 +16466,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1912,
+									"id": 1914,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16495,7 +16495,7 @@
 					]
 				},
 				{
-					"id": 1963,
+					"id": 1965,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16511,14 +16511,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1964,
+							"id": 1966,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1965,
+									"id": 1967,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16543,7 +16543,7 @@
 					]
 				},
 				{
-					"id": 1913,
+					"id": 1915,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16559,7 +16559,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1914,
+							"id": 1916,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16570,7 +16570,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1915,
+									"id": 1917,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16582,7 +16582,7 @@
 									}
 								},
 								{
-									"id": 1916,
+									"id": 1918,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16590,12 +16590,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2005,
+										"id": 2007,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1917,
+									"id": 1919,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16641,7 +16641,7 @@
 					]
 				},
 				{
-					"id": 1953,
+					"id": 1955,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16657,7 +16657,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1954,
+							"id": 1956,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16668,7 +16668,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1955,
+									"id": 1957,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16682,7 +16682,7 @@
 									}
 								},
 								{
-									"id": 1956,
+									"id": 1958,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16710,7 +16710,7 @@
 					]
 				},
 				{
-					"id": 1931,
+					"id": 1933,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16726,7 +16726,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1932,
+							"id": 1934,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16737,7 +16737,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1933,
+									"id": 1935,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16750,7 +16750,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1934,
+									"id": 1936,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16779,7 +16779,7 @@
 					]
 				},
 				{
-					"id": 1924,
+					"id": 1926,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16795,7 +16795,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1925,
+							"id": 1927,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16806,7 +16806,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1926,
+									"id": 1928,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16819,7 +16819,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1927,
+									"id": 1929,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16838,14 +16838,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1928,
+											"id": 1930,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1929,
+													"id": 1931,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16856,7 +16856,7 @@
 													}
 												},
 												{
-													"id": 1930,
+													"id": 1932,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16872,8 +16872,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1929,
-														1930
+														1931,
+														1932
 													]
 												}
 											]
@@ -16886,7 +16886,7 @@
 					]
 				},
 				{
-					"id": 1935,
+					"id": 1937,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16902,7 +16902,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1936,
+							"id": 1938,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16913,7 +16913,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1937,
+									"id": 1939,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16926,7 +16926,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1938,
+									"id": 1940,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16941,7 +16941,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1939,
+									"id": 1941,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16970,7 +16970,7 @@
 					]
 				},
 				{
-					"id": 1959,
+					"id": 1961,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16986,7 +16986,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1960,
+							"id": 1962,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17005,7 +17005,7 @@
 					]
 				},
 				{
-					"id": 1940,
+					"id": 1942,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17021,7 +17021,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1941,
+							"id": 1943,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17032,7 +17032,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1942,
+									"id": 1944,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17045,7 +17045,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1943,
+									"id": 1945,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17066,7 +17066,7 @@
 					]
 				},
 				{
-					"id": 1944,
+					"id": 1946,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17082,7 +17082,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1945,
+							"id": 1947,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17092,7 +17092,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1946,
+									"id": 1948,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17105,7 +17105,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1947,
+									"id": 1949,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17118,7 +17118,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1948,
+									"id": 1950,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17141,7 +17141,7 @@
 					]
 				},
 				{
-					"id": 1921,
+					"id": 1923,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17157,14 +17157,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1922,
+							"id": 1924,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1923,
+									"id": 1925,
 									"name": "fetchSQLWithAllColumns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17190,7 +17190,7 @@
 					]
 				},
 				{
-					"id": 1957,
+					"id": 1959,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17206,7 +17206,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1958,
+							"id": 1960,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17217,14 +17217,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1969,
+								"id": 1971,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1902,
+					"id": 1904,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17240,7 +17240,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1903,
+							"id": 1905,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17262,7 +17262,7 @@
 					]
 				},
 				{
-					"id": 1961,
+					"id": 1963,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17278,7 +17278,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1962,
+							"id": 1964,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17297,7 +17297,7 @@
 					]
 				},
 				{
-					"id": 1949,
+					"id": 1951,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17313,7 +17313,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1950,
+							"id": 1952,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17333,7 +17333,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1951,
+									"id": 1953,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17348,7 +17348,7 @@
 									}
 								},
 								{
-									"id": 1952,
+									"id": 1954,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17360,7 +17360,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1976,
+											"id": 1978,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -17371,7 +17371,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -17381,7 +17381,7 @@
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1906,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17397,7 +17397,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1907,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17408,7 +17408,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1906,
+									"id": 1908,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17437,7 +17437,7 @@
 					]
 				},
 				{
-					"id": 1966,
+					"id": 1968,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17453,14 +17453,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1967,
+							"id": 1969,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1968,
+									"id": 1970,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17479,7 +17479,7 @@
 					]
 				},
 				{
-					"id": 1918,
+					"id": 1920,
 					"name": "updateDisplayMode",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17495,14 +17495,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1919,
+							"id": 1921,
 							"name": "updateDisplayMode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1920,
+									"id": 1922,
 									"name": "displayMode",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17533,32 +17533,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1893
+						1895
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1907,
-						1910,
-						1963,
-						1913,
-						1953,
-						1931,
-						1924,
-						1935,
-						1959,
-						1940,
-						1944,
-						1921,
-						1957,
-						1902,
+						1909,
+						1912,
+						1965,
+						1915,
+						1955,
+						1933,
+						1926,
+						1937,
 						1961,
-						1949,
+						1942,
+						1946,
+						1923,
+						1959,
 						1904,
-						1966,
-						1918
+						1963,
+						1951,
+						1906,
+						1968,
+						1920
 					]
 				}
 			],
@@ -17615,7 +17615,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2891,
+										"id": 2893,
 										"name": "DOMSelector"
 									}
 								},
@@ -17627,7 +17627,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2744,
+										"id": 2746,
 										"name": "AppViewConfig"
 									}
 								}
@@ -17748,7 +17748,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -18293,7 +18293,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18308,7 +18308,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -18375,7 +18375,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18387,7 +18387,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
@@ -18399,7 +18399,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18689,12 +18689,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -18807,7 +18807,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
@@ -18826,7 +18826,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
@@ -18958,7 +18958,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19609,7 +19609,7 @@
 			]
 		},
 		{
-			"id": 1634,
+			"id": 1636,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19637,7 +19637,7 @@
 			},
 			"children": [
 				{
-					"id": 1635,
+					"id": 1637,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19645,20 +19645,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 829,
+							"line": 854,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1636,
+							"id": 1638,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1637,
+									"id": 1639,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19669,21 +19669,21 @@
 									}
 								},
 								{
-									"id": 1638,
+									"id": 1640,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1573,
+										"id": 1575,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1634,
+								"id": 1636,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
@@ -19700,7 +19700,7 @@
 					}
 				},
 				{
-					"id": 1797,
+					"id": 1799,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19716,7 +19716,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1798,
+							"id": 1800,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19748,7 +19748,7 @@
 					}
 				},
 				{
-					"id": 1819,
+					"id": 1821,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19764,7 +19764,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1820,
+							"id": 1822,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19780,7 +19780,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1821,
+									"id": 1823,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19801,7 +19801,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -19821,7 +19821,7 @@
 					}
 				},
 				{
-					"id": 1782,
+					"id": 1784,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19837,7 +19837,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1783,
+							"id": 1785,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19880,7 +19880,7 @@
 					}
 				},
 				{
-					"id": 1644,
+					"id": 1646,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19890,13 +19890,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 755,
+							"line": 780,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1645,
+							"id": 1647,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19919,7 +19919,7 @@
 					}
 				},
 				{
-					"id": 1813,
+					"id": 1815,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19935,7 +19935,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1814,
+							"id": 1816,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19957,14 +19957,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1815,
+									"id": 1817,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1817,
+											"id": 1819,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19976,7 +19976,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1818,
+											"id": 1820,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -19988,7 +19988,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1816,
+											"id": 1818,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20005,9 +20005,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1817,
-												1818,
-												1816
+												1819,
+												1820,
+												1818
 											]
 										}
 									]
@@ -20027,7 +20027,7 @@
 					}
 				},
 				{
-					"id": 1791,
+					"id": 1793,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20043,7 +20043,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1792,
+							"id": 1794,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20059,7 +20059,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1793,
+									"id": 1795,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20067,20 +20067,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1794,
+											"id": 1796,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1795,
+												"id": 1797,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1796,
+														"id": 1798,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -20127,7 +20127,7 @@
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1801,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20143,7 +20143,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1802,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20166,7 +20166,7 @@
 					}
 				},
 				{
-					"id": 1811,
+					"id": 1813,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20182,7 +20182,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1812,
+							"id": 1814,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20208,7 +20208,7 @@
 					}
 				},
 				{
-					"id": 1749,
+					"id": 1751,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20224,7 +20224,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1750,
+							"id": 1752,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20240,7 +20240,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1751,
+									"id": 1753,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20250,12 +20250,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1752,
+									"id": 1754,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20265,7 +20265,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -20288,7 +20288,7 @@
 					}
 				},
 				{
-					"id": 1743,
+					"id": 1745,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20304,7 +20304,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1744,
+							"id": 1746,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20324,7 +20324,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1745,
+									"id": 1747,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20334,12 +20334,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1746,
+									"id": 1748,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20349,12 +20349,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1747,
+									"id": 1749,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20364,13 +20364,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1748,
+									"id": 1750,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20401,7 +20401,7 @@
 					}
 				},
 				{
-					"id": 1787,
+					"id": 1789,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20417,7 +20417,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1788,
+							"id": 1790,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20427,7 +20427,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1789,
+									"id": 1791,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20442,7 +20442,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1790,
+									"id": 1792,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20478,7 +20478,7 @@
 					}
 				},
 				{
-					"id": 1801,
+					"id": 1803,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20494,7 +20494,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1802,
+							"id": 1804,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20533,7 +20533,7 @@
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1648,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20543,13 +20543,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 802,
+							"line": 827,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1647,
+							"id": 1649,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20579,7 +20579,7 @@
 					}
 				},
 				{
-					"id": 1805,
+					"id": 1807,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20595,7 +20595,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1806,
+							"id": 1808,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20627,7 +20627,7 @@
 					}
 				},
 				{
-					"id": 1784,
+					"id": 1786,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20643,7 +20643,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1785,
+							"id": 1787,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20661,7 +20661,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1786,
+									"id": 1788,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20674,12 +20674,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -20704,7 +20704,7 @@
 					}
 				},
 				{
-					"id": 1809,
+					"id": 1811,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20720,7 +20720,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1810,
+							"id": 1812,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20752,7 +20752,7 @@
 					}
 				},
 				{
-					"id": 1767,
+					"id": 1769,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20768,7 +20768,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1768,
+							"id": 1770,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20789,40 +20789,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1769,
+									"id": 1771,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1770,
+									"id": 1772,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1771,
+									"id": 1773,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1772,
+									"id": 1774,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20836,7 +20836,7 @@
 									}
 								},
 								{
-									"id": 1773,
+									"id": 1775,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20861,7 +20861,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1774,
+									"id": 1776,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20915,7 +20915,7 @@
 					}
 				},
 				{
-					"id": 1775,
+					"id": 1777,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20931,7 +20931,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1776,
+							"id": 1778,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20942,21 +20942,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1777,
+									"id": 1779,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1778,
+									"id": 1780,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20970,7 +20970,7 @@
 									}
 								},
 								{
-									"id": 1779,
+									"id": 1781,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21025,38 +21025,38 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1635
+						1637
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1797,
-						1819,
-						1782,
-						1644,
-						1813,
-						1791,
 						1799,
-						1811,
-						1749,
-						1743,
-						1787,
-						1801,
-						1646,
-						1805,
+						1821,
 						1784,
-						1809,
-						1767,
-						1775
+						1646,
+						1815,
+						1793,
+						1801,
+						1813,
+						1751,
+						1745,
+						1789,
+						1803,
+						1648,
+						1807,
+						1786,
+						1811,
+						1769,
+						1777
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 828,
+					"line": 853,
 					"character": 13
 				}
 			],
@@ -21117,7 +21117,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2891,
+										"id": 2893,
 										"name": "DOMSelector"
 									}
 								},
@@ -21129,7 +21129,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2621,
+										"id": 2623,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -21250,7 +21250,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -21799,7 +21799,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21814,7 +21814,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -21881,7 +21881,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21893,7 +21893,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
@@ -21905,7 +21905,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -22195,12 +22195,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -22303,7 +22303,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
@@ -22322,7 +22322,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
@@ -22451,7 +22451,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22629,7 +22629,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2568,
+										"id": 2570,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -22750,7 +22750,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -23185,7 +23185,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23200,7 +23200,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -23267,7 +23267,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23282,7 +23282,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
@@ -23297,7 +23297,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23600,12 +23600,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -23718,7 +23718,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
@@ -23737,7 +23737,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
@@ -23869,7 +23869,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -24030,7 +24030,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2891,
+										"id": 2893,
 										"name": "DOMSelector"
 									}
 								},
@@ -24042,7 +24042,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2502,
+										"id": 2504,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -24163,7 +24163,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -24630,7 +24630,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24645,7 +24645,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -24712,7 +24712,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24727,7 +24727,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
@@ -24742,7 +24742,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -25045,12 +25045,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -25163,7 +25163,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
@@ -25182,7 +25182,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
@@ -25314,7 +25314,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -25966,7 +25966,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 663,
+							"line": 688,
 							"character": 4
 						}
 					],
@@ -26118,7 +26118,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1892,
+										"id": 1894,
 										"name": "AnswerService"
 									}
 								],
@@ -26203,7 +26203,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 755,
+							"line": 780,
 							"character": 11
 						}
 					],
@@ -26553,7 +26553,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26568,7 +26568,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								}
@@ -26635,7 +26635,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2021,
+										"id": 2023,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26650,7 +26650,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2897,
 										"name": "MessageCallback"
 									}
 								},
@@ -26665,7 +26665,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2892,
+										"id": 2894,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -26838,7 +26838,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 802,
+							"line": 827,
 							"character": 17
 						}
 					],
@@ -26965,12 +26965,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2253,
+												"id": 2255,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2150,
+												"id": 2152,
 												"name": "HostEvent"
 											}
 										]
@@ -27083,7 +27083,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2150,
+										"id": 2152,
 										"name": "HostEvent"
 									}
 								},
@@ -27102,7 +27102,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2243,
+										"id": 2245,
 										"name": "ContextType"
 									}
 								}
@@ -27234,7 +27234,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3239,
+										"id": 3241,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -27339,7 +27339,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 662,
+					"line": 687,
 					"character": 13
 				}
 			],
@@ -27352,13 +27352,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1634,
+					"id": 1636,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2744,
+			"id": 2746,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27374,7 +27374,7 @@
 			},
 			"children": [
 				{
-					"id": 2801,
+					"id": 2803,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27405,20 +27405,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2802,
+							"id": 2804,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2803,
+								"id": 2805,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2804,
+										"id": 2806,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27454,7 +27454,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2837,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27496,7 +27496,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2766,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27533,7 +27533,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2834,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27563,7 +27563,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2447,
+						"id": 2449,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -27572,7 +27572,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2855,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27610,7 +27610,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2825,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27659,7 +27659,7 @@
 					}
 				},
 				{
-					"id": 2805,
+					"id": 2807,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27688,7 +27688,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27697,7 +27697,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2767,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27731,12 +27731,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3265,
+						"id": 3267,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2838,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27778,7 +27778,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2781,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27812,12 +27812,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1558,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 2747,
+					"id": 2749,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27855,7 +27855,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2817,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27893,7 +27893,7 @@
 					}
 				},
 				{
-					"id": 2797,
+					"id": 2799,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27931,7 +27931,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2798,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27963,7 +27963,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -27973,7 +27973,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2765,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28010,7 +28010,7 @@
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2811,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28055,7 +28055,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2849,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28097,7 +28097,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2854,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28139,7 +28139,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2839,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28181,7 +28181,7 @@
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2790,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28215,7 +28215,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2821,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28253,7 +28253,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2791,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28286,7 +28286,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2782,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28324,7 +28324,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2750,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28362,7 +28362,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2762,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28400,7 +28400,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2788,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28434,7 +28434,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2814,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28472,7 +28472,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2835,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28510,7 +28510,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2836,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28548,7 +28548,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2816,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28585,7 +28585,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2795,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28615,7 +28615,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28624,7 +28624,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2763,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28658,7 +28658,7 @@
 					}
 				},
 				{
-					"id": 2798,
+					"id": 2800,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28694,7 +28694,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -28704,7 +28704,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2844,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28736,7 +28736,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2872,
+							"id": 2874,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -28746,7 +28746,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2842,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28778,7 +28778,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2884,
+							"id": 2886,
 							"name": "HomepageModule"
 						}
 					},
@@ -28788,7 +28788,7 @@
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2841,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28820,7 +28820,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3257,
+							"id": 3259,
 							"name": "ListPageColumns"
 						}
 					},
@@ -28830,7 +28830,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2754,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28868,7 +28868,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2751,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28906,7 +28906,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2748,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28944,7 +28944,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2852,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28986,7 +28986,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2845,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29028,7 +29028,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2753,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29066,7 +29066,7 @@
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2752,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29104,7 +29104,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2760,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29141,7 +29141,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2755,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29179,7 +29179,7 @@
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2759,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29213,7 +29213,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2768,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29239,12 +29239,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3203,
+						"id": 3205,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2806,
+					"id": 2808,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29282,7 +29282,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2831,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29319,7 +29319,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2830,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29359,7 +29359,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2856,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29401,7 +29401,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2773,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29439,7 +29439,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2859,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29477,7 +29477,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2775,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29515,7 +29515,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2858,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29553,7 +29553,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2850,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29595,7 +29595,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2848,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29633,7 +29633,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2861,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29675,7 +29675,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2771,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29712,7 +29712,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2774,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29750,7 +29750,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2829,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29784,7 +29784,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2772,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29818,7 +29818,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2857,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29856,7 +29856,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2840,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29894,7 +29894,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2769,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29932,7 +29932,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2776,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29969,7 +29969,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2778,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30003,7 +30003,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2820,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30041,7 +30041,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2802,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30079,7 +30079,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2789,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30116,7 +30116,7 @@
 					}
 				},
 				{
-					"id": 2762,
+					"id": 2764,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30157,7 +30157,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2862,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30199,7 +30199,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2770,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30237,7 +30237,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2819,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30275,7 +30275,7 @@
 					}
 				},
 				{
-					"id": 2816,
+					"id": 2818,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30313,7 +30313,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2757,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30343,12 +30343,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1979,
+						"id": 1981,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2756,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30382,7 +30382,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2813,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30419,7 +30419,7 @@
 					}
 				},
 				{
-					"id": 2810,
+					"id": 2812,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30470,7 +30470,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2810,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30512,7 +30512,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2822,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30550,7 +30550,7 @@
 					}
 				},
 				{
-					"id": 2824,
+					"id": 2826,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30591,7 +30591,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2843,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30623,7 +30623,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2884,
+							"id": 2886,
 							"name": "HomepageModule"
 						}
 					},
@@ -30633,7 +30633,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2832,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30665,7 +30665,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30675,7 +30675,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2833,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30707,7 +30707,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30717,7 +30717,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2827,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30758,7 +30758,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2824,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30795,7 +30795,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2847,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30837,7 +30837,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2853,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30879,7 +30879,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2846,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30921,7 +30921,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2851,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30963,7 +30963,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2860,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31005,7 +31005,7 @@
 					}
 				},
 				{
-					"id": 2745,
+					"id": 2747,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31043,7 +31043,7 @@
 					}
 				},
 				{
-					"id": 2778,
+					"id": 2780,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31081,7 +31081,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2784,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31116,7 +31116,7 @@
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2786,
 					"name": "spotterDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31153,7 +31153,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2785,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31183,12 +31183,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1559,
+						"id": 1561,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2783,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31223,7 +31223,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2787,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31253,12 +31253,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2723,
+						"id": 2725,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2758,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31292,7 +31292,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2779,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31330,7 +31330,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2793,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31368,7 +31368,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2828,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31409,7 +31409,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2801,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31445,7 +31445,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -31455,7 +31455,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2792,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31480,7 +31480,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3311,
+						"id": 3313,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -31490,111 +31490,111 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2801,
-						2835,
-						2764,
-						2832,
-						2853,
-						2823,
-						2805,
-						2765,
-						2836,
-						2779,
-						2747,
-						2815,
-						2797,
-						2796,
-						2763,
-						2809,
-						2847,
-						2852,
+						2803,
 						2837,
-						2788,
-						2819,
-						2789,
-						2780,
-						2748,
-						2760,
-						2786,
-						2812,
-						2833,
-						2834,
-						2814,
-						2793,
-						2761,
-						2798,
-						2842,
-						2840,
-						2839,
-						2752,
-						2749,
-						2746,
-						2850,
-						2843,
-						2751,
-						2750,
-						2758,
-						2753,
-						2757,
 						2766,
-						2806,
-						2829,
-						2828,
-						2854,
-						2771,
-						2857,
-						2773,
-						2856,
-						2848,
-						2846,
-						2859,
-						2769,
-						2772,
-						2827,
-						2770,
+						2834,
 						2855,
-						2838,
-						2767,
-						2774,
-						2776,
-						2818,
-						2800,
-						2787,
-						2762,
-						2860,
-						2768,
-						2817,
-						2816,
-						2755,
-						2754,
-						2811,
-						2810,
-						2808,
-						2820,
-						2824,
-						2841,
-						2830,
-						2831,
 						2825,
-						2822,
-						2845,
-						2851,
-						2844,
-						2849,
-						2858,
-						2745,
-						2778,
-						2782,
-						2784,
-						2783,
+						2807,
+						2767,
+						2838,
 						2781,
-						2785,
-						2756,
-						2777,
-						2791,
-						2826,
+						2749,
+						2817,
 						2799,
-						2790
+						2798,
+						2765,
+						2811,
+						2849,
+						2854,
+						2839,
+						2790,
+						2821,
+						2791,
+						2782,
+						2750,
+						2762,
+						2788,
+						2814,
+						2835,
+						2836,
+						2816,
+						2795,
+						2763,
+						2800,
+						2844,
+						2842,
+						2841,
+						2754,
+						2751,
+						2748,
+						2852,
+						2845,
+						2753,
+						2752,
+						2760,
+						2755,
+						2759,
+						2768,
+						2808,
+						2831,
+						2830,
+						2856,
+						2773,
+						2859,
+						2775,
+						2858,
+						2850,
+						2848,
+						2861,
+						2771,
+						2774,
+						2829,
+						2772,
+						2857,
+						2840,
+						2769,
+						2776,
+						2778,
+						2820,
+						2802,
+						2789,
+						2764,
+						2862,
+						2770,
+						2819,
+						2818,
+						2757,
+						2756,
+						2813,
+						2812,
+						2810,
+						2822,
+						2826,
+						2843,
+						2832,
+						2833,
+						2827,
+						2824,
+						2847,
+						2853,
+						2846,
+						2851,
+						2860,
+						2747,
+						2780,
+						2784,
+						2786,
+						2785,
+						2783,
+						2787,
+						2758,
+						2779,
+						2793,
+						2828,
+						2801,
+						2792
 					]
 				}
 			],
@@ -31613,7 +31613,7 @@
 			]
 		},
 		{
-			"id": 1839,
+			"id": 1841,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31629,14 +31629,14 @@
 			},
 			"children": [
 				{
-					"id": 1876,
+					"id": 1878,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1877,
+							"id": 1879,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31646,19 +31646,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1878,
+									"id": 1880,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1838,
+										"id": 1840,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1879,
+									"id": 1881,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31682,14 +31682,14 @@
 					]
 				},
 				{
-					"id": 1880,
+					"id": 1882,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1881,
+							"id": 1883,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31699,7 +31699,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1882,
+									"id": 1884,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31707,12 +31707,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1829,
+										"id": 1831,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1883,
+									"id": 1885,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31721,21 +31721,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1884,
+											"id": 1886,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1885,
+													"id": 1887,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1886,
+															"id": 1888,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31761,7 +31761,7 @@
 									}
 								},
 								{
-									"id": 1887,
+									"id": 1889,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31773,7 +31773,7 @@
 									}
 								},
 								{
-									"id": 1888,
+									"id": 1890,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31789,21 +31789,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1840,
+					"id": 1842,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1841,
+							"id": 1843,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31813,7 +31813,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1842,
+									"id": 1844,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31821,12 +31821,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1830,
+										"id": 1832,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1843,
+									"id": 1845,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31837,28 +31837,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1844,
+											"id": 1846,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1845,
+													"id": 1847,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1846,
+															"id": 1848,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1822,
+																"id": 1824,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31875,12 +31875,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1847,
+							"id": 1849,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31890,7 +31890,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1848,
+									"id": 1850,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31901,29 +31901,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1831,
+												"id": 1833,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1834,
+												"id": 1836,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1835,
+												"id": 1837,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1838,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1849,
+									"id": 1851,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31934,14 +31934,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1850,
+											"id": 1852,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1851,
+													"id": 1853,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -31958,31 +31958,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1852,
+							"id": 1854,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1853,
+									"id": 1855,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1833,
+										"id": 1835,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1854,
+									"id": 1856,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31990,21 +31990,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1855,
+											"id": 1857,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1856,
+													"id": 1858,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1857,
+															"id": 1859,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32027,40 +32027,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1858,
+					"id": 1860,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1859,
+							"id": 1861,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1860,
+									"id": 1862,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1830,
+										"id": 1832,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1861,
+									"id": 1863,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32068,28 +32068,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1862,
+											"id": 1864,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1863,
+													"id": 1865,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1864,
+															"id": 1866,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1822,
+																"id": 1824,
 																"name": "AuthFailureType"
 															}
 														}
@@ -32106,19 +32106,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1865,
+							"id": 1867,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1866,
+									"id": 1868,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32128,29 +32128,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1831,
+												"id": 1833,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1834,
+												"id": 1836,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1835,
+												"id": 1837,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1838,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1867,
+									"id": 1869,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32158,14 +32158,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1868,
+											"id": 1870,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1869,
+													"id": 1871,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -32182,31 +32182,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1870,
+							"id": 1872,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1871,
+									"id": 1873,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1833,
+										"id": 1835,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1872,
+									"id": 1874,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32214,21 +32214,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1873,
+											"id": 1875,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1874,
+													"id": 1876,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1875,
+															"id": 1877,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32251,21 +32251,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1889,
+					"id": 1891,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1890,
+							"id": 1892,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -32275,7 +32275,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1891,
+									"id": 1893,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32285,14 +32285,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1829,
+										"id": 1831,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1839,
+								"id": 1841,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -32304,11 +32304,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1876,
-						1880,
-						1840,
-						1858,
-						1889
+						1878,
+						1882,
+						1842,
+						1860,
+						1891
 					]
 				}
 			],
@@ -32501,7 +32501,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -32621,7 +32621,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -32824,7 +32824,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -32870,7 +32870,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -33523,7 +33523,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -33613,7 +33613,7 @@
 			]
 		},
 		{
-			"id": 1573,
+			"id": 1575,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33633,7 +33633,7 @@
 			},
 			"children": [
 				{
-					"id": 1606,
+					"id": 1608,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33664,20 +33664,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1607,
+							"id": 1609,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1608,
+								"id": 1610,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1609,
+										"id": 1611,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33714,46 +33714,7 @@
 					}
 				},
 				{
-					"id": 1576,
-					"name": "analystId",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Pins the embed to a single spotter analyst. Implies no default Spotter\nand no \"Show all\".",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "version",
-								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   analystId: 'analyst-id-1234',\n})\n```\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 320,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"id": 1477,
-						"name": "SpotterEmbedViewConfig.analystId"
-					}
-				},
-				{
-					"id": 1627,
+					"id": 1629,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33803,7 +33764,7 @@
 					}
 				},
 				{
-					"id": 1610,
+					"id": 1612,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33832,7 +33793,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -33842,7 +33803,7 @@
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1582,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33870,7 +33831,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 369,
+							"line": 394,
 							"character": 4
 						}
 					],
@@ -33885,7 +33846,7 @@
 					}
 				},
 				{
-					"id": 1575,
+					"id": 1577,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33909,7 +33870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 305,
+							"line": 329,
 							"character": 4
 						}
 					],
@@ -33927,7 +33888,7 @@
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1591,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33955,13 +33916,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 512,
+							"line": 537,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1558,
 						"name": "SpotterQueryMode"
 					},
 					"inheritedFrom": {
@@ -33971,7 +33932,7 @@
 					}
 				},
 				{
-					"id": 1620,
+					"id": 1622,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34010,7 +33971,7 @@
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1580,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34034,7 +33995,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 339,
+							"line": 364,
 							"character": 4
 						}
 					],
@@ -34049,7 +34010,7 @@
 					}
 				},
 				{
-					"id": 1602,
+					"id": 1604,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34088,7 +34049,7 @@
 					}
 				},
 				{
-					"id": 1601,
+					"id": 1603,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34120,7 +34081,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -34131,7 +34092,7 @@
 					}
 				},
 				{
-					"id": 1614,
+					"id": 1616,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34177,7 +34138,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1626,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34216,7 +34177,7 @@
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1593,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34244,7 +34205,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 531,
+							"line": 556,
 							"character": 4
 						}
 					],
@@ -34259,7 +34220,7 @@
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1592,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34283,7 +34244,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 521,
+							"line": 546,
 							"character": 4
 						}
 					],
@@ -34298,7 +34259,7 @@
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1619,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34337,7 +34298,7 @@
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1586,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34361,7 +34322,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 433,
+							"line": 458,
 							"character": 4
 						}
 					],
@@ -34376,7 +34337,7 @@
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1588,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34400,7 +34361,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 464,
+							"line": 489,
 							"character": 4
 						}
 					],
@@ -34415,7 +34376,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1621,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34453,7 +34414,7 @@
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1600,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34483,7 +34444,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -34493,7 +34454,7 @@
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1605,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34529,7 +34490,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -34540,7 +34501,7 @@
 					}
 				},
 				{
-					"id": 1582,
+					"id": 1584,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34564,7 +34525,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 400,
+							"line": 425,
 							"character": 4
 						}
 					],
@@ -34579,7 +34540,7 @@
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1581,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34603,7 +34564,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 353,
+							"line": 378,
 							"character": 4
 						}
 					],
@@ -34618,7 +34579,7 @@
 					}
 				},
 				{
-					"id": 1611,
+					"id": 1613,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34657,7 +34618,7 @@
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1635,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34695,7 +34656,7 @@
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1634,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34736,7 +34697,7 @@
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1633,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34771,7 +34732,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1625,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34810,7 +34771,7 @@
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1607,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34849,7 +34810,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1624,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34888,7 +34849,7 @@
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1623,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34927,7 +34888,7 @@
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1618,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34965,7 +34926,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1617,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35017,7 +34978,7 @@
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1615,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35060,7 +35021,7 @@
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1630,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35102,7 +35063,7 @@
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1585,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35126,7 +35087,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 421,
+							"line": 446,
 							"character": 4
 						}
 					],
@@ -35134,7 +35095,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -35145,7 +35106,7 @@
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1587,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35169,7 +35130,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 452,
+							"line": 477,
 							"character": 4
 						}
 					],
@@ -35177,7 +35138,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -35188,7 +35149,7 @@
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1579,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35201,7 +35162,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 324,
+							"line": 349,
 							"character": 4
 						}
 					],
@@ -35216,7 +35177,7 @@
 					}
 				},
 				{
-					"id": 1595,
+					"id": 1597,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35240,7 +35201,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 608,
+							"line": 633,
 							"character": 4
 						}
 					],
@@ -35255,7 +35216,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1631,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35297,7 +35258,7 @@
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1628,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35335,7 +35296,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1583,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35359,7 +35320,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 385,
+							"line": 410,
 							"character": 4
 						}
 					],
@@ -35374,7 +35335,7 @@
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1590,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35402,7 +35363,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 494,
+							"line": 519,
 							"character": 4
 						}
 					],
@@ -35417,7 +35378,47 @@
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1578,
+					"name": "spotterAnalystConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the Spotter Analyst experience.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterAnalystConfig: {\n       analystId: 'analyst-id-1234',\n   },\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 345,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1556,
+						"name": "SpotterAnalystConfig"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"id": 1477,
+						"name": "SpotterEmbedViewConfig.spotterAnalystConfig"
+					}
+				},
+				{
+					"id": 1595,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35441,7 +35442,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 570,
+							"line": 595,
 							"character": 4
 						}
 					],
@@ -35457,7 +35458,7 @@
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1596,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35481,13 +35482,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 586,
+							"line": 611,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1559,
+						"id": 1561,
 						"name": "SpotterShareConversationConfig"
 					},
 					"inheritedFrom": {
@@ -35497,7 +35498,7 @@
 					}
 				},
 				{
-					"id": 1592,
+					"id": 1594,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35521,7 +35522,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 552,
+							"line": 577,
 							"character": 4
 						}
 					],
@@ -35537,7 +35538,7 @@
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1589,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35565,7 +35566,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 479,
+							"line": 504,
 							"character": 4
 						}
 					],
@@ -35580,7 +35581,7 @@
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1598,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35608,7 +35609,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 623,
+							"line": 648,
 							"character": 4
 						}
 					],
@@ -35623,7 +35624,7 @@
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1632,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35665,7 +35666,7 @@
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1606,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35701,7 +35702,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -35712,7 +35713,7 @@
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1576,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35725,7 +35726,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 288,
+							"line": 312,
 							"character": 4
 						}
 					],
@@ -35745,64 +35746,64 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1606,
-						1576,
-						1627,
-						1610,
-						1580,
-						1575,
-						1589,
-						1620,
-						1578,
-						1602,
-						1601,
-						1614,
-						1624,
-						1591,
-						1590,
-						1617,
-						1584,
-						1586,
-						1619,
-						1598,
-						1603,
+						1608,
+						1629,
+						1612,
 						1582,
-						1579,
-						1611,
-						1633,
-						1632,
-						1631,
-						1623,
-						1605,
+						1577,
+						1591,
 						1622,
-						1621,
+						1580,
+						1604,
+						1603,
 						1616,
-						1615,
+						1626,
+						1593,
+						1592,
+						1619,
+						1586,
+						1588,
+						1621,
+						1600,
+						1605,
+						1584,
+						1581,
 						1613,
+						1635,
+						1634,
+						1633,
+						1625,
+						1607,
+						1624,
+						1623,
+						1618,
+						1617,
+						1615,
+						1630,
+						1585,
+						1587,
+						1579,
+						1597,
+						1631,
 						1628,
 						1583,
-						1585,
-						1577,
+						1590,
+						1578,
 						1595,
-						1629,
-						1626,
-						1581,
-						1588,
-						1593,
-						1594,
-						1592,
-						1587,
 						1596,
-						1630,
-						1604,
-						1574
+						1594,
+						1589,
+						1598,
+						1632,
+						1606,
+						1576
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 633,
+					"line": 658,
 					"character": 17
 				}
 			],
@@ -35815,7 +35816,7 @@
 			]
 		},
 		{
-			"id": 3219,
+			"id": 3221,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35830,7 +35831,7 @@
 			},
 			"children": [
 				{
-					"id": 3220,
+					"id": 3222,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35847,14 +35848,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3221,
+							"id": 3223,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3222,
+									"id": 3224,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35868,12 +35869,12 @@
 									],
 									"type": {
 										"type": "reference",
-										"id": 3216,
+										"id": 3218,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3223,
+									"id": 3225,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35889,7 +35890,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3216,
+											"id": 3218,
 											"name": "VizPoint"
 										}
 									}
@@ -35900,8 +35901,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3222,
-										3223
+										3224,
+										3225
 									]
 								}
 							]
@@ -35909,7 +35910,7 @@
 					}
 				},
 				{
-					"id": 3224,
+					"id": 3226,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35924,14 +35925,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3225,
+							"id": 3227,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3233,
+									"id": 3235,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35952,7 +35953,7 @@
 									}
 								},
 								{
-									"id": 3234,
+									"id": 3236,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35973,7 +35974,7 @@
 									}
 								},
 								{
-									"id": 3227,
+									"id": 3229,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35991,7 +35992,7 @@
 									}
 								},
 								{
-									"id": 3226,
+									"id": 3228,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36009,7 +36010,7 @@
 									}
 								},
 								{
-									"id": 3228,
+									"id": 3230,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36024,14 +36025,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3229,
+											"id": 3231,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3230,
+													"id": 3232,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -36046,14 +36047,14 @@
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3231,
+															"id": 3233,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3232,
+																	"id": 3234,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -36076,7 +36077,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3232
+																		3234
 																	]
 																}
 															]
@@ -36089,7 +36090,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3230
+														3232
 													]
 												}
 											]
@@ -36102,23 +36103,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3233,
-										3234,
-										3227,
-										3226,
-										3228
+										3235,
+										3236,
+										3229,
+										3228,
+										3230
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3235,
+								"id": 3237,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3236,
+										"id": 3238,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36137,7 +36138,7 @@
 					}
 				},
 				{
-					"id": 3237,
+					"id": 3239,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36151,12 +36152,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1969,
+						"id": 1971,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3238,
+					"id": 3240,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36181,10 +36182,10 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3220,
-						3224,
-						3237,
-						3238
+						3222,
+						3226,
+						3239,
+						3240
 					]
 				}
 			],
@@ -36197,7 +36198,7 @@
 			]
 		},
 		{
-			"id": 2930,
+			"id": 2932,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36207,7 +36208,7 @@
 			},
 			"children": [
 				{
-					"id": 2993,
+					"id": 2995,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36230,7 +36231,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 2994,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36253,7 +36254,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2964,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36276,7 +36277,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2965,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36299,7 +36300,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2967,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36322,7 +36323,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2966,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36345,7 +36346,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2937,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36368,7 +36369,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3007,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36391,7 +36392,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3008,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36414,7 +36415,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3005,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36437,7 +36438,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3006,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36460,7 +36461,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2969,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36483,7 +36484,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2974,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36506,7 +36507,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2971,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36529,7 +36530,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2973,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36552,7 +36553,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2972,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36575,7 +36576,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2970,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36598,7 +36599,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2979,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36621,7 +36622,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2976,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36644,7 +36645,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2978,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36667,7 +36668,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2977,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36690,7 +36691,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2975,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36713,7 +36714,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2983,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36736,7 +36737,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2982,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36759,7 +36760,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2981,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36782,7 +36783,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2980,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36805,7 +36806,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2968,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36828,7 +36829,7 @@
 					}
 				},
 				{
-					"id": 3101,
+					"id": 3103,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36851,7 +36852,7 @@
 					}
 				},
 				{
-					"id": 3096,
+					"id": 3098,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36874,7 +36875,7 @@
 					}
 				},
 				{
-					"id": 3091,
+					"id": 3093,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36897,7 +36898,7 @@
 					}
 				},
 				{
-					"id": 3090,
+					"id": 3092,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36920,7 +36921,7 @@
 					}
 				},
 				{
-					"id": 3093,
+					"id": 3095,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36943,7 +36944,7 @@
 					}
 				},
 				{
-					"id": 3092,
+					"id": 3094,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36966,7 +36967,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3030,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36989,7 +36990,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3033,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37012,7 +37013,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3028,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37035,7 +37036,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3031,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37058,7 +37059,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3032,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37081,7 +37082,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3027,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37104,7 +37105,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3029,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37127,7 +37128,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3000,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37150,7 +37151,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 2999,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37173,7 +37174,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3002,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37196,7 +37197,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3001,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37219,7 +37220,7 @@
 					}
 				},
 				{
-					"id": 2996,
+					"id": 2998,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37242,7 +37243,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 2996,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37265,7 +37266,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 2997,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37288,7 +37289,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3003,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37311,7 +37312,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3004,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37334,7 +37335,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3015,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37357,7 +37358,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3016,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37380,7 +37381,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3019,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37403,7 +37404,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3017,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37426,7 +37427,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3018,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37449,7 +37450,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3026,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37472,7 +37473,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3025,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37495,7 +37496,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3024,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37518,7 +37519,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3023,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37541,7 +37542,7 @@
 					}
 				},
 				{
-					"id": 3089,
+					"id": 3091,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37564,7 +37565,7 @@
 					}
 				},
 				{
-					"id": 3088,
+					"id": 3090,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37587,7 +37588,7 @@
 					}
 				},
 				{
-					"id": 3087,
+					"id": 3089,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37610,7 +37611,7 @@
 					}
 				},
 				{
-					"id": 3095,
+					"id": 3097,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37633,7 +37634,7 @@
 					}
 				},
 				{
-					"id": 3094,
+					"id": 3096,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37656,7 +37657,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2941,
 					"name": "--ts-var-left-nav-active-tab-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37679,7 +37680,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2942,
 					"name": "--ts-var-left-nav-active-tab-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37702,7 +37703,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2940,
 					"name": "--ts-var-left-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37725,7 +37726,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2944,
 					"name": "--ts-var-left-nav-item-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37748,7 +37749,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2946,
 					"name": "--ts-var-left-nav-item-selection-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37771,7 +37772,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2945,
 					"name": "--ts-var-left-nav-item-selection-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37794,7 +37795,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2943,
 					"name": "--ts-var-left-nav-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37817,7 +37818,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2947,
 					"name": "--ts-var-left-nav-tab-icon-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37840,7 +37841,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2948,
 					"name": "--ts-var-left-nav-tab-icon-inactive-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37863,7 +37864,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3021,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37886,7 +37887,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3020,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37909,7 +37910,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3050,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37932,7 +37933,7 @@
 					}
 				},
 				{
-					"id": 3061,
+					"id": 3063,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37956,7 +37957,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3062,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37980,7 +37981,7 @@
 					}
 				},
 				{
-					"id": 3058,
+					"id": 3060,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38004,7 +38005,7 @@
 					}
 				},
 				{
-					"id": 3059,
+					"id": 3061,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38028,7 +38029,7 @@
 					}
 				},
 				{
-					"id": 3066,
+					"id": 3068,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38051,7 +38052,7 @@
 					}
 				},
 				{
-					"id": 3064,
+					"id": 3066,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38074,7 +38075,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3065,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38097,7 +38098,7 @@
 					}
 				},
 				{
-					"id": 3150,
+					"id": 3152,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38120,7 +38121,7 @@
 					}
 				},
 				{
-					"id": 3154,
+					"id": 3156,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38143,7 +38144,7 @@
 					}
 				},
 				{
-					"id": 3155,
+					"id": 3157,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38166,7 +38167,7 @@
 					}
 				},
 				{
-					"id": 3151,
+					"id": 3153,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38189,7 +38190,7 @@
 					}
 				},
 				{
-					"id": 3152,
+					"id": 3154,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38212,7 +38213,7 @@
 					}
 				},
 				{
-					"id": 3153,
+					"id": 3155,
 					"name": "--ts-var-liveboard-edit-toolbar-text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38235,7 +38236,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3051,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38259,7 +38260,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3052,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38283,7 +38284,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3056,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38307,7 +38308,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3044,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38331,7 +38332,7 @@
 					}
 				},
 				{
-					"id": 3057,
+					"id": 3059,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38355,7 +38356,7 @@
 					}
 				},
 				{
-					"id": 3056,
+					"id": 3058,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38379,7 +38380,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3049,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38403,7 +38404,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3057,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38427,7 +38428,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3047,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38451,7 +38452,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3048,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38475,7 +38476,7 @@
 					}
 				},
 				{
-					"id": 3053,
+					"id": 3055,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38499,7 +38500,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3045,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38523,7 +38524,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3046,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38547,7 +38548,7 @@
 					}
 				},
 				{
-					"id": 3080,
+					"id": 3082,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38570,7 +38571,7 @@
 					}
 				},
 				{
-					"id": 3077,
+					"id": 3079,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38593,7 +38594,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3080,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38616,7 +38617,7 @@
 					}
 				},
 				{
-					"id": 3079,
+					"id": 3081,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38639,7 +38640,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3035,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38662,7 +38663,7 @@
 					}
 				},
 				{
-					"id": 3086,
+					"id": 3088,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38685,7 +38686,7 @@
 					}
 				},
 				{
-					"id": 3081,
+					"id": 3083,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38708,7 +38709,7 @@
 					}
 				},
 				{
-					"id": 3082,
+					"id": 3084,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38731,7 +38732,7 @@
 					}
 				},
 				{
-					"id": 3085,
+					"id": 3087,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38754,7 +38755,7 @@
 					}
 				},
 				{
-					"id": 3083,
+					"id": 3085,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38777,7 +38778,7 @@
 					}
 				},
 				{
-					"id": 3084,
+					"id": 3086,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38800,7 +38801,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3036,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38823,7 +38824,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3040,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38846,7 +38847,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3039,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38869,7 +38870,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3034,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38892,7 +38893,7 @@
 					}
 				},
 				{
-					"id": 3052,
+					"id": 3054,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38915,7 +38916,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3053,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38938,7 +38939,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3067,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38961,7 +38962,7 @@
 					}
 				},
 				{
-					"id": 3120,
+					"id": 3122,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38984,7 +38985,7 @@
 					}
 				},
 				{
-					"id": 3117,
+					"id": 3119,
 					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39007,7 +39008,7 @@
 					}
 				},
 				{
-					"id": 3119,
+					"id": 3121,
 					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39030,7 +39031,7 @@
 					}
 				},
 				{
-					"id": 3121,
+					"id": 3123,
 					"name": "--ts-var-liveboard-styling-button-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39053,7 +39054,7 @@
 					}
 				},
 				{
-					"id": 3122,
+					"id": 3124,
 					"name": "--ts-var-liveboard-styling-button-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39076,7 +39077,7 @@
 					}
 				},
 				{
-					"id": 3118,
+					"id": 3120,
 					"name": "--ts-var-liveboard-styling-button-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39099,7 +39100,7 @@
 					}
 				},
 				{
-					"id": 3123,
+					"id": 3125,
 					"name": "--ts-var-liveboard-styling-color-palette-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39122,7 +39123,7 @@
 					}
 				},
 				{
-					"id": 3116,
+					"id": 3118,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39145,7 +39146,7 @@
 					}
 				},
 				{
-					"id": 3115,
+					"id": 3117,
 					"name": "--ts-var-liveboard-styling-panel-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39168,7 +39169,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3069,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39191,7 +39192,7 @@
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3070,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39214,7 +39215,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3038,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39237,7 +39238,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3037,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39260,7 +39261,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3041,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39283,7 +39284,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3042,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39306,7 +39307,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3043,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39329,7 +39330,7 @@
 					}
 				},
 				{
-					"id": 3069,
+					"id": 3071,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39352,7 +39353,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3072,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39375,7 +39376,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3013,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39398,7 +39399,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3010,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39421,7 +39422,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3009,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39444,7 +39445,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3011,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39467,7 +39468,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3014,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39490,7 +39491,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3012,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39513,7 +39514,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2938,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39536,7 +39537,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2939,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39559,7 +39560,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3077,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39582,7 +39583,7 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3078,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39605,7 +39606,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3073,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39628,7 +39629,7 @@
 					}
 				},
 				{
-					"id": 3073,
+					"id": 3075,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39651,7 +39652,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3076,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39674,7 +39675,7 @@
 					}
 				},
 				{
-					"id": 3072,
+					"id": 3074,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39697,7 +39698,7 @@
 					}
 				},
 				{
-					"id": 2931,
+					"id": 2933,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39720,7 +39721,7 @@
 					}
 				},
 				{
-					"id": 2932,
+					"id": 2934,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39743,7 +39744,7 @@
 					}
 				},
 				{
-					"id": 2933,
+					"id": 2935,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39766,7 +39767,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2936,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39789,7 +39790,7 @@
 					}
 				},
 				{
-					"id": 3104,
+					"id": 3106,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39812,7 +39813,7 @@
 					}
 				},
 				{
-					"id": 3103,
+					"id": 3105,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39835,7 +39836,7 @@
 					}
 				},
 				{
-					"id": 3108,
+					"id": 3110,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39858,7 +39859,7 @@
 					}
 				},
 				{
-					"id": 3109,
+					"id": 3111,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39881,7 +39882,7 @@
 					}
 				},
 				{
-					"id": 3112,
+					"id": 3114,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39904,7 +39905,7 @@
 					}
 				},
 				{
-					"id": 3111,
+					"id": 3113,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39927,7 +39928,7 @@
 					}
 				},
 				{
-					"id": 3110,
+					"id": 3112,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39950,7 +39951,7 @@
 					}
 				},
 				{
-					"id": 3113,
+					"id": 3115,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39973,7 +39974,7 @@
 					}
 				},
 				{
-					"id": 3106,
+					"id": 3108,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39996,7 +39997,7 @@
 					}
 				},
 				{
-					"id": 3114,
+					"id": 3116,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40019,7 +40020,7 @@
 					}
 				},
 				{
-					"id": 3105,
+					"id": 3107,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40042,7 +40043,7 @@
 					}
 				},
 				{
-					"id": 3107,
+					"id": 3109,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40065,7 +40066,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2956,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40088,7 +40089,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2960,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40111,7 +40112,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2961,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40134,7 +40135,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2959,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40157,7 +40158,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2955,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40180,7 +40181,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2958,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40203,7 +40204,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2952,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40226,7 +40227,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2953,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40249,7 +40250,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2954,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40272,7 +40273,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2949,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40295,7 +40296,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2950,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40318,7 +40319,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2951,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40341,7 +40342,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2957,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40364,7 +40365,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3022,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40387,7 +40388,7 @@
 					}
 				},
 				{
-					"id": 3166,
+					"id": 3168,
 					"name": "--ts-var-share-chat-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40410,7 +40411,7 @@
 					}
 				},
 				{
-					"id": 3165,
+					"id": 3167,
 					"name": "--ts-var-share-chat-header-container-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40433,7 +40434,7 @@
 					}
 				},
 				{
-					"id": 3169,
+					"id": 3171,
 					"name": "--ts-var-share-chat-header-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40456,7 +40457,7 @@
 					}
 				},
 				{
-					"id": 3170,
+					"id": 3172,
 					"name": "--ts-var-share-chat-header-input-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40479,7 +40480,7 @@
 					}
 				},
 				{
-					"id": 3168,
+					"id": 3170,
 					"name": "--ts-var-share-chat-header-input-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40502,7 +40503,7 @@
 					}
 				},
 				{
-					"id": 3167,
+					"id": 3169,
 					"name": "--ts-var-share-chat-header-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40525,7 +40526,7 @@
 					}
 				},
 				{
-					"id": 3162,
+					"id": 3164,
 					"name": "--ts-var-shared-conv-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40548,7 +40549,7 @@
 					}
 				},
 				{
-					"id": 3163,
+					"id": 3165,
 					"name": "--ts-var-shared-conv-header-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40571,7 +40572,7 @@
 					}
 				},
 				{
-					"id": 3164,
+					"id": 3166,
 					"name": "--ts-var-shared-conv-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40594,7 +40595,7 @@
 					}
 				},
 				{
-					"id": 3171,
+					"id": 3173,
 					"name": "--ts-var-shimmer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40617,7 +40618,7 @@
 					}
 				},
 				{
-					"id": 3172,
+					"id": 3174,
 					"name": "--ts-var-shimmer-sweep-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40640,7 +40641,7 @@
 					}
 				},
 				{
-					"id": 3062,
+					"id": 3064,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40663,7 +40664,7 @@
 					}
 				},
 				{
-					"id": 3100,
+					"id": 3102,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40686,7 +40687,7 @@
 					}
 				},
 				{
-					"id": 3097,
+					"id": 3099,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40709,7 +40710,7 @@
 					}
 				},
 				{
-					"id": 3098,
+					"id": 3100,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40732,7 +40733,7 @@
 					}
 				},
 				{
-					"id": 3099,
+					"id": 3101,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40755,7 +40756,7 @@
 					}
 				},
 				{
-					"id": 3102,
+					"id": 3104,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40778,7 +40779,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2962,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40801,7 +40802,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2963,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40824,7 +40825,7 @@
 					}
 				},
 				{
-					"id": 3157,
+					"id": 3159,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40847,7 +40848,7 @@
 					}
 				},
 				{
-					"id": 3129,
+					"id": 3131,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40870,7 +40871,7 @@
 					}
 				},
 				{
-					"id": 3158,
+					"id": 3160,
 					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40893,7 +40894,7 @@
 					}
 				},
 				{
-					"id": 3156,
+					"id": 3158,
 					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40916,7 +40917,7 @@
 					}
 				},
 				{
-					"id": 3125,
+					"id": 3127,
 					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40939,7 +40940,7 @@
 					}
 				},
 				{
-					"id": 3127,
+					"id": 3129,
 					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40962,7 +40963,7 @@
 					}
 				},
 				{
-					"id": 3128,
+					"id": 3130,
 					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40985,7 +40986,7 @@
 					}
 				},
 				{
-					"id": 3126,
+					"id": 3128,
 					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41008,7 +41009,7 @@
 					}
 				},
 				{
-					"id": 3148,
+					"id": 3150,
 					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41031,7 +41032,7 @@
 					}
 				},
 				{
-					"id": 3149,
+					"id": 3151,
 					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41054,7 +41055,7 @@
 					}
 				},
 				{
-					"id": 3134,
+					"id": 3136,
 					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41077,7 +41078,7 @@
 					}
 				},
 				{
-					"id": 3124,
+					"id": 3126,
 					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41100,7 +41101,7 @@
 					}
 				},
 				{
-					"id": 3130,
+					"id": 3132,
 					"name": "--ts-var-spotterviz-prompt-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41123,7 +41124,7 @@
 					}
 				},
 				{
-					"id": 3131,
+					"id": 3133,
 					"name": "--ts-var-spotterviz-prompt-card-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41146,7 +41147,7 @@
 					}
 				},
 				{
-					"id": 3159,
+					"id": 3161,
 					"name": "--ts-var-spotterviz-reference-icon-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41169,7 +41170,7 @@
 					}
 				},
 				{
-					"id": 3161,
+					"id": 3163,
 					"name": "--ts-var-spotterviz-reference-icon-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41192,7 +41193,7 @@
 					}
 				},
 				{
-					"id": 3160,
+					"id": 3162,
 					"name": "--ts-var-spotterviz-reference-icon-selected-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41215,7 +41216,7 @@
 					}
 				},
 				{
-					"id": 3132,
+					"id": 3134,
 					"name": "--ts-var-spotterviz-text-primary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41238,7 +41239,7 @@
 					}
 				},
 				{
-					"id": 3133,
+					"id": 3135,
 					"name": "--ts-var-spotterviz-text-secondary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41261,7 +41262,7 @@
 					}
 				},
 				{
-					"id": 3138,
+					"id": 3140,
 					"name": "--ts-var-spotterviz-thinking-completed-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41284,7 +41285,7 @@
 					}
 				},
 				{
-					"id": 3140,
+					"id": 3142,
 					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41307,7 +41308,7 @@
 					}
 				},
 				{
-					"id": 3137,
+					"id": 3139,
 					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41330,7 +41331,7 @@
 					}
 				},
 				{
-					"id": 3139,
+					"id": 3141,
 					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41353,7 +41354,7 @@
 					}
 				},
 				{
-					"id": 3143,
+					"id": 3145,
 					"name": "--ts-var-spotterviz-tool-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41376,7 +41377,7 @@
 					}
 				},
 				{
-					"id": 3141,
+					"id": 3143,
 					"name": "--ts-var-spotterviz-tool-call-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41399,7 +41400,7 @@
 					}
 				},
 				{
-					"id": 3145,
+					"id": 3147,
 					"name": "--ts-var-spotterviz-tool-feedback-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41422,7 +41423,7 @@
 					}
 				},
 				{
-					"id": 3146,
+					"id": 3148,
 					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41445,7 +41446,7 @@
 					}
 				},
 				{
-					"id": 3144,
+					"id": 3146,
 					"name": "--ts-var-spotterviz-tool-json-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41468,7 +41469,7 @@
 					}
 				},
 				{
-					"id": 3147,
+					"id": 3149,
 					"name": "--ts-var-spotterviz-tool-json-input-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41491,7 +41492,7 @@
 					}
 				},
 				{
-					"id": 3142,
+					"id": 3144,
 					"name": "--ts-var-spotterviz-tool-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41514,7 +41515,7 @@
 					}
 				},
 				{
-					"id": 3136,
+					"id": 3138,
 					"name": "--ts-var-spotterviz-usermessage-icon-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41537,7 +41538,7 @@
 					}
 				},
 				{
-					"id": 3135,
+					"id": 3137,
 					"name": "--ts-var-spotterviz-usermessage-icon-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41560,7 +41561,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 2992,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41583,7 +41584,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 2990,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41606,7 +41607,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 2991,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41629,7 +41630,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 2987,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41652,7 +41653,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 2988,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41675,7 +41676,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 2989,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41698,7 +41699,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 2993,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41721,7 +41722,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2984,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41744,7 +41745,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 2985,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41767,7 +41768,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 2986,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41795,248 +41796,248 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2993,
-						2992,
-						2962,
-						2963,
-						2965,
+						2995,
+						2994,
 						2964,
-						2935,
+						2965,
+						2967,
+						2966,
+						2937,
+						3007,
+						3008,
 						3005,
 						3006,
-						3003,
-						3004,
-						2967,
-						2972,
 						2969,
-						2971,
-						2970,
-						2968,
-						2977,
 						2974,
-						2976,
-						2975,
+						2971,
 						2973,
+						2972,
+						2970,
+						2979,
+						2976,
+						2978,
+						2977,
+						2975,
+						2983,
+						2982,
 						2981,
 						2980,
-						2979,
-						2978,
-						2966,
-						3101,
-						3096,
-						3091,
-						3090,
+						2968,
+						3103,
+						3098,
 						3093,
 						3092,
-						3028,
-						3031,
-						3026,
-						3029,
-						3030,
-						3025,
-						3027,
-						2998,
-						2997,
-						3000,
-						2999,
-						2996,
-						2994,
-						2995,
-						3001,
-						3002,
-						3013,
-						3014,
-						3017,
-						3015,
-						3016,
-						3024,
-						3023,
-						3022,
-						3021,
-						3089,
-						3088,
-						3087,
 						3095,
 						3094,
-						2939,
-						2940,
-						2938,
-						2942,
-						2944,
-						2943,
-						2941,
-						2945,
-						2946,
+						3030,
+						3033,
+						3028,
+						3031,
+						3032,
+						3027,
+						3029,
+						3000,
+						2999,
+						3002,
+						3001,
+						2998,
+						2996,
+						2997,
+						3003,
+						3004,
+						3015,
+						3016,
 						3019,
+						3017,
 						3018,
-						3048,
-						3061,
-						3060,
-						3058,
-						3059,
-						3066,
-						3064,
+						3026,
+						3025,
+						3024,
+						3023,
+						3091,
+						3090,
+						3089,
+						3097,
+						3096,
+						2941,
+						2942,
+						2940,
+						2944,
+						2946,
+						2945,
+						2943,
+						2947,
+						2948,
+						3021,
+						3020,
+						3050,
 						3063,
-						3150,
+						3062,
+						3060,
+						3061,
+						3068,
+						3066,
+						3065,
+						3152,
+						3156,
+						3157,
+						3153,
 						3154,
 						3155,
-						3151,
-						3152,
-						3153,
-						3049,
-						3050,
-						3054,
-						3042,
-						3057,
+						3051,
+						3052,
 						3056,
+						3044,
+						3059,
+						3058,
+						3049,
+						3057,
 						3047,
+						3048,
 						3055,
 						3045,
 						3046,
-						3053,
-						3043,
-						3044,
-						3080,
-						3077,
-						3078,
-						3079,
-						3033,
-						3086,
-						3081,
 						3082,
-						3085,
+						3079,
+						3080,
+						3081,
+						3035,
+						3088,
 						3083,
 						3084,
+						3087,
+						3085,
+						3086,
+						3036,
+						3040,
+						3039,
 						3034,
-						3038,
-						3037,
-						3032,
-						3052,
-						3051,
-						3065,
-						3120,
-						3117,
+						3054,
+						3053,
+						3067,
+						3122,
 						3119,
 						3121,
-						3122,
-						3118,
 						3123,
-						3116,
-						3115,
-						3067,
-						3068,
-						3036,
-						3035,
-						3039,
-						3040,
-						3041,
+						3124,
+						3120,
+						3125,
+						3118,
+						3117,
 						3069,
 						3070,
-						3011,
-						3008,
-						3007,
-						3009,
-						3012,
+						3038,
+						3037,
+						3041,
+						3042,
+						3043,
+						3071,
+						3072,
+						3013,
 						3010,
-						2936,
-						2937,
+						3009,
+						3011,
+						3014,
+						3012,
+						2938,
+						2939,
+						3077,
+						3078,
+						3073,
 						3075,
 						3076,
-						3071,
-						3073,
 						3074,
-						3072,
-						2931,
-						2932,
 						2933,
 						2934,
-						3104,
-						3103,
-						3108,
-						3109,
-						3112,
-						3111,
-						3110,
-						3113,
+						2935,
+						2936,
 						3106,
-						3114,
 						3105,
+						3110,
+						3111,
+						3114,
+						3113,
+						3112,
+						3115,
+						3108,
+						3116,
 						3107,
-						2954,
-						2958,
-						2959,
-						2957,
-						2953,
+						3109,
 						2956,
-						2950,
-						2951,
-						2952,
-						2947,
-						2948,
-						2949,
-						2955,
-						3020,
-						3166,
-						3165,
-						3169,
-						3170,
-						3168,
-						3167,
-						3162,
-						3163,
-						3164,
-						3171,
-						3172,
-						3062,
-						3100,
-						3097,
-						3098,
-						3099,
-						3102,
 						2960,
 						2961,
-						3157,
-						3129,
-						3158,
-						3156,
-						3125,
-						3127,
-						3128,
-						3126,
-						3148,
-						3149,
-						3134,
-						3124,
-						3130,
-						3131,
+						2959,
+						2955,
+						2958,
+						2952,
+						2953,
+						2954,
+						2949,
+						2950,
+						2951,
+						2957,
+						3022,
+						3168,
+						3167,
+						3171,
+						3172,
+						3170,
+						3169,
+						3164,
+						3165,
+						3166,
+						3173,
+						3174,
+						3064,
+						3102,
+						3099,
+						3100,
+						3101,
+						3104,
+						2962,
+						2963,
 						3159,
-						3161,
+						3131,
 						3160,
+						3158,
+						3127,
+						3129,
+						3130,
+						3128,
+						3150,
+						3151,
+						3136,
+						3126,
 						3132,
 						3133,
-						3138,
+						3161,
+						3163,
+						3162,
+						3134,
+						3135,
 						3140,
-						3137,
+						3142,
 						3139,
-						3143,
 						3141,
 						3145,
-						3146,
-						3144,
+						3143,
 						3147,
-						3142,
-						3136,
-						3135,
+						3148,
+						3146,
+						3149,
+						3144,
+						3138,
+						3137,
+						2992,
 						2990,
+						2991,
+						2987,
 						2988,
 						2989,
+						2993,
+						2984,
 						2985,
-						2986,
-						2987,
-						2991,
-						2982,
-						2983,
-						2984
+						2986
 					]
 				}
 			],
@@ -42049,7 +42050,7 @@
 			]
 		},
 		{
-			"id": 2918,
+			"id": 2920,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42059,7 +42060,7 @@
 			},
 			"children": [
 				{
-					"id": 2920,
+					"id": 2922,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42075,12 +42076,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2921,
+						"id": 2923,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2919,
+					"id": 2921,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42105,8 +42106,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2920,
-						2919
+						2922,
+						2921
 					]
 				}
 			],
@@ -42119,7 +42120,7 @@
 			]
 		},
 		{
-			"id": 2908,
+			"id": 2910,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42135,7 +42136,7 @@
 			},
 			"children": [
 				{
-					"id": 2910,
+					"id": 2912,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42152,14 +42153,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2911,
+							"id": 2913,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2913,
+									"id": 2915,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42189,7 +42190,7 @@
 									}
 								},
 								{
-									"id": 2914,
+									"id": 2916,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42209,7 +42210,7 @@
 									}
 								},
 								{
-									"id": 2912,
+									"id": 2914,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42252,21 +42253,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2913,
-										2914,
-										2912
+										2915,
+										2916,
+										2914
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2915,
+								"id": 2917,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2916,
+										"id": 2918,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42285,7 +42286,7 @@
 					}
 				},
 				{
-					"id": 2917,
+					"id": 2919,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42305,7 +42306,7 @@
 					}
 				},
 				{
-					"id": 2909,
+					"id": 2911,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42321,7 +42322,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2918,
+						"id": 2920,
 						"name": "CustomStyles"
 					}
 				}
@@ -42331,9 +42332,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2910,
-						2917,
-						2909
+						2912,
+						2919,
+						2911
 					]
 				}
 			],
@@ -42346,7 +42347,7 @@
 			]
 		},
 		{
-			"id": 2451,
+			"id": 2453,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42362,7 +42363,7 @@
 			},
 			"children": [
 				{
-					"id": 2492,
+					"id": 2494,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42392,20 +42393,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2493,
+							"id": 2495,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2494,
+								"id": 2496,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2495,
+										"id": 2497,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42437,7 +42438,7 @@
 					}
 				},
 				{
-					"id": 2454,
+					"id": 2456,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42460,7 +42461,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2476,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42502,7 +42503,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2478,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42531,7 +42532,7 @@
 					}
 				},
 				{
-					"id": 2453,
+					"id": 2455,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42548,12 +42549,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1989,
+						"id": 1991,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2468,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42582,7 +42583,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2479,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42615,7 +42616,7 @@
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2471,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42644,7 +42645,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2503,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42677,7 +42678,7 @@
 					}
 				},
 				{
-					"id": 2489,
+					"id": 2491,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42706,7 +42707,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2501,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42750,7 +42751,7 @@
 					}
 				},
 				{
-					"id": 2496,
+					"id": 2498,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42793,7 +42794,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2475,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42818,12 +42819,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2489,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42852,7 +42853,7 @@
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2473,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42882,7 +42883,7 @@
 					}
 				},
 				{
-					"id": 2498,
+					"id": 2500,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42919,7 +42920,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2493,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42948,7 +42949,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2469,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42981,7 +42982,7 @@
 					}
 				},
 				{
-					"id": 2497,
+					"id": 2499,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43001,7 +43002,7 @@
 					}
 				},
 				{
-					"id": 2465,
+					"id": 2467,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43030,7 +43031,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2462,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43064,7 +43065,7 @@
 					}
 				},
 				{
-					"id": 2485,
+					"id": 2487,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43097,12 +43098,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3176,
+						"id": 3178,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2470,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43131,7 +43132,7 @@
 					}
 				},
 				{
-					"id": 2459,
+					"id": 2461,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43164,7 +43165,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2490,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43193,7 +43194,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2460,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43217,7 +43218,7 @@
 					}
 				},
 				{
-					"id": 2483,
+					"id": 2485,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43246,7 +43247,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2472,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43279,7 +43280,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2463,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43309,7 +43310,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2465,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43338,7 +43339,7 @@
 					}
 				},
 				{
-					"id": 2484,
+					"id": 2486,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43367,7 +43368,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2466,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43396,7 +43397,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2474,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43425,7 +43426,7 @@
 					}
 				},
 				{
-					"id": 2452,
+					"id": 2454,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43446,7 +43447,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2477,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43469,7 +43470,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2459,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43492,7 +43493,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2502,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43525,7 +43526,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2457,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -43541,7 +43542,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2456,
+							"id": 2458,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -43569,50 +43570,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2492,
-						2454,
-						2474,
+						2494,
+						2456,
 						2476,
-						2453,
-						2466,
-						2477,
-						2469,
-						2501,
-						2489,
-						2499,
-						2496,
-						2473,
-						2487,
-						2471,
-						2498,
-						2491,
-						2467,
-						2497,
-						2465,
-						2460,
-						2485,
+						2478,
+						2455,
 						2468,
-						2459,
-						2488,
-						2458,
-						2483,
+						2479,
+						2471,
+						2503,
+						2491,
+						2501,
+						2498,
+						2475,
+						2489,
+						2473,
+						2500,
+						2493,
+						2469,
+						2499,
+						2467,
+						2462,
+						2487,
 						2470,
 						2461,
-						2463,
-						2484,
-						2464,
+						2490,
+						2460,
+						2485,
 						2472,
-						2452,
-						2475,
-						2457,
-						2500
+						2463,
+						2465,
+						2486,
+						2466,
+						2474,
+						2454,
+						2477,
+						2459,
+						2502
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2455
+						2457
 					]
 				}
 			],
@@ -43625,7 +43626,7 @@
 			]
 		},
 		{
-			"id": 3300,
+			"id": 3302,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43654,7 +43655,7 @@
 			},
 			"children": [
 				{
-					"id": 3303,
+					"id": 3305,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43671,12 +43672,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3282,
+						"id": 3284,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3301,
+					"id": 3303,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43693,12 +43694,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3306,
+						"id": 3308,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3302,
+					"id": 3304,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43736,9 +43737,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
+						3305,
 						3303,
-						3301,
-						3302
+						3304
 					]
 				}
 			],
@@ -43750,7 +43751,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 3304,
+				"id": 3306,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43760,7 +43761,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3305,
+						"id": 3307,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43777,7 +43778,7 @@
 			}
 		},
 		{
-			"id": 2866,
+			"id": 2868,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43793,7 +43794,7 @@
 			},
 			"children": [
 				{
-					"id": 2868,
+					"id": 2870,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43825,7 +43826,7 @@
 					}
 				},
 				{
-					"id": 2869,
+					"id": 2871,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43861,7 +43862,7 @@
 					}
 				},
 				{
-					"id": 2867,
+					"id": 2869,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43898,9 +43899,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2868,
-						2869,
-						2867
+						2870,
+						2871,
+						2869
 					]
 				}
 			],
@@ -43912,7 +43913,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2870,
+				"id": 2872,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43922,7 +43923,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2871,
+						"id": 2873,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43956,7 +43957,7 @@
 			}
 		},
 		{
-			"id": 2621,
+			"id": 2623,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43972,7 +43973,7 @@
 			},
 			"children": [
 				{
-					"id": 2633,
+					"id": 2635,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44006,7 +44007,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2669,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44037,20 +44038,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2668,
+							"id": 2670,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2669,
+								"id": 2671,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2670,
+										"id": 2672,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -44086,7 +44087,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2703,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44128,7 +44129,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2700,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44158,7 +44159,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2447,
+						"id": 2449,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -44167,7 +44168,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2717,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44205,7 +44206,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2691,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44254,7 +44255,7 @@
 					}
 				},
 				{
-					"id": 2671,
+					"id": 2673,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44283,7 +44284,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44292,7 +44293,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2704,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44334,7 +44335,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2625,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44376,7 +44377,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2683,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44414,7 +44415,7 @@
 					}
 				},
 				{
-					"id": 2663,
+					"id": 2665,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44452,7 +44453,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2664,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44484,7 +44485,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -44494,7 +44495,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2677,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44539,7 +44540,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2711,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44581,7 +44582,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2716,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44623,7 +44624,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2705,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44665,7 +44666,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2687,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44703,7 +44704,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2658,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44736,7 +44737,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2650,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44766,7 +44767,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2655,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44800,7 +44801,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2680,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44838,7 +44839,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2627,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44875,7 +44876,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2701,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44913,7 +44914,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2702,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44951,7 +44952,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2682,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44988,7 +44989,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2661,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45018,7 +45019,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45027,7 +45028,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2624,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45061,7 +45062,7 @@
 					}
 				},
 				{
-					"id": 2664,
+					"id": 2666,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45097,7 +45098,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -45107,7 +45108,7 @@
 					}
 				},
 				{
-					"id": 2640,
+					"id": 2642,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45144,7 +45145,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2714,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45186,7 +45187,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2707,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45228,7 +45229,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2637,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45262,7 +45263,7 @@
 					}
 				},
 				{
-					"id": 2672,
+					"id": 2674,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45300,7 +45301,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2697,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45337,7 +45338,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2696,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45377,7 +45378,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2718,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45419,7 +45420,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2646,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45457,7 +45458,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2721,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45495,7 +45496,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2648,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45533,7 +45534,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2720,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45571,7 +45572,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2712,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45613,7 +45614,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2710,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45651,7 +45652,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2723,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45693,7 +45694,7 @@
 					}
 				},
 				{
-					"id": 2642,
+					"id": 2644,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45730,7 +45731,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2647,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45768,7 +45769,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2695,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45802,7 +45803,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2645,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45836,7 +45837,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2719,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45874,7 +45875,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2706,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45912,7 +45913,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2649,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45949,7 +45950,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2651,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45983,7 +45984,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2686,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46021,7 +46022,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2628,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46055,7 +46056,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2634,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46089,7 +46090,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2668,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46127,7 +46128,7 @@
 					}
 				},
 				{
-					"id": 2624,
+					"id": 2626,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46164,7 +46165,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2724,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46206,7 +46207,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2685,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46244,7 +46245,7 @@
 					}
 				},
 				{
-					"id": 2682,
+					"id": 2684,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46282,7 +46283,7 @@
 					}
 				},
 				{
-					"id": 2634,
+					"id": 2636,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46316,7 +46317,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2679,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46353,7 +46354,7 @@
 					}
 				},
 				{
-					"id": 2676,
+					"id": 2678,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46404,7 +46405,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2676,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46446,7 +46447,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2631,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46480,7 +46481,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2688,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46518,7 +46519,7 @@
 					}
 				},
 				{
-					"id": 2690,
+					"id": 2692,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46559,7 +46560,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2698,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46591,7 +46592,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46601,7 +46602,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2699,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46633,7 +46634,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46643,7 +46644,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2693,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46684,7 +46685,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2690,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46721,7 +46722,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2709,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46763,7 +46764,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2715,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46805,7 +46806,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2708,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46847,7 +46848,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2713,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46889,7 +46890,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2722,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46931,7 +46932,7 @@
 					}
 				},
 				{
-					"id": 2636,
+					"id": 2638,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46965,7 +46966,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2652,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46998,7 +46999,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2654,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47036,7 +47037,7 @@
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2656,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47071,7 +47072,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2657,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47101,12 +47102,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2723,
+						"id": 2725,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2653,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47144,7 +47145,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2659,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47182,7 +47183,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2694,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47223,7 +47224,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2667,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47259,7 +47260,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -47269,7 +47270,7 @@
 					}
 				},
 				{
-					"id": 2641,
+					"id": 2643,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47306,7 +47307,7 @@
 					}
 				},
 				{
-					"id": 2630,
+					"id": 2632,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47343,7 +47344,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2630,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47382,93 +47383,93 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2633,
-						2667,
-						2701,
-						2698,
-						2715,
-						2689,
-						2671,
-						2702,
-						2623,
-						2681,
-						2663,
-						2662,
-						2675,
-						2709,
-						2714,
-						2703,
-						2685,
-						2656,
-						2648,
-						2653,
-						2678,
-						2625,
-						2699,
-						2700,
-						2680,
-						2659,
-						2622,
-						2664,
-						2640,
-						2712,
-						2705,
 						2635,
-						2672,
-						2695,
-						2694,
-						2716,
-						2644,
-						2719,
-						2646,
-						2718,
-						2710,
-						2708,
-						2721,
-						2642,
-						2645,
-						2693,
-						2643,
+						2669,
+						2703,
+						2700,
 						2717,
-						2704,
-						2647,
-						2649,
-						2684,
-						2626,
-						2632,
-						2666,
-						2624,
-						2722,
-						2683,
-						2682,
-						2634,
-						2677,
-						2676,
-						2674,
-						2629,
-						2686,
-						2690,
-						2696,
-						2697,
 						2691,
-						2688,
-						2707,
-						2713,
-						2706,
+						2673,
+						2704,
+						2625,
+						2683,
+						2665,
+						2664,
+						2677,
 						2711,
-						2720,
-						2636,
+						2716,
+						2705,
+						2687,
+						2658,
 						2650,
+						2655,
+						2680,
+						2627,
+						2701,
+						2702,
+						2682,
+						2661,
+						2624,
+						2666,
+						2642,
+						2714,
+						2707,
+						2637,
+						2674,
+						2697,
+						2696,
+						2718,
+						2646,
+						2721,
+						2648,
+						2720,
+						2712,
+						2710,
+						2723,
+						2644,
+						2647,
+						2695,
+						2645,
+						2719,
+						2706,
+						2649,
+						2651,
+						2686,
+						2628,
+						2634,
+						2668,
+						2626,
+						2724,
+						2685,
+						2684,
+						2636,
+						2679,
+						2678,
+						2676,
+						2631,
+						2688,
+						2692,
+						2698,
+						2699,
+						2693,
+						2690,
+						2709,
+						2715,
+						2708,
+						2713,
+						2722,
+						2638,
 						2652,
 						2654,
-						2655,
-						2651,
+						2656,
 						2657,
-						2692,
-						2665,
-						2641,
-						2630,
-						2628
+						2653,
+						2659,
+						2694,
+						2667,
+						2643,
+						2632,
+						2630
 					]
 				}
 			],
@@ -47495,7 +47496,7 @@
 			]
 		},
 		{
-			"id": 2001,
+			"id": 2003,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47505,7 +47506,7 @@
 			},
 			"children": [
 				{
-					"id": 2002,
+					"id": 2004,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47526,7 +47527,7 @@
 					}
 				},
 				{
-					"id": 2003,
+					"id": 2005,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47543,12 +47544,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2005,
+						"id": 2007,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2004,
+					"id": 2006,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47594,9 +47595,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2002,
-						2003,
-						2004
+						2004,
+						2005,
+						2006
 					]
 				}
 			],
@@ -47609,7 +47610,7 @@
 			]
 		},
 		{
-			"id": 3173,
+			"id": 3175,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47619,7 +47620,7 @@
 			},
 			"children": [
 				{
-					"id": 3174,
+					"id": 3176,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47640,7 +47641,7 @@
 					}
 				},
 				{
-					"id": 3175,
+					"id": 3177,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47679,8 +47680,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3174,
-						3175
+						3176,
+						3177
 					]
 				}
 			],
@@ -47693,7 +47694,7 @@
 			]
 		},
 		{
-			"id": 2568,
+			"id": 2570,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47708,7 +47709,7 @@
 			},
 			"children": [
 				{
-					"id": 2583,
+					"id": 2585,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47739,20 +47740,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2584,
+							"id": 2586,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2585,
+								"id": 2587,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2586,
+										"id": 2588,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47788,7 +47789,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2619,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47830,7 +47831,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2616,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47860,7 +47861,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2447,
+						"id": 2449,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47869,7 +47870,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2607,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47918,7 +47919,7 @@
 					}
 				},
 				{
-					"id": 2587,
+					"id": 2589,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47947,7 +47948,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -47956,7 +47957,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2620,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47998,7 +47999,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2572,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48032,7 +48033,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2571,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48073,7 +48074,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2599,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48111,7 +48112,7 @@
 					}
 				},
 				{
-					"id": 2579,
+					"id": 2581,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48149,7 +48150,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2580,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48181,7 +48182,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -48191,7 +48192,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2593,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48236,7 +48237,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2621,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48278,7 +48279,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2603,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48316,7 +48317,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2596,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48354,7 +48355,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2617,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48392,7 +48393,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2618,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48430,7 +48431,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2575,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48464,7 +48465,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2598,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48501,7 +48502,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2577,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48531,7 +48532,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48540,7 +48541,7 @@
 					}
 				},
 				{
-					"id": 2580,
+					"id": 2582,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48576,7 +48577,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -48586,7 +48587,7 @@
 					}
 				},
 				{
-					"id": 2588,
+					"id": 2590,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48624,7 +48625,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2613,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48661,7 +48662,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2612,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48701,7 +48702,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2611,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48735,7 +48736,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2622,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48773,7 +48774,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2602,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48811,7 +48812,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2584,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48849,7 +48850,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2601,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48887,7 +48888,7 @@
 					}
 				},
 				{
-					"id": 2598,
+					"id": 2600,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48925,7 +48926,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2595,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48962,7 +48963,7 @@
 					}
 				},
 				{
-					"id": 2592,
+					"id": 2594,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49013,7 +49014,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2592,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49055,7 +49056,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2604,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49093,7 +49094,7 @@
 					}
 				},
 				{
-					"id": 2606,
+					"id": 2608,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49134,7 +49135,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2614,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49166,7 +49167,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -49176,7 +49177,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2615,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49208,7 +49209,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -49218,7 +49219,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2574,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49252,7 +49253,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2609,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49293,7 +49294,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2606,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49330,7 +49331,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2610,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49371,7 +49372,7 @@
 					}
 				},
 				{
-					"id": 2571,
+					"id": 2573,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49405,7 +49406,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2583,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49441,7 +49442,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -49456,49 +49457,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2583,
-						2617,
-						2614,
-						2605,
-						2587,
-						2618,
-						2570,
-						2569,
-						2597,
-						2579,
-						2578,
-						2591,
+						2585,
 						2619,
-						2601,
-						2594,
-						2615,
 						2616,
-						2573,
-						2596,
-						2575,
-						2580,
-						2588,
-						2611,
-						2610,
-						2609,
-						2620,
-						2600,
-						2582,
-						2599,
-						2598,
-						2593,
-						2592,
-						2590,
-						2602,
-						2606,
-						2612,
-						2613,
-						2572,
 						2607,
+						2589,
+						2620,
+						2572,
+						2571,
+						2599,
+						2581,
+						2580,
+						2593,
+						2621,
+						2603,
+						2596,
+						2617,
+						2618,
+						2575,
+						2598,
+						2577,
+						2582,
+						2590,
+						2613,
+						2612,
+						2611,
+						2622,
+						2602,
+						2584,
+						2601,
+						2600,
+						2595,
+						2594,
+						2592,
 						2604,
 						2608,
-						2571,
-						2581
+						2614,
+						2615,
+						2574,
+						2609,
+						2606,
+						2610,
+						2573,
+						2583
 					]
 				}
 			],
@@ -49521,7 +49522,7 @@
 			]
 		},
 		{
-			"id": 2502,
+			"id": 2504,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49537,7 +49538,7 @@
 			},
 			"children": [
 				{
-					"id": 2540,
+					"id": 2542,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49568,20 +49569,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2541,
+							"id": 2543,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2542,
+								"id": 2544,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2543,
+										"id": 2545,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -49617,7 +49618,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2516,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49651,7 +49652,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2506,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49685,7 +49686,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2505,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49719,7 +49720,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2529,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49761,7 +49762,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2519,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49798,7 +49799,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2526,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49828,7 +49829,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2447,
+						"id": 2449,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -49837,7 +49838,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2563,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49886,7 +49887,7 @@
 					}
 				},
 				{
-					"id": 2544,
+					"id": 2546,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49915,7 +49916,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49924,7 +49925,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2520,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49962,7 +49963,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2530,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50004,7 +50005,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2512,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50038,7 +50039,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2511,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50074,7 +50075,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2556,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50112,7 +50113,7 @@
 					}
 				},
 				{
-					"id": 2536,
+					"id": 2538,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50150,7 +50151,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2537,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50182,7 +50183,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -50192,7 +50193,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2550,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50237,7 +50238,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2531,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50279,7 +50280,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2560,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50317,7 +50318,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2509,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50351,7 +50352,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2553,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50389,7 +50390,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2527,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50427,7 +50428,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2528,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50465,7 +50466,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2515,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50499,7 +50500,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2555,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50536,7 +50537,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2521,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50574,7 +50575,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2510,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50608,7 +50609,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2534,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50638,7 +50639,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50647,7 +50648,7 @@
 					}
 				},
 				{
-					"id": 2537,
+					"id": 2539,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50683,7 +50684,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -50693,7 +50694,7 @@
 					}
 				},
 				{
-					"id": 2505,
+					"id": 2507,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50727,7 +50728,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2508,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50761,7 +50762,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2517,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50795,7 +50796,7 @@
 					}
 				},
 				{
-					"id": 2545,
+					"id": 2547,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50833,7 +50834,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2569,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50870,7 +50871,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2568,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50910,7 +50911,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2567,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50944,7 +50945,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2532,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50982,7 +50983,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2559,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51020,7 +51021,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2541,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51058,7 +51059,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2522,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51096,7 +51097,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2558,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51134,7 +51135,7 @@
 					}
 				},
 				{
-					"id": 2555,
+					"id": 2557,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51172,7 +51173,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2552,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51209,7 +51210,7 @@
 					}
 				},
 				{
-					"id": 2549,
+					"id": 2551,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51260,7 +51261,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2549,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51302,7 +51303,7 @@
 					}
 				},
 				{
-					"id": 2562,
+					"id": 2564,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51343,7 +51344,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2524,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51375,7 +51376,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -51385,7 +51386,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2525,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51417,7 +51418,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -51427,7 +51428,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2514,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51457,7 +51458,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2513,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51486,7 +51487,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2565,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51527,7 +51528,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2562,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51564,7 +51565,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2566,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51605,7 +51606,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2518,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51635,7 +51636,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2540,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51671,7 +51672,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -51681,7 +51682,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2523,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51706,7 +51707,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3311,
+						"id": 3313,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -51716,62 +51717,62 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2540,
-						2514,
-						2504,
-						2503,
-						2527,
-						2517,
-						2524,
-						2561,
-						2544,
-						2518,
-						2528,
-						2510,
-						2509,
-						2554,
-						2536,
-						2535,
-						2548,
-						2529,
-						2558,
-						2507,
-						2551,
-						2525,
-						2526,
-						2513,
-						2553,
-						2519,
-						2508,
-						2532,
-						2537,
-						2505,
+						2542,
+						2516,
 						2506,
-						2515,
-						2545,
-						2567,
-						2566,
-						2565,
-						2530,
-						2557,
-						2539,
+						2505,
+						2529,
+						2519,
+						2526,
+						2563,
+						2546,
 						2520,
-						2556,
-						2555,
-						2550,
-						2549,
-						2547,
-						2562,
-						2522,
-						2523,
+						2530,
 						2512,
 						2511,
-						2563,
-						2560,
-						2564,
-						2516,
+						2556,
 						2538,
-						2521
+						2537,
+						2550,
+						2531,
+						2560,
+						2509,
+						2553,
+						2527,
+						2528,
+						2515,
+						2555,
+						2521,
+						2510,
+						2534,
+						2539,
+						2507,
+						2508,
+						2517,
+						2547,
+						2569,
+						2568,
+						2567,
+						2532,
+						2559,
+						2541,
+						2522,
+						2558,
+						2557,
+						2552,
+						2551,
+						2549,
+						2564,
+						2524,
+						2525,
+						2514,
+						2513,
+						2565,
+						2562,
+						2566,
+						2518,
+						2540,
+						2523
 					]
 				}
 			],
@@ -51804,14 +51805,14 @@
 			]
 		},
 		{
-			"id": 1969,
+			"id": 1971,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1972,
+					"id": 1974,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51826,14 +51827,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1973,
+							"id": 1975,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1975,
+									"id": 1977,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51851,7 +51852,7 @@
 									}
 								},
 								{
-									"id": 1974,
+									"id": 1976,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51874,8 +51875,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1975,
-										1974
+										1977,
+										1976
 									]
 								}
 							]
@@ -51883,7 +51884,7 @@
 					}
 				},
 				{
-					"id": 1971,
+					"id": 1973,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51901,7 +51902,7 @@
 					}
 				},
 				{
-					"id": 1970,
+					"id": 1972,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51924,9 +51925,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1972,
-						1971,
-						1970
+						1974,
+						1973,
+						1972
 					]
 				}
 			],
@@ -52113,7 +52114,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -52230,7 +52231,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -52428,7 +52429,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -52473,7 +52474,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -53110,7 +53111,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -53206,6 +53207,77 @@
 					"type": "reference",
 					"id": 1216,
 					"name": "BodylessConversationViewConfig"
+				}
+			]
+		},
+		{
+			"id": 1556,
+			"name": "SpotterAnalystConfig",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for the Spotter Analyst experience.\nCan be used in SpotterEmbed.",
+				"tags": [
+					{
+						"tag": "group",
+						"text": "Embed components"
+					},
+					{
+						"tag": "version",
+						"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+					},
+					{
+						"tag": "example",
+						"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterAnalystConfig: {\n       analystId: 'analyst-id-1234',\n   },\n})\n```\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1557,
+					"name": "analystId",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Pins the embed to a single spotter analyst. Implies no default Spotter\nand no \"Show all\".",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 298,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1557
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 292,
+					"character": 17
 				}
 			]
 		},
@@ -53498,40 +53570,6 @@
 					}
 				},
 				{
-					"id": 1477,
-					"name": "analystId",
-					"kind": 1024,
-					"kindString": "Property",
-					"flags": {
-						"isOptional": true
-					},
-					"comment": {
-						"shortText": "Pins the embed to a single spotter analyst. Implies no default Spotter\nand no \"Show all\".",
-						"text": "Supported embed types: `SpotterEmbed`",
-						"tags": [
-							{
-								"tag": "version",
-								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
-							},
-							{
-								"tag": "example",
-								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   analystId: 'analyst-id-1234',\n})\n```\n"
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "embed/conversation.ts",
-							"line": 320,
-							"character": 4
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
 					"id": 1528,
 					"name": "customActions",
 					"kind": 1024,
@@ -53610,7 +53648,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2908,
+						"id": 2910,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -53647,7 +53685,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 369,
+							"line": 394,
 							"character": 4
 						}
 					],
@@ -53681,7 +53719,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 305,
+							"line": 329,
 							"character": 4
 						}
 					],
@@ -53722,13 +53760,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 512,
+							"line": 537,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1558,
 						"name": "SpotterQueryMode"
 					}
 				},
@@ -53795,7 +53833,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 339,
+							"line": 364,
 							"character": 4
 						}
 					],
@@ -53875,7 +53913,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -53996,7 +54034,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 531,
+							"line": 556,
 							"character": 4
 						}
 					],
@@ -54030,7 +54068,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 521,
+							"line": 546,
 							"character": 4
 						}
 					],
@@ -54102,7 +54140,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 433,
+							"line": 458,
 							"character": 4
 						}
 					],
@@ -54136,7 +54174,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 464,
+							"line": 489,
 							"character": 4
 						}
 					],
@@ -54213,7 +54251,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2866,
+						"id": 2868,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -54258,7 +54296,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -54292,7 +54330,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 400,
+							"line": 425,
 							"character": 4
 						}
 					],
@@ -54326,7 +54364,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 353,
+							"line": 378,
 							"character": 4
 						}
 					],
@@ -54832,7 +54870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 421,
+							"line": 446,
 							"character": 4
 						}
 					],
@@ -54840,7 +54878,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2001,
+							"id": 2003,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -54870,7 +54908,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 452,
+							"line": 477,
 							"character": 4
 						}
 					],
@@ -54878,7 +54916,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3173,
+							"id": 3175,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -54897,7 +54935,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 324,
+							"line": 349,
 							"character": 4
 						}
 					],
@@ -54931,7 +54969,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 608,
+							"line": 633,
 							"character": 4
 						}
 					],
@@ -55043,7 +55081,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 385,
+							"line": 410,
 							"character": 4
 						}
 					],
@@ -55081,13 +55119,48 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 494,
+							"line": 519,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "intrinsic",
 						"name": "boolean"
+					}
+				},
+				{
+					"id": 1477,
+					"name": "spotterAnalystConfig",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Configuration for the Spotter Analyst experience.",
+						"text": "Supported embed types: `SpotterEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   ... //other embed view config\n   spotterAnalystConfig: {\n       analystId: 'analyst-id-1234',\n   },\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 345,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1556,
+						"name": "SpotterAnalystConfig"
 					}
 				},
 				{
@@ -55115,7 +55188,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 570,
+							"line": 595,
 							"character": 4
 						}
 					],
@@ -55150,13 +55223,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 586,
+							"line": 611,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1559,
+						"id": 1561,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
@@ -55185,7 +55258,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 552,
+							"line": 577,
 							"character": 4
 						}
 					],
@@ -55224,7 +55297,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 479,
+							"line": 504,
 							"character": 4
 						}
 					],
@@ -55262,7 +55335,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 623,
+							"line": 648,
 							"character": 4
 						}
 					],
@@ -55349,7 +55422,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2253,
+							"id": 2255,
 							"name": "Action"
 						}
 					},
@@ -55372,7 +55445,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 288,
+							"line": 312,
 							"character": 4
 						}
 					],
@@ -55388,7 +55461,6 @@
 					"kind": 1024,
 					"children": [
 						1507,
-						1477,
 						1528,
 						1511,
 						1481,
@@ -55430,6 +55502,7 @@
 						1527,
 						1482,
 						1489,
+						1477,
 						1494,
 						1495,
 						1493,
@@ -55444,7 +55517,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 281,
+					"line": 305,
 					"character": 17
 				}
 			],
@@ -55467,13 +55540,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1573,
+					"id": 1575,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1559,
+			"id": 1561,
 			"name": "SpotterShareConversationConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55493,7 +55566,7 @@
 			},
 			"children": [
 				{
-					"id": 1560,
+					"id": 1562,
 					"name": "enableShareConversation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55526,7 +55599,7 @@
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1567,
 					"name": "spotterShareAddUsersLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55555,7 +55628,7 @@
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1566,
 					"name": "spotterShareCancelLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55588,7 +55661,7 @@
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1565,
 					"name": "spotterShareConfirmLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55621,7 +55694,7 @@
 					}
 				},
 				{
-					"id": 1567,
+					"id": 1569,
 					"name": "spotterShareEmptySubtitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55650,7 +55723,7 @@
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1568,
 					"name": "spotterShareEmptyTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55679,7 +55752,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1570,
 					"name": "spotterShareIncludeNewMessagesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55708,7 +55781,7 @@
 					}
 				},
 				{
-					"id": 1561,
+					"id": 1563,
 					"name": "spotterShareLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55741,7 +55814,7 @@
 					}
 				},
 				{
-					"id": 1562,
+					"id": 1564,
 					"name": "spotterShareModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55770,7 +55843,7 @@
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1572,
 					"name": "spotterShareStaleInfoLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55799,7 +55872,7 @@
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1571,
 					"name": "spotterShareUpToCurrentLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55828,7 +55901,7 @@
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1573,
 					"name": "spotterSharedConversationBannerMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55857,7 +55930,7 @@
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1574,
 					"name": "spotterSharedConversationExitLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55895,19 +55968,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1560,
-						1565,
-						1564,
-						1563,
+						1562,
 						1567,
 						1566,
-						1568,
-						1561,
-						1562,
-						1570,
+						1565,
 						1569,
+						1568,
+						1570,
+						1563,
+						1564,
+						1572,
 						1571,
-						1572
+						1573,
+						1574
 					]
 				}
 			],
@@ -56397,7 +56470,7 @@
 			]
 		},
 		{
-			"id": 2723,
+			"id": 2725,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56421,7 +56494,7 @@
 			},
 			"children": [
 				{
-					"id": 2725,
+					"id": 2727,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56454,7 +56527,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2726,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56487,7 +56560,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2729,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56514,13 +56587,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2737,
+							"id": 2739,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2728,
+					"id": 2730,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56549,7 +56622,7 @@
 					}
 				},
 				{
-					"id": 2726,
+					"id": 2728,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56582,7 +56655,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2731,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56611,7 +56684,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2736,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56644,7 +56717,7 @@
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2738,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56673,7 +56746,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2737,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56702,7 +56775,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2734,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56735,7 +56808,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2732,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56764,7 +56837,7 @@
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2733,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56791,13 +56864,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2741,
+							"id": 2743,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2735,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56835,19 +56908,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2725,
-						2724,
 						2727,
-						2728,
 						2726,
 						2729,
-						2734,
-						2736,
-						2735,
-						2732,
 						2730,
+						2728,
 						2731,
-						2733
+						2736,
+						2738,
+						2737,
+						2734,
+						2732,
+						2733,
+						2735
 					]
 				}
 			],
@@ -56860,7 +56933,7 @@
 			]
 		},
 		{
-			"id": 2741,
+			"id": 2743,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56880,7 +56953,7 @@
 			},
 			"children": [
 				{
-					"id": 2742,
+					"id": 2744,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56901,7 +56974,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2745,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56927,8 +57000,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2742,
-						2743
+						2744,
+						2745
 					]
 				}
 			],
@@ -56941,7 +57014,7 @@
 			]
 		},
 		{
-			"id": 2737,
+			"id": 2739,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56961,7 +57034,7 @@
 			},
 			"children": [
 				{
-					"id": 2739,
+					"id": 2741,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56982,7 +57055,7 @@
 					}
 				},
 				{
-					"id": 2740,
+					"id": 2742,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57003,7 +57076,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2740,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57029,9 +57102,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2739,
-						2740,
-						2738
+						2741,
+						2742,
+						2740
 					]
 				}
 			],
@@ -57044,14 +57117,14 @@
 			]
 		},
 		{
-			"id": 1976,
+			"id": 1978,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1977,
+					"id": 1979,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57069,7 +57142,7 @@
 					}
 				},
 				{
-					"id": 1978,
+					"id": 1980,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57092,8 +57165,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1977,
-						1978
+						1979,
+						1980
 					]
 				}
 			],
@@ -57106,7 +57179,7 @@
 			]
 		},
 		{
-			"id": 3311,
+			"id": 3313,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57126,7 +57199,7 @@
 			},
 			"children": [
 				{
-					"id": 3312,
+					"id": 3314,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57149,7 +57222,7 @@
 					}
 				},
 				{
-					"id": 3313,
+					"id": 3315,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57177,8 +57250,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3312,
-						3313
+						3314,
+						3315
 					]
 				}
 			],
@@ -57191,14 +57264,14 @@
 			]
 		},
 		{
-			"id": 3216,
+			"id": 3218,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3217,
+					"id": 3219,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57219,7 +57292,7 @@
 					}
 				},
 				{
-					"id": 3218,
+					"id": 3220,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57245,8 +57318,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3217,
-						3218
+						3219,
+						3220
 					]
 				}
 			],
@@ -57259,7 +57332,7 @@
 			]
 		},
 		{
-			"id": 2921,
+			"id": 2923,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57269,7 +57342,7 @@
 			},
 			"children": [
 				{
-					"id": 2923,
+					"id": 2925,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57299,20 +57372,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2924,
+							"id": 2926,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2925,
+								"id": 2927,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2926,
+										"id": 2928,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -57325,7 +57398,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2927,
+										"id": 2929,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -57338,14 +57411,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2928,
+											"id": 2930,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2929,
+													"id": 2931,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -57367,7 +57440,7 @@
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2924,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57386,7 +57459,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2930,
+						"id": 2932,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -57396,8 +57469,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2923,
-						2922
+						2925,
+						2924
 					]
 				}
 			],
@@ -57702,7 +57775,7 @@
 			]
 		},
 		{
-			"id": 3310,
+			"id": 3312,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57759,7 +57832,7 @@
 			}
 		},
 		{
-			"id": 2891,
+			"id": 2893,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57786,7 +57859,7 @@
 			}
 		},
 		{
-			"id": 2895,
+			"id": 2897,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57801,7 +57874,7 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2896,
+					"id": 2898,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -57824,7 +57897,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2897,
+							"id": 2899,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -57834,19 +57907,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2898,
+									"id": 2900,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2903,
+										"id": 2905,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2899,
+									"id": 2901,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -57856,7 +57929,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2900,
+											"id": 2902,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -57870,7 +57943,7 @@
 											],
 											"signatures": [
 												{
-													"id": 2901,
+													"id": 2903,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -57880,7 +57953,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2902,
+															"id": 2904,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -57911,7 +57984,7 @@
 			}
 		},
 		{
-			"id": 2892,
+			"id": 2894,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57935,14 +58008,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2893,
+					"id": 2895,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2894,
+							"id": 2896,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -57970,7 +58043,7 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2894
+								2896
 							]
 						}
 					],
@@ -57985,7 +58058,7 @@
 			}
 		},
 		{
-			"id": 2903,
+			"id": 2905,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -58009,14 +58082,14 @@
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2904,
+					"id": 2906,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2906,
+							"id": 2908,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58034,7 +58107,7 @@
 							}
 						},
 						{
-							"id": 2907,
+							"id": 2909,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58054,7 +58127,7 @@
 							}
 						},
 						{
-							"id": 2905,
+							"id": 2907,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58077,9 +58150,9 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2906,
-								2907,
-								2905
+								2908,
+								2909,
+								2907
 							]
 						}
 					],
@@ -58144,7 +58217,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1892,
+									"id": 1894,
 									"name": "AnswerService"
 								}
 							}
@@ -58406,7 +58479,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1892,
+												"id": 1894,
 												"name": "AnswerService"
 											}
 										},
@@ -58493,7 +58566,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2451,
+						"id": 2453,
 						"name": "EmbedConfig"
 					}
 				}
@@ -58593,14 +58666,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2451,
+								"id": 2453,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1839,
+						"id": 1841,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -58740,7 +58813,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2861,
+									"id": 2863,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -58868,7 +58941,7 @@
 			]
 		},
 		{
-			"id": 3356,
+			"id": 3358,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -58884,7 +58957,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3357,
+					"id": 3359,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58914,7 +58987,7 @@
 			]
 		},
 		{
-			"id": 3358,
+			"id": 3360,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -58928,7 +59001,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3359,
+					"id": 3361,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -58950,7 +59023,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3360,
+							"id": 3362,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -58960,7 +59033,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3310,
+								"id": 3312,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -59138,7 +59211,7 @@
 			]
 		},
 		{
-			"id": 3183,
+			"id": 3185,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -59152,7 +59225,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3184,
+					"id": 3186,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59162,7 +59235,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3185,
+							"id": 3187,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59174,7 +59247,7 @@
 							}
 						},
 						{
-							"id": 3186,
+							"id": 3188,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59185,7 +59258,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3187,
+									"id": 3189,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -59208,52 +59281,52 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2253,
-				1837,
-				1822,
-				1829,
-				1989,
-				3319,
-				3322,
-				3326,
-				2447,
-				2243,
-				3273,
-				3269,
-				3342,
-				3265,
-				2249,
-				3282,
-				2021,
-				3306,
-				2872,
+				2255,
+				1839,
+				1824,
+				1831,
+				1991,
+				3321,
+				3324,
+				3328,
+				2449,
+				2245,
+				3275,
+				3271,
+				3344,
+				3267,
+				2251,
+				3284,
+				2023,
+				3308,
+				2874,
+				3211,
+				3205,
+				2886,
+				2152,
+				3280,
+				3316,
+				3215,
+				3259,
+				3178,
+				1981,
+				2863,
 				3209,
-				3203,
-				2884,
-				2150,
-				3278,
-				3314,
-				3213,
-				3257,
-				3176,
-				1979,
-				2861,
-				3207,
-				2005,
-				1556,
-				3353,
-				3349,
-				3239
+				2007,
+				1558,
+				3355,
+				3351,
+				3241
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1892,
+				1894,
 				911,
 				1255,
-				1634,
+				1636,
 				661,
 				256,
 				58,
@@ -59265,35 +59338,36 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2744,
-				1839,
+				2746,
+				1841,
 				1216,
-				1573,
-				3219,
-				2930,
-				2918,
-				2908,
-				2451,
-				3300,
-				2866,
-				2621,
-				2001,
-				3173,
-				2568,
-				2502,
-				1969,
+				1575,
+				3221,
+				2932,
+				2920,
+				2910,
+				2453,
+				3302,
+				2868,
+				2623,
+				2003,
+				3175,
+				2570,
+				2504,
+				1971,
 				1177,
+				1556,
 				1535,
 				1474,
-				1559,
+				1561,
 				1541,
-				2723,
-				2741,
-				2737,
-				1976,
-				3311,
-				3216,
-				2921,
+				2725,
+				2743,
+				2739,
+				1978,
+				3313,
+				3218,
+				2923,
 				21,
 				28
 			]
@@ -59302,11 +59376,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3310,
-				2891,
-				2895,
-				2892,
-				2903
+				3312,
+				2893,
+				2897,
+				2894,
+				2905
 			]
 		},
 		{
@@ -59323,10 +59397,10 @@
 				4,
 				7,
 				25,
-				3356,
 				3358,
+				3360,
 				40,
-				3183
+				3185
 			]
 		}
 	],


### PR DESCRIPTION
## Summary

Two additions for the Spotter Analyst experience, targeting **ThoughtSpot 26.10.0.cl / SDK 1.53.0**.

### 1. Two new `Action` enum members

```ts
SpotterAnalystList = 'spotterAnalystList',
SpotterDefaultAnalyst = 'spotterDefaultAnalyst',
```

They control the analyst list ("Show all") and the default Spotter analyst entry. These flow through the existing `hiddenActions` / `disabledActions` / `visibleActions` arrays, so there is **no new plumbing** — the enum entries just give hosts types and autocomplete instead of raw strings.

### 2. New `SpotterAnalystConfig` on `SpotterEmbedViewConfig`

```ts
export interface SpotterAnalystConfig {
    /**
     * Pins the embed to a single spotter analyst. Implies no default Spotter
     * and no "Show all".
     */
    analystId?: string;
}
```

Used as `spotterAnalystConfig?: SpotterAnalystConfig` on the view config:

```js
const embed = new SpotterEmbed('#tsEmbed', {
    // ...other embed view config
    spotterAnalystConfig: {
        analystId: 'analyst-id-1234',
    },
});
```

Grouping it into an object matches the existing `spotterChatConfig` / `spotterSidebarConfig` pattern, so future analyst settings have a home instead of accumulating at the top level. It is defined in `conversation.ts` next to the other Spotter sub-configs and exported from `index.ts`.

**Consumption is unchanged.** The value is serialized as the `analystId` query param via `Param.AnalystId`, so the FE reads `embedParams.analystId` exactly as before. `setParamIfDefined` omits it when unset, so the URL is unchanged for hosts that don't use it — including when `spotterAnalystConfig: {}` is passed with no `analystId`.

## Note on the typedoc diff

`static/typedoc/typedoc.json` is regenerated via `npm run docgen`. The diff is large, but nearly all of it is mechanical `id` renumbering and `line` shifts caused by inserting symbols into `types.ts` and `conversation.ts`.

`main` was merged in and the generated file was resolved by regenerating from the merged source rather than hand-merging. Verified against `origin/main`:

- **0 documented symbols removed**; added symbols are exactly `SpotterAnalystList`, `SpotterDefaultAnalyst`, `SpotterAnalystConfig`, `spotterAnalystConfig`, `analystId`
- **0 comment/doc-text differences** beyond this PR's own additions

## Test plan

- URL assertions for `analystId`: present when `spotterAnalystConfig.analystId` is set, absent when the config is omitted, and absent when the config is an empty object.
- Both new actions added to the existing hidden/disabled `it.each` tables in `conversation.spec.ts`.
- Full SDK suite after merging `main`: **44/44 suites, 1653 passed, 4 skipped**.
- `tsc --noEmit` and `eslint` clean on all changed files.
