### PR TITLE
SCAL-332735 Add TSE customization for Spotter on Liveboard

### DIFF
--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1192,6 +1192,7 @@ export class AppEmbed extends V1Embed {
                 spotterFileUploadEnabled,
                 spotterFileUploadFileTypes,
                 enableStarterPrompts,
+                openSpotterOnLiveboardByDefault,
             } = spotterChatConfig;
 
             setParamIfDefined(params, Param.HideToolResponseCardBranding, hideToolResponseCardBranding, true);
@@ -1205,6 +1206,12 @@ export class AppEmbed extends V1Embed {
             if (spotterFileUploadFileTypes !== undefined) {
                 params[Param.SpotterFileUploadFileTypes] = JSON.stringify(spotterFileUploadFileTypes);
             }
+            setParamIfDefined(
+                params,
+                Param.OpenSpotterOnLiveboardByDefault,
+                openSpotterOnLiveboardByDefault,
+                true,
+            );
         }
 
         if (!isUndefined(updatedSpotterExperience)) {

--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -283,8 +283,9 @@ export interface StarterPreviewDataCategory {
  * Category keys are fixed: `quick` (Basic Search), `research` (Deep Analysis)
  * and `previewData` (Data Literacy).
  *
- * Note: this controls the Spotter chat interface only. The starter prompts on
- * the Liveboard SpotterViz surface are configured separately through
+ * Note: the category keys control the Spotter chat interface, and `liveboard`
+ * controls the Spotter chat panel on a Liveboard. The starter prompts on the
+ * Liveboard SpotterViz surface are configured separately through
  * {@link SpotterVizConfig.customStarterPrompts}.
  * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
  * @group Embed components
@@ -305,6 +306,13 @@ export interface StarterPromptsConfig {
     research?: StarterPromptCategory;
     /** Data Literacy category configuration. */
     previewData?: StarterPreviewDataCategory;
+    /**
+     * Starter prompt questions for the Spotter chat panel on a Liveboard.
+     *
+     * Supported embed types: `LiveboardEmbed`, `AppEmbed`
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     */
+    liveboard?: StarterPromptQuestion[];
 }
 
 /**
@@ -384,6 +392,14 @@ export interface SpotterChatViewConfig {
      * ```
      */
     starterPrompts?: StarterPromptsConfig;
+    /**
+     * Opens the Spotter chat panel on the Liveboard by default.
+     *
+     * Supported embed types: `LiveboardEmbed`, `AppEmbed`
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @default false
+     */
+    openSpotterOnLiveboardByDefault?: boolean;
 }
 
 /**

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -852,6 +852,7 @@ export class LiveboardEmbed extends V1Embed {
                 spotterFileUploadEnabled,
                 spotterFileUploadFileTypes,
                 enableStarterPrompts,
+                openSpotterOnLiveboardByDefault,
             } = spotterChatConfig;
 
             setParamIfDefined(params, Param.HideToolResponseCardBranding, hideToolResponseCardBranding, true);
@@ -865,6 +866,12 @@ export class LiveboardEmbed extends V1Embed {
             if (spotterFileUploadFileTypes !== undefined) {
                 params[Param.SpotterFileUploadFileTypes] = JSON.stringify(spotterFileUploadFileTypes);
             }
+            setParamIfDefined(
+                params,
+                Param.OpenSpotterOnLiveboardByDefault,
+                openSpotterOnLiveboardByDefault,
+                true,
+            );
         }
 
         if (isLinkParametersEnabled !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6794,6 +6794,7 @@ export enum Param {
     UpdatedSpotterExperience = 'updatedSpotterExperience',
     SpotterDataSources = 'spotterDataSources',
     AnalystId = 'analystId',
+    OpenSpotterOnLiveboardByDefault = 'openSpotterOnLiveboardByDefault',
 }
 
 /**
@@ -8597,6 +8598,17 @@ export enum Action {
      * @version SDK: 1.48.0 | ThoughtSpot Cloud: 26.5.0.cl
      */
     SpotterChatModeSwitcher = 'spotterChatModeSwitcher',
+    /**
+     * Controls visibility and disable state of the Spotter chat panel
+     * on an embedded Liveboard.
+     * @example
+     * ```js
+     * hiddenActions: [Action.SpotterOnLiveboard]
+     * disabledActions: [Action.SpotterOnLiveboard]
+     * ```
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     */
+    SpotterOnLiveboard = 'spotterOnLiveboard',
     /**
      * The **Basic Search** starter prompt pill.
      *

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2255,
+			"id": 2271,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2379,
+					"id": 2395,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -49,14 +49,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7975,
+							"line": 8000,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2276,
+					"id": 2292,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -77,14 +77,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7008,
+							"line": 7033,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2269,
+					"id": 2285,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -105,14 +105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6937,
+							"line": 6962,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2268,
+					"id": 2284,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -129,14 +129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6926,
+							"line": 6951,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2274,
+					"id": 2290,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -153,14 +153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6989,
+							"line": 7014,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2275,
+					"id": 2291,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -177,14 +177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6998,
+							"line": 7023,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2277,
+					"id": 2293,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -205,14 +205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7018,
+							"line": 7043,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2359,
+					"id": 2375,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -233,14 +233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7743,
+							"line": 7768,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2329,
+					"id": 2345,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -261,14 +261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7436,
+							"line": 7461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2375,
+					"id": 2391,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -289,14 +289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7928,
+							"line": 7953,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2389,
+					"id": 2405,
 					"name": "AllLiveboardFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -317,14 +317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8087,
+							"line": 8112,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"allLiveboardFilters\""
 				},
 				{
-					"id": 2328,
+					"id": 2344,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -345,14 +345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7424,
+							"line": 7449,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2327,
+					"id": 2343,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7412,
+							"line": 7437,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2374,
+					"id": 2390,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -402,14 +402,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7917,
+							"line": 7942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2341,
+					"id": 2357,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -430,14 +430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7558,
+							"line": 7583,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2353,
+					"id": 2369,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -458,14 +458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7689,
+							"line": 7714,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2344,
+					"id": 2360,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -486,14 +486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7592,
+							"line": 7617,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2349,
+					"id": 2365,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -514,14 +514,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7647,
+							"line": 7672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2343,
+					"id": 2359,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -542,14 +542,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7581,
+							"line": 7606,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2346,
+					"id": 2362,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -570,14 +570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7615,
+							"line": 7640,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2354,
+					"id": 2370,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -598,14 +598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7699,
+							"line": 7724,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2350,
+					"id": 2366,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -626,14 +626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7657,
+							"line": 7682,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2347,
+					"id": 2363,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -654,14 +654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7626,
+							"line": 7651,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2352,
+					"id": 2368,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -682,14 +682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7679,
+							"line": 7704,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2348,
+					"id": 2364,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -710,14 +710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7636,
+							"line": 7661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2345,
+					"id": 2361,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -738,14 +738,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7603,
+							"line": 7628,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2351,
+					"id": 2367,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -766,14 +766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7667,
+							"line": 7692,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2342,
+					"id": 2358,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -794,14 +794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7569,
+							"line": 7594,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2388,
+					"id": 2404,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -822,14 +822,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8073,
+							"line": 8098,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2273,
+					"id": 2289,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -846,14 +846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6980,
+							"line": 7005,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2272,
+					"id": 2288,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -874,14 +874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6971,
+							"line": 6996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2271,
+					"id": 2287,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -902,14 +902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6959,
+							"line": 6984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2397,
+					"id": 2413,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -930,14 +930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8175,
+							"line": 8200,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2270,
+					"id": 2286,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -954,14 +954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6948,
+							"line": 6973,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2320,
+					"id": 2336,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -969,14 +969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7361,
+							"line": 7386,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2263,
+					"id": 2279,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -993,14 +993,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6885,
+							"line": 6910,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2319,
+					"id": 2335,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1017,14 +1017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7360,
+							"line": 7385,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2398,
+					"id": 2414,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1045,14 +1045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8185,
+							"line": 8210,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2412,
+					"id": 2428,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1073,14 +1073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8349,
+							"line": 8374,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2372,
+					"id": 2388,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1101,14 +1101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7892,
+							"line": 7917,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2332,
+					"id": 2348,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1129,14 +1129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7466,
+							"line": 7491,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2337,
+					"id": 2353,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1157,14 +1157,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7516,
+							"line": 7541,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2390,
+					"id": 2454,
+					"name": "DataLiteracyPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Data Literacy** starter prompt pill, next to\n{@link Action.QuickSearchPill} above the Spotter chat input.",
+						"text": "Unlike the other two pills it opens no card: clicking it submits a prompt\nthat describes the data the model can answer over, helping a user who does\nnot yet know what is in the data source. The prompt text always comes from\nThoughtSpot, so only its label is customizable. Visible by default.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.DataLiteracyPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8661,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"dataLiteracyPill\""
+				},
+				{
+					"id": 2406,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1185,14 +1214,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8099,
+							"line": 8124,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2395,
+					"id": 2453,
+					"name": "DeepAnalysisPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Deep Analysis** starter prompt pill, next to\n{@link Action.QuickSearchPill} above the Spotter chat input.",
+						"text": "Clicking it opens a card of suggested investigative questions (\"why did\nrevenue drop?\"). Picking one fills the chat input in Deep Analysis mode\nrather than submitting immediately, so the user can edit it first.\nVisible by default.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.DeepAnalysisPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8646,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"deepAnalysisPill\""
+				},
+				{
+					"id": 2411,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1213,14 +1271,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8156,
+							"line": 8181,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2385,
+					"id": 2401,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1241,14 +1299,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8042,
+							"line": 8067,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2387,
+					"id": 2403,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1269,14 +1327,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8061,
+							"line": 8086,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2285,
+					"id": 2301,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1293,14 +1351,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7068,
+							"line": 7093,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2288,
+					"id": 2304,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1317,14 +1375,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7101,
+							"line": 7126,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2287,
+					"id": 2303,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1342,14 +1400,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7091,
+							"line": 7116,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2286,
+					"id": 2302,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1366,14 +1424,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7078,
+							"line": 7103,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2289,
+					"id": 2305,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1390,14 +1448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7111,
+							"line": 7136,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2290,
+					"id": 2306,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1418,14 +1476,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7121,
+							"line": 7146,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2292,
+					"id": 2308,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1446,14 +1504,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7145,
+							"line": 7170,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2291,
+					"id": 2307,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1474,14 +1532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7131,
+							"line": 7156,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2294,
+					"id": 2310,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1502,14 +1560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7165,
+							"line": 7190,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2293,
+					"id": 2309,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1530,14 +1588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7155,
+							"line": 7180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2324,
+					"id": 2340,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1554,14 +1612,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7377,
+							"line": 7402,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2318,
+					"id": 2334,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1578,14 +1636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7350,
+							"line": 7375,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2317,
+					"id": 2333,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1602,14 +1660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7341,
+							"line": 7366,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2302,
+					"id": 2318,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1626,14 +1684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7241,
+							"line": 7266,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2262,
+					"id": 2278,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1650,14 +1708,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6876,
+							"line": 6901,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2331,
+					"id": 2347,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1678,14 +1736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7455,
+							"line": 7480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2260,
+					"id": 2276,
 					"name": "EditInputTable",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1699,21 +1757,21 @@
 							},
 							{
 								"tag": "version",
-								"text": "SDK: 1.51.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6854,
+							"line": 6879,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editInputTable\""
 				},
 				{
-					"id": 2322,
+					"id": 2338,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1721,14 +1779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7366,
+							"line": 7391,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2394,
+					"id": 2410,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1749,14 +1807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8145,
+							"line": 8170,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2363,
+					"id": 2379,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1777,14 +1835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7787,
+							"line": 7812,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2380,
+					"id": 2396,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1805,14 +1863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7988,
+							"line": 8013,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2299,
+					"id": 2315,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1829,14 +1887,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7209,
+							"line": 7234,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2303,
+					"id": 2319,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1853,14 +1911,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7249,
+							"line": 7274,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2396,
+					"id": 2412,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1881,14 +1939,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8166,
+							"line": 8191,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2360,
+					"id": 2376,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1909,14 +1967,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7753,
+							"line": 7778,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2361,
+					"id": 2377,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1937,14 +1995,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7764,
+							"line": 7789,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2316,
+					"id": 2332,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1961,14 +2019,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7330,
+							"line": 7355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2296,
+					"id": 2312,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1986,14 +2044,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7181,
+							"line": 7206,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2297,
+					"id": 2313,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2010,14 +2068,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7191,
+							"line": 7216,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2399,
+					"id": 2415,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2039,14 +2097,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8204,
+							"line": 8229,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2435,
+					"id": 2455,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2067,14 +2125,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8673,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2386,
+					"id": 2402,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2095,14 +2153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8052,
+							"line": 8077,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2310,
+					"id": 2326,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2119,14 +2177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7291,
+							"line": 7316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2405,
+					"id": 2421,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2147,14 +2205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8270,
+							"line": 8295,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2370,
+					"id": 2386,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2175,14 +2233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7860,
+							"line": 7885,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2261,
+					"id": 2277,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2199,14 +2257,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6867,
+							"line": 6892,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2367,
+					"id": 2383,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,14 +2281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7828,
+							"line": 7853,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2336,
+					"id": 2352,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,14 +2309,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7506,
+							"line": 7531,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2407,
+					"id": 2423,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,14 +2337,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8296,
+							"line": 8321,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2384,
+					"id": 2400,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,14 +2365,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8031,
+							"line": 8056,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2358,
+					"id": 2374,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2335,14 +2393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7733,
+							"line": 7758,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2365,
+					"id": 2381,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2362,14 +2420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7808,
+							"line": 7833,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2411,
+					"id": 2427,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2390,14 +2448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8339,
+							"line": 8364,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2410,
+					"id": 2426,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2418,14 +2476,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8329,
+							"line": 8354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2366,
+					"id": 2382,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2442,14 +2500,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7817,
+							"line": 7842,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2377,
+					"id": 2393,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2474,14 +2532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7952,
+							"line": 7977,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2378,
+					"id": 2394,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2502,14 +2560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7964,
+							"line": 7989,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2409,
+					"id": 2425,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2530,14 +2588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8319,
+							"line": 8344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2381,
+					"id": 2397,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2558,14 +2616,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7999,
+							"line": 8024,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2368,
+					"id": 2384,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2590,14 +2648,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7840,
+							"line": 7865,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2369,
+					"id": 2385,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2618,14 +2676,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7850,
+							"line": 7875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2313,
+					"id": 2329,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2642,14 +2700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7308,
+							"line": 7333,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2403,
+					"id": 2419,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2666,14 +2724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8248,
+							"line": 8273,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2300,
+					"id": 2316,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2690,14 +2748,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7219,
+							"line": 7244,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2391,
+					"id": 2407,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2718,14 +2776,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8111,
+							"line": 8136,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2406,
+					"id": 2422,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2746,14 +2804,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8283,
+							"line": 8308,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2326,
+					"id": 2342,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2771,14 +2829,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7402,
+							"line": 7427,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2441,
+					"id": 2452,
+					"name": "QuickSearchPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Basic Search** starter prompt pill.",
+						"text": "Starter prompt pills are the row of category buttons shown above the\nSpotter chat input before a conversation starts. They give a new user\nready-made questions to click instead of typing one from scratch, and\ndisappear once the conversation begins. There are three, one per action\nbelow.\n\nClicking this pill opens a card of suggested simple questions; picking one\nsubmits it to Spotter right away. Visible by default, and hidden along\nwith the other pills when the surface itself is off (see\n{@link SpotterChatViewConfig.starterPrompts}).",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.QuickSearchPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8631,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"quickSearchPill\""
+				},
+				{
+					"id": 2461,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2799,14 +2886,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8660,
+							"line": 8746,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2304,
+					"id": 2320,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2823,14 +2910,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7259,
+							"line": 7284,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2404,
+					"id": 2420,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2851,14 +2938,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8260,
+							"line": 8285,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2340,
+					"id": 2356,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2879,14 +2966,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7547,
+							"line": 7572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2330,
+					"id": 2346,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2907,14 +2994,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7446,
+							"line": 7471,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2376,
+					"id": 2392,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2935,14 +3022,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7939,
+							"line": 7964,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2356,
+					"id": 2372,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2963,14 +3050,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7713,
+							"line": 7738,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2333,
+					"id": 2349,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2994,14 +3081,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7475,
+							"line": 7500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2325,
+					"id": 2341,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3018,14 +3105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7386,
+							"line": 7411,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2357,
+					"id": 2373,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3046,14 +3133,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7723,
+							"line": 7748,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2392,
+					"id": 2408,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3074,14 +3161,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8123,
+							"line": 8148,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2364,
+					"id": 2380,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3102,14 +3189,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7799,
+							"line": 7824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2256,
+					"id": 2272,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3126,14 +3213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6825,
+							"line": 6850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2259,
+					"id": 2275,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3150,14 +3237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6843,
+							"line": 6868,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2265,
+					"id": 2281,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3174,14 +3261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6899,
+							"line": 6924,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2266,
+					"id": 2282,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3198,14 +3285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6908,
+							"line": 6933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2436,
+					"id": 2456,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3226,14 +3313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8599,
+							"line": 8685,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2323,
+					"id": 2339,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3241,14 +3328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7367,
+							"line": 7392,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2267,
+					"id": 2283,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3265,14 +3352,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6917,
+							"line": 6942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2282,
+					"id": 2298,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3283,14 +3370,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7043,
+							"line": 7068,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2362,
+					"id": 2378,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3311,14 +3398,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7774,
+							"line": 7799,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2284,
+					"id": 2300,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3335,14 +3422,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7058,
+							"line": 7083,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2279,
+					"id": 2295,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3359,14 +3446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7031,
+							"line": 7056,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2444,
+					"id": 2464,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3387,14 +3474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8693,
+							"line": 8779,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2445,
+					"id": 2465,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3415,14 +3502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8704,
+							"line": 8790,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2443,
+					"id": 2463,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3443,14 +3530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8768,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2448,
+					"id": 2468,
 					"name": "SpotterAnalystList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3471,14 +3558,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8737,
+							"line": 8823,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystList\""
 				},
 				{
-					"id": 2446,
+					"id": 2466,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3499,14 +3586,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8715,
+							"line": 8801,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2442,
+					"id": 2462,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3527,14 +3614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8671,
+							"line": 8757,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2447,
+					"id": 2467,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3555,14 +3642,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8726,
+							"line": 8812,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2432,
+					"id": 2448,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3583,14 +3670,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8553,
+							"line": 8578,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2433,
+					"id": 2449,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3611,14 +3698,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8564,
+							"line": 8589,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2429,
+					"id": 2445,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3639,14 +3726,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8522,
+							"line": 8547,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2419,
+					"id": 2435,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3667,14 +3754,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8419,
+							"line": 8444,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2434,
+					"id": 2450,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3695,14 +3782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8575,
+							"line": 8600,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2430,
+					"id": 2446,
 					"name": "SpotterChatPin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3723,14 +3810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8532,
+							"line": 8557,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatPin\""
 				},
 				{
-					"id": 2420,
+					"id": 2436,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3751,14 +3838,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8429,
+							"line": 8454,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2449,
+					"id": 2469,
 					"name": "SpotterDefaultAnalyst",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3779,14 +3866,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8748,
+							"line": 8834,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDefaultAnalyst\""
 				},
 				{
-					"id": 2431,
+					"id": 2447,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3807,14 +3894,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8542,
+							"line": 8567,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2393,
+					"id": 2409,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3835,14 +3922,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8134,
+							"line": 8159,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2417,
+					"id": 2433,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3863,14 +3950,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8399,
+							"line": 8424,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2418,
+					"id": 2451,
+					"name": "SpotterOnLiveboard",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "Controls visibility and disable state of the Spotter chat panel\non an embedded Liveboard.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.SpotterOnLiveboard]\ndisabledActions: [Action.SpotterOnLiveboard]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8611,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"spotterOnLiveboard\""
+				},
+				{
+					"id": 2434,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3891,14 +4006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8409,
+							"line": 8434,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2421,
+					"id": 2437,
 					"name": "SpotterShareConversationButtonHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3919,14 +4034,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8440,
+							"line": 8465,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeader\""
 				},
 				{
-					"id": 2422,
+					"id": 2438,
 					"name": "SpotterShareConversationMenuItemSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3947,14 +4062,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8451,
+							"line": 8476,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebar\""
 				},
 				{
-					"id": 2427,
+					"id": 2443,
 					"name": "SpotterShareIncludeNewMessagesCheckbox",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3975,14 +4090,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8502,
+							"line": 8527,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckbox\""
 				},
 				{
-					"id": 2428,
+					"id": 2444,
 					"name": "SpotterShareStaleInfoBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4003,14 +4118,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8512,
+							"line": 8537,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissButton\""
 				},
 				{
-					"id": 2426,
+					"id": 2442,
 					"name": "SpotterShareUpToCurrentInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,14 +4146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8492,
+							"line": 8517,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareUpToCurrentInfo\""
 				},
 				{
-					"id": 2423,
+					"id": 2439,
 					"name": "SpotterSharedConversationBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4059,14 +4174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8461,
+							"line": 8486,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBanner\""
 				},
 				{
-					"id": 2424,
+					"id": 2440,
 					"name": "SpotterSharedConversationBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4087,14 +4202,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8471,
+							"line": 8496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBannerDismissButton\""
 				},
 				{
-					"id": 2425,
+					"id": 2441,
 					"name": "SpotterSharedConversationExitButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4115,14 +4230,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8482,
+							"line": 8507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButton\""
 				},
 				{
-					"id": 2415,
+					"id": 2431,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4143,14 +4258,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8379,
+							"line": 8404,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2414,
+					"id": 2430,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4171,14 +4286,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8369,
+							"line": 8394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2416,
+					"id": 2432,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4199,14 +4314,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8389,
+							"line": 8414,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2402,
+					"id": 2418,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4227,14 +4342,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8237,
+							"line": 8262,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2439,
+					"id": 2459,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4255,14 +4370,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8635,
+							"line": 8721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2438,
+					"id": 2458,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4283,14 +4398,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8623,
+							"line": 8709,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2437,
+					"id": 2457,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4311,14 +4426,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8611,
+							"line": 8697,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2440,
+					"id": 2460,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4339,14 +4454,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8735,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2400,
+					"id": 2416,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4367,14 +4482,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8215,
+							"line": 8240,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2401,
+					"id": 2417,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4395,14 +4510,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8226,
+							"line": 8251,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2315,
+					"id": 2331,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4419,14 +4534,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7322,
+							"line": 7347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2335,
+					"id": 2351,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4447,14 +4562,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7496,
+							"line": 7521,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2334,
+					"id": 2350,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4475,14 +4590,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7485,
+							"line": 7510,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2338,
+					"id": 2354,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4503,14 +4618,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7526,
+							"line": 7551,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2339,
+					"id": 2355,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4531,14 +4646,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7536,
+							"line": 7561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2371,
+					"id": 2387,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4563,14 +4678,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7879,
+							"line": 7904,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2301,
+					"id": 2317,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4587,14 +4702,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7231,
+							"line": 7256,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2413,
+					"id": 2429,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4615,14 +4730,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8359,
+							"line": 8384,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2408,
+					"id": 2424,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4643,14 +4758,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8308,
+							"line": 8333,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2383,
+					"id": 2399,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4671,14 +4786,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8021,
+							"line": 8046,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2298,
+					"id": 2314,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4695,14 +4810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7200,
+							"line": 7225,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2373,
+					"id": 2389,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4723,14 +4838,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7903,
+							"line": 7928,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2382,
+					"id": 2398,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4751,7 +4866,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8010,
+							"line": 8035,
 							"character": 4
 						}
 					],
@@ -4763,195 +4878,199 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2379,
-						2276,
-						2269,
-						2268,
-						2274,
-						2275,
-						2277,
-						2359,
-						2329,
-						2375,
-						2389,
-						2328,
-						2327,
-						2374,
-						2341,
-						2353,
-						2344,
-						2349,
-						2343,
-						2346,
-						2354,
-						2350,
-						2347,
-						2352,
-						2348,
-						2345,
-						2351,
-						2342,
-						2388,
-						2273,
-						2272,
-						2271,
-						2397,
-						2270,
-						2320,
-						2263,
-						2319,
-						2398,
-						2412,
-						2372,
-						2332,
-						2337,
-						2390,
 						2395,
-						2385,
-						2387,
+						2292,
 						2285,
+						2284,
+						2290,
+						2291,
+						2293,
+						2375,
+						2345,
+						2391,
+						2405,
+						2344,
+						2343,
+						2390,
+						2357,
+						2369,
+						2360,
+						2365,
+						2359,
+						2362,
+						2370,
+						2366,
+						2363,
+						2368,
+						2364,
+						2361,
+						2367,
+						2358,
+						2404,
+						2289,
 						2288,
 						2287,
-						2286,
-						2289,
-						2290,
-						2292,
-						2291,
-						2294,
-						2293,
-						2324,
-						2318,
-						2317,
-						2302,
-						2262,
-						2331,
-						2260,
-						2322,
-						2394,
-						2363,
-						2380,
-						2299,
-						2303,
-						2396,
-						2360,
-						2361,
-						2316,
-						2296,
-						2297,
-						2399,
-						2435,
-						2386,
-						2310,
-						2405,
-						2370,
-						2261,
-						2367,
-						2336,
-						2407,
-						2384,
-						2358,
-						2365,
-						2411,
-						2410,
-						2366,
-						2377,
-						2378,
-						2409,
-						2381,
-						2368,
-						2369,
-						2313,
-						2403,
-						2300,
-						2391,
-						2406,
-						2326,
-						2441,
-						2304,
-						2404,
-						2340,
-						2330,
-						2376,
-						2356,
-						2333,
-						2325,
-						2357,
-						2392,
-						2364,
-						2256,
-						2259,
-						2265,
-						2266,
-						2436,
-						2323,
-						2267,
-						2282,
-						2362,
-						2284,
-						2279,
-						2444,
-						2445,
-						2443,
-						2448,
-						2446,
-						2442,
-						2447,
-						2432,
-						2433,
-						2429,
-						2419,
-						2434,
-						2430,
-						2420,
-						2449,
-						2431,
-						2393,
-						2417,
-						2418,
-						2421,
-						2422,
-						2427,
-						2428,
-						2426,
-						2423,
-						2424,
-						2425,
-						2415,
-						2414,
-						2416,
-						2402,
-						2439,
-						2438,
-						2437,
-						2440,
-						2400,
-						2401,
-						2315,
-						2335,
-						2334,
-						2338,
-						2339,
-						2371,
-						2301,
 						2413,
-						2408,
+						2286,
+						2336,
+						2279,
+						2335,
+						2414,
+						2428,
+						2388,
+						2348,
+						2353,
+						2454,
+						2406,
+						2453,
+						2411,
+						2401,
+						2403,
+						2301,
+						2304,
+						2303,
+						2302,
+						2305,
+						2306,
+						2308,
+						2307,
+						2310,
+						2309,
+						2340,
+						2334,
+						2333,
+						2318,
+						2278,
+						2347,
+						2276,
+						2338,
+						2410,
+						2379,
+						2396,
+						2315,
+						2319,
+						2412,
+						2376,
+						2377,
+						2332,
+						2312,
+						2313,
+						2415,
+						2455,
+						2402,
+						2326,
+						2421,
+						2386,
+						2277,
 						2383,
-						2298,
+						2352,
+						2423,
+						2400,
+						2374,
+						2381,
+						2427,
+						2426,
+						2382,
+						2393,
+						2394,
+						2425,
+						2397,
+						2384,
+						2385,
+						2329,
+						2419,
+						2316,
+						2407,
+						2422,
+						2342,
+						2452,
+						2461,
+						2320,
+						2420,
+						2356,
+						2346,
+						2392,
+						2372,
+						2349,
+						2341,
 						2373,
-						2382
+						2408,
+						2380,
+						2272,
+						2275,
+						2281,
+						2282,
+						2456,
+						2339,
+						2283,
+						2298,
+						2378,
+						2300,
+						2295,
+						2464,
+						2465,
+						2463,
+						2468,
+						2466,
+						2462,
+						2467,
+						2448,
+						2449,
+						2445,
+						2435,
+						2450,
+						2446,
+						2436,
+						2469,
+						2447,
+						2409,
+						2433,
+						2451,
+						2434,
+						2437,
+						2438,
+						2443,
+						2444,
+						2442,
+						2439,
+						2440,
+						2441,
+						2431,
+						2430,
+						2432,
+						2418,
+						2459,
+						2458,
+						2457,
+						2460,
+						2416,
+						2417,
+						2331,
+						2351,
+						2350,
+						2354,
+						2355,
+						2387,
+						2317,
+						2429,
+						2424,
+						2399,
+						2314,
+						2389,
+						2398
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6816,
+					"line": 6841,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1839,
+			"id": 1855,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4967,7 +5086,7 @@
 			},
 			"children": [
 				{
-					"id": 1840,
+					"id": 1856,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4990,7 +5109,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1840
+						1856
 					]
 				}
 			],
@@ -5003,7 +5122,7 @@
 			]
 		},
 		{
-			"id": 1824,
+			"id": 1840,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5019,7 +5138,7 @@
 			},
 			"children": [
 				{
-					"id": 1827,
+					"id": 1843,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5038,7 +5157,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1829,
+					"id": 1845,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5057,7 +5176,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1826,
+					"id": 1842,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5076,7 +5195,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1828,
+					"id": 1844,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5095,7 +5214,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1825,
+					"id": 1841,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5114,7 +5233,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1830,
+					"id": 1846,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5138,12 +5257,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1827,
-						1829,
-						1826,
-						1828,
-						1825,
-						1830
+						1843,
+						1845,
+						1842,
+						1844,
+						1841,
+						1846
 					]
 				}
 			],
@@ -5156,7 +5275,7 @@
 			]
 		},
 		{
-			"id": 1831,
+			"id": 1847,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5172,7 +5291,7 @@
 			},
 			"children": [
 				{
-					"id": 1832,
+					"id": 1848,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5190,7 +5309,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1836,
+					"id": 1852,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5208,7 +5327,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1838,
+					"id": 1854,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5226,7 +5345,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1833,
+					"id": 1849,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5250,7 +5369,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1835,
+					"id": 1851,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5283,7 +5402,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1837,
+					"id": 1853,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5312,12 +5431,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1832,
-						1836,
-						1838,
-						1833,
-						1835,
-						1837
+						1848,
+						1852,
+						1854,
+						1849,
+						1851,
+						1853
 					]
 				}
 			],
@@ -5330,7 +5449,7 @@
 			]
 		},
 		{
-			"id": 1991,
+			"id": 2007,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5346,7 +5465,7 @@
 			},
 			"children": [
 				{
-					"id": 2002,
+					"id": 2018,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5365,7 +5484,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1993,
+					"id": 2009,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5394,7 +5513,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1992,
+					"id": 2008,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5418,7 +5537,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1998,
+					"id": 2014,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5436,7 +5555,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1996,
+					"id": 2012,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5469,7 +5588,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 2000,
+					"id": 2016,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5493,7 +5612,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 2001,
+					"id": 2017,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5526,13 +5645,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2002,
-						1993,
-						1992,
-						1998,
-						1996,
-						2000,
-						2001
+						2018,
+						2009,
+						2008,
+						2014,
+						2012,
+						2016,
+						2017
 					]
 				}
 			],
@@ -5545,7 +5664,7 @@
 			]
 		},
 		{
-			"id": 3323,
+			"id": 3343,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5561,7 +5680,7 @@
 			},
 			"children": [
 				{
-					"id": 3325,
+					"id": 3345,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5572,14 +5691,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9453,
+							"line": 9539,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3324,
+					"id": 3344,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5590,7 +5709,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9451,
+							"line": 9537,
 							"character": 4
 						}
 					],
@@ -5602,21 +5721,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3325,
-						3324
+						3345,
+						3344
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9449,
+					"line": 9535,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3326,
+			"id": 3346,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5632,7 +5751,7 @@
 			},
 			"children": [
 				{
-					"id": 3328,
+					"id": 3348,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5643,14 +5762,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9464,
+							"line": 9550,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3329,
+					"id": 3349,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5661,14 +5780,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9466,
+							"line": 9552,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3327,
+					"id": 3347,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5679,7 +5798,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9462,
+							"line": 9548,
 							"character": 4
 						}
 					],
@@ -5691,22 +5810,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3328,
-						3329,
-						3327
+						3348,
+						3349,
+						3347
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9460,
+					"line": 9546,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3330,
+			"id": 3350,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5722,7 +5841,7 @@
 			},
 			"children": [
 				{
-					"id": 3333,
+					"id": 3353,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5733,14 +5852,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9418,
+							"line": 9504,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3334,
+					"id": 3354,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5751,14 +5870,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9420,
+							"line": 9506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3336,
+					"id": 3356,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5769,14 +5888,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9424,
+							"line": 9510,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3341,
+					"id": 3361,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5787,14 +5906,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9434,
+							"line": 9520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3337,
+					"id": 3357,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5805,14 +5924,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9426,
+							"line": 9512,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3339,
+					"id": 3359,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5823,14 +5942,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9430,
+							"line": 9516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3331,
+					"id": 3351,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5841,14 +5960,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9414,
+							"line": 9500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3343,
+					"id": 3363,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5859,14 +5978,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9438,
+							"line": 9524,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3332,
+					"id": 3352,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5877,14 +5996,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9416,
+							"line": 9502,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3345,
+					"id": 3365,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5895,14 +6014,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9442,
+							"line": 9528,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3344,
+					"id": 3364,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5913,14 +6032,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9440,
+							"line": 9526,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3338,
+					"id": 3358,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5931,14 +6050,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9428,
+							"line": 9514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3340,
+					"id": 3360,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5949,14 +6068,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9432,
+							"line": 9518,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3342,
+					"id": 3362,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5967,14 +6086,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9436,
+							"line": 9522,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3335,
+					"id": 3355,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5985,7 +6104,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9422,
+							"line": 9508,
 							"character": 4
 						}
 					],
@@ -5997,34 +6116,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3333,
-						3334,
-						3336,
-						3341,
-						3337,
-						3339,
-						3331,
-						3343,
-						3332,
-						3345,
-						3344,
-						3338,
-						3340,
-						3342,
-						3335
+						3353,
+						3354,
+						3356,
+						3361,
+						3357,
+						3359,
+						3351,
+						3363,
+						3352,
+						3365,
+						3364,
+						3358,
+						3360,
+						3362,
+						3355
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9412,
+					"line": 9498,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2450,
+			"id": 2470,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6034,7 +6153,7 @@
 			},
 			"children": [
 				{
-					"id": 2453,
+					"id": 2473,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6042,14 +6161,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8768,
+							"line": 8854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2451,
+					"id": 2471,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6057,14 +6176,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8766,
+							"line": 8852,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2452,
+					"id": 2472,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6072,7 +6191,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8767,
+							"line": 8853,
 							"character": 4
 						}
 					],
@@ -6084,22 +6203,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2453,
-						2451,
-						2452
+						2473,
+						2471,
+						2472
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8765,
+					"line": 8851,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2245,
+			"id": 2261,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6123,7 +6242,7 @@
 			},
 			"children": [
 				{
-					"id": 2248,
+					"id": 2264,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6134,14 +6253,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9216,
+							"line": 9302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2247,
+					"id": 2263,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6152,14 +6271,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9212,
+							"line": 9298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2250,
+					"id": 2266,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6170,14 +6289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9225,
+							"line": 9311,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2246,
+					"id": 2262,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6188,14 +6307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9208,
+							"line": 9294,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2249,
+					"id": 2265,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6206,7 +6325,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9220,
+							"line": 9306,
 							"character": 4
 						}
 					],
@@ -6218,24 +6337,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2248,
-						2247,
-						2250,
-						2246,
-						2249
+						2264,
+						2263,
+						2266,
+						2262,
+						2265
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9204,
+					"line": 9290,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3277,
+			"id": 3297,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6245,7 +6364,7 @@
 			},
 			"children": [
 				{
-					"id": 3280,
+					"id": 3300,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6256,14 +6375,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8905,
+							"line": 8991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3278,
+					"id": 3298,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6274,14 +6393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8878,
+							"line": 8964,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3281,
+					"id": 3301,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6292,14 +6411,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8916,
+							"line": 9002,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3279,
+					"id": 3299,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6310,7 +6429,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8892,
+							"line": 8978,
 							"character": 4
 						}
 					],
@@ -6322,23 +6441,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3280,
-						3278,
-						3281,
-						3279
+						3300,
+						3298,
+						3301,
+						3299
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8868,
+					"line": 8954,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3273,
+			"id": 3293,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6348,7 +6467,7 @@
 			},
 			"children": [
 				{
-					"id": 3276,
+					"id": 3296,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6359,14 +6478,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8859,
+							"line": 8945,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3275,
+					"id": 3295,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6377,14 +6496,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8851,
+							"line": 8937,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3274,
+					"id": 3294,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6395,7 +6514,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8846,
+							"line": 8932,
 							"character": 4
 						}
 					],
@@ -6407,22 +6526,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3276,
-						3275,
-						3274
+						3296,
+						3295,
+						3294
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8841,
+					"line": 8927,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3346,
+			"id": 3366,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6438,7 +6557,7 @@
 			},
 			"children": [
 				{
-					"id": 3351,
+					"id": 3371,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6449,14 +6568,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9403,
+							"line": 9489,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3347,
+					"id": 3367,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6467,14 +6586,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9395,
+							"line": 9481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3349,
+					"id": 3369,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6485,14 +6604,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9399,
+							"line": 9485,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3348,
+					"id": 3368,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6503,14 +6622,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9397,
+							"line": 9483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3350,
+					"id": 3370,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6521,14 +6640,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9401,
+							"line": 9487,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3352,
+					"id": 3372,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6539,7 +6658,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9405,
+							"line": 9491,
 							"character": 4
 						}
 					],
@@ -6551,25 +6670,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3351,
-						3347,
-						3349,
-						3348,
-						3350,
-						3352
+						3371,
+						3367,
+						3369,
+						3368,
+						3370,
+						3372
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9393,
+					"line": 9479,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3269,
+			"id": 3289,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6579,7 +6698,7 @@
 			},
 			"children": [
 				{
-					"id": 3271,
+					"id": 3291,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6597,7 +6716,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3270,
+					"id": 3290,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6615,7 +6734,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3272,
+					"id": 3292,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6638,9 +6757,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3271,
-						3270,
-						3272
+						3291,
+						3290,
+						3292
 					]
 				}
 			],
@@ -6653,7 +6772,7 @@
 			]
 		},
 		{
-			"id": 2251,
+			"id": 2267,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6663,7 +6782,7 @@
 			},
 			"children": [
 				{
-					"id": 2253,
+					"id": 2269,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6674,14 +6793,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6599,
+							"line": 6623,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2254,
+					"id": 2270,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6692,14 +6811,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6603,
+							"line": 6627,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2252,
+					"id": 2268,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6710,7 +6829,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6595,
+							"line": 6619,
 							"character": 4
 						}
 					],
@@ -6722,22 +6841,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2253,
-						2254,
-						2252
+						2269,
+						2270,
+						2268
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6591,
+					"line": 6615,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3286,
+			"id": 3306,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6761,7 +6880,7 @@
 			},
 			"children": [
 				{
-					"id": 3289,
+					"id": 3309,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6772,14 +6891,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9082,
+							"line": 9168,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3290,
+					"id": 3310,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6790,14 +6909,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9085,
+							"line": 9171,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3293,
+					"id": 3313,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6808,14 +6927,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9094,
+							"line": 9180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3302,
+					"id": 3322,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6826,14 +6945,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9121,
+							"line": 9207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3296,
+					"id": 3316,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6844,14 +6963,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9103,
+							"line": 9189,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3300,
+					"id": 3320,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6862,14 +6981,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9115,
+							"line": 9201,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3291,
+					"id": 3311,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6880,14 +6999,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9088,
+							"line": 9174,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3299,
+					"id": 3319,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6898,14 +7017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9112,
+							"line": 9198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3288,
+					"id": 3308,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6916,14 +7035,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9079,
+							"line": 9165,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3294,
+					"id": 3314,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6934,14 +7053,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9097,
+							"line": 9183,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3292,
+					"id": 3312,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6952,14 +7071,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9091,
+							"line": 9177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3297,
+					"id": 3317,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6970,14 +7089,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9106,
+							"line": 9192,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3295,
+					"id": 3315,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6988,14 +7107,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9100,
+							"line": 9186,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3301,
+					"id": 3321,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7006,14 +7125,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9118,
+							"line": 9204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3303,
+					"id": 3323,
 					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7024,14 +7143,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9124,
+							"line": 9210,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3298,
+					"id": 3318,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7042,14 +7161,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9109,
+							"line": 9195,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3287,
+					"id": 3307,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7060,7 +7179,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9076,
+							"line": 9162,
 							"character": 4
 						}
 					],
@@ -7072,36 +7191,36 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3289,
-						3290,
-						3293,
-						3302,
-						3296,
-						3300,
-						3291,
-						3299,
-						3288,
-						3294,
-						3292,
-						3297,
-						3295,
-						3301,
-						3303,
-						3298,
-						3287
+						3309,
+						3310,
+						3313,
+						3322,
+						3316,
+						3320,
+						3311,
+						3319,
+						3308,
+						3314,
+						3312,
+						3317,
+						3315,
+						3321,
+						3323,
+						3318,
+						3307
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9074,
+					"line": 9160,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2023,
+			"id": 2039,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7126,7 +7245,7 @@
 			},
 			"children": [
 				{
-					"id": 2060,
+					"id": 2076,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7147,14 +7266,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3021,
+							"line": 3045,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2051,
+					"id": 2067,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7175,14 +7294,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2884,
+							"line": 2908,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2031,
+					"id": 2047,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7207,14 +7326,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2632,
+							"line": 2656,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2113,
+					"id": 2129,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7235,14 +7354,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3687,
+							"line": 3711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2077,
+					"id": 2093,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7263,14 +7382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3234,
+							"line": 3258,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2036,
+					"id": 2052,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7295,14 +7414,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2742,
+							"line": 2766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2073,
+					"id": 2089,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7323,14 +7442,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3202,
+							"line": 3226,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2059,
+					"id": 2075,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7351,14 +7470,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3010,
+							"line": 3034,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2123,
+					"id": 2139,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7380,14 +7499,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3853,
+							"line": 3877,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2102,
+					"id": 2118,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7420,14 +7539,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3491,
+							"line": 3515,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2037,
+					"id": 2053,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7448,14 +7567,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2755,
+							"line": 2779,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2025,
+					"id": 2041,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7480,14 +7599,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2534,
+							"line": 2558,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2084,
+					"id": 2100,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7508,14 +7627,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3310,
+							"line": 3334,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2100,
+					"id": 2116,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7552,14 +7671,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3477,
+							"line": 3501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2071,
+					"id": 2087,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7580,14 +7699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3180,
+							"line": 3204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2086,
+					"id": 2102,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7608,14 +7727,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3330,
+							"line": 3354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2066,
+					"id": 2082,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7636,14 +7755,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3113,
+							"line": 3137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2092,
+					"id": 2108,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7660,14 +7779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3389,
+							"line": 3413,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2107,
+					"id": 2123,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7685,14 +7804,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3637,
+							"line": 3661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2108,
+					"id": 2124,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7709,14 +7828,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3642,
+							"line": 3666,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2101,
+					"id": 2117,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7733,14 +7852,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3482,
+							"line": 3506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2087,
+					"id": 2103,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7761,14 +7880,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3341,
+							"line": 3365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2032,
+					"id": 2048,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7797,14 +7916,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2649,
+							"line": 2673,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2027,
+					"id": 2043,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7833,14 +7952,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2562,
+							"line": 2586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2114,
+					"id": 2130,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7861,14 +7980,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3698,
+							"line": 3722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2030,
+					"id": 2046,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7893,14 +8012,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2620,
+							"line": 2644,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2082,
+					"id": 2098,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7921,14 +8040,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3292,
+							"line": 3316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2098,
+					"id": 2114,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7957,14 +8076,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3449,
+							"line": 3473,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2099,
+					"id": 2115,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7989,14 +8108,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3456,
+							"line": 3480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2049,
+					"id": 2065,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8017,14 +8136,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2851,
+							"line": 2875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2048,
+					"id": 2064,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8045,14 +8164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2840,
+							"line": 2864,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2053,
+					"id": 2069,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8074,14 +8193,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2919,
+							"line": 2943,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2056,
+					"id": 2072,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8102,14 +8221,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2967,
+							"line": 2991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2055,
+					"id": 2071,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8130,14 +8249,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2951,
+							"line": 2975,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2054,
+					"id": 2070,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8158,14 +8277,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2935,
+							"line": 2959,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2057,
+					"id": 2073,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8186,14 +8305,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2983,
+							"line": 3007,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2058,
+					"id": 2074,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8214,14 +8333,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2994,
+							"line": 3018,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2065,
+					"id": 2081,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8242,14 +8361,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3102,
+							"line": 3126,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2064,
+					"id": 2080,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8270,14 +8389,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3090,
+							"line": 3114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2029,
+					"id": 2045,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8314,14 +8433,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2608,
+							"line": 2632,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2079,
+					"id": 2095,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8342,14 +8461,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3256,
+							"line": 3280,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2068,
+					"id": 2084,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8370,14 +8489,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3136,
+							"line": 3160,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2141,
+					"id": 2157,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8398,14 +8517,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4091,
+							"line": 4115,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 2035,
+					"id": 2051,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8435,14 +8554,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2732,
+							"line": 2756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2085,
+					"id": 2101,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8463,14 +8582,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3320,
+							"line": 3344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2069,
+					"id": 2085,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8491,14 +8610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3153,
+							"line": 3177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2090,
+					"id": 2106,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8519,14 +8638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3379,
+							"line": 3403,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2043,
+					"id": 2059,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8547,14 +8666,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2797,
+							"line": 2821,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2024,
+					"id": 2040,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8575,14 +8694,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2522,
+							"line": 2546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2117,
+					"id": 2133,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8603,14 +8722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3731,
+							"line": 3755,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2116,
+					"id": 2132,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8631,14 +8750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3720,
+							"line": 3744,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2076,
+					"id": 2092,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8659,14 +8778,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3223,
+							"line": 3247,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2050,
+					"id": 2066,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8691,14 +8810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2873,
+							"line": 2897,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2026,
+					"id": 2042,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8723,14 +8842,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2548,
+							"line": 2572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2080,
+					"id": 2096,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8751,14 +8870,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3267,
+							"line": 3291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2046,
+					"id": 2062,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8779,14 +8898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2823,
+							"line": 2847,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2104,
+					"id": 2120,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8817,14 +8936,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3562,
+							"line": 3586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2122,
+					"id": 2138,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8845,14 +8964,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3787,
+							"line": 3811,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2105,
+					"id": 2121,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8869,14 +8988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3581,
+							"line": 3605,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2061,
+					"id": 2077,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8897,14 +9016,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3042,
+							"line": 3066,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2081,
+					"id": 2097,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8929,14 +9048,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3282,
+							"line": 3306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2112,
+					"id": 2128,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8957,14 +9076,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3676,
+							"line": 3700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2028,
+					"id": 2044,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8985,14 +9104,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2571,
+							"line": 2595,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2151,
+					"id": 2167,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9013,14 +9132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4233,
+							"line": 4257,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2103,
+					"id": 2119,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9037,14 +9156,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3496,
+							"line": 3520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2097,
+					"id": 2113,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9077,14 +9196,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3440,
+							"line": 3464,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2118,
+					"id": 2134,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9105,14 +9224,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3742,
+							"line": 3766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2044,
+					"id": 2060,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9133,14 +9252,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2807,
+							"line": 2831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2052,
+					"id": 2068,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9161,14 +9280,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2903,
+							"line": 2927,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2070,
+					"id": 2086,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9189,14 +9308,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3164,
+							"line": 3188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2095,
+					"id": 2111,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9233,14 +9352,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3422,
+							"line": 3446,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2096,
+					"id": 2112,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9273,14 +9392,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3431,
+							"line": 3455,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2078,
+					"id": 2094,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9301,14 +9420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3245,
+							"line": 3269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2083,
+					"id": 2099,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9329,14 +9448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3301,
+							"line": 3325,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2143,
+					"id": 2159,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9357,14 +9476,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4130,
+							"line": 4154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2063,
+					"id": 2079,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9385,14 +9504,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3078,
+							"line": 3102,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2072,
+					"id": 2088,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9413,14 +9532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3191,
+							"line": 3215,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2062,
+					"id": 2078,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9441,14 +9560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3060,
+							"line": 3084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2125,
+					"id": 2141,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9469,14 +9588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3877,
+							"line": 3901,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2136,
+					"id": 2152,
 					"name": "SpotterConversationPinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9497,14 +9616,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4017,
+							"line": 4041,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationPinned\""
 				},
 				{
-					"id": 2124,
+					"id": 2140,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9525,14 +9644,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3865,
+							"line": 3889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2138,
+					"id": 2154,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9553,14 +9672,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4041,
+							"line": 4065,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2129,
+					"id": 2145,
 					"name": "SpotterConversationShareRevoked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9581,14 +9700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3932,
+							"line": 3956,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShareRevoked\""
 				},
 				{
-					"id": 2128,
+					"id": 2144,
 					"name": "SpotterConversationShared",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9609,14 +9728,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3918,
+							"line": 3942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShared\""
 				},
 				{
-					"id": 2137,
+					"id": 2153,
 					"name": "SpotterConversationUnpinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9637,14 +9756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4029,
+							"line": 4053,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationUnpinned\""
 				},
 				{
-					"id": 2111,
+					"id": 2127,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9665,14 +9784,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3665,
+							"line": 3689,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2119,
+					"id": 2135,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9693,14 +9812,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3753,
+							"line": 3777,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2120,
+					"id": 2136,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9721,14 +9840,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3764,
+							"line": 3788,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2115,
+					"id": 2131,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9749,14 +9868,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3709,
+							"line": 3733,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2139,
+					"id": 2155,
 					"name": "SpotterResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9782,14 +9901,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4066,
+							"line": 4090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterResponseComplete\""
 				},
 				{
-					"id": 2126,
+					"id": 2142,
 					"name": "SpotterShareConversationButtonHeaderClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9810,14 +9929,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3890,
+							"line": 3914,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeaderClicked\""
 				},
 				{
-					"id": 2127,
+					"id": 2143,
 					"name": "SpotterShareConversationMenuItemSidebarClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9838,14 +9957,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3902,
+							"line": 3926,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebarClicked\""
 				},
 				{
-					"id": 2131,
+					"id": 2147,
 					"name": "SpotterShareIncludeNewMessagesCheckboxToggled",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9866,14 +9985,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3957,
+							"line": 3981,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckboxToggled\""
 				},
 				{
-					"id": 2134,
+					"id": 2150,
 					"name": "SpotterShareModalCancelButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9894,14 +10013,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3993,
+							"line": 4017,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalCancelButtonClicked\""
 				},
 				{
-					"id": 2133,
+					"id": 2149,
 					"name": "SpotterShareModalConfirmButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9922,14 +10041,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3982,
+							"line": 4006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalConfirmButtonClicked\""
 				},
 				{
-					"id": 2132,
+					"id": 2148,
 					"name": "SpotterShareStaleInfoBannerDismissed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9950,14 +10069,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3969,
+							"line": 3993,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissed\""
 				},
 				{
-					"id": 2135,
+					"id": 2151,
 					"name": "SpotterSharedConversationExitButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9978,14 +10097,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4005,
+							"line": 4029,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButtonClicked\""
 				},
 				{
-					"id": 2130,
+					"id": 2146,
 					"name": "SpotterSharedConversationViewed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10006,14 +10125,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3945,
+							"line": 3969,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationViewed\""
 				},
 				{
-					"id": 2147,
+					"id": 2163,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10034,14 +10153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4182,
+							"line": 4206,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2148,
+					"id": 2164,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10062,14 +10181,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4195,
+							"line": 4219,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2150,
+					"id": 2166,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10090,14 +10209,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4219,
+							"line": 4243,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2149,
+					"id": 2165,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10118,14 +10237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4207,
+							"line": 4231,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2144,
+					"id": 2160,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10146,14 +10265,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4143,
+							"line": 4167,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2145,
+					"id": 2161,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10174,14 +10293,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4156,
+							"line": 4180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2146,
+					"id": 2162,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10202,14 +10321,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4169,
+							"line": 4193,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2142,
+					"id": 2158,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10235,14 +10354,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4115,
+							"line": 4139,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2106,
+					"id": 2122,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10264,14 +10383,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3624,
+							"line": 3648,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2091,
+					"id": 2107,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10288,14 +10407,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3384,
+							"line": 3408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2093,
+					"id": 2109,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10332,14 +10451,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3401,
+							"line": 3425,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2094,
+					"id": 2110,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10372,14 +10491,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3411,
+							"line": 3435,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2067,
+					"id": 2083,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10400,14 +10519,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3124,
+							"line": 3148,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2034,
+					"id": 2050,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10436,14 +10555,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2680,
+							"line": 2704,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2033,
+					"id": 2049,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10468,14 +10587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2661,
+							"line": 2685,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2088,
+					"id": 2104,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10496,7 +10615,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3352,
+							"line": 3376,
 							"character": 4
 						}
 					],
@@ -10508,133 +10627,133 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2060,
-						2051,
-						2031,
-						2113,
-						2077,
-						2036,
-						2073,
-						2059,
-						2123,
-						2102,
-						2037,
-						2025,
-						2084,
-						2100,
-						2071,
-						2086,
-						2066,
-						2092,
-						2107,
-						2108,
-						2101,
-						2087,
-						2032,
-						2027,
-						2114,
-						2030,
-						2082,
-						2098,
-						2099,
-						2049,
-						2048,
+						2076,
+						2067,
+						2047,
+						2129,
+						2093,
+						2052,
+						2089,
+						2075,
+						2139,
+						2118,
 						2053,
-						2056,
-						2055,
-						2054,
-						2057,
-						2058,
+						2041,
+						2100,
+						2116,
+						2087,
+						2102,
+						2082,
+						2108,
+						2123,
+						2124,
+						2117,
+						2103,
+						2048,
+						2043,
+						2130,
+						2046,
+						2098,
+						2114,
+						2115,
 						2065,
 						2064,
-						2029,
-						2079,
-						2068,
-						2141,
-						2035,
-						2085,
 						2069,
-						2090,
-						2043,
-						2024,
-						2117,
-						2116,
-						2076,
-						2050,
-						2026,
-						2080,
-						2046,
-						2104,
-						2122,
-						2105,
-						2061,
-						2081,
-						2112,
-						2028,
-						2151,
-						2103,
-						2097,
-						2118,
-						2044,
-						2052,
-						2070,
-						2095,
-						2096,
-						2078,
-						2083,
-						2143,
-						2063,
 						2072,
-						2062,
-						2125,
-						2136,
-						2124,
-						2138,
-						2129,
-						2128,
-						2137,
-						2111,
-						2119,
-						2120,
-						2115,
-						2139,
-						2126,
-						2127,
-						2131,
-						2134,
+						2071,
+						2070,
+						2073,
+						2074,
+						2081,
+						2080,
+						2045,
+						2095,
+						2084,
+						2157,
+						2051,
+						2101,
+						2085,
+						2106,
+						2059,
+						2040,
 						2133,
 						2132,
+						2092,
+						2066,
+						2042,
+						2096,
+						2062,
+						2120,
+						2138,
+						2121,
+						2077,
+						2097,
+						2128,
+						2044,
+						2167,
+						2119,
+						2113,
+						2134,
+						2060,
+						2068,
+						2086,
+						2111,
+						2112,
+						2094,
+						2099,
+						2159,
+						2079,
+						2088,
+						2078,
+						2141,
+						2152,
+						2140,
+						2154,
+						2145,
+						2144,
+						2153,
+						2127,
 						2135,
-						2130,
+						2136,
+						2131,
+						2155,
+						2142,
+						2143,
 						2147,
-						2148,
 						2150,
 						2149,
-						2144,
-						2145,
+						2148,
+						2151,
 						2146,
-						2142,
-						2106,
-						2091,
-						2093,
-						2094,
-						2067,
-						2034,
-						2033,
-						2088
+						2163,
+						2164,
+						2166,
+						2165,
+						2160,
+						2161,
+						2162,
+						2158,
+						2122,
+						2107,
+						2109,
+						2110,
+						2083,
+						2050,
+						2049,
+						2104
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2509,
+					"line": 2533,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3310,
+			"id": 3330,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10659,7 +10778,7 @@
 			},
 			"children": [
 				{
-					"id": 3311,
+					"id": 3331,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10670,14 +10789,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9036,
+							"line": 9122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3313,
+					"id": 3333,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10688,14 +10807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9040,
+							"line": 9126,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3312,
+					"id": 3332,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10706,7 +10825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9038,
+							"line": 9124,
 							"character": 4
 						}
 					],
@@ -10718,22 +10837,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3311,
-						3313,
-						3312
+						3331,
+						3333,
+						3332
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9034,
+					"line": 9120,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2875,
+			"id": 2895,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10743,7 +10862,7 @@
 			},
 			"children": [
 				{
-					"id": 2879,
+					"id": 2899,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10767,7 +10886,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2886,
+					"id": 2906,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10791,7 +10910,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 2883,
+					"id": 2903,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10815,7 +10934,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2885,
+					"id": 2905,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10839,7 +10958,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2877,
+					"id": 2897,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10863,7 +10982,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2882,
+					"id": 2902,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10887,7 +11006,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2878,
+					"id": 2898,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10911,7 +11030,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2880,
+					"id": 2900,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10935,7 +11054,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2876,
+					"id": 2896,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10959,7 +11078,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2881,
+					"id": 2901,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10983,7 +11102,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2884,
+					"id": 2904,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11012,17 +11131,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2879,
-						2886,
-						2883,
-						2885,
-						2877,
-						2882,
-						2878,
-						2880,
-						2876,
-						2881,
-						2884
+						2899,
+						2906,
+						2903,
+						2905,
+						2897,
+						2902,
+						2898,
+						2900,
+						2896,
+						2901,
+						2904
 					]
 				}
 			],
@@ -11035,7 +11154,7 @@
 			]
 		},
 		{
-			"id": 3213,
+			"id": 3233,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11051,7 +11170,7 @@
 			},
 			"children": [
 				{
-					"id": 3216,
+					"id": 3236,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11075,7 +11194,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3214,
+					"id": 3234,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11099,7 +11218,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3215,
+					"id": 3235,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11122,9 +11241,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3216,
-						3214,
-						3215
+						3236,
+						3234,
+						3235
 					]
 				}
 			],
@@ -11137,14 +11256,14 @@
 			]
 		},
 		{
-			"id": 3207,
+			"id": 3227,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3209,
+					"id": 3229,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11159,7 +11278,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3210,
+					"id": 3230,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11174,7 +11293,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3208,
+					"id": 3228,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11194,9 +11313,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3209,
-						3210,
-						3208
+						3229,
+						3230,
+						3228
 					]
 				}
 			],
@@ -11209,7 +11328,7 @@
 			]
 		},
 		{
-			"id": 2887,
+			"id": 2907,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11226,7 +11345,7 @@
 			},
 			"children": [
 				{
-					"id": 2890,
+					"id": 2910,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11237,14 +11356,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2381,
+							"line": 2405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2893,
+					"id": 2913,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11255,14 +11374,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2393,
+							"line": 2417,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2891,
+					"id": 2911,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11273,14 +11392,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2385,
+							"line": 2409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2888,
+					"id": 2908,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11291,14 +11410,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2373,
+							"line": 2397,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2892,
+					"id": 2912,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11309,14 +11428,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2389,
+							"line": 2413,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2889,
+					"id": 2909,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11327,7 +11446,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2377,
+							"line": 2401,
 							"character": 4
 						}
 					],
@@ -11339,25 +11458,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2890,
-						2893,
-						2891,
-						2888,
-						2892,
-						2889
+						2910,
+						2913,
+						2911,
+						2908,
+						2912,
+						2909
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2369,
+					"line": 2393,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2152,
+			"id": 2168,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11390,7 +11509,7 @@
 			},
 			"children": [
 				{
-					"id": 2176,
+					"id": 2192,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11411,14 +11530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4950,
+							"line": 4974,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2164,
+					"id": 2180,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11448,14 +11567,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4648,
+							"line": 4672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2222,
+					"id": 2238,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11481,14 +11600,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6316,
+							"line": 6340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2229,
+					"id": 2245,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11514,14 +11633,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6388,
+							"line": 6412,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2206,
+					"id": 2222,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11542,14 +11661,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5972,
+							"line": 5996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2232,
+					"id": 2248,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11575,14 +11694,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6426,
+							"line": 6450,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2226,
+					"id": 2242,
 					"name": "CloseSpotterShareConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11603,14 +11722,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6355,
+							"line": 6379,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterShareConversation\""
 				},
 				{
-					"id": 2243,
+					"id": 2259,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11631,14 +11750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6572,
+							"line": 6596,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2183,
+					"id": 2199,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11680,14 +11799,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5183,
+							"line": 5207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2180,
+					"id": 2196,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11725,14 +11844,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5058,
+							"line": 5082,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2223,
+					"id": 2239,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11753,14 +11872,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6325,
+							"line": 6349,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2187,
+					"id": 2203,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11794,14 +11913,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5336,
+							"line": 5360,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2228,
+					"id": 2244,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11822,14 +11941,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6373,
+							"line": 6397,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2234,
+					"id": 2250,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11850,14 +11969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6446,
+							"line": 6470,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2189,
+					"id": 2205,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11887,14 +12006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5398,
+							"line": 5422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2191,
+					"id": 2207,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11928,14 +12047,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5468,
+							"line": 5492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2174,
+					"id": 2190,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11973,14 +12092,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4928,
+							"line": 4952,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2190,
+					"id": 2206,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12005,14 +12124,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5429,
+							"line": 5453,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2192,
+					"id": 2208,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12046,14 +12165,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5507,
+							"line": 5531,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2175,
+					"id": 2191,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12074,14 +12193,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4940,
+							"line": 4964,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2154,
+					"id": 2170,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12119,14 +12238,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4408,
+							"line": 4432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2182,
+					"id": 2198,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12165,14 +12284,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5138,
+							"line": 5162,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2220,
+					"id": 2236,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12202,14 +12321,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6290,
+							"line": 6314,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2172,
+					"id": 2188,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12238,14 +12357,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4874,
+							"line": 4898,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2227,
+					"id": 2243,
 					"name": "ExitSpotterSharedConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12266,14 +12385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6364,
+							"line": 6388,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ExitSpotterSharedConversation\""
 				},
 				{
-					"id": 2179,
+					"id": 2195,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12303,14 +12422,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5027,
+							"line": 5051,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2171,
+					"id": 2187,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12339,14 +12458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4852,
+							"line": 4876,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2205,
+					"id": 2221,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12372,14 +12491,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5962,
+							"line": 5986,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2199,
+					"id": 2215,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12404,14 +12523,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5717,
+							"line": 5741,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2202,
+					"id": 2218,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12436,14 +12555,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5888,
+							"line": 5912,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 2157,
+					"id": 2173,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12468,14 +12587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4435,
+							"line": 4459,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2211,
+					"id": 2227,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12501,14 +12620,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6095,
+							"line": 6119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2185,
+					"id": 2201,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12545,14 +12664,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5274,
+							"line": 5298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2201,
+					"id": 2217,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12577,14 +12696,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5866,
+							"line": 5890,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2241,
+					"id": 2257,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12605,14 +12724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6552,
+							"line": 6576,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2168,
+					"id": 2184,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12637,14 +12756,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4800,
+							"line": 4824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2177,
+					"id": 2193,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12689,14 +12808,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4995,
+							"line": 5019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2181,
+					"id": 2197,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12738,14 +12857,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5093,
+							"line": 5117,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2197,
+					"id": 2213,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12779,14 +12898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5673,
+							"line": 5697,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2161,
+					"id": 2177,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12813,14 +12932,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4551,
+							"line": 4575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2162,
+					"id": 2178,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12858,14 +12977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4598,
+							"line": 4622,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2163,
+					"id": 2179,
 					"name": "OpenParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12895,14 +13014,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4630,
+							"line": 4654,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openParameter\""
 				},
 				{
-					"id": 2242,
+					"id": 2258,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12923,14 +13042,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6562,
+							"line": 6586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2167,
+					"id": 2183,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12984,14 +13103,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4784,
+							"line": 4808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2236,
+					"id": 2252,
 					"name": "PinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13013,14 +13132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6479,
+							"line": 6503,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinSpotterConversation\""
 				},
 				{
-					"id": 2184,
+					"id": 2200,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13062,14 +13181,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5228,
+							"line": 5252,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2221,
+					"id": 2237,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13094,14 +13213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6305,
+							"line": 6329,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2244,
+					"id": 2260,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13122,14 +13241,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6583,
+							"line": 6607,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2178,
+					"id": 2194,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13158,14 +13277,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5009,
+							"line": 5033,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2165,
+					"id": 2181,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13195,14 +13314,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4666,
+							"line": 4690,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2208,
+					"id": 2224,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13227,14 +13346,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5999,
+							"line": 6023,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2209,
+					"id": 2225,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13255,14 +13374,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6008,
+							"line": 6032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2198,
+					"id": 2214,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13287,14 +13406,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5691,
+							"line": 5715,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2224,
+					"id": 2240,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13315,14 +13434,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6334,
+							"line": 6358,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2194,
+					"id": 2210,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13356,14 +13475,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5584,
+							"line": 5608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2216,
+					"id": 2232,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13405,14 +13524,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6224,
+							"line": 6248,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2169,
+					"id": 2185,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13437,14 +13556,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4815,
+							"line": 4839,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2170,
+					"id": 2186,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13469,14 +13588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4830,
+							"line": 4854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2153,
+					"id": 2169,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13502,14 +13621,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4339,
+							"line": 4363,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2214,
+					"id": 2230,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13538,14 +13657,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6154,
+							"line": 6178,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2239,
+					"id": 2255,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13570,14 +13689,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6529,
+							"line": 6553,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2159,
+					"id": 2175,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13607,14 +13726,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4477,
+							"line": 4501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2204,
+					"id": 2220,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13644,14 +13763,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5932,
+							"line": 5956,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2203,
+					"id": 2219,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13681,14 +13800,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5910,
+							"line": 5934,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2158,
+					"id": 2174,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13718,14 +13837,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4457,
+							"line": 4481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2193,
+					"id": 2209,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13754,14 +13873,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5532,
+							"line": 5556,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2225,
+					"id": 2241,
 					"name": "ShareSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13782,14 +13901,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6346,
+							"line": 6370,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ShareSpotterConversation\""
 				},
 				{
-					"id": 2186,
+					"id": 2202,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13823,14 +13942,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5307,
+							"line": 5331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2188,
+					"id": 2204,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13864,14 +13983,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5370,
+							"line": 5394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2219,
+					"id": 2235,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13901,14 +14020,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6274,
+							"line": 6298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2240,
+					"id": 2256,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13934,14 +14053,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6542,
+							"line": 6566,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2235,
+					"id": 2251,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13963,14 +14082,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6460,
+							"line": 6484,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2196,
+					"id": 2212,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14004,14 +14123,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5643,
+							"line": 5667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2195,
+					"id": 2211,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14045,14 +14164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5613,
+							"line": 5637,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2218,
+					"id": 2234,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14078,14 +14197,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6249,
+							"line": 6273,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2237,
+					"id": 2253,
 					"name": "UnpinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14107,14 +14226,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6497,
+							"line": 6521,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UnpinSpotterConversation\""
 				},
 				{
-					"id": 2207,
+					"id": 2223,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14135,14 +14254,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5988,
+							"line": 6012,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2200,
+					"id": 2216,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14188,14 +14307,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5845,
+							"line": 5869,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2210,
+					"id": 2226,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14229,14 +14348,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6058,
+							"line": 6082,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2212,
+					"id": 2228,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14261,14 +14380,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6113,
+							"line": 6137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2213,
+					"id": 2229,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14285,14 +14404,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6121,
+							"line": 6145,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2160,
+					"id": 2176,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14327,14 +14446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4520,
+							"line": 4544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2173,
+					"id": 2189,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14359,14 +14478,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4889,
+							"line": 4913,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2166,
+					"id": 2182,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14387,7 +14506,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4682,
+							"line": 4706,
 							"character": 4
 						}
 					],
@@ -14399,103 +14518,103 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2176,
-						2164,
-						2222,
-						2229,
-						2206,
-						2232,
-						2226,
-						2243,
-						2183,
-						2180,
-						2223,
-						2187,
-						2228,
-						2234,
-						2189,
-						2191,
-						2174,
-						2190,
 						2192,
-						2175,
-						2154,
-						2182,
-						2220,
-						2172,
-						2227,
-						2179,
-						2171,
-						2205,
-						2199,
-						2202,
-						2157,
-						2211,
-						2185,
-						2201,
-						2241,
-						2168,
-						2177,
-						2181,
-						2197,
-						2161,
-						2162,
-						2163,
+						2180,
+						2238,
+						2245,
+						2222,
+						2248,
 						2242,
-						2167,
-						2236,
-						2184,
-						2221,
-						2244,
-						2178,
-						2165,
-						2208,
-						2209,
-						2198,
-						2224,
-						2194,
-						2216,
-						2169,
-						2170,
-						2153,
-						2214,
-						2239,
-						2159,
-						2204,
-						2203,
-						2158,
-						2193,
-						2225,
-						2186,
-						2188,
-						2219,
-						2240,
-						2235,
+						2259,
+						2199,
 						2196,
-						2195,
-						2218,
-						2237,
+						2239,
+						2203,
+						2244,
+						2250,
+						2205,
 						2207,
-						2200,
-						2210,
-						2212,
-						2213,
-						2160,
+						2190,
+						2206,
+						2208,
+						2191,
+						2170,
+						2198,
+						2236,
+						2188,
+						2243,
+						2195,
+						2187,
+						2221,
+						2215,
+						2218,
 						2173,
-						2166
+						2227,
+						2201,
+						2217,
+						2257,
+						2184,
+						2193,
+						2197,
+						2213,
+						2177,
+						2178,
+						2179,
+						2258,
+						2183,
+						2252,
+						2200,
+						2237,
+						2260,
+						2194,
+						2181,
+						2224,
+						2225,
+						2214,
+						2240,
+						2210,
+						2232,
+						2185,
+						2186,
+						2169,
+						2230,
+						2255,
+						2175,
+						2220,
+						2219,
+						2174,
+						2209,
+						2241,
+						2202,
+						2204,
+						2235,
+						2256,
+						2251,
+						2212,
+						2211,
+						2234,
+						2253,
+						2223,
+						2216,
+						2226,
+						2228,
+						2229,
+						2176,
+						2189,
+						2182
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4309,
+					"line": 4333,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3282,
+			"id": 3302,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14505,7 +14624,7 @@
 			},
 			"children": [
 				{
-					"id": 3284,
+					"id": 3304,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14516,14 +14635,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9258,
+							"line": 9344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3283,
+					"id": 3303,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14534,14 +14653,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9254,
+							"line": 9340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3285,
+					"id": 3305,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14552,7 +14671,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9262,
+							"line": 9348,
 							"character": 4
 						}
 					],
@@ -14564,22 +14683,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3284,
-						3283,
-						3285
+						3304,
+						3303,
+						3305
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9250,
+					"line": 9336,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3318,
+			"id": 3338,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14595,7 +14714,7 @@
 			},
 			"children": [
 				{
-					"id": 3320,
+					"id": 3340,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14606,14 +14725,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9528,
+							"line": 9614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3321,
+					"id": 3341,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14624,14 +14743,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9530,
+							"line": 9616,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3322,
+					"id": 3342,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14642,14 +14761,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9532,
+							"line": 9618,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3319,
+					"id": 3339,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14660,7 +14779,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9526,
+							"line": 9612,
 							"character": 4
 						}
 					],
@@ -14672,23 +14791,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3320,
-						3321,
-						3322,
-						3319
+						3340,
+						3341,
+						3342,
+						3339
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9524,
+					"line": 9610,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3217,
+			"id": 3237,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14704,7 +14823,7 @@
 			},
 			"children": [
 				{
-					"id": 3218,
+					"id": 3238,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14722,7 +14841,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3219,
+					"id": 3239,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14745,8 +14864,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3218,
-						3219
+						3238,
+						3239
 					]
 				}
 			],
@@ -14759,7 +14878,7 @@
 			]
 		},
 		{
-			"id": 3261,
+			"id": 3281,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14775,7 +14894,7 @@
 			},
 			"children": [
 				{
-					"id": 3265,
+					"id": 3285,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14786,14 +14905,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2419,
+							"line": 2443,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3266,
+					"id": 3286,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14804,14 +14923,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2423,
+							"line": 2447,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3262,
+					"id": 3282,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14822,14 +14941,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2406,
+							"line": 2430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3263,
+					"id": 3283,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14846,14 +14965,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2411,
+							"line": 2435,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3267,
+					"id": 3287,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14864,14 +14983,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2427,
+							"line": 2451,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3264,
+					"id": 3284,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14882,14 +15001,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2415,
+							"line": 2439,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3268,
+					"id": 3288,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14900,7 +15019,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2431,
+							"line": 2455,
 							"character": 4
 						}
 					],
@@ -14912,26 +15031,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3265,
-						3266,
-						3262,
-						3263,
-						3267,
-						3264,
-						3268
+						3285,
+						3286,
+						3282,
+						3283,
+						3287,
+						3284,
+						3288
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2402,
+					"line": 2426,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3180,
+			"id": 3200,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14941,7 +15060,7 @@
 			},
 			"children": [
 				{
-					"id": 3185,
+					"id": 3205,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14962,14 +15081,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8990,
+							"line": 9076,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3182,
+					"id": 3202,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14990,14 +15109,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8951,
+							"line": 9037,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3184,
+					"id": 3204,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15018,14 +15137,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8976,
+							"line": 9062,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3181,
+					"id": 3201,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15046,14 +15165,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8939,
+							"line": 9025,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3186,
+					"id": 3206,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15074,14 +15193,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9002,
+							"line": 9088,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3183,
+					"id": 3203,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15102,7 +15221,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8963,
+							"line": 9049,
 							"character": 4
 						}
 					],
@@ -15114,25 +15233,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3185,
-						3182,
-						3184,
-						3181,
-						3186,
-						3183
+						3205,
+						3202,
+						3204,
+						3201,
+						3206,
+						3203
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8926,
+					"line": 9012,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1981,
+			"id": 1997,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15142,7 +15261,7 @@
 			},
 			"children": [
 				{
-					"id": 1984,
+					"id": 2000,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15160,7 +15279,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1990,
+					"id": 2006,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15178,7 +15297,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 1987,
+					"id": 2003,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15196,7 +15315,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1982,
+					"id": 1998,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15214,7 +15333,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1985,
+					"id": 2001,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15232,7 +15351,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1989,
+					"id": 2005,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15250,7 +15369,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1983,
+					"id": 1999,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15268,7 +15387,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1988,
+					"id": 2004,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15291,14 +15410,14 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1984,
-						1990,
-						1987,
-						1982,
-						1985,
-						1989,
-						1983,
-						1988
+						2000,
+						2006,
+						2003,
+						1998,
+						2001,
+						2005,
+						1999,
+						2004
 					]
 				}
 			],
@@ -15311,14 +15430,14 @@
 			]
 		},
 		{
-			"id": 2864,
+			"id": 2884,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2865,
+					"id": 2885,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15326,14 +15445,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8755,
+							"line": 8841,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2867,
+					"id": 2887,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15341,14 +15460,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8757,
+							"line": 8843,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2866,
+					"id": 2886,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15356,14 +15475,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8756,
+							"line": 8842,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2868,
+					"id": 2888,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15371,7 +15490,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8758,
+							"line": 8844,
 							"character": 4
 						}
 					],
@@ -15383,23 +15502,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2865,
-						2867,
-						2866,
-						2868
+						2885,
+						2887,
+						2886,
+						2888
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8754,
+					"line": 8840,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3211,
+			"id": 3231,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15415,7 +15534,7 @@
 			},
 			"children": [
 				{
-					"id": 3212,
+					"id": 3232,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15438,7 +15557,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3212
+						3232
 					]
 				}
 			],
@@ -15451,7 +15570,7 @@
 			]
 		},
 		{
-			"id": 2007,
+			"id": 2023,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15461,7 +15580,7 @@
 			},
 			"children": [
 				{
-					"id": 2015,
+					"id": 2031,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15472,14 +15591,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2327,
+							"line": 2351,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2020,
+					"id": 2036,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15490,14 +15609,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2347,
+							"line": 2371,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2019,
+					"id": 2035,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15508,14 +15627,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2343,
+							"line": 2367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2017,
+					"id": 2033,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15526,14 +15645,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2335,
+							"line": 2359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2018,
+					"id": 2034,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15544,14 +15663,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2339,
+							"line": 2363,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2014,
+					"id": 2030,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15562,14 +15681,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2323,
+							"line": 2347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2016,
+					"id": 2032,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15580,14 +15699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2331,
+							"line": 2355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2008,
+					"id": 2024,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15598,14 +15717,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2299,
+							"line": 2323,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2013,
+					"id": 2029,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15616,14 +15735,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2319,
+							"line": 2343,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2012,
+					"id": 2028,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15634,14 +15753,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2315,
+							"line": 2339,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2021,
+					"id": 2037,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15652,14 +15771,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2351,
+							"line": 2375,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2011,
+					"id": 2027,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15670,14 +15789,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2311,
+							"line": 2335,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2010,
+					"id": 2026,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15688,14 +15807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2307,
+							"line": 2331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2009,
+					"id": 2025,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15706,14 +15825,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2303,
+							"line": 2327,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2022,
+					"id": 2038,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15724,7 +15843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2355,
+							"line": 2379,
 							"character": 4
 						}
 					],
@@ -15736,34 +15855,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2015,
-						2020,
-						2019,
-						2017,
-						2018,
-						2014,
-						2016,
-						2008,
-						2013,
-						2012,
-						2021,
-						2011,
-						2010,
-						2009,
-						2022
+						2031,
+						2036,
+						2035,
+						2033,
+						2034,
+						2030,
+						2032,
+						2024,
+						2029,
+						2028,
+						2037,
+						2027,
+						2026,
+						2025,
+						2038
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2295,
+					"line": 2319,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1558,
+			"id": 1560,
 			"name": "SpotterQueryMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15779,7 +15898,7 @@
 			},
 			"children": [
 				{
-					"id": 1559,
+					"id": 1561,
 					"name": "FAST_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15794,7 +15913,7 @@
 					"defaultValue": "\"fastSearch\""
 				},
 				{
-					"id": 1560,
+					"id": 1562,
 					"name": "RESEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15814,8 +15933,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1559,
-						1560
+						1561,
+						1562
 					]
 				}
 			],
@@ -15828,7 +15947,7 @@
 			]
 		},
 		{
-			"id": 3357,
+			"id": 3377,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15844,7 +15963,7 @@
 			},
 			"children": [
 				{
-					"id": 3359,
+					"id": 3379,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15855,14 +15974,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9556,
+							"line": 9642,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3358,
+					"id": 3378,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15873,7 +15992,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9554,
+							"line": 9640,
 							"character": 4
 						}
 					],
@@ -15885,21 +16004,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3359,
-						3358
+						3379,
+						3378
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9552,
+					"line": 9638,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3353,
+			"id": 3373,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15915,7 +16034,7 @@
 			},
 			"children": [
 				{
-					"id": 3354,
+					"id": 3374,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15926,14 +16045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9541,
+							"line": 9627,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3355,
+					"id": 3375,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15944,14 +16063,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9543,
+							"line": 9629,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3356,
+					"id": 3376,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15962,7 +16081,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9545,
+							"line": 9631,
 							"character": 4
 						}
 					],
@@ -15974,29 +16093,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3354,
-						3355,
-						3356
+						3374,
+						3375,
+						3376
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9539,
+					"line": 9625,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3243,
+			"id": 3263,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3252,
+					"id": 3272,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16011,7 +16130,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3248,
+					"id": 3268,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16026,7 +16145,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3253,
+					"id": 3273,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16041,7 +16160,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3247,
+					"id": 3267,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16056,7 +16175,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3246,
+					"id": 3266,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16071,7 +16190,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3260,
+					"id": 3280,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16086,7 +16205,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3254,
+					"id": 3274,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16101,7 +16220,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3259,
+					"id": 3279,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16116,7 +16235,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 3255,
+					"id": 3275,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16131,7 +16250,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3249,
+					"id": 3269,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16146,7 +16265,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3256,
+					"id": 3276,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16161,7 +16280,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3257,
+					"id": 3277,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16176,7 +16295,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3258,
+					"id": 3278,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16191,7 +16310,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3250,
+					"id": 3270,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16206,7 +16325,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3244,
+					"id": 3264,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16221,7 +16340,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3245,
+					"id": 3265,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16236,7 +16355,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3251,
+					"id": 3271,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16256,23 +16375,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3252,
-						3248,
-						3253,
-						3247,
-						3246,
-						3260,
-						3254,
-						3259,
-						3255,
-						3249,
-						3256,
-						3257,
-						3258,
-						3250,
-						3244,
-						3245,
-						3251
+						3272,
+						3268,
+						3273,
+						3267,
+						3266,
+						3280,
+						3274,
+						3279,
+						3275,
+						3269,
+						3276,
+						3277,
+						3278,
+						3270,
+						3264,
+						3265,
+						3271
 					]
 				}
 			],
@@ -16285,7 +16404,7 @@
 			]
 		},
 		{
-			"id": 1894,
+			"id": 1910,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -16314,7 +16433,7 @@
 			},
 			"children": [
 				{
-					"id": 1895,
+					"id": 1911,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16331,7 +16450,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1896,
+							"id": 1912,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -16341,7 +16460,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1897,
+									"id": 1913,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16349,12 +16468,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1971,
+										"id": 1987,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1898,
+									"id": 1914,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16366,7 +16485,7 @@
 									}
 								},
 								{
-									"id": 1899,
+									"id": 1915,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16378,7 +16497,7 @@
 									}
 								},
 								{
-									"id": 1900,
+									"id": 1916,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16392,7 +16511,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3220,
+											"id": 3240,
 											"name": "VizPoint"
 										}
 									}
@@ -16400,14 +16519,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1894,
+								"id": 1910,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1909,
+					"id": 1925,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16423,7 +16542,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1910,
+							"id": 1926,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16434,7 +16553,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1911,
+									"id": 1927,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16463,7 +16582,7 @@
 					]
 				},
 				{
-					"id": 1912,
+					"id": 1928,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16479,7 +16598,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1913,
+							"id": 1929,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16495,7 +16614,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1914,
+									"id": 1930,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16524,7 +16643,7 @@
 					]
 				},
 				{
-					"id": 1965,
+					"id": 1981,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16540,14 +16659,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1966,
+							"id": 1982,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1967,
+									"id": 1983,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16572,7 +16691,7 @@
 					]
 				},
 				{
-					"id": 1915,
+					"id": 1931,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16588,7 +16707,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1916,
+							"id": 1932,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16599,7 +16718,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1917,
+									"id": 1933,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16611,7 +16730,7 @@
 									}
 								},
 								{
-									"id": 1918,
+									"id": 1934,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16619,12 +16738,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2007,
+										"id": 2023,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1919,
+									"id": 1935,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16670,7 +16789,7 @@
 					]
 				},
 				{
-					"id": 1955,
+					"id": 1971,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16686,7 +16805,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1956,
+							"id": 1972,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16697,7 +16816,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1957,
+									"id": 1973,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16711,7 +16830,7 @@
 									}
 								},
 								{
-									"id": 1958,
+									"id": 1974,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16739,7 +16858,7 @@
 					]
 				},
 				{
-					"id": 1933,
+					"id": 1949,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16755,7 +16874,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1934,
+							"id": 1950,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16766,7 +16885,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1935,
+									"id": 1951,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16779,7 +16898,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1936,
+									"id": 1952,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16808,7 +16927,7 @@
 					]
 				},
 				{
-					"id": 1926,
+					"id": 1942,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16824,7 +16943,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1927,
+							"id": 1943,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16835,7 +16954,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1928,
+									"id": 1944,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16848,7 +16967,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1929,
+									"id": 1945,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16867,14 +16986,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1930,
+											"id": 1946,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1931,
+													"id": 1947,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16885,7 +17004,7 @@
 													}
 												},
 												{
-													"id": 1932,
+													"id": 1948,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16901,8 +17020,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1931,
-														1932
+														1947,
+														1948
 													]
 												}
 											]
@@ -16915,7 +17034,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1953,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16931,7 +17050,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1954,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16942,7 +17061,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1939,
+									"id": 1955,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16955,7 +17074,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1940,
+									"id": 1956,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16970,7 +17089,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1941,
+									"id": 1957,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16999,7 +17118,7 @@
 					]
 				},
 				{
-					"id": 1961,
+					"id": 1977,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17015,7 +17134,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1962,
+							"id": 1978,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17034,7 +17153,7 @@
 					]
 				},
 				{
-					"id": 1942,
+					"id": 1958,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17050,7 +17169,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1943,
+							"id": 1959,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17061,7 +17180,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1944,
+									"id": 1960,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17074,7 +17193,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1945,
+									"id": 1961,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17095,7 +17214,7 @@
 					]
 				},
 				{
-					"id": 1946,
+					"id": 1962,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17111,7 +17230,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1947,
+							"id": 1963,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17121,7 +17240,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1948,
+									"id": 1964,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17134,7 +17253,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1949,
+									"id": 1965,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17147,7 +17266,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1950,
+									"id": 1966,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17170,7 +17289,7 @@
 					]
 				},
 				{
-					"id": 1923,
+					"id": 1939,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17186,14 +17305,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1924,
+							"id": 1940,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1925,
+									"id": 1941,
 									"name": "fetchSQLWithAllColumns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17219,7 +17338,7 @@
 					]
 				},
 				{
-					"id": 1959,
+					"id": 1975,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17235,7 +17354,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1960,
+							"id": 1976,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17246,14 +17365,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1971,
+								"id": 1987,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1920,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17269,7 +17388,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1921,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17291,7 +17410,7 @@
 					]
 				},
 				{
-					"id": 1963,
+					"id": 1979,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17307,7 +17426,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1964,
+							"id": 1980,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17326,7 +17445,7 @@
 					]
 				},
 				{
-					"id": 1951,
+					"id": 1967,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17342,7 +17461,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1952,
+							"id": 1968,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17362,7 +17481,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1953,
+									"id": 1969,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17377,7 +17496,7 @@
 									}
 								},
 								{
-									"id": 1954,
+									"id": 1970,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17389,7 +17508,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1978,
+											"id": 1994,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -17400,7 +17519,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -17410,7 +17529,7 @@
 					]
 				},
 				{
-					"id": 1906,
+					"id": 1922,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17426,7 +17545,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1907,
+							"id": 1923,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17437,7 +17556,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1908,
+									"id": 1924,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17466,7 +17585,7 @@
 					]
 				},
 				{
-					"id": 1968,
+					"id": 1984,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17482,14 +17601,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1969,
+							"id": 1985,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1970,
+									"id": 1986,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17508,7 +17627,7 @@
 					]
 				},
 				{
-					"id": 1920,
+					"id": 1936,
 					"name": "updateDisplayMode",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17524,14 +17643,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1937,
 							"name": "updateDisplayMode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1938,
 									"name": "displayMode",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17562,32 +17681,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1895
+						1911
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1909,
-						1912,
-						1965,
-						1915,
-						1955,
-						1933,
-						1926,
-						1937,
-						1961,
+						1925,
+						1928,
+						1981,
+						1931,
+						1971,
+						1949,
 						1942,
-						1946,
-						1923,
-						1959,
-						1904,
-						1963,
-						1951,
-						1906,
-						1968,
-						1920
+						1953,
+						1977,
+						1958,
+						1962,
+						1939,
+						1975,
+						1920,
+						1979,
+						1967,
+						1922,
+						1984,
+						1936
 					]
 				}
 			],
@@ -17624,7 +17743,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1021,
+							"line": 1022,
 							"character": 4
 						}
 					],
@@ -17644,7 +17763,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2914,
 										"name": "DOMSelector"
 									}
 								},
@@ -17656,7 +17775,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2747,
+										"id": 2767,
 										"name": "AppViewConfig"
 									}
 								}
@@ -17688,7 +17807,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1539,
+							"line": 1548,
 							"character": 11
 						}
 					],
@@ -17777,7 +17896,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -17862,7 +17981,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1405,
+							"line": 1414,
 							"character": 11
 						}
 					],
@@ -18212,7 +18331,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1512,
+							"line": 1521,
 							"character": 11
 						}
 					],
@@ -18322,7 +18441,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18337,7 +18456,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -18404,7 +18523,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18416,7 +18535,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
@@ -18428,7 +18547,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18588,7 +18707,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1595,
+							"line": 1604,
 							"character": 17
 						}
 					],
@@ -18718,12 +18837,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -18836,7 +18955,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
@@ -18855,7 +18974,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -18987,7 +19106,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19094,7 +19213,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 1012,
+					"line": 1013,
 					"character": 13
 				}
 			],
@@ -19638,7 +19757,7 @@
 			]
 		},
 		{
-			"id": 1636,
+			"id": 1652,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19666,7 +19785,7 @@
 			},
 			"children": [
 				{
-					"id": 1637,
+					"id": 1653,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19674,20 +19793,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 854,
+							"line": 984,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1638,
+							"id": 1654,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1639,
+									"id": 1655,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19698,21 +19817,21 @@
 									}
 								},
 								{
-									"id": 1640,
+									"id": 1656,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1575,
+										"id": 1591,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1636,
+								"id": 1652,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
@@ -19729,7 +19848,7 @@
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1815,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19745,7 +19864,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1816,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19777,7 +19896,7 @@
 					}
 				},
 				{
-					"id": 1821,
+					"id": 1837,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19793,7 +19912,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1822,
+							"id": 1838,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19809,7 +19928,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1823,
+									"id": 1839,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19830,7 +19949,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -19850,7 +19969,7 @@
 					}
 				},
 				{
-					"id": 1784,
+					"id": 1800,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19866,7 +19985,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1785,
+							"id": 1801,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19909,7 +20028,7 @@
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1662,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19919,13 +20038,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 780,
+							"line": 910,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1647,
+							"id": 1663,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19948,7 +20067,7 @@
 					}
 				},
 				{
-					"id": 1815,
+					"id": 1831,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19964,7 +20083,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1816,
+							"id": 1832,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19986,14 +20105,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1817,
+									"id": 1833,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1819,
+											"id": 1835,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20005,7 +20124,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1820,
+											"id": 1836,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20017,7 +20136,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1818,
+											"id": 1834,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20034,9 +20153,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1819,
-												1820,
-												1818
+												1835,
+												1836,
+												1834
 											]
 										}
 									]
@@ -20056,7 +20175,7 @@
 					}
 				},
 				{
-					"id": 1793,
+					"id": 1809,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20072,7 +20191,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1794,
+							"id": 1810,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20088,7 +20207,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1795,
+									"id": 1811,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20096,20 +20215,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1796,
+											"id": 1812,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1797,
+												"id": 1813,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1798,
+														"id": 1814,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -20156,7 +20275,7 @@
 					}
 				},
 				{
-					"id": 1801,
+					"id": 1817,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20172,7 +20291,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1802,
+							"id": 1818,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20195,7 +20314,7 @@
 					}
 				},
 				{
-					"id": 1813,
+					"id": 1829,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20211,7 +20330,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1814,
+							"id": 1830,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20237,7 +20356,7 @@
 					}
 				},
 				{
-					"id": 1751,
+					"id": 1767,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20253,7 +20372,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1752,
+							"id": 1768,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20269,7 +20388,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1753,
+									"id": 1769,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20279,12 +20398,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1754,
+									"id": 1770,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20294,7 +20413,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -20317,7 +20436,7 @@
 					}
 				},
 				{
-					"id": 1745,
+					"id": 1761,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20333,7 +20452,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1746,
+							"id": 1762,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20353,7 +20472,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1747,
+									"id": 1763,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20363,12 +20482,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1748,
+									"id": 1764,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20378,12 +20497,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1749,
+									"id": 1765,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20393,13 +20512,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1750,
+									"id": 1766,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20430,7 +20549,7 @@
 					}
 				},
 				{
-					"id": 1789,
+					"id": 1805,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20446,7 +20565,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1790,
+							"id": 1806,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20456,7 +20575,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1791,
+									"id": 1807,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20471,7 +20590,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1792,
+									"id": 1808,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20507,7 +20626,7 @@
 					}
 				},
 				{
-					"id": 1803,
+					"id": 1819,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20523,7 +20642,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1804,
+							"id": 1820,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20562,7 +20681,7 @@
 					}
 				},
 				{
-					"id": 1648,
+					"id": 1664,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20572,13 +20691,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 827,
+							"line": 957,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1649,
+							"id": 1665,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20608,7 +20727,7 @@
 					}
 				},
 				{
-					"id": 1807,
+					"id": 1823,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20624,7 +20743,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1808,
+							"id": 1824,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20656,7 +20775,7 @@
 					}
 				},
 				{
-					"id": 1786,
+					"id": 1802,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20672,7 +20791,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1787,
+							"id": 1803,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20690,7 +20809,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1788,
+									"id": 1804,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20703,12 +20822,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -20733,7 +20852,7 @@
 					}
 				},
 				{
-					"id": 1811,
+					"id": 1827,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20749,7 +20868,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1812,
+							"id": 1828,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20781,7 +20900,7 @@
 					}
 				},
 				{
-					"id": 1769,
+					"id": 1785,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20797,7 +20916,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1770,
+							"id": 1786,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20818,40 +20937,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1771,
+									"id": 1787,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1772,
+									"id": 1788,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1773,
+									"id": 1789,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1774,
+									"id": 1790,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20865,7 +20984,7 @@
 									}
 								},
 								{
-									"id": 1775,
+									"id": 1791,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20890,7 +21009,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1776,
+									"id": 1792,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20944,7 +21063,7 @@
 					}
 				},
 				{
-					"id": 1777,
+					"id": 1793,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20960,7 +21079,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1794,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20971,21 +21090,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1779,
+									"id": 1795,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1780,
+									"id": 1796,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20999,7 +21118,7 @@
 									}
 								},
 								{
-									"id": 1781,
+									"id": 1797,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21054,38 +21173,38 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1637
+						1653
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1799,
-						1821,
-						1784,
-						1646,
 						1815,
-						1793,
-						1801,
-						1813,
-						1751,
-						1745,
-						1789,
-						1803,
-						1648,
-						1807,
-						1786,
-						1811,
-						1769,
-						1777
+						1837,
+						1800,
+						1662,
+						1831,
+						1809,
+						1817,
+						1829,
+						1767,
+						1761,
+						1805,
+						1819,
+						1664,
+						1823,
+						1802,
+						1827,
+						1785,
+						1793
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 853,
+					"line": 983,
 					"character": 13
 				}
 			],
@@ -21126,7 +21245,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 669,
+							"line": 671,
 							"character": 4
 						}
 					],
@@ -21146,7 +21265,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2914,
 										"name": "DOMSelector"
 									}
 								},
@@ -21158,7 +21277,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2624,
+										"id": 2644,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -21190,7 +21309,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1163,
+							"line": 1173,
 							"character": 11
 						}
 					],
@@ -21279,7 +21398,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -21401,7 +21520,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1255,
+							"line": 1265,
 							"character": 11
 						}
 					],
@@ -21715,7 +21834,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1230,
+							"line": 1240,
 							"character": 11
 						}
 					],
@@ -21828,7 +21947,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21843,7 +21962,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -21910,7 +22029,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21922,7 +22041,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
@@ -21934,7 +22053,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -22094,7 +22213,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1219,
+							"line": 1229,
 							"character": 17
 						}
 					],
@@ -22224,12 +22343,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -22308,7 +22427,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1144,
+							"line": 1154,
 							"character": 11
 						}
 					],
@@ -22332,7 +22451,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
@@ -22351,7 +22470,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -22480,7 +22599,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22587,7 +22706,7 @@
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 659,
+					"line": 661,
 					"character": 13
 				}
 			],
@@ -22658,7 +22777,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2571,
+										"id": 2591,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -22779,7 +22898,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -23214,7 +23333,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23229,7 +23348,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -23296,7 +23415,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23311,7 +23430,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
@@ -23326,7 +23445,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23629,12 +23748,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -23747,7 +23866,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
@@ -23766,7 +23885,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -23898,7 +24017,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -24059,7 +24178,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2914,
 										"name": "DOMSelector"
 									}
 								},
@@ -24071,7 +24190,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2505,
+										"id": 2525,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -24192,7 +24311,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -24659,7 +24778,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24674,7 +24793,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -24741,7 +24860,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24756,7 +24875,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
@@ -24771,7 +24890,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -25074,12 +25193,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -25192,7 +25311,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
@@ -25211,7 +25330,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -25343,7 +25462,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -25995,7 +26114,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 688,
+							"line": 817,
 							"character": 4
 						}
 					],
@@ -26147,7 +26266,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1910,
 										"name": "AnswerService"
 									}
 								],
@@ -26232,7 +26351,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 780,
+							"line": 910,
 							"character": 11
 						}
 					],
@@ -26582,7 +26701,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26597,7 +26716,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								}
@@ -26664,7 +26783,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2039,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26679,7 +26798,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2918,
 										"name": "MessageCallback"
 									}
 								},
@@ -26694,7 +26813,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2915,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -26867,7 +26986,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 827,
+							"line": 957,
 							"character": 17
 						}
 					],
@@ -26994,12 +27113,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2271,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2168,
 												"name": "HostEvent"
 											}
 										]
@@ -27112,7 +27231,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2168,
 										"name": "HostEvent"
 									}
 								},
@@ -27131,7 +27250,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2261,
 										"name": "ContextType"
 									}
 								}
@@ -27263,7 +27382,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3263,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -27368,7 +27487,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 687,
+					"line": 816,
 					"character": 13
 				}
 			],
@@ -27381,13 +27500,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1636,
+					"id": 1652,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2747,
+			"id": 2767,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27403,7 +27522,7 @@
 			},
 			"children": [
 				{
-					"id": 2804,
+					"id": 2824,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27427,27 +27546,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2805,
+							"id": 2825,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2806,
+								"id": 2826,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2807,
+										"id": 2827,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27483,7 +27602,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2858,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27511,7 +27630,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -27525,7 +27644,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2787,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27562,7 +27681,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2855,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27586,13 +27705,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2470,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -27601,7 +27720,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2876,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27625,7 +27744,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2110,
+							"line": 2134,
 							"character": 4
 						}
 					],
@@ -27639,7 +27758,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2846,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27671,7 +27790,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -27688,7 +27807,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2828,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27711,13 +27830,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27726,7 +27845,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2788,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27760,12 +27879,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3269,
+						"id": 3289,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2859,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27793,7 +27912,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -27807,7 +27926,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2802,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27841,12 +27960,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1560,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2770,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27884,7 +28003,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2838,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27908,7 +28027,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -27922,7 +28041,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2820,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27946,7 +28065,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -27960,7 +28079,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2819,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27984,7 +28103,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -27992,7 +28111,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -28002,7 +28121,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2786,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28039,7 +28158,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2832,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28070,7 +28189,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -28084,7 +28203,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2870,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28112,7 +28231,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2006,
+							"line": 2030,
 							"character": 4
 						}
 					],
@@ -28126,7 +28245,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2875,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28154,7 +28273,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2094,
+							"line": 2118,
 							"character": 4
 						}
 					],
@@ -28168,7 +28287,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2860,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28196,7 +28315,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -28210,7 +28329,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2811,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28244,7 +28363,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2842,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28268,7 +28387,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -28282,7 +28401,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2812,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28315,7 +28434,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2803,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28353,7 +28472,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2771,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28391,7 +28510,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2783,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28429,7 +28548,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2809,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28463,7 +28582,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2835,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28487,7 +28606,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -28501,7 +28620,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2856,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28525,7 +28644,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -28539,7 +28658,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2857,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28563,7 +28682,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -28577,7 +28696,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2837,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28600,7 +28719,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -28614,7 +28733,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2816,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28638,13 +28757,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28653,7 +28772,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2784,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28687,7 +28806,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2821,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28715,7 +28834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -28723,7 +28842,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -28733,7 +28852,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2865,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28757,7 +28876,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1766,
+							"line": 1790,
 							"character": 4
 						}
 					],
@@ -28765,7 +28884,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2875,
+							"id": 2895,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -28775,7 +28894,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2863,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28799,7 +28918,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1719,
+							"line": 1743,
 							"character": 4
 						}
 					],
@@ -28807,7 +28926,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2887,
+							"id": 2907,
 							"name": "HomepageModule"
 						}
 					},
@@ -28817,7 +28936,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2862,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28841,7 +28960,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1696,
+							"line": 1720,
 							"character": 4
 						}
 					],
@@ -28849,7 +28968,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3261,
+							"id": 3281,
 							"name": "ListPageColumns"
 						}
 					},
@@ -28859,7 +28978,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2775,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28897,7 +29016,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2772,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28935,7 +29054,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2769,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28973,7 +29092,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2873,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29001,7 +29120,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2061,
+							"line": 2085,
 							"character": 4
 						}
 					],
@@ -29015,7 +29134,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2866,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29043,7 +29162,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1942,
+							"line": 1966,
 							"character": 4
 						}
 					],
@@ -29057,7 +29176,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2774,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29095,7 +29214,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2773,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29133,7 +29252,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2781,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29170,7 +29289,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2776,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29208,7 +29327,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2780,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29242,7 +29361,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2789,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29268,12 +29387,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3207,
+						"id": 3227,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2829,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29297,7 +29416,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -29311,7 +29430,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2852,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29334,7 +29453,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -29348,7 +29467,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2851,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29371,7 +29490,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -29388,7 +29507,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2877,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29412,7 +29531,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2128,
+							"line": 2152,
 							"character": 4
 						}
 					],
@@ -29426,7 +29545,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2794,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29464,7 +29583,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2880,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29488,7 +29607,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2178,
+							"line": 2202,
 							"character": 4
 						}
 					],
@@ -29502,7 +29621,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2796,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29540,7 +29659,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2879,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29564,7 +29683,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2161,
+							"line": 2185,
 							"character": 4
 						}
 					],
@@ -29578,7 +29697,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2871,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29606,7 +29725,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2023,
+							"line": 2047,
 							"character": 4
 						}
 					],
@@ -29620,7 +29739,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2869,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29644,7 +29763,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2013,
 							"character": 4
 						}
 					],
@@ -29658,7 +29777,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2882,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29686,7 +29805,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2210,
+							"line": 2234,
 							"character": 4
 						}
 					],
@@ -29700,7 +29819,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2792,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29737,7 +29856,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2795,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29775,7 +29894,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2850,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29795,7 +29914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -29809,7 +29928,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2793,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29843,7 +29962,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2878,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29867,7 +29986,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2146,
+							"line": 2170,
 							"character": 4
 						}
 					],
@@ -29881,7 +30000,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2861,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29905,7 +30024,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -29919,7 +30038,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2790,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29957,7 +30076,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2797,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29994,7 +30113,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2799,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30028,7 +30147,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2841,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30052,7 +30171,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -30066,7 +30185,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2823,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30090,7 +30209,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -30104,7 +30223,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2810,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30141,7 +30260,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2785,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30182,7 +30301,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2883,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30210,7 +30329,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2226,
+							"line": 2250,
 							"character": 4
 						}
 					],
@@ -30224,7 +30343,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2791,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30262,7 +30381,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2840,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30286,7 +30405,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -30300,7 +30419,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2839,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30324,7 +30443,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -30338,7 +30457,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2778,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30368,12 +30487,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1981,
+						"id": 1997,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2777,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30407,7 +30526,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2834,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30430,7 +30549,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -30444,7 +30563,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2833,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30472,7 +30591,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -30495,7 +30614,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2831,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30523,7 +30642,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -30537,7 +30656,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2843,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30561,7 +30680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -30575,7 +30694,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2847,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30602,7 +30721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -30616,7 +30735,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2864,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30640,7 +30759,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1743,
+							"line": 1767,
 							"character": 4
 						}
 					],
@@ -30648,7 +30767,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2887,
+							"id": 2907,
 							"name": "HomepageModule"
 						}
 					},
@@ -30658,7 +30777,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2853,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30682,7 +30801,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -30690,7 +30809,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30700,7 +30819,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2854,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30724,7 +30843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -30732,7 +30851,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30742,7 +30861,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2848,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30769,7 +30888,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -30783,7 +30902,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2845,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30806,7 +30925,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -30820,7 +30939,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2868,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30848,7 +30967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1974,
+							"line": 1998,
 							"character": 4
 						}
 					],
@@ -30862,7 +30981,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2874,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30890,7 +31009,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2078,
+							"line": 2102,
 							"character": 4
 						}
 					],
@@ -30904,7 +31023,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2867,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30932,7 +31051,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1958,
+							"line": 1982,
 							"character": 4
 						}
 					],
@@ -30946,7 +31065,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2872,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30974,7 +31093,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2040,
+							"line": 2064,
 							"character": 4
 						}
 					],
@@ -30988,7 +31107,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2881,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31016,7 +31135,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2194,
+							"line": 2218,
 							"character": 4
 						}
 					],
@@ -31030,7 +31149,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2768,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31068,7 +31187,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2801,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31106,7 +31225,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2805,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31141,7 +31260,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2807,
 					"name": "spotterDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31178,7 +31297,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2806,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31208,12 +31327,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1563,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2804,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31243,12 +31362,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1543,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2808,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31278,12 +31397,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2726,
+						"id": 2746,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2779,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31317,7 +31436,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2800,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31355,7 +31474,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2814,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31393,7 +31512,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2849,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31420,7 +31539,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -31434,7 +31553,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2822,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31462,7 +31581,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -31470,7 +31589,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -31480,7 +31599,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2813,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31505,7 +31624,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3315,
+						"id": 3335,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -31515,111 +31634,111 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2804,
-						2838,
-						2767,
-						2835,
-						2856,
-						2826,
-						2808,
-						2768,
-						2839,
-						2782,
-						2750,
-						2818,
-						2800,
-						2799,
-						2766,
-						2812,
-						2850,
-						2855,
-						2840,
-						2791,
-						2822,
-						2792,
-						2783,
-						2751,
-						2763,
-						2789,
-						2815,
-						2836,
-						2837,
-						2817,
-						2796,
-						2764,
-						2801,
-						2845,
-						2843,
-						2842,
-						2755,
-						2752,
-						2749,
-						2853,
-						2846,
-						2754,
-						2753,
-						2761,
-						2756,
-						2760,
-						2769,
-						2809,
-						2832,
-						2831,
-						2857,
-						2774,
-						2860,
-						2776,
-						2859,
-						2851,
-						2849,
-						2862,
-						2772,
-						2775,
-						2830,
-						2773,
+						2824,
 						2858,
-						2841,
+						2787,
+						2855,
+						2876,
+						2846,
+						2828,
+						2788,
+						2859,
+						2802,
 						2770,
-						2777,
-						2779,
-						2821,
-						2803,
-						2790,
-						2765,
-						2863,
-						2771,
+						2838,
 						2820,
 						2819,
-						2758,
-						2757,
-						2814,
-						2813,
-						2811,
-						2823,
-						2827,
-						2844,
-						2833,
-						2834,
-						2828,
-						2825,
-						2848,
-						2854,
-						2847,
-						2852,
-						2861,
-						2748,
-						2781,
-						2785,
-						2787,
 						2786,
+						2832,
+						2870,
+						2875,
+						2860,
+						2811,
+						2842,
+						2812,
+						2803,
+						2771,
+						2783,
+						2809,
+						2835,
+						2856,
+						2857,
+						2837,
+						2816,
 						2784,
-						2788,
-						2759,
+						2821,
+						2865,
+						2863,
+						2862,
+						2775,
+						2772,
+						2769,
+						2873,
+						2866,
+						2774,
+						2773,
+						2781,
+						2776,
 						2780,
-						2794,
+						2789,
 						2829,
-						2802,
-						2793
+						2852,
+						2851,
+						2877,
+						2794,
+						2880,
+						2796,
+						2879,
+						2871,
+						2869,
+						2882,
+						2792,
+						2795,
+						2850,
+						2793,
+						2878,
+						2861,
+						2790,
+						2797,
+						2799,
+						2841,
+						2823,
+						2810,
+						2785,
+						2883,
+						2791,
+						2840,
+						2839,
+						2778,
+						2777,
+						2834,
+						2833,
+						2831,
+						2843,
+						2847,
+						2864,
+						2853,
+						2854,
+						2848,
+						2845,
+						2868,
+						2874,
+						2867,
+						2872,
+						2881,
+						2768,
+						2801,
+						2805,
+						2807,
+						2806,
+						2804,
+						2808,
+						2779,
+						2800,
+						2814,
+						2849,
+						2822,
+						2813
 					]
 				}
 			],
@@ -31638,7 +31757,7 @@
 			]
 		},
 		{
-			"id": 1841,
+			"id": 1857,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31654,14 +31773,14 @@
 			},
 			"children": [
 				{
-					"id": 1878,
+					"id": 1894,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1879,
+							"id": 1895,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31671,19 +31790,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1880,
+									"id": 1896,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1840,
+										"id": 1856,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1881,
+									"id": 1897,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31707,14 +31826,14 @@
 					]
 				},
 				{
-					"id": 1882,
+					"id": 1898,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1883,
+							"id": 1899,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31724,7 +31843,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1884,
+									"id": 1900,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31732,12 +31851,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1831,
+										"id": 1847,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1885,
+									"id": 1901,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31746,21 +31865,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1886,
+											"id": 1902,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1887,
+													"id": 1903,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1888,
+															"id": 1904,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31786,7 +31905,7 @@
 									}
 								},
 								{
-									"id": 1889,
+									"id": 1905,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31798,7 +31917,7 @@
 									}
 								},
 								{
-									"id": 1890,
+									"id": 1906,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31814,21 +31933,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1842,
+					"id": 1858,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1843,
+							"id": 1859,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31838,7 +31957,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1844,
+									"id": 1860,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31846,12 +31965,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1832,
+										"id": 1848,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1845,
+									"id": 1861,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31862,28 +31981,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1846,
+											"id": 1862,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1847,
+													"id": 1863,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1848,
+															"id": 1864,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1824,
+																"id": 1840,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31900,12 +32019,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1849,
+							"id": 1865,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31915,7 +32034,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1850,
+									"id": 1866,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31926,29 +32045,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1833,
+												"id": 1849,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1852,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1837,
+												"id": 1853,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1838,
+												"id": 1854,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1851,
+									"id": 1867,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31959,14 +32078,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1852,
+											"id": 1868,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1853,
+													"id": 1869,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -31983,31 +32102,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1854,
+							"id": 1870,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1855,
+									"id": 1871,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1835,
+										"id": 1851,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1856,
+									"id": 1872,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32015,21 +32134,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1857,
+											"id": 1873,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1858,
+													"id": 1874,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1859,
+															"id": 1875,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32052,40 +32171,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1860,
+					"id": 1876,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1861,
+							"id": 1877,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1862,
+									"id": 1878,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1832,
+										"id": 1848,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1863,
+									"id": 1879,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32093,28 +32212,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1864,
+											"id": 1880,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1865,
+													"id": 1881,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1866,
+															"id": 1882,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1824,
+																"id": 1840,
 																"name": "AuthFailureType"
 															}
 														}
@@ -32131,19 +32250,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1867,
+							"id": 1883,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1868,
+									"id": 1884,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32153,29 +32272,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1833,
+												"id": 1849,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1852,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1837,
+												"id": 1853,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1838,
+												"id": 1854,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1869,
+									"id": 1885,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32183,14 +32302,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1870,
+											"id": 1886,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1871,
+													"id": 1887,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -32207,31 +32326,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1872,
+							"id": 1888,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1873,
+									"id": 1889,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1835,
+										"id": 1851,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1874,
+									"id": 1890,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32239,21 +32358,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1875,
+											"id": 1891,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1876,
+													"id": 1892,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1877,
+															"id": 1893,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32276,21 +32395,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1891,
+					"id": 1907,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1892,
+							"id": 1908,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -32300,7 +32419,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1893,
+									"id": 1909,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32310,14 +32429,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1831,
+										"id": 1847,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1857,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -32329,11 +32448,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1878,
-						1882,
-						1842,
-						1860,
-						1891
+						1894,
+						1898,
+						1858,
+						1876,
+						1907
 					]
 				}
 			],
@@ -32390,7 +32509,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -32479,7 +32598,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -32520,13 +32639,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -32560,7 +32679,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -32599,7 +32718,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -32638,7 +32757,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -32646,7 +32765,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -32688,7 +32807,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -32727,7 +32846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -32766,7 +32885,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -32804,7 +32923,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -32843,13 +32962,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -32887,7 +33006,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -32895,7 +33014,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -32930,7 +33049,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -32968,7 +33087,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -33006,7 +33125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -33044,7 +33163,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -33083,7 +33202,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -33122,7 +33241,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -33161,7 +33280,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -33200,7 +33319,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -33238,7 +33357,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -33281,7 +33400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -33333,7 +33452,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -33375,7 +33494,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -33417,7 +33536,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -33455,7 +33574,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -33497,7 +33616,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -33540,7 +33659,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -33548,7 +33667,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -33638,7 +33757,7 @@
 			]
 		},
 		{
-			"id": 1575,
+			"id": 1591,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33658,7 +33777,7 @@
 			},
 			"children": [
 				{
-					"id": 1608,
+					"id": 1624,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33682,27 +33801,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1609,
+							"id": 1625,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1610,
+								"id": 1626,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1611,
+										"id": 1627,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33739,7 +33858,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1645,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33771,7 +33890,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -33789,7 +33908,7 @@
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1628,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33812,13 +33931,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -33828,7 +33947,7 @@
 					}
 				},
 				{
-					"id": 1582,
+					"id": 1598,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33856,7 +33975,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 394,
+							"line": 522,
 							"character": 4
 						}
 					],
@@ -33871,7 +33990,7 @@
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1593,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33895,7 +34014,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 329,
+							"line": 457,
 							"character": 4
 						}
 					],
@@ -33913,7 +34032,7 @@
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1607,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33941,13 +34060,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 665,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1560,
 						"name": "SpotterQueryMode"
 					},
 					"inheritedFrom": {
@@ -33957,7 +34076,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1638,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33981,7 +34100,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -33996,7 +34115,7 @@
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1596,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34020,7 +34139,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 364,
+							"line": 492,
 							"character": 4
 						}
 					],
@@ -34035,7 +34154,7 @@
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1620,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34059,7 +34178,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -34074,7 +34193,7 @@
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1619,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34098,7 +34217,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -34106,7 +34225,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -34117,7 +34236,7 @@
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1632,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34148,7 +34267,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -34163,7 +34282,7 @@
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1642,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34187,7 +34306,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -34202,7 +34321,7 @@
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1609,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34230,7 +34349,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 556,
+							"line": 684,
 							"character": 4
 						}
 					],
@@ -34245,7 +34364,7 @@
 					}
 				},
 				{
-					"id": 1592,
+					"id": 1608,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34269,7 +34388,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 546,
+							"line": 674,
 							"character": 4
 						}
 					],
@@ -34284,7 +34403,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1635,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34308,7 +34427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -34323,7 +34442,7 @@
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1602,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34347,7 +34466,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 458,
+							"line": 586,
 							"character": 4
 						}
 					],
@@ -34362,7 +34481,7 @@
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1604,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34386,7 +34505,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 489,
+							"line": 617,
 							"character": 4
 						}
 					],
@@ -34401,7 +34520,7 @@
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1637,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34424,7 +34543,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -34439,7 +34558,7 @@
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1616,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34463,13 +34582,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -34479,7 +34598,7 @@
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1621,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34507,7 +34626,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -34515,7 +34634,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -34526,7 +34645,7 @@
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1600,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34550,7 +34669,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 425,
+							"line": 553,
 							"character": 4
 						}
 					],
@@ -34565,7 +34684,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1597,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34589,7 +34708,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 378,
+							"line": 506,
 							"character": 4
 						}
 					],
@@ -34604,7 +34723,7 @@
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1629,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34628,7 +34747,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -34643,7 +34762,7 @@
 					}
 				},
 				{
-					"id": 1635,
+					"id": 1651,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34666,7 +34785,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -34681,7 +34800,7 @@
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1650,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34704,7 +34823,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -34722,7 +34841,7 @@
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1649,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34742,7 +34861,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -34757,7 +34876,7 @@
 					}
 				},
 				{
-					"id": 1625,
+					"id": 1641,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34781,7 +34900,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -34796,7 +34915,7 @@
 					}
 				},
 				{
-					"id": 1607,
+					"id": 1623,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34820,7 +34939,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -34835,7 +34954,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1640,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34859,7 +34978,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -34874,7 +34993,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1639,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34898,7 +35017,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -34913,7 +35032,7 @@
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1634,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34936,7 +35055,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -34951,7 +35070,7 @@
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1633,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34979,7 +35098,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -35003,7 +35122,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1631,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35031,7 +35150,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -35046,7 +35165,7 @@
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1646,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35073,7 +35192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -35088,7 +35207,7 @@
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1601,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35112,7 +35231,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 446,
+							"line": 574,
 							"character": 4
 						}
 					],
@@ -35120,7 +35239,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -35131,7 +35250,7 @@
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1603,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35155,7 +35274,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 477,
+							"line": 605,
 							"character": 4
 						}
 					],
@@ -35163,7 +35282,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -35174,7 +35293,7 @@
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1595,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35187,7 +35306,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 349,
+							"line": 477,
 							"character": 4
 						}
 					],
@@ -35202,7 +35321,7 @@
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1613,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35226,7 +35345,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 633,
+							"line": 761,
 							"character": 4
 						}
 					],
@@ -35241,7 +35360,7 @@
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1647,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35268,7 +35387,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -35283,7 +35402,7 @@
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1644,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35306,7 +35425,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -35321,7 +35440,7 @@
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1599,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35345,7 +35464,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 410,
+							"line": 538,
 							"character": 4
 						}
 					],
@@ -35360,7 +35479,7 @@
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1606,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35388,7 +35507,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 519,
+							"line": 647,
 							"character": 4
 						}
 					],
@@ -35403,7 +35522,7 @@
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1594,
 					"name": "spotterAnalystConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35427,13 +35546,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 345,
+							"line": 473,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1558,
 						"name": "SpotterAnalystConfig"
 					},
 					"inheritedFrom": {
@@ -35443,7 +35562,7 @@
 					}
 				},
 				{
-					"id": 1595,
+					"id": 1611,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35467,7 +35586,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 595,
+							"line": 723,
 							"character": 4
 						}
 					],
@@ -35483,7 +35602,7 @@
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1612,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35507,13 +35626,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 611,
+							"line": 739,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1563,
 						"name": "SpotterShareConversationConfig"
 					},
 					"inheritedFrom": {
@@ -35523,7 +35642,7 @@
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1610,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35547,13 +35666,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 577,
+							"line": 705,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1543,
 						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
@@ -35563,7 +35682,7 @@
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1605,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35591,7 +35710,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 504,
+							"line": 632,
 							"character": 4
 						}
 					],
@@ -35606,7 +35725,7 @@
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1614,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35634,7 +35753,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 648,
+							"line": 776,
 							"character": 4
 						}
 					],
@@ -35649,7 +35768,7 @@
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1648,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35676,7 +35795,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -35691,7 +35810,7 @@
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1622,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35719,7 +35838,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -35727,7 +35846,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -35738,7 +35857,7 @@
 					}
 				},
 				{
-					"id": 1576,
+					"id": 1592,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35751,7 +35870,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 312,
+							"line": 440,
 							"character": 4
 						}
 					],
@@ -35771,64 +35890,64 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1608,
-						1629,
-						1612,
-						1582,
-						1577,
-						1591,
-						1622,
-						1580,
-						1604,
-						1603,
-						1616,
-						1626,
+						1624,
+						1645,
+						1628,
+						1598,
 						1593,
-						1592,
+						1607,
+						1638,
+						1596,
+						1620,
 						1619,
-						1586,
-						1588,
+						1632,
+						1642,
+						1609,
+						1608,
+						1635,
+						1602,
+						1604,
+						1637,
+						1616,
 						1621,
 						1600,
-						1605,
-						1584,
-						1581,
-						1613,
-						1635,
+						1597,
+						1629,
+						1651,
+						1650,
+						1649,
+						1641,
+						1623,
+						1640,
+						1639,
 						1634,
 						1633,
-						1625,
-						1607,
-						1624,
-						1623,
-						1618,
-						1617,
-						1615,
-						1630,
-						1585,
-						1587,
-						1579,
-						1597,
 						1631,
-						1628,
-						1583,
-						1590,
-						1578,
+						1646,
+						1601,
+						1603,
 						1595,
-						1596,
-						1594,
-						1589,
-						1598,
-						1632,
+						1613,
+						1647,
+						1644,
+						1599,
 						1606,
-						1576
+						1594,
+						1611,
+						1612,
+						1610,
+						1605,
+						1614,
+						1648,
+						1622,
+						1592
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 658,
+					"line": 786,
 					"character": 17
 				}
 			],
@@ -35841,7 +35960,7 @@
 			]
 		},
 		{
-			"id": 3223,
+			"id": 3243,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35856,7 +35975,7 @@
 			},
 			"children": [
 				{
-					"id": 3224,
+					"id": 3244,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35866,21 +35985,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8799,
+							"line": 8885,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3225,
+							"id": 3245,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3226,
+									"id": 3246,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35888,18 +36007,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8800,
+											"line": 8886,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3220,
+										"id": 3240,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3227,
+									"id": 3247,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35907,7 +36026,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8801,
+											"line": 8887,
 											"character": 8
 										}
 									],
@@ -35915,7 +36034,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3220,
+											"id": 3240,
 											"name": "VizPoint"
 										}
 									}
@@ -35926,8 +36045,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3226,
-										3227
+										3246,
+										3247
 									]
 								}
 							]
@@ -35935,7 +36054,7 @@
 					}
 				},
 				{
-					"id": 3228,
+					"id": 3248,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35943,21 +36062,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8803,
+							"line": 8889,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3229,
+							"id": 3249,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3237,
+									"id": 3257,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35965,7 +36084,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8811,
+											"line": 8897,
 											"character": 8
 										}
 									],
@@ -35978,7 +36097,7 @@
 									}
 								},
 								{
-									"id": 3238,
+									"id": 3258,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35986,7 +36105,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8812,
+											"line": 8898,
 											"character": 8
 										}
 									],
@@ -35999,7 +36118,7 @@
 									}
 								},
 								{
-									"id": 3231,
+									"id": 3251,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36007,7 +36126,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8805,
+											"line": 8891,
 											"character": 8
 										}
 									],
@@ -36017,7 +36136,7 @@
 									}
 								},
 								{
-									"id": 3230,
+									"id": 3250,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36025,7 +36144,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8804,
+											"line": 8890,
 											"character": 8
 										}
 									],
@@ -36035,7 +36154,7 @@
 									}
 								},
 								{
-									"id": 3232,
+									"id": 3252,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36043,21 +36162,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8806,
+											"line": 8892,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3233,
+											"id": 3253,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3234,
+													"id": 3254,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -36065,21 +36184,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8807,
+															"line": 8893,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3235,
+															"id": 3255,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3236,
+																	"id": 3256,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -36087,7 +36206,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8808,
+																			"line": 8894,
 																			"character": 16
 																		}
 																	],
@@ -36102,7 +36221,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3236
+																		3256
 																	]
 																}
 															]
@@ -36115,7 +36234,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3234
+														3254
 													]
 												}
 											]
@@ -36128,23 +36247,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3237,
-										3238,
-										3231,
-										3230,
-										3232
+										3257,
+										3258,
+										3251,
+										3250,
+										3252
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3239,
+								"id": 3259,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3240,
+										"id": 3260,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36163,7 +36282,7 @@
 					}
 				},
 				{
-					"id": 3241,
+					"id": 3261,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36171,18 +36290,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8815,
+							"line": 8901,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1971,
+						"id": 1987,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3242,
+					"id": 3262,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36192,7 +36311,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8816,
+							"line": 8902,
 							"character": 4
 						}
 					],
@@ -36207,23 +36326,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3224,
-						3228,
-						3241,
-						3242
+						3244,
+						3248,
+						3261,
+						3262
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8798,
+					"line": 8884,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2933,
+			"id": 2953,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36233,7 +36352,7 @@
 			},
 			"children": [
 				{
-					"id": 2996,
+					"id": 3016,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36256,7 +36375,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3015,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36279,7 +36398,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2985,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36302,7 +36421,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2986,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36325,7 +36444,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2988,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36348,7 +36467,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2987,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36371,7 +36490,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2958,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36394,7 +36513,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3028,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36417,7 +36536,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3029,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36440,7 +36559,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3026,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36463,7 +36582,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3027,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36486,7 +36605,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2990,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36509,7 +36628,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2995,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36532,7 +36651,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2992,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36555,7 +36674,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2994,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36578,7 +36697,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2993,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36601,7 +36720,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2991,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36624,7 +36743,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 3000,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36647,7 +36766,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2997,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36670,7 +36789,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2999,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36693,7 +36812,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2998,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36716,7 +36835,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2996,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36739,7 +36858,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 3004,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,7 +36881,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 3003,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36785,7 +36904,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 3002,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36808,7 +36927,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 3001,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36831,7 +36950,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2989,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36854,7 +36973,7 @@
 					}
 				},
 				{
-					"id": 3105,
+					"id": 3125,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36877,7 +36996,7 @@
 					}
 				},
 				{
-					"id": 3100,
+					"id": 3120,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36900,7 +37019,7 @@
 					}
 				},
 				{
-					"id": 3095,
+					"id": 3115,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36923,7 +37042,7 @@
 					}
 				},
 				{
-					"id": 3094,
+					"id": 3114,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36946,7 +37065,7 @@
 					}
 				},
 				{
-					"id": 3097,
+					"id": 3117,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36969,7 +37088,7 @@
 					}
 				},
 				{
-					"id": 3096,
+					"id": 3116,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36992,7 +37111,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3051,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37015,7 +37134,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3054,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37038,7 +37157,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3049,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37061,7 +37180,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3052,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37084,7 +37203,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3053,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37107,7 +37226,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3048,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37130,7 +37249,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3050,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37153,7 +37272,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3021,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37176,7 +37295,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3020,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37199,7 +37318,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3023,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37222,7 +37341,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3022,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37245,7 +37364,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3019,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37268,7 +37387,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3017,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37291,7 +37410,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3018,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37314,7 +37433,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3024,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37337,7 +37456,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3025,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37360,7 +37479,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3036,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37383,7 +37502,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3037,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37406,7 +37525,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3040,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37429,7 +37548,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3038,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37452,7 +37571,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3039,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,7 +37594,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3047,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37498,7 +37617,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3046,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37521,7 +37640,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3045,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37544,7 +37663,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3044,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37567,7 +37686,7 @@
 					}
 				},
 				{
-					"id": 3093,
+					"id": 3113,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37590,7 +37709,7 @@
 					}
 				},
 				{
-					"id": 3092,
+					"id": 3112,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37613,7 +37732,7 @@
 					}
 				},
 				{
-					"id": 3091,
+					"id": 3111,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37636,7 +37755,7 @@
 					}
 				},
 				{
-					"id": 3099,
+					"id": 3119,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37659,7 +37778,7 @@
 					}
 				},
 				{
-					"id": 3098,
+					"id": 3118,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37682,7 +37801,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2962,
 					"name": "--ts-var-left-nav-active-tab-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37705,7 +37824,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2963,
 					"name": "--ts-var-left-nav-active-tab-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37728,7 +37847,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2961,
 					"name": "--ts-var-left-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37751,7 +37870,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2965,
 					"name": "--ts-var-left-nav-item-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37774,7 +37893,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2967,
 					"name": "--ts-var-left-nav-item-selection-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37797,7 +37916,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2966,
 					"name": "--ts-var-left-nav-item-selection-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37820,7 +37939,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2964,
 					"name": "--ts-var-left-nav-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37843,7 +37962,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2968,
 					"name": "--ts-var-left-nav-tab-icon-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37866,7 +37985,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2969,
 					"name": "--ts-var-left-nav-tab-icon-inactive-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37889,7 +38008,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3042,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37912,7 +38031,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3041,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37935,7 +38054,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3071,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37958,7 +38077,7 @@
 					}
 				},
 				{
-					"id": 3064,
+					"id": 3084,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37982,7 +38101,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3083,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38006,7 +38125,7 @@
 					}
 				},
 				{
-					"id": 3061,
+					"id": 3081,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38030,7 +38149,7 @@
 					}
 				},
 				{
-					"id": 3062,
+					"id": 3082,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38054,7 +38173,7 @@
 					}
 				},
 				{
-					"id": 3069,
+					"id": 3089,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38077,7 +38196,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3087,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38100,7 +38219,7 @@
 					}
 				},
 				{
-					"id": 3066,
+					"id": 3086,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38123,7 +38242,7 @@
 					}
 				},
 				{
-					"id": 3154,
+					"id": 3174,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38146,7 +38265,7 @@
 					}
 				},
 				{
-					"id": 3158,
+					"id": 3178,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38169,7 +38288,7 @@
 					}
 				},
 				{
-					"id": 3159,
+					"id": 3179,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38192,7 +38311,7 @@
 					}
 				},
 				{
-					"id": 3155,
+					"id": 3175,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38215,7 +38334,7 @@
 					}
 				},
 				{
-					"id": 3156,
+					"id": 3176,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38238,7 +38357,7 @@
 					}
 				},
 				{
-					"id": 3157,
+					"id": 3177,
 					"name": "--ts-var-liveboard-edit-toolbar-text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38261,7 +38380,7 @@
 					}
 				},
 				{
-					"id": 3052,
+					"id": 3072,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38285,7 +38404,7 @@
 					}
 				},
 				{
-					"id": 3053,
+					"id": 3073,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38309,7 +38428,7 @@
 					}
 				},
 				{
-					"id": 3057,
+					"id": 3077,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38333,7 +38452,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3065,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38357,7 +38476,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3080,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38381,7 +38500,7 @@
 					}
 				},
 				{
-					"id": 3059,
+					"id": 3079,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38405,7 +38524,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3070,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38429,7 +38548,7 @@
 					}
 				},
 				{
-					"id": 3058,
+					"id": 3078,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38453,7 +38572,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3068,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38477,7 +38596,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3069,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38501,7 +38620,7 @@
 					}
 				},
 				{
-					"id": 3056,
+					"id": 3076,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38525,7 +38644,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3066,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38549,7 +38668,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3067,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38573,7 +38692,7 @@
 					}
 				},
 				{
-					"id": 3084,
+					"id": 3104,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38596,7 +38715,7 @@
 					}
 				},
 				{
-					"id": 3081,
+					"id": 3101,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38619,7 +38738,7 @@
 					}
 				},
 				{
-					"id": 3082,
+					"id": 3102,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38642,7 +38761,7 @@
 					}
 				},
 				{
-					"id": 3083,
+					"id": 3103,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38665,7 +38784,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3056,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38688,7 +38807,7 @@
 					}
 				},
 				{
-					"id": 3090,
+					"id": 3110,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38711,7 +38830,7 @@
 					}
 				},
 				{
-					"id": 3085,
+					"id": 3105,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38734,7 +38853,7 @@
 					}
 				},
 				{
-					"id": 3086,
+					"id": 3106,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38757,7 +38876,7 @@
 					}
 				},
 				{
-					"id": 3089,
+					"id": 3109,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38780,7 +38899,7 @@
 					}
 				},
 				{
-					"id": 3087,
+					"id": 3107,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38803,7 +38922,7 @@
 					}
 				},
 				{
-					"id": 3088,
+					"id": 3108,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38826,7 +38945,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3057,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38849,7 +38968,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3061,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38872,7 +38991,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3060,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38895,7 +39014,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3055,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38918,7 +39037,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3075,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38941,7 +39060,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3074,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38964,7 +39083,7 @@
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3088,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38987,7 +39106,7 @@
 					}
 				},
 				{
-					"id": 3124,
+					"id": 3144,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39010,7 +39129,7 @@
 					}
 				},
 				{
-					"id": 3121,
+					"id": 3141,
 					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39033,7 +39152,7 @@
 					}
 				},
 				{
-					"id": 3123,
+					"id": 3143,
 					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39056,7 +39175,7 @@
 					}
 				},
 				{
-					"id": 3125,
+					"id": 3145,
 					"name": "--ts-var-liveboard-styling-button-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39079,7 +39198,7 @@
 					}
 				},
 				{
-					"id": 3126,
+					"id": 3146,
 					"name": "--ts-var-liveboard-styling-button-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39102,7 +39221,7 @@
 					}
 				},
 				{
-					"id": 3122,
+					"id": 3142,
 					"name": "--ts-var-liveboard-styling-button-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39125,7 +39244,7 @@
 					}
 				},
 				{
-					"id": 3127,
+					"id": 3147,
 					"name": "--ts-var-liveboard-styling-color-palette-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39148,7 +39267,7 @@
 					}
 				},
 				{
-					"id": 3120,
+					"id": 3140,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39171,7 +39290,7 @@
 					}
 				},
 				{
-					"id": 3119,
+					"id": 3139,
 					"name": "--ts-var-liveboard-styling-panel-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39194,7 +39313,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3090,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39217,7 +39336,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3091,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39240,7 +39359,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3059,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39263,7 +39382,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3058,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39286,7 +39405,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3062,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39309,7 +39428,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3063,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39332,7 +39451,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3064,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39355,7 +39474,7 @@
 					}
 				},
 				{
-					"id": 3072,
+					"id": 3092,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39378,7 +39497,7 @@
 					}
 				},
 				{
-					"id": 3073,
+					"id": 3093,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39401,7 +39520,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3034,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39424,7 +39543,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3031,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39447,7 +39566,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3030,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39470,7 +39589,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3032,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39493,7 +39612,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3035,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39516,7 +39635,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3033,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39539,7 +39658,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2959,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39562,7 +39681,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2960,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39585,7 +39704,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3098,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39608,7 +39727,7 @@
 					}
 				},
 				{
-					"id": 3079,
+					"id": 3099,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39631,7 +39750,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3094,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39654,7 +39773,7 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3096,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39677,7 +39796,7 @@
 					}
 				},
 				{
-					"id": 3077,
+					"id": 3097,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39700,7 +39819,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3095,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39723,7 +39842,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2954,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39746,7 +39865,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2955,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39769,7 +39888,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2956,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39792,7 +39911,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2957,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39815,7 +39934,7 @@
 					}
 				},
 				{
-					"id": 3108,
+					"id": 3128,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39838,7 +39957,7 @@
 					}
 				},
 				{
-					"id": 3107,
+					"id": 3127,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39861,7 +39980,7 @@
 					}
 				},
 				{
-					"id": 3112,
+					"id": 3132,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39884,7 +40003,7 @@
 					}
 				},
 				{
-					"id": 3113,
+					"id": 3133,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39907,7 +40026,7 @@
 					}
 				},
 				{
-					"id": 3116,
+					"id": 3136,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39930,7 +40049,7 @@
 					}
 				},
 				{
-					"id": 3115,
+					"id": 3135,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39953,7 +40072,7 @@
 					}
 				},
 				{
-					"id": 3114,
+					"id": 3134,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39976,7 +40095,7 @@
 					}
 				},
 				{
-					"id": 3117,
+					"id": 3137,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39999,7 +40118,7 @@
 					}
 				},
 				{
-					"id": 3110,
+					"id": 3130,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40022,7 +40141,7 @@
 					}
 				},
 				{
-					"id": 3118,
+					"id": 3138,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40045,7 +40164,7 @@
 					}
 				},
 				{
-					"id": 3109,
+					"id": 3129,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40068,7 +40187,7 @@
 					}
 				},
 				{
-					"id": 3111,
+					"id": 3131,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40091,7 +40210,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2977,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40114,7 +40233,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2981,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40137,7 +40256,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2982,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40160,7 +40279,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2980,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40183,7 +40302,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2976,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40206,7 +40325,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2979,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40229,7 +40348,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2973,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40252,7 +40371,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2974,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40275,7 +40394,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2975,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40298,7 +40417,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2970,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40321,7 +40440,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2971,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40344,7 +40463,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2972,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40367,7 +40486,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2978,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40390,7 +40509,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3043,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40413,7 +40532,7 @@
 					}
 				},
 				{
-					"id": 3170,
+					"id": 3190,
 					"name": "--ts-var-share-chat-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40436,7 +40555,7 @@
 					}
 				},
 				{
-					"id": 3169,
+					"id": 3189,
 					"name": "--ts-var-share-chat-header-container-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40459,7 +40578,7 @@
 					}
 				},
 				{
-					"id": 3173,
+					"id": 3193,
 					"name": "--ts-var-share-chat-header-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40482,7 +40601,7 @@
 					}
 				},
 				{
-					"id": 3174,
+					"id": 3194,
 					"name": "--ts-var-share-chat-header-input-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40505,7 +40624,7 @@
 					}
 				},
 				{
-					"id": 3172,
+					"id": 3192,
 					"name": "--ts-var-share-chat-header-input-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40528,7 +40647,7 @@
 					}
 				},
 				{
-					"id": 3171,
+					"id": 3191,
 					"name": "--ts-var-share-chat-header-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40551,7 +40670,7 @@
 					}
 				},
 				{
-					"id": 3166,
+					"id": 3186,
 					"name": "--ts-var-shared-conv-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40574,7 +40693,7 @@
 					}
 				},
 				{
-					"id": 3167,
+					"id": 3187,
 					"name": "--ts-var-shared-conv-header-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40597,7 +40716,7 @@
 					}
 				},
 				{
-					"id": 3168,
+					"id": 3188,
 					"name": "--ts-var-shared-conv-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40620,7 +40739,7 @@
 					}
 				},
 				{
-					"id": 3175,
+					"id": 3195,
 					"name": "--ts-var-shimmer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40643,7 +40762,7 @@
 					}
 				},
 				{
-					"id": 3176,
+					"id": 3196,
 					"name": "--ts-var-shimmer-sweep-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40666,7 +40785,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3085,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40689,7 +40808,7 @@
 					}
 				},
 				{
-					"id": 3104,
+					"id": 3124,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40712,7 +40831,7 @@
 					}
 				},
 				{
-					"id": 3101,
+					"id": 3121,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40735,7 +40854,7 @@
 					}
 				},
 				{
-					"id": 3102,
+					"id": 3122,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40758,7 +40877,7 @@
 					}
 				},
 				{
-					"id": 3103,
+					"id": 3123,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40781,7 +40900,7 @@
 					}
 				},
 				{
-					"id": 3106,
+					"id": 3126,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40804,7 +40923,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2983,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40827,7 +40946,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2984,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40850,7 +40969,7 @@
 					}
 				},
 				{
-					"id": 3161,
+					"id": 3181,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40873,7 +40992,7 @@
 					}
 				},
 				{
-					"id": 3133,
+					"id": 3153,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40896,7 +41015,7 @@
 					}
 				},
 				{
-					"id": 3162,
+					"id": 3182,
 					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40919,7 +41038,7 @@
 					}
 				},
 				{
-					"id": 3160,
+					"id": 3180,
 					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40942,7 +41061,7 @@
 					}
 				},
 				{
-					"id": 3129,
+					"id": 3149,
 					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40965,7 +41084,7 @@
 					}
 				},
 				{
-					"id": 3131,
+					"id": 3151,
 					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40988,7 +41107,7 @@
 					}
 				},
 				{
-					"id": 3132,
+					"id": 3152,
 					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41011,7 +41130,7 @@
 					}
 				},
 				{
-					"id": 3130,
+					"id": 3150,
 					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41034,7 +41153,7 @@
 					}
 				},
 				{
-					"id": 3152,
+					"id": 3172,
 					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41057,7 +41176,7 @@
 					}
 				},
 				{
-					"id": 3153,
+					"id": 3173,
 					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41080,7 +41199,7 @@
 					}
 				},
 				{
-					"id": 3138,
+					"id": 3158,
 					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41103,7 +41222,7 @@
 					}
 				},
 				{
-					"id": 3128,
+					"id": 3148,
 					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41126,7 +41245,7 @@
 					}
 				},
 				{
-					"id": 3134,
+					"id": 3154,
 					"name": "--ts-var-spotterviz-prompt-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41149,7 +41268,7 @@
 					}
 				},
 				{
-					"id": 3135,
+					"id": 3155,
 					"name": "--ts-var-spotterviz-prompt-card-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41172,7 +41291,7 @@
 					}
 				},
 				{
-					"id": 3163,
+					"id": 3183,
 					"name": "--ts-var-spotterviz-reference-icon-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41195,7 +41314,7 @@
 					}
 				},
 				{
-					"id": 3165,
+					"id": 3185,
 					"name": "--ts-var-spotterviz-reference-icon-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41218,7 +41337,7 @@
 					}
 				},
 				{
-					"id": 3164,
+					"id": 3184,
 					"name": "--ts-var-spotterviz-reference-icon-selected-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41241,7 +41360,7 @@
 					}
 				},
 				{
-					"id": 3136,
+					"id": 3156,
 					"name": "--ts-var-spotterviz-text-primary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41264,7 +41383,7 @@
 					}
 				},
 				{
-					"id": 3137,
+					"id": 3157,
 					"name": "--ts-var-spotterviz-text-secondary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41287,7 +41406,7 @@
 					}
 				},
 				{
-					"id": 3142,
+					"id": 3162,
 					"name": "--ts-var-spotterviz-thinking-completed-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41310,7 +41429,7 @@
 					}
 				},
 				{
-					"id": 3144,
+					"id": 3164,
 					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41333,7 +41452,7 @@
 					}
 				},
 				{
-					"id": 3141,
+					"id": 3161,
 					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41356,7 +41475,7 @@
 					}
 				},
 				{
-					"id": 3143,
+					"id": 3163,
 					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41379,7 +41498,7 @@
 					}
 				},
 				{
-					"id": 3147,
+					"id": 3167,
 					"name": "--ts-var-spotterviz-tool-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41402,7 +41521,7 @@
 					}
 				},
 				{
-					"id": 3145,
+					"id": 3165,
 					"name": "--ts-var-spotterviz-tool-call-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41425,7 +41544,7 @@
 					}
 				},
 				{
-					"id": 3149,
+					"id": 3169,
 					"name": "--ts-var-spotterviz-tool-feedback-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41448,7 +41567,7 @@
 					}
 				},
 				{
-					"id": 3150,
+					"id": 3170,
 					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41471,7 +41590,7 @@
 					}
 				},
 				{
-					"id": 3148,
+					"id": 3168,
 					"name": "--ts-var-spotterviz-tool-json-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41494,7 +41613,7 @@
 					}
 				},
 				{
-					"id": 3151,
+					"id": 3171,
 					"name": "--ts-var-spotterviz-tool-json-input-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41517,7 +41636,7 @@
 					}
 				},
 				{
-					"id": 3146,
+					"id": 3166,
 					"name": "--ts-var-spotterviz-tool-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41540,7 +41659,7 @@
 					}
 				},
 				{
-					"id": 3140,
+					"id": 3160,
 					"name": "--ts-var-spotterviz-usermessage-icon-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41563,7 +41682,7 @@
 					}
 				},
 				{
-					"id": 3139,
+					"id": 3159,
 					"name": "--ts-var-spotterviz-usermessage-icon-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41586,7 +41705,7 @@
 					}
 				},
 				{
-					"id": 3080,
+					"id": 3100,
 					"name": "--ts-var-unsaved-filter-indicator-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41615,7 +41734,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 3013,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41638,7 +41757,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 3011,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41661,7 +41780,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 3012,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41684,7 +41803,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 3008,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41707,7 +41826,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 3009,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41730,7 +41849,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 3010,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41753,7 +41872,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3014,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41776,7 +41895,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 3005,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41799,7 +41918,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 3006,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41822,7 +41941,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 3007,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41850,249 +41969,249 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2996,
-						2995,
-						2965,
-						2966,
-						2968,
-						2967,
-						2938,
-						3008,
-						3009,
-						3006,
-						3007,
-						2970,
-						2975,
-						2972,
-						2974,
-						2973,
-						2971,
-						2980,
-						2977,
-						2979,
-						2978,
-						2976,
-						2984,
-						2983,
-						2982,
-						2981,
-						2969,
-						3105,
-						3100,
-						3095,
-						3094,
-						3097,
-						3096,
-						3031,
-						3034,
-						3029,
-						3032,
-						3033,
+						3016,
+						3015,
+						2985,
+						2986,
+						2988,
+						2987,
+						2958,
 						3028,
-						3030,
-						3001,
+						3029,
+						3026,
+						3027,
+						2990,
+						2995,
+						2992,
+						2994,
+						2993,
+						2991,
 						3000,
+						2997,
+						2999,
+						2998,
+						2996,
+						3004,
 						3003,
 						3002,
-						2999,
-						2997,
-						2998,
-						3004,
-						3005,
-						3016,
-						3017,
-						3020,
-						3018,
-						3019,
-						3027,
-						3026,
-						3025,
-						3024,
-						3093,
-						3092,
-						3091,
-						3099,
-						3098,
-						2942,
-						2943,
-						2941,
-						2945,
-						2947,
-						2946,
-						2944,
-						2948,
-						2949,
-						3022,
-						3021,
-						3051,
-						3064,
-						3063,
-						3061,
-						3062,
-						3069,
-						3067,
-						3066,
-						3154,
-						3158,
-						3159,
-						3155,
-						3156,
-						3157,
-						3052,
-						3053,
-						3057,
-						3045,
-						3060,
-						3059,
-						3050,
-						3058,
-						3048,
-						3049,
-						3056,
-						3046,
-						3047,
-						3084,
-						3081,
-						3082,
-						3083,
-						3036,
-						3090,
-						3085,
-						3086,
-						3089,
-						3087,
-						3088,
-						3037,
-						3041,
-						3040,
-						3035,
-						3055,
-						3054,
-						3068,
-						3124,
-						3121,
-						3123,
+						3001,
+						2989,
 						3125,
-						3126,
-						3122,
-						3127,
 						3120,
-						3119,
-						3070,
-						3071,
-						3039,
-						3038,
-						3042,
-						3043,
-						3044,
-						3072,
-						3073,
-						3014,
-						3011,
-						3010,
-						3012,
-						3015,
-						3013,
-						2939,
-						2940,
-						3078,
-						3079,
-						3074,
-						3076,
-						3077,
-						3075,
-						2934,
-						2935,
-						2936,
-						2937,
-						3108,
-						3107,
-						3112,
-						3113,
-						3116,
 						3115,
 						3114,
 						3117,
-						3110,
-						3118,
-						3109,
-						3111,
-						2957,
-						2961,
-						2962,
-						2960,
-						2956,
-						2959,
-						2953,
-						2954,
-						2955,
-						2950,
-						2951,
-						2952,
-						2958,
+						3116,
+						3051,
+						3054,
+						3049,
+						3052,
+						3053,
+						3048,
+						3050,
+						3021,
+						3020,
 						3023,
-						3170,
-						3169,
-						3173,
+						3022,
+						3019,
+						3017,
+						3018,
+						3024,
+						3025,
+						3036,
+						3037,
+						3040,
+						3038,
+						3039,
+						3047,
+						3046,
+						3045,
+						3044,
+						3113,
+						3112,
+						3111,
+						3119,
+						3118,
+						2962,
+						2963,
+						2961,
+						2965,
+						2967,
+						2966,
+						2964,
+						2968,
+						2969,
+						3042,
+						3041,
+						3071,
+						3084,
+						3083,
+						3081,
+						3082,
+						3089,
+						3087,
+						3086,
 						3174,
-						3172,
-						3171,
-						3166,
-						3167,
-						3168,
+						3178,
+						3179,
 						3175,
 						3176,
+						3177,
+						3072,
+						3073,
+						3077,
 						3065,
+						3080,
+						3079,
+						3070,
+						3078,
+						3068,
+						3069,
+						3076,
+						3066,
+						3067,
 						3104,
 						3101,
 						3102,
 						3103,
+						3056,
+						3110,
+						3105,
 						3106,
-						2963,
-						2964,
-						3161,
-						3133,
-						3162,
-						3160,
-						3129,
-						3131,
-						3132,
-						3130,
-						3152,
-						3153,
-						3138,
-						3128,
-						3134,
-						3135,
-						3163,
-						3165,
-						3164,
-						3136,
-						3137,
-						3142,
+						3109,
+						3107,
+						3108,
+						3057,
+						3061,
+						3060,
+						3055,
+						3075,
+						3074,
+						3088,
 						3144,
 						3141,
 						3143,
-						3147,
 						3145,
-						3149,
-						3150,
-						3148,
-						3151,
 						3146,
+						3142,
+						3147,
 						3140,
 						3139,
-						3080,
-						2993,
-						2991,
-						2992,
-						2988,
-						2989,
-						2990,
-						2994,
-						2985,
-						2986,
-						2987
+						3090,
+						3091,
+						3059,
+						3058,
+						3062,
+						3063,
+						3064,
+						3092,
+						3093,
+						3034,
+						3031,
+						3030,
+						3032,
+						3035,
+						3033,
+						2959,
+						2960,
+						3098,
+						3099,
+						3094,
+						3096,
+						3097,
+						3095,
+						2954,
+						2955,
+						2956,
+						2957,
+						3128,
+						3127,
+						3132,
+						3133,
+						3136,
+						3135,
+						3134,
+						3137,
+						3130,
+						3138,
+						3129,
+						3131,
+						2977,
+						2981,
+						2982,
+						2980,
+						2976,
+						2979,
+						2973,
+						2974,
+						2975,
+						2970,
+						2971,
+						2972,
+						2978,
+						3043,
+						3190,
+						3189,
+						3193,
+						3194,
+						3192,
+						3191,
+						3186,
+						3187,
+						3188,
+						3195,
+						3196,
+						3085,
+						3124,
+						3121,
+						3122,
+						3123,
+						3126,
+						2983,
+						2984,
+						3181,
+						3153,
+						3182,
+						3180,
+						3149,
+						3151,
+						3152,
+						3150,
+						3172,
+						3173,
+						3158,
+						3148,
+						3154,
+						3155,
+						3183,
+						3185,
+						3184,
+						3156,
+						3157,
+						3162,
+						3164,
+						3161,
+						3163,
+						3167,
+						3165,
+						3169,
+						3170,
+						3168,
+						3171,
+						3166,
+						3160,
+						3159,
+						3100,
+						3013,
+						3011,
+						3012,
+						3008,
+						3009,
+						3010,
+						3014,
+						3005,
+						3006,
+						3007
 					]
 				}
 			],
@@ -42105,7 +42224,7 @@
 			]
 		},
 		{
-			"id": 2921,
+			"id": 2941,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42115,7 +42234,7 @@
 			},
 			"children": [
 				{
-					"id": 2923,
+					"id": 2943,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42131,12 +42250,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2924,
+						"id": 2944,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2942,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42161,8 +42280,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2923,
-						2922
+						2943,
+						2942
 					]
 				}
 			],
@@ -42175,7 +42294,7 @@
 			]
 		},
 		{
-			"id": 2911,
+			"id": 2931,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42191,7 +42310,7 @@
 			},
 			"children": [
 				{
-					"id": 2913,
+					"id": 2933,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42208,14 +42327,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2914,
+							"id": 2934,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2916,
+									"id": 2936,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42245,7 +42364,7 @@
 									}
 								},
 								{
-									"id": 2917,
+									"id": 2937,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42265,7 +42384,7 @@
 									}
 								},
 								{
-									"id": 2915,
+									"id": 2935,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42308,21 +42427,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2916,
-										2917,
-										2915
+										2936,
+										2937,
+										2935
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2918,
+								"id": 2938,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2919,
+										"id": 2939,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42341,7 +42460,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2940,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42361,7 +42480,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2932,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42377,7 +42496,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2921,
+						"id": 2941,
 						"name": "CustomStyles"
 					}
 				}
@@ -42387,9 +42506,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2913,
-						2920,
-						2912
+						2933,
+						2940,
+						2932
 					]
 				}
 			],
@@ -42402,7 +42521,7 @@
 			]
 		},
 		{
-			"id": 2454,
+			"id": 2474,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42418,7 +42537,7 @@
 			},
 			"children": [
 				{
-					"id": 2495,
+					"id": 2515,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42448,20 +42567,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2496,
+							"id": 2516,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2497,
+								"id": 2517,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2498,
+										"id": 2518,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42493,7 +42612,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2477,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42516,7 +42635,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2497,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42558,7 +42677,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2499,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42587,7 +42706,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2476,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42604,12 +42723,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1991,
+						"id": 2007,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2489,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42638,7 +42757,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2500,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42671,7 +42790,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2492,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42700,7 +42819,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2524,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42733,7 +42852,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2512,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42762,7 +42881,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2522,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42806,7 +42925,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2519,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42849,7 +42968,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2496,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42874,12 +42993,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2510,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42908,7 +43027,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2494,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42938,7 +43057,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2521,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42975,7 +43094,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2514,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43004,7 +43123,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2490,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43037,7 +43156,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2520,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43057,7 +43176,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2488,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43086,7 +43205,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2483,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43120,7 +43239,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2508,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43153,12 +43272,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3180,
+						"id": 3200,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2491,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43187,7 +43306,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2482,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43220,7 +43339,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2511,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43249,7 +43368,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2481,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43273,7 +43392,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2506,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43302,7 +43421,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2493,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43335,7 +43454,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2484,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43365,7 +43484,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2486,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43394,7 +43513,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2507,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43423,7 +43542,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2487,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43452,7 +43571,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2495,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43481,7 +43600,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2475,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43502,7 +43621,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2498,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43525,7 +43644,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2480,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43548,7 +43667,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2523,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43581,7 +43700,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2478,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -43597,7 +43716,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2459,
+							"id": 2479,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -43625,50 +43744,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2495,
-						2457,
+						2515,
 						2477,
-						2479,
-						2456,
-						2469,
-						2480,
-						2472,
-						2504,
-						2492,
-						2502,
+						2497,
 						2499,
 						2476,
-						2490,
-						2474,
-						2501,
-						2494,
-						2470,
+						2489,
 						2500,
-						2468,
-						2463,
+						2492,
+						2524,
+						2512,
+						2522,
+						2519,
+						2496,
+						2510,
+						2494,
+						2521,
+						2514,
+						2490,
+						2520,
 						2488,
-						2471,
-						2462,
+						2483,
+						2508,
 						2491,
-						2461,
+						2482,
+						2511,
+						2481,
+						2506,
+						2493,
+						2484,
 						2486,
-						2473,
-						2464,
-						2466,
+						2507,
 						2487,
-						2467,
+						2495,
 						2475,
-						2455,
-						2478,
-						2460,
-						2503
+						2498,
+						2480,
+						2523
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2458
+						2478
 					]
 				}
 			],
@@ -43681,7 +43800,7 @@
 			]
 		},
 		{
-			"id": 3304,
+			"id": 3324,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43710,7 +43829,7 @@
 			},
 			"children": [
 				{
-					"id": 3307,
+					"id": 3327,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43721,18 +43840,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9183,
+							"line": 9269,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3286,
+						"id": 3306,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3305,
+					"id": 3325,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43743,18 +43862,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9179,
+							"line": 9265,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3310,
+						"id": 3330,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3306,
+					"id": 3326,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43765,7 +43884,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9181,
+							"line": 9267,
 							"character": 4
 						}
 					],
@@ -43792,21 +43911,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3307,
-						3305,
-						3306
+						3327,
+						3325,
+						3326
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9177,
+					"line": 9263,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3308,
+				"id": 3328,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43816,7 +43935,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3309,
+						"id": 3329,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43833,7 +43952,7 @@
 			}
 		},
 		{
-			"id": 2869,
+			"id": 2889,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43849,7 +43968,7 @@
 			},
 			"children": [
 				{
-					"id": 2871,
+					"id": 2891,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43881,7 +44000,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2892,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43917,7 +44036,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2890,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43954,9 +44073,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2871,
-						2872,
-						2870
+						2891,
+						2892,
+						2890
 					]
 				}
 			],
@@ -43968,7 +44087,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2873,
+				"id": 2893,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43978,7 +44097,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2874,
+						"id": 2894,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -44012,7 +44131,7 @@
 			}
 		},
 		{
-			"id": 2624,
+			"id": 2644,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44028,7 +44147,7 @@
 			},
 			"children": [
 				{
-					"id": 2636,
+					"id": 2656,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44052,7 +44171,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 227,
+							"line": 229,
 							"character": 4
 						}
 					],
@@ -44062,7 +44181,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2690,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44086,27 +44205,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2671,
+							"id": 2691,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2672,
+								"id": 2692,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2673,
+										"id": 2693,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -44142,7 +44261,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2724,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44170,7 +44289,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -44184,7 +44303,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2721,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44208,13 +44327,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2470,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -44223,7 +44342,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2738,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44247,7 +44366,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2110,
+							"line": 2134,
 							"character": 4
 						}
 					],
@@ -44261,7 +44380,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2712,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44293,7 +44412,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -44310,7 +44429,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2694,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44333,13 +44452,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44348,7 +44467,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2725,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44376,7 +44495,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -44390,7 +44509,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2646,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44422,7 +44541,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 94,
+							"line": 96,
 							"character": 4
 						}
 					],
@@ -44432,7 +44551,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2704,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44456,7 +44575,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -44470,7 +44589,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2686,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44494,7 +44613,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -44508,7 +44627,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2685,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44532,7 +44651,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -44540,7 +44659,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -44550,7 +44669,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2698,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44581,7 +44700,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -44595,7 +44714,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2732,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44623,7 +44742,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2006,
+							"line": 2030,
 							"character": 4
 						}
 					],
@@ -44637,7 +44756,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2737,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44665,7 +44784,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2094,
+							"line": 2118,
 							"character": 4
 						}
 					],
@@ -44679,7 +44798,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2726,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44707,7 +44826,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -44721,7 +44840,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2708,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44745,7 +44864,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -44759,7 +44878,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2679,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44782,7 +44901,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 626,
+							"line": 628,
 							"character": 4
 						}
 					],
@@ -44792,7 +44911,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2671,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44812,7 +44931,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 482,
+							"line": 484,
 							"character": 4
 						}
 					],
@@ -44822,7 +44941,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2676,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44846,7 +44965,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 560,
+							"line": 562,
 							"character": 4
 						}
 					],
@@ -44856,7 +44975,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2701,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44880,7 +44999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -44894,7 +45013,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2648,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44921,7 +45040,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 124,
+							"line": 126,
 							"character": 4
 						}
 					],
@@ -44931,7 +45050,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2722,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44955,7 +45074,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -44969,7 +45088,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2723,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44993,7 +45112,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -45007,7 +45126,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2703,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45030,7 +45149,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -45044,7 +45163,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2682,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45068,13 +45187,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45083,7 +45202,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2645,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45107,7 +45226,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 75,
+							"line": 77,
 							"character": 4
 						}
 					],
@@ -45117,7 +45236,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2687,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45145,7 +45264,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -45153,7 +45272,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -45163,7 +45282,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2663,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45187,7 +45306,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 347,
+							"line": 349,
 							"character": 4
 						}
 					],
@@ -45200,7 +45319,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2735,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45228,7 +45347,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2061,
+							"line": 2085,
 							"character": 4
 						}
 					],
@@ -45242,7 +45361,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2728,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45270,7 +45389,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1942,
+							"line": 1966,
 							"character": 4
 						}
 					],
@@ -45284,7 +45403,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2658,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45308,7 +45427,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 258,
+							"line": 260,
 							"character": 4
 						}
 					],
@@ -45318,7 +45437,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2695,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45342,7 +45461,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -45356,7 +45475,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2718,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45379,7 +45498,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -45393,7 +45512,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2717,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45416,7 +45535,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -45433,7 +45552,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2739,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45457,7 +45576,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2128,
+							"line": 2152,
 							"character": 4
 						}
 					],
@@ -45471,7 +45590,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2667,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45499,7 +45618,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 420,
+							"line": 422,
 							"character": 4
 						}
 					],
@@ -45509,7 +45628,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2742,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45533,7 +45652,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2178,
+							"line": 2202,
 							"character": 4
 						}
 					],
@@ -45547,7 +45666,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2669,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45575,7 +45694,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 456,
+							"line": 458,
 							"character": 4
 						}
 					],
@@ -45585,7 +45704,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2741,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45609,7 +45728,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2161,
+							"line": 2185,
 							"character": 4
 						}
 					],
@@ -45623,7 +45742,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2733,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45651,7 +45770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2023,
+							"line": 2047,
 							"character": 4
 						}
 					],
@@ -45665,7 +45784,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2731,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45689,7 +45808,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2013,
 							"character": 4
 						}
 					],
@@ -45703,7 +45822,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2744,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45731,7 +45850,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2210,
+							"line": 2234,
 							"character": 4
 						}
 					],
@@ -45745,7 +45864,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2665,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45772,7 +45891,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 384,
+							"line": 386,
 							"character": 4
 						}
 					],
@@ -45782,7 +45901,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2668,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45810,7 +45929,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 438,
+							"line": 440,
 							"character": 4
 						}
 					],
@@ -45820,7 +45939,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2716,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45840,7 +45959,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -45854,7 +45973,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2666,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45878,7 +45997,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 401,
+							"line": 403,
 							"character": 4
 						}
 					],
@@ -45888,7 +46007,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2740,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45912,7 +46031,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2146,
+							"line": 2170,
 							"character": 4
 						}
 					],
@@ -45926,7 +46045,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2727,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45950,7 +46069,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -45964,7 +46083,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2670,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45991,7 +46110,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 472,
+							"line": 474,
 							"character": 4
 						}
 					],
@@ -46001,7 +46120,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2672,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46025,7 +46144,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 505,
+							"line": 507,
 							"character": 4
 						}
 					],
@@ -46035,7 +46154,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2707,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46059,7 +46178,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -46073,7 +46192,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2649,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46097,7 +46216,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 139,
+							"line": 141,
 							"character": 4
 						}
 					],
@@ -46107,7 +46226,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2655,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46131,7 +46250,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 212,
+							"line": 214,
 							"character": 4
 						}
 					],
@@ -46141,7 +46260,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2689,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46165,7 +46284,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -46179,7 +46298,7 @@
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2647,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46206,7 +46325,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 111,
+							"line": 113,
 							"character": 4
 						}
 					],
@@ -46216,7 +46335,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2745,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46244,7 +46363,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2226,
+							"line": 2250,
 							"character": 4
 						}
 					],
@@ -46258,7 +46377,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2706,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46282,7 +46401,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -46296,7 +46415,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2705,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46320,7 +46439,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -46334,7 +46453,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2657,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46358,7 +46477,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 244,
+							"line": 246,
 							"character": 4
 						}
 					],
@@ -46368,7 +46487,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2700,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46391,7 +46510,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -46405,7 +46524,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2699,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46433,7 +46552,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -46456,7 +46575,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2697,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46484,7 +46603,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -46498,7 +46617,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2652,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46522,7 +46641,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 173,
+							"line": 175,
 							"character": 4
 						}
 					],
@@ -46532,7 +46651,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2709,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46556,7 +46675,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -46570,7 +46689,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2713,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46597,7 +46716,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -46611,7 +46730,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2719,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46635,7 +46754,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -46643,7 +46762,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46653,7 +46772,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2720,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46677,7 +46796,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -46685,7 +46804,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46695,7 +46814,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2714,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46722,7 +46841,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -46736,7 +46855,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2711,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46759,7 +46878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -46773,7 +46892,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2730,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46801,7 +46920,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1974,
+							"line": 1998,
 							"character": 4
 						}
 					],
@@ -46815,7 +46934,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2736,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46843,7 +46962,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2078,
+							"line": 2102,
 							"character": 4
 						}
 					],
@@ -46857,7 +46976,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2729,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46885,7 +47004,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1958,
+							"line": 1982,
 							"character": 4
 						}
 					],
@@ -46899,7 +47018,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2734,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46927,7 +47046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2040,
+							"line": 2064,
 							"character": 4
 						}
 					],
@@ -46941,7 +47060,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2743,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46969,7 +47088,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2194,
+							"line": 2218,
 							"character": 4
 						}
 					],
@@ -46983,7 +47102,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2659,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47007,7 +47126,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 281,
+							"line": 283,
 							"character": 4
 						}
 					],
@@ -47017,7 +47136,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2673,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47040,7 +47159,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 521,
+							"line": 523,
 							"character": 4
 						}
 					],
@@ -47050,7 +47169,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2675,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47078,7 +47197,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 551,
+							"line": 553,
 							"character": 4
 						}
 					],
@@ -47088,7 +47207,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2677,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47112,7 +47231,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 578,
+							"line": 580,
 							"character": 4
 						}
 					],
@@ -47123,7 +47242,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2678,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47147,18 +47266,18 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 613,
+							"line": 615,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2726,
+						"id": 2746,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2674,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47186,7 +47305,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 536,
+							"line": 538,
 							"character": 4
 						}
 					],
@@ -47196,7 +47315,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2680,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47224,7 +47343,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 641,
+							"line": 643,
 							"character": 4
 						}
 					],
@@ -47234,7 +47353,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2715,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47261,7 +47380,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -47275,7 +47394,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2688,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47303,7 +47422,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -47311,7 +47430,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -47321,7 +47440,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2664,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47345,7 +47464,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 367,
+							"line": 369,
 							"character": 4
 						}
 					],
@@ -47358,7 +47477,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2653,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47382,7 +47501,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 192,
+							"line": 194,
 							"character": 4
 						}
 					],
@@ -47395,7 +47514,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2651,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47419,7 +47538,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 158,
+							"line": 160,
 							"character": 4
 						}
 					],
@@ -47434,100 +47553,100 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2636,
-						2670,
-						2704,
-						2701,
-						2718,
-						2692,
-						2674,
-						2705,
-						2626,
-						2684,
-						2666,
-						2665,
-						2678,
-						2712,
-						2717,
-						2706,
-						2688,
-						2659,
-						2651,
 						2656,
-						2681,
-						2628,
-						2702,
-						2703,
-						2683,
-						2662,
-						2625,
-						2667,
-						2643,
-						2715,
-						2708,
-						2638,
-						2675,
-						2698,
-						2697,
-						2719,
-						2647,
-						2722,
-						2649,
-						2721,
-						2713,
-						2711,
+						2690,
 						2724,
-						2645,
-						2648,
-						2696,
-						2646,
-						2720,
-						2707,
-						2650,
-						2652,
-						2687,
-						2629,
-						2635,
-						2669,
-						2627,
+						2721,
+						2738,
+						2712,
+						2694,
 						2725,
+						2646,
+						2704,
 						2686,
 						2685,
-						2637,
-						2680,
+						2698,
+						2732,
+						2737,
+						2726,
+						2708,
 						2679,
-						2677,
-						2632,
-						2689,
-						2693,
-						2699,
-						2700,
-						2694,
-						2691,
-						2710,
-						2716,
-						2709,
-						2714,
+						2671,
+						2676,
+						2701,
+						2648,
+						2722,
 						2723,
-						2639,
-						2653,
-						2655,
-						2657,
+						2703,
+						2682,
+						2645,
+						2687,
+						2663,
+						2735,
+						2728,
 						2658,
-						2654,
-						2660,
 						2695,
+						2718,
+						2717,
+						2739,
+						2667,
+						2742,
+						2669,
+						2741,
+						2733,
+						2731,
+						2744,
+						2665,
 						2668,
-						2644,
-						2633,
-						2631
+						2716,
+						2666,
+						2740,
+						2727,
+						2670,
+						2672,
+						2707,
+						2649,
+						2655,
+						2689,
+						2647,
+						2745,
+						2706,
+						2705,
+						2657,
+						2700,
+						2699,
+						2697,
+						2652,
+						2709,
+						2713,
+						2719,
+						2720,
+						2714,
+						2711,
+						2730,
+						2736,
+						2729,
+						2734,
+						2743,
+						2659,
+						2673,
+						2675,
+						2677,
+						2678,
+						2674,
+						2680,
+						2715,
+						2688,
+						2664,
+						2653,
+						2651
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 52,
+					"line": 54,
 					"character": 17
 				}
 			],
@@ -47547,7 +47666,7 @@
 			]
 		},
 		{
-			"id": 2003,
+			"id": 2019,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47557,7 +47676,7 @@
 			},
 			"children": [
 				{
-					"id": 2004,
+					"id": 2020,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47568,7 +47687,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2442,
+							"line": 2466,
 							"character": 4
 						}
 					],
@@ -47578,7 +47697,7 @@
 					}
 				},
 				{
-					"id": 2005,
+					"id": 2021,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47589,18 +47708,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2446,
+							"line": 2470,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2007,
+						"id": 2023,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2006,
+					"id": 2022,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47611,7 +47730,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2452,
+							"line": 2476,
 							"character": 4
 						}
 					],
@@ -47646,22 +47765,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2004,
-						2005,
-						2006
+						2020,
+						2021,
+						2022
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2438,
+					"line": 2462,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3177,
+			"id": 3197,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47671,7 +47790,7 @@
 			},
 			"children": [
 				{
-					"id": 3178,
+					"id": 3198,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47682,7 +47801,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2462,
+							"line": 2486,
 							"character": 4
 						}
 					],
@@ -47692,7 +47811,7 @@
 					}
 				},
 				{
-					"id": 3179,
+					"id": 3199,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47703,7 +47822,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2466,
+							"line": 2490,
 							"character": 4
 						}
 					],
@@ -47731,21 +47850,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3178,
-						3179
+						3198,
+						3199
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2458,
+					"line": 2482,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2571,
+			"id": 2591,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47760,7 +47879,7 @@
 			},
 			"children": [
 				{
-					"id": 2586,
+					"id": 2606,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47784,27 +47903,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2587,
+							"id": 2607,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2588,
+								"id": 2608,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2589,
+										"id": 2609,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47840,7 +47959,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2640,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47868,7 +47987,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -47882,7 +48001,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2637,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47906,13 +48025,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2470,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47921,7 +48040,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2628,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47953,7 +48072,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -47970,7 +48089,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2610,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47993,13 +48112,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -48008,7 +48127,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2641,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48036,7 +48155,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -48050,7 +48169,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2593,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48084,7 +48203,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2592,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48125,7 +48244,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2620,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48149,7 +48268,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -48163,7 +48282,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2602,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48187,7 +48306,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -48201,7 +48320,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2601,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48225,7 +48344,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -48233,7 +48352,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -48243,7 +48362,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2614,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48274,7 +48393,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -48288,7 +48407,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2642,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48316,7 +48435,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -48330,7 +48449,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2624,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48354,7 +48473,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -48368,7 +48487,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2617,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48392,7 +48511,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -48406,7 +48525,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2638,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48430,7 +48549,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -48444,7 +48563,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2639,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48468,7 +48587,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -48482,7 +48601,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2596,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48516,7 +48635,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2619,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48539,7 +48658,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -48553,7 +48672,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2598,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48577,13 +48696,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48592,7 +48711,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2603,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48620,7 +48739,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -48628,7 +48747,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -48638,7 +48757,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2611,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48662,7 +48781,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -48676,7 +48795,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2634,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48699,7 +48818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -48713,7 +48832,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2633,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48736,7 +48855,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -48753,7 +48872,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2632,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48773,7 +48892,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -48787,7 +48906,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2643,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48811,7 +48930,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -48825,7 +48944,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2623,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48849,7 +48968,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -48863,7 +48982,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2605,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48887,7 +49006,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -48901,7 +49020,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2622,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48925,7 +49044,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -48939,7 +49058,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2621,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48963,7 +49082,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -48977,7 +49096,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2616,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49000,7 +49119,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -49014,7 +49133,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2615,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49042,7 +49161,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -49065,7 +49184,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2613,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49093,7 +49212,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -49107,7 +49226,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2625,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49131,7 +49250,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -49145,7 +49264,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2629,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49172,7 +49291,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -49186,7 +49305,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2635,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49210,7 +49329,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -49218,7 +49337,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -49228,7 +49347,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2636,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49252,7 +49371,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -49260,7 +49379,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -49270,7 +49389,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2595,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49304,7 +49423,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2630,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49331,7 +49450,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -49345,7 +49464,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2627,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49368,7 +49487,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -49382,7 +49501,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2631,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49409,7 +49528,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -49423,7 +49542,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2594,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49457,7 +49576,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2604,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49485,7 +49604,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -49493,7 +49612,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -49508,49 +49627,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2586,
+						2606,
+						2640,
+						2637,
+						2628,
+						2610,
+						2641,
+						2593,
+						2592,
 						2620,
-						2617,
-						2608,
-						2590,
-						2621,
-						2573,
-						2572,
-						2600,
-						2582,
-						2581,
-						2594,
-						2622,
-						2604,
-						2597,
-						2618,
-						2619,
-						2576,
-						2599,
-						2578,
-						2583,
-						2591,
-						2614,
-						2613,
-						2612,
-						2623,
-						2603,
-						2585,
 						2602,
 						2601,
+						2614,
+						2642,
+						2624,
+						2617,
+						2638,
+						2639,
 						2596,
-						2595,
-						2593,
-						2605,
-						2609,
-						2615,
-						2616,
-						2575,
-						2610,
-						2607,
+						2619,
+						2598,
+						2603,
 						2611,
-						2574,
-						2584
+						2634,
+						2633,
+						2632,
+						2643,
+						2623,
+						2605,
+						2622,
+						2621,
+						2616,
+						2615,
+						2613,
+						2625,
+						2629,
+						2635,
+						2636,
+						2595,
+						2630,
+						2627,
+						2631,
+						2594,
+						2604
 					]
 				}
 			],
@@ -49573,7 +49692,7 @@
 			]
 		},
 		{
-			"id": 2505,
+			"id": 2525,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49589,7 +49708,7 @@
 			},
 			"children": [
 				{
-					"id": 2543,
+					"id": 2563,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49613,27 +49732,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2544,
+							"id": 2564,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2545,
+								"id": 2565,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2546,
+										"id": 2566,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -49669,7 +49788,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2537,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49703,7 +49822,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2527,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49737,7 +49856,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2526,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49771,7 +49890,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2550,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49799,7 +49918,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -49813,7 +49932,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2540,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49850,7 +49969,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2547,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49874,13 +49993,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2470,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -49889,7 +50008,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2584,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49921,7 +50040,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -49938,7 +50057,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2567,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49961,13 +50080,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49976,7 +50095,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2541,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50014,7 +50133,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2551,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50042,7 +50161,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -50056,7 +50175,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2533,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50090,7 +50209,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2532,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50126,7 +50245,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2577,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50150,7 +50269,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -50164,7 +50283,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2559,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50188,7 +50307,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -50202,7 +50321,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2558,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50226,7 +50345,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -50234,7 +50353,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -50244,7 +50363,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2571,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50275,7 +50394,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -50289,7 +50408,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2552,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50317,7 +50436,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -50331,7 +50450,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2581,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50355,7 +50474,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -50369,7 +50488,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2530,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50403,7 +50522,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2574,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50427,7 +50546,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -50441,7 +50560,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2548,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50465,7 +50584,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -50479,7 +50598,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2549,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50503,7 +50622,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -50517,7 +50636,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2536,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50551,7 +50670,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2576,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50574,7 +50693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -50588,7 +50707,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2542,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50626,7 +50745,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2531,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50660,7 +50779,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2555,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50684,13 +50803,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50699,7 +50818,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2560,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50727,7 +50846,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -50735,7 +50854,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -50745,7 +50864,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2528,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50779,7 +50898,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2529,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50813,7 +50932,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2538,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50847,7 +50966,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2568,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50871,7 +50990,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -50885,7 +51004,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2590,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50908,7 +51027,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -50922,7 +51041,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2589,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50945,7 +51064,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -50962,7 +51081,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2588,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50982,7 +51101,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -50996,7 +51115,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2553,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51020,7 +51139,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -51034,7 +51153,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2580,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51058,7 +51177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -51072,7 +51191,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2562,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51096,7 +51215,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -51110,7 +51229,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2543,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51148,7 +51267,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2579,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51172,7 +51291,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -51186,7 +51305,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2578,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51210,7 +51329,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -51224,7 +51343,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2573,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51247,7 +51366,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -51261,7 +51380,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2572,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51289,7 +51408,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -51312,7 +51431,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2570,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51340,7 +51459,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -51354,7 +51473,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2585,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51381,7 +51500,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -51395,7 +51514,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2545,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51419,7 +51538,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -51427,7 +51546,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -51437,7 +51556,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2546,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51461,7 +51580,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -51469,7 +51588,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -51479,7 +51598,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2535,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51509,7 +51628,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2534,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51538,7 +51657,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2586,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51565,7 +51684,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -51579,7 +51698,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2583,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51602,7 +51721,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -51616,7 +51735,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2587,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51643,7 +51762,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -51657,7 +51776,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2539,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51687,7 +51806,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2561,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51715,7 +51834,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -51723,7 +51842,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -51733,7 +51852,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2544,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51758,7 +51877,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3315,
+						"id": 3335,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -51768,62 +51887,62 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2543,
-						2517,
-						2507,
-						2506,
-						2530,
-						2520,
+						2563,
+						2537,
 						2527,
-						2564,
-						2547,
-						2521,
-						2531,
-						2513,
-						2512,
-						2557,
-						2539,
-						2538,
-						2551,
-						2532,
-						2561,
-						2510,
-						2554,
-						2528,
-						2529,
-						2516,
-						2556,
-						2522,
-						2511,
-						2535,
+						2526,
+						2550,
 						2540,
-						2508,
-						2509,
-						2518,
-						2548,
-						2570,
-						2569,
-						2568,
+						2547,
+						2584,
+						2567,
+						2541,
+						2551,
 						2533,
-						2560,
-						2542,
-						2523,
+						2532,
+						2577,
 						2559,
 						2558,
-						2553,
+						2571,
 						2552,
-						2550,
-						2565,
-						2525,
-						2526,
-						2515,
-						2514,
-						2566,
-						2563,
-						2567,
-						2519,
-						2541,
-						2524
+						2581,
+						2530,
+						2574,
+						2548,
+						2549,
+						2536,
+						2576,
+						2542,
+						2531,
+						2555,
+						2560,
+						2528,
+						2529,
+						2538,
+						2568,
+						2590,
+						2589,
+						2588,
+						2553,
+						2580,
+						2562,
+						2543,
+						2579,
+						2578,
+						2573,
+						2572,
+						2570,
+						2585,
+						2545,
+						2546,
+						2535,
+						2534,
+						2586,
+						2583,
+						2587,
+						2539,
+						2561,
+						2544
 					]
 				}
 			],
@@ -51856,14 +51975,14 @@
 			]
 		},
 		{
-			"id": 1971,
+			"id": 1987,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1974,
+					"id": 1990,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51878,14 +51997,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1975,
+							"id": 1991,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1977,
+									"id": 1993,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51903,7 +52022,7 @@
 									}
 								},
 								{
-									"id": 1976,
+									"id": 1992,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51926,8 +52045,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1977,
-										1976
+										1993,
+										1992
 									]
 								}
 							]
@@ -51935,7 +52054,7 @@
 					}
 				},
 				{
-					"id": 1973,
+					"id": 1989,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51953,7 +52072,7 @@
 					}
 				},
 				{
-					"id": 1972,
+					"id": 1988,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51976,9 +52095,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1974,
-						1973,
-						1972
+						1990,
+						1989,
+						1988
 					]
 				}
 			],
@@ -52031,7 +52150,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -52119,7 +52238,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -52159,13 +52278,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -52198,7 +52317,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -52236,7 +52355,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -52274,7 +52393,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -52282,7 +52401,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -52323,7 +52442,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -52361,7 +52480,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -52399,7 +52518,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -52436,7 +52555,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -52474,13 +52593,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -52517,7 +52636,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -52525,7 +52644,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -52559,7 +52678,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -52596,7 +52715,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -52633,7 +52752,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -52670,7 +52789,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -52708,7 +52827,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -52746,7 +52865,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -52784,7 +52903,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -52822,7 +52941,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -52859,7 +52978,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -52901,7 +53020,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -52952,7 +53071,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -52993,7 +53112,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -53034,7 +53153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -53071,7 +53190,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -53112,7 +53231,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -53154,7 +53273,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -53162,7 +53281,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -53262,7 +53381,7 @@
 			]
 		},
 		{
-			"id": 1556,
+			"id": 1558,
 			"name": "SpotterAnalystConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53286,7 +53405,7 @@
 			},
 			"children": [
 				{
-					"id": 1557,
+					"id": 1559,
 					"name": "analystId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53305,7 +53424,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 298,
+							"line": 426,
 							"character": 4
 						}
 					],
@@ -53320,14 +53439,14 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1557
+						1559
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 292,
+					"line": 420,
 					"character": 17
 				}
 			]
@@ -53362,7 +53481,7 @@
 					},
 					"comment": {
 						"shortText": "Enables starter prompts in the Spotter chat interface.",
-						"text": "Supported embed types: SpotterEmbed, LiveboardEmbed, AppEmbed",
+						"text": "Either this or `starterPrompts.enable` turns the surface on, so it stays\non while this is `true` even if `starterPrompts.enable` is `false`.\n\nSupported embed types: `SpotterEmbed`, `LiveboardEmbed`, `AppEmbed`",
 						"tags": [
 							{
 								"tag": "version",
@@ -53377,7 +53496,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 274,
+							"line": 365,
 							"character": 4
 						}
 					],
@@ -53406,7 +53525,41 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 243,
+							"line": 331,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1542,
+					"name": "openSpotterOnLiveboardByDefault",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Opens the Spotter chat panel on the Liveboard by default.",
+						"text": "Supported embed types: `LiveboardEmbed`, `AppEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl"
+							},
+							{
+								"tag": "default",
+								"text": "false\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 402,
 							"character": 4
 						}
 					],
@@ -53440,7 +53593,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 259,
+							"line": 347,
 							"character": 4
 						}
 					],
@@ -53470,13 +53623,48 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 266,
+							"line": 354,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
 						"name": "SpotterFileUploadFileTypes"
+					}
+				},
+				{
+					"id": 1541,
+					"name": "starterPrompts",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Customizes the labels and questions of the Spotter starter prompts.\nIndividual pills are hidden or shown with `hiddenActions` /\n`visibleActions` using `Action.QuickSearchPill`,\n`Action.DeepAnalysisPill` and `Action.DataLiteracyPill`.",
+						"text": "Supported embed types: `SpotterEmbed`, `LiveboardEmbed`, `AppEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   worksheetId: 'worksheet-id',\n   hiddenActions: [Action.DeepAnalysisPill],\n   spotterChatConfig: {\n       starterPrompts: {\n           enable: true,\n           quick: {\n               label: 'Quick questions',\n               questions: [\n                   { label: 'Top products', prompt: 'What are the top products by revenue?' },\n               ],\n           },\n           previewData: { label: 'Explore your data' },\n       },\n   },\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 394,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1577,
+						"name": "StarterPromptsConfig"
 					}
 				},
 				{
@@ -53493,7 +53681,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 251,
+							"line": 339,
 							"character": 4
 						}
 					],
@@ -53510,8 +53698,10 @@
 					"children": [
 						1540,
 						1536,
+						1542,
 						1538,
 						1539,
+						1541,
 						1537
 					]
 				}
@@ -53519,7 +53709,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 235,
+					"line": 323,
 					"character": 17
 				}
 			]
@@ -53565,7 +53755,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -53653,7 +53843,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -53693,13 +53883,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2931,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -53736,7 +53926,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 394,
+							"line": 522,
 							"character": 4
 						}
 					],
@@ -53770,7 +53960,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 329,
+							"line": 457,
 							"character": 4
 						}
 					],
@@ -53811,13 +54001,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 665,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1560,
 						"name": "SpotterQueryMode"
 					}
 				},
@@ -53846,7 +54036,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -53884,7 +54074,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 364,
+							"line": 492,
 							"character": 4
 						}
 					],
@@ -53918,7 +54108,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -53956,7 +54146,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -53964,7 +54154,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -54005,7 +54195,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -54043,7 +54233,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -54085,7 +54275,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 556,
+							"line": 684,
 							"character": 4
 						}
 					],
@@ -54119,7 +54309,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 546,
+							"line": 674,
 							"character": 4
 						}
 					],
@@ -54153,7 +54343,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -54191,7 +54381,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 458,
+							"line": 586,
 							"character": 4
 						}
 					],
@@ -54225,7 +54415,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 489,
+							"line": 617,
 							"character": 4
 						}
 					],
@@ -54258,7 +54448,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -54296,13 +54486,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2889,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -54339,7 +54529,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -54347,7 +54537,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -54381,7 +54571,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 425,
+							"line": 553,
 							"character": 4
 						}
 					],
@@ -54415,7 +54605,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 378,
+							"line": 506,
 							"character": 4
 						}
 					],
@@ -54449,7 +54639,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -54486,7 +54676,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9392,
 							"character": 4
 						}
 					],
@@ -54523,7 +54713,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9375,
 							"character": 4
 						}
 					],
@@ -54560,7 +54750,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9359,
 							"character": 4
 						}
 					],
@@ -54598,7 +54788,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -54636,7 +54826,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -54674,7 +54864,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -54712,7 +54902,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -54749,7 +54939,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -54791,7 +54981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -54842,7 +55032,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -54883,7 +55073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -54921,7 +55111,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 446,
+							"line": 574,
 							"character": 4
 						}
 					],
@@ -54929,7 +55119,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2019,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -54959,7 +55149,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 477,
+							"line": 605,
 							"character": 4
 						}
 					],
@@ -54967,7 +55157,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3197,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -54986,7 +55176,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 349,
+							"line": 477,
 							"character": 4
 						}
 					],
@@ -55020,7 +55210,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 633,
+							"line": 761,
 							"character": 4
 						}
 					],
@@ -55057,7 +55247,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -55094,7 +55284,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -55132,7 +55322,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 410,
+							"line": 538,
 							"character": 4
 						}
 					],
@@ -55170,7 +55360,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 519,
+							"line": 647,
 							"character": 4
 						}
 					],
@@ -55204,13 +55394,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 345,
+							"line": 473,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1558,
 						"name": "SpotterAnalystConfig"
 					}
 				},
@@ -55239,7 +55429,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 595,
+							"line": 723,
 							"character": 4
 						}
 					],
@@ -55274,13 +55464,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 611,
+							"line": 739,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1563,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
@@ -55309,13 +55499,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 577,
+							"line": 705,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1543,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
@@ -55348,7 +55538,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 504,
+							"line": 632,
 							"character": 4
 						}
 					],
@@ -55386,7 +55576,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 648,
+							"line": 776,
 							"character": 4
 						}
 					],
@@ -55423,7 +55613,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -55465,7 +55655,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -55473,7 +55663,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2271,
 							"name": "Action"
 						}
 					},
@@ -55496,7 +55686,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 312,
+							"line": 440,
 							"character": 4
 						}
 					],
@@ -55568,7 +55758,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 305,
+					"line": 433,
 					"character": 17
 				}
 			],
@@ -55591,13 +55781,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1575,
+					"id": 1591,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1561,
+			"id": 1563,
 			"name": "SpotterShareConversationConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55617,7 +55807,7 @@
 			},
 			"children": [
 				{
-					"id": 1562,
+					"id": 1564,
 					"name": "enableShareConversation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55650,7 +55840,7 @@
 					}
 				},
 				{
-					"id": 1567,
+					"id": 1569,
 					"name": "spotterShareAddUsersLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55679,7 +55869,7 @@
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1568,
 					"name": "spotterShareCancelLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55712,7 +55902,7 @@
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1567,
 					"name": "spotterShareConfirmLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55745,7 +55935,7 @@
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1571,
 					"name": "spotterShareEmptySubtitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55774,7 +55964,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1570,
 					"name": "spotterShareEmptyTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55803,7 +55993,7 @@
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1572,
 					"name": "spotterShareIncludeNewMessagesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55832,7 +56022,7 @@
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1565,
 					"name": "spotterShareLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55865,7 +56055,7 @@
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1566,
 					"name": "spotterShareModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55894,7 +56084,7 @@
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1574,
 					"name": "spotterShareStaleInfoLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55923,7 +56113,7 @@
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1573,
 					"name": "spotterShareUpToCurrentLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55952,7 +56142,7 @@
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1575,
 					"name": "spotterSharedConversationBannerMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55981,7 +56171,7 @@
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1576,
 					"name": "spotterSharedConversationExitLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56019,19 +56209,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1562,
-						1567,
-						1566,
-						1565,
+						1564,
 						1569,
 						1568,
-						1570,
-						1563,
-						1564,
-						1572,
+						1567,
 						1571,
+						1570,
+						1572,
+						1565,
+						1566,
+						1574,
 						1573,
-						1574
+						1575,
+						1576
 					]
 				}
 			],
@@ -56044,7 +56234,7 @@
 			]
 		},
 		{
-			"id": 1541,
+			"id": 1543,
 			"name": "SpotterSidebarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56064,7 +56254,7 @@
 			},
 			"children": [
 				{
-					"id": 1542,
+					"id": 1544,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56097,7 +56287,7 @@
 					}
 				},
 				{
-					"id": 1554,
+					"id": 1556,
 					"name": "spotterAnalystLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56130,7 +56320,7 @@
 					}
 				},
 				{
-					"id": 1555,
+					"id": 1557,
 					"name": "spotterAnalystsLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56163,7 +56353,7 @@
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1553,
 					"name": "spotterBestPracticesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56192,7 +56382,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1548,
 					"name": "spotterChatDeleteLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56221,7 +56411,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1549,
 					"name": "spotterChatPinConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56250,7 +56440,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1547,
 					"name": "spotterChatRenameLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56279,7 +56469,7 @@
 					}
 				},
 				{
-					"id": 1552,
+					"id": 1554,
 					"name": "spotterConversationsBatchSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56312,7 +56502,7 @@
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1550,
 					"name": "spotterDeleteConversationModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56341,7 +56531,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1552,
 					"name": "spotterDocumentationUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56370,7 +56560,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1555,
 					"name": "spotterNewChatButtonTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56399,7 +56589,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1551,
 					"name": "spotterPastConversationAlertMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56428,7 +56618,7 @@
 					}
 				},
 				{
-					"id": 1544,
+					"id": 1546,
 					"name": "spotterSidebarDefaultExpanded",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56461,7 +56651,7 @@
 					}
 				},
 				{
-					"id": 1543,
+					"id": 1545,
 					"name": "spotterSidebarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56495,20 +56685,20 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1542,
+						1544,
+						1556,
+						1557,
+						1553,
+						1548,
+						1549,
+						1547,
 						1554,
+						1550,
+						1552,
 						1555,
 						1551,
 						1546,
-						1547,
-						1545,
-						1552,
-						1548,
-						1550,
-						1553,
-						1549,
-						1544,
-						1543
+						1545
 					]
 				}
 			],
@@ -56521,7 +56711,7 @@
 			]
 		},
 		{
-			"id": 2726,
+			"id": 2746,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56545,7 +56735,7 @@
 			},
 			"children": [
 				{
-					"id": 2728,
+					"id": 2748,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56578,7 +56768,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2747,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56611,7 +56801,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2750,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56638,13 +56828,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2740,
+							"id": 2760,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2751,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56673,7 +56863,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2749,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56706,7 +56896,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2752,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56735,7 +56925,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2757,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56768,7 +56958,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2759,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56797,7 +56987,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2758,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56826,7 +57016,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2755,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56859,7 +57049,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2753,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56888,7 +57078,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2754,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56915,13 +57105,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2744,
+							"id": 2764,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2756,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56959,19 +57149,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2728,
-						2727,
-						2730,
-						2731,
-						2729,
-						2732,
-						2737,
-						2739,
-						2738,
-						2735,
-						2733,
-						2734,
-						2736
+						2748,
+						2747,
+						2750,
+						2751,
+						2749,
+						2752,
+						2757,
+						2759,
+						2758,
+						2755,
+						2753,
+						2754,
+						2756
 					]
 				}
 			],
@@ -56984,7 +57174,7 @@
 			]
 		},
 		{
-			"id": 2744,
+			"id": 2764,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57004,7 +57194,7 @@
 			},
 			"children": [
 				{
-					"id": 2745,
+					"id": 2765,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57025,7 +57215,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2766,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57051,8 +57241,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2745,
-						2746
+						2765,
+						2766
 					]
 				}
 			],
@@ -57065,7 +57255,7 @@
 			]
 		},
 		{
-			"id": 2740,
+			"id": 2760,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57085,7 +57275,7 @@
 			},
 			"children": [
 				{
-					"id": 2742,
+					"id": 2762,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57106,7 +57296,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2763,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57127,7 +57317,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2761,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57153,9 +57343,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2742,
-						2743,
-						2741
+						2762,
+						2763,
+						2761
 					]
 				}
 			],
@@ -57168,14 +57358,426 @@
 			]
 		},
 		{
-			"id": 1978,
+			"id": 1586,
+			"name": "StarterPreviewDataCategory",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for the Data Literacy starter prompt category.\nOnly the label is customizable; the prompt text comes from the backend.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1587,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Overrides the default category pill label. ThoughtSpot truncates it\nbeyond 30 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 278,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1587
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 273,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1583,
+			"name": "StarterPromptCategory",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for a starter prompt category with questions\n(`quick` and `research`).",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1584,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Overrides the default category pill label. ThoughtSpot truncates it\nbeyond 30 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 259,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1585,
+					"name": "questions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Replaces the backend-generated prompts. ThoughtSpot renders the first 4\nand drops any entry without a `prompt`."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 264,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 1588,
+							"name": "StarterPromptQuestion"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1584,
+						1585
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 254,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1588,
+			"name": "StarterPromptQuestion",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "A single starter prompt question shown under a category pill.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1589,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Short label shown as a clickable suggestion. Falls back to `prompt` when\nomitted. ThoughtSpot truncates it beyond 80 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1590,
+					"name": "prompt",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {},
+					"comment": {
+						"shortText": "Prompt text sent to Spotter on click. ThoughtSpot truncates it beyond\n300 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 245,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1589,
+						1590
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 235,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1577,
+			"name": "StarterPromptsConfig",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Content configuration for the Spotter starter prompts.\nCategory keys are fixed: `quick` (Basic Search), `research` (Deep Analysis)\nand `previewData` (Data Literacy).",
+				"text": "Note: the category keys control the Spotter chat interface, and `liveboard`\ncontrols the Spotter chat panel on a Liveboard. The starter prompts on the\nLiveboard SpotterViz surface are configured separately through\n{@link SpotterVizConfig.customStarterPrompts}.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1578,
+					"name": "enable",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Turns the starter prompts surface on. Must be set explicitly, an\nunset flag leaves the surface off.",
+						"text": "Either this or `enableStarterPrompts` turns the surface on, so `false`\nhere does not switch it off while `enableStarterPrompts` is `true`.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 302,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1582,
+					"name": "liveboard",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Starter prompt questions for the Spotter chat panel on a Liveboard.",
+						"text": "Supported embed types: `LiveboardEmbed`, `AppEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 315,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 1588,
+							"name": "StarterPromptQuestion"
+						}
+					}
+				},
+				{
+					"id": 1581,
+					"name": "previewData",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Data Literacy category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 308,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1586,
+						"name": "StarterPreviewDataCategory"
+					}
+				},
+				{
+					"id": 1579,
+					"name": "quick",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Basic Search category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 304,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1583,
+						"name": "StarterPromptCategory"
+					}
+				},
+				{
+					"id": 1580,
+					"name": "research",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Deep Analysis category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 306,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1583,
+						"name": "StarterPromptCategory"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1578,
+						1582,
+						1581,
+						1579,
+						1580
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 293,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1994,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1979,
+					"id": 1995,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57193,7 +57795,7 @@
 					}
 				},
 				{
-					"id": 1980,
+					"id": 1996,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57216,8 +57818,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1979,
-						1980
+						1995,
+						1996
 					]
 				}
 			],
@@ -57230,7 +57832,7 @@
 			]
 		},
 		{
-			"id": 3315,
+			"id": 3335,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57250,7 +57852,7 @@
 			},
 			"children": [
 				{
-					"id": 3316,
+					"id": 3336,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57263,7 +57865,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9799,
+							"line": 9885,
 							"character": 4
 						}
 					],
@@ -57273,7 +57875,7 @@
 					}
 				},
 				{
-					"id": 3317,
+					"id": 3337,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57286,7 +57888,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9801,
+							"line": 9887,
 							"character": 4
 						}
 					],
@@ -57301,28 +57903,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3316,
-						3317
+						3336,
+						3337
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9797,
+					"line": 9883,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3220,
+			"id": 3240,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3221,
+					"id": 3241,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57330,7 +57932,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8791,
+							"line": 8877,
 							"character": 4
 						}
 					],
@@ -57343,7 +57945,7 @@
 					}
 				},
 				{
-					"id": 3222,
+					"id": 3242,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57351,7 +57953,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8792,
+							"line": 8878,
 							"character": 4
 						}
 					],
@@ -57369,21 +57971,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3221,
-						3222
+						3241,
+						3242
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8790,
+					"line": 8876,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2924,
+			"id": 2944,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57393,7 +57995,7 @@
 			},
 			"children": [
 				{
-					"id": 2926,
+					"id": 2946,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57423,20 +58025,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2927,
+							"id": 2947,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2928,
+								"id": 2948,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2929,
+										"id": 2949,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -57449,7 +58051,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2930,
+										"id": 2950,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -57462,14 +58064,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2931,
+											"id": 2951,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2932,
+													"id": 2952,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -57491,7 +58093,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2945,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57510,7 +58112,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2933,
+						"id": 2953,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -57520,8 +58122,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2926,
-						2925
+						2946,
+						2945
 					]
 				}
 			],
@@ -57826,7 +58428,7 @@
 			]
 		},
 		{
-			"id": 3314,
+			"id": 3334,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57838,7 +58440,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1660,
+					"line": 1684,
 					"character": 12
 				}
 			],
@@ -57883,7 +58485,7 @@
 			}
 		},
 		{
-			"id": 2894,
+			"id": 2914,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57910,7 +58512,7 @@
 			}
 		},
 		{
-			"id": 2898,
+			"id": 2918,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57918,14 +58520,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2263,
+					"line": 2287,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2899,
+					"id": 2919,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -57942,13 +58544,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2263,
+							"line": 2287,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2900,
+							"id": 2920,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -57958,19 +58560,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2901,
+									"id": 2921,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2906,
+										"id": 2926,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2902,
+									"id": 2922,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -57980,7 +58582,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2903,
+											"id": 2923,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -57988,13 +58590,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2270,
+													"line": 2294,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2904,
+													"id": 2924,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -58004,7 +58606,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2905,
+															"id": 2925,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -58035,7 +58637,7 @@
 			}
 		},
 		{
-			"id": 2895,
+			"id": 2915,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -58052,21 +58654,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2252,
+					"line": 2276,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2896,
+					"id": 2916,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2897,
+							"id": 2917,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58079,7 +58681,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2257,
+									"line": 2281,
 									"character": 4
 								}
 							],
@@ -58094,14 +58696,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2897
+								2917
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2252,
+							"line": 2276,
 							"character": 29
 						}
 					]
@@ -58109,7 +58711,7 @@
 			}
 		},
 		{
-			"id": 2906,
+			"id": 2926,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -58126,21 +58728,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2239,
+					"line": 2263,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2907,
+					"id": 2927,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2909,
+							"id": 2929,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58148,7 +58750,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2243,
+									"line": 2267,
 									"character": 4
 								}
 							],
@@ -58158,7 +58760,7 @@
 							}
 						},
 						{
-							"id": 2910,
+							"id": 2930,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58168,7 +58770,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2245,
+									"line": 2269,
 									"character": 4
 								}
 							],
@@ -58178,7 +58780,7 @@
 							}
 						},
 						{
-							"id": 2908,
+							"id": 2928,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58186,7 +58788,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2241,
+									"line": 2265,
 									"character": 4
 								}
 							],
@@ -58201,16 +58803,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2909,
-								2910,
-								2908
+								2929,
+								2930,
+								2928
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2239,
+							"line": 2263,
 							"character": 29
 						}
 					]
@@ -58268,7 +58870,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1894,
+									"id": 1910,
 									"name": "AnswerService"
 								}
 							}
@@ -58530,7 +59132,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1894,
+												"id": 1910,
 												"name": "AnswerService"
 											}
 										},
@@ -58617,7 +59219,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2454,
+						"id": 2474,
 						"name": "EmbedConfig"
 					}
 				}
@@ -58717,14 +59319,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2454,
+								"id": 2474,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1841,
+						"id": 1857,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -58864,7 +59466,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2864,
+									"id": 2884,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -58992,7 +59594,7 @@
 			]
 		},
 		{
-			"id": 3360,
+			"id": 3380,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -59008,7 +59610,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3361,
+					"id": 3381,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59038,7 +59640,7 @@
 			]
 		},
 		{
-			"id": 3362,
+			"id": 3382,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -59052,7 +59654,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3363,
+					"id": 3383,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59074,7 +59676,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3364,
+							"id": 3384,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59084,7 +59686,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3314,
+								"id": 3334,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -59262,7 +59864,7 @@
 			]
 		},
 		{
-			"id": 3187,
+			"id": 3207,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -59276,7 +59878,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3188,
+					"id": 3208,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59286,7 +59888,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3189,
+							"id": 3209,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59298,7 +59900,7 @@
 							}
 						},
 						{
-							"id": 3190,
+							"id": 3210,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59309,7 +59911,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3191,
+									"id": 3211,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -59332,52 +59934,52 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2255,
-				1839,
-				1824,
-				1831,
-				1991,
-				3323,
-				3326,
-				3330,
-				2450,
-				2245,
-				3277,
-				3273,
-				3346,
-				3269,
-				2251,
-				3286,
-				2023,
-				3310,
-				2875,
-				3213,
-				3207,
-				2887,
-				2152,
-				3282,
-				3318,
-				3217,
-				3261,
-				3180,
-				1981,
-				2864,
-				3211,
+				2271,
+				1855,
+				1840,
+				1847,
 				2007,
-				1558,
-				3357,
-				3353,
-				3243
+				3343,
+				3346,
+				3350,
+				2470,
+				2261,
+				3297,
+				3293,
+				3366,
+				3289,
+				2267,
+				3306,
+				2039,
+				3330,
+				2895,
+				3233,
+				3227,
+				2907,
+				2168,
+				3302,
+				3338,
+				3237,
+				3281,
+				3200,
+				1997,
+				2884,
+				3231,
+				2023,
+				1560,
+				3377,
+				3373,
+				3263
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1894,
+				1910,
 				911,
 				1255,
-				1636,
+				1652,
 				661,
 				256,
 				58,
@@ -59389,36 +59991,40 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2747,
-				1841,
+				2767,
+				1857,
 				1216,
-				1575,
-				3223,
-				2933,
-				2921,
-				2911,
-				2454,
-				3304,
-				2869,
-				2624,
-				2003,
-				3177,
-				2571,
-				2505,
-				1971,
+				1591,
+				3243,
+				2953,
+				2941,
+				2931,
+				2474,
+				3324,
+				2889,
+				2644,
+				2019,
+				3197,
+				2591,
+				2525,
+				1987,
 				1177,
-				1556,
+				1558,
 				1535,
 				1474,
-				1561,
-				1541,
-				2726,
-				2744,
-				2740,
-				1978,
-				3315,
-				3220,
-				2924,
+				1563,
+				1543,
+				2746,
+				2764,
+				2760,
+				1586,
+				1583,
+				1588,
+				1577,
+				1994,
+				3335,
+				3240,
+				2944,
 				21,
 				28
 			]
@@ -59427,11 +60033,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3314,
-				2894,
-				2898,
-				2895,
-				2906
+				3334,
+				2914,
+				2918,
+				2915,
+				2926
 			]
 		},
 		{
@@ -59448,10 +60054,10 @@
 				4,
 				7,
 				25,
-				3360,
-				3362,
+				3380,
+				3382,
 				40,
-				3187
+				3207
 			]
 		}
 	],


### PR DESCRIPTION

SDK counterpart of scaligent [#67191](https://galaxy.corp.thoughtspot.com/dev/scaligent/pull/67191), which lifted the hard isEmbedded block on Spotter chat and put it behind the standard embed action contract.

Jira: SCAL-332735

Changes

- Action.SpotterOnLiveboard ('spotterOnLiveboard') — new action so hosts can control the Spotter chat entry point on an embedded Liveboard: hiddenActions removes the panel and header button, disabledActions greys the button and surfaces the host's disabledActionReason. Matches the enum value added to blink's embed-util in [#67191](https://galaxy.corp.thoughtspot.com/dev/scaligent/pull/67191).
- StarterPromptsConfig.liveboard?: StarterPromptQuestion[] — starter-prompt customization for the Spotter chat panel on a Liveboard, alongside the existing quick/research/previewData categories. Delivered through the existing starterPrompts APP_INIT payload (buildStarterPromptsAppInitData), so no new plumbing.
- SpotterChatViewConfig.openSpotterOnLiveboardByDefault?: boolean — opens the Spotter chat panel on the Liveboard by default. Passed as a URL query param (Param.OpenSpotterOnLiveboardByDefault) by both LiveboardEmbed and AppEmbed, following the same pattern as the other spotterChatConfig sub-flags.