### PR TITLE
SCAL-330172 Deprecate the host event updatePersonalizedView

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6119,7 +6119,10 @@ export enum HostEvent {
     GetParameters = 'GetParameters',
     /**
      * Triggers an event to update a personalized view of a Liveboard.
-     * This event is deprecated. Use {@link HostEvent.UpdatePersonalizedView} instead.
+     * This event is deprecated. Use {@link HostEvent.SelectPersonalizedView} instead,
+     * which additionally accepts a `viewName`, resets to the original view when
+     * called with an empty payload, and reports an error when a named view
+     * cannot be found.
      * ```js
      * liveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})
      * ```
@@ -6137,10 +6140,15 @@ export enum HostEvent {
     UpdatePersonalisedView = 'UpdatePersonalisedView',
     /**
      * Triggers an event to update a personalized view of a Liveboard.
+     * This event is deprecated. Use {@link HostEvent.SelectPersonalizedView} instead,
+     * which additionally accepts a `viewName`, resets to the original view when
+     * called with an empty payload, and reports an error when a named view
+     * cannot be found.
      * ```js
      * liveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})
      * ```
      * @version SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl
+     * @deprecated SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
      */
     UpdatePersonalizedView = UpdatePersonalisedView,
     /**

--- a/static/typedoc/typedoc.json
+++ b/static/typedoc/typedoc.json
@@ -7,7 +7,7 @@
 	"originalName": "",
 	"children": [
 		{
-			"id": 2255,
+			"id": 2269,
 			"name": "Action",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -28,7 +28,7 @@
 			},
 			"children": [
 				{
-					"id": 2379,
+					"id": 2393,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -49,14 +49,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7975,
+							"line": 8007,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2276,
+					"id": 2290,
 					"name": "AddColumnSet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -77,14 +77,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7008,
+							"line": 7040,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addSimpleCohort\""
 				},
 				{
-					"id": 2269,
+					"id": 2283,
 					"name": "AddDataPanelObjects",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -105,14 +105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6937,
+							"line": 6969,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addDataPanelObjects\""
 				},
 				{
-					"id": 2268,
+					"id": 2282,
 					"name": "AddFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -129,14 +129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6926,
+							"line": 6958,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFilter\""
 				},
 				{
-					"id": 2274,
+					"id": 2288,
 					"name": "AddFormula",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -153,14 +153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6989,
+							"line": 7021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addFormula\""
 				},
 				{
-					"id": 2275,
+					"id": 2289,
 					"name": "AddParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -177,14 +177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6998,
+							"line": 7030,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addParameter\""
 				},
 				{
-					"id": 2277,
+					"id": 2291,
 					"name": "AddQuerySet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -205,14 +205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7018,
+							"line": 7050,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addAdvancedCohort\""
 				},
 				{
-					"id": 2359,
+					"id": 2373,
 					"name": "AddTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -233,14 +233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7743,
+							"line": 7775,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addTab\""
 				},
 				{
-					"id": 2329,
+					"id": 2343,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -261,14 +261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7436,
+							"line": 7468,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2375,
+					"id": 2389,
 					"name": "AddToWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -289,14 +289,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7928,
+							"line": 7960,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToWatchlist\""
 				},
 				{
-					"id": 2389,
+					"id": 2403,
 					"name": "AllLiveboardFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -317,14 +317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8087,
+							"line": 8119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"allLiveboardFilters\""
 				},
 				{
-					"id": 2328,
+					"id": 2342,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -345,14 +345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7424,
+							"line": 7456,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2327,
+					"id": 2341,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -373,14 +373,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7412,
+							"line": 7444,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2374,
+					"id": 2388,
 					"name": "AskAi",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -402,14 +402,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7917,
+							"line": 7949,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskAi\""
 				},
 				{
-					"id": 2341,
+					"id": 2355,
 					"name": "AxisMenuAggregate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -430,14 +430,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7558,
+							"line": 7590,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuAggregate\""
 				},
 				{
-					"id": 2353,
+					"id": 2367,
 					"name": "AxisMenuCompare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -458,14 +458,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7689,
+							"line": 7721,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuCompare\""
 				},
 				{
-					"id": 2344,
+					"id": 2358,
 					"name": "AxisMenuConditionalFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -486,14 +486,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7592,
+							"line": 7624,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuConditionalFormat\""
 				},
 				{
-					"id": 2349,
+					"id": 2363,
 					"name": "AxisMenuEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -514,14 +514,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7647,
+							"line": 7679,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuEdit\""
 				},
 				{
-					"id": 2343,
+					"id": 2357,
 					"name": "AxisMenuFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -542,14 +542,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7581,
+							"line": 7613,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuFilter\""
 				},
 				{
-					"id": 2346,
+					"id": 2360,
 					"name": "AxisMenuGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -570,14 +570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7615,
+							"line": 7647,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuGroup\""
 				},
 				{
-					"id": 2354,
+					"id": 2368,
 					"name": "AxisMenuMerge",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -598,14 +598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7699,
+							"line": 7731,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuMerge\""
 				},
 				{
-					"id": 2350,
+					"id": 2364,
 					"name": "AxisMenuNumberFormat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -626,14 +626,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7657,
+							"line": 7689,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuNumberFormat\""
 				},
 				{
-					"id": 2347,
+					"id": 2361,
 					"name": "AxisMenuPosition",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -654,14 +654,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7626,
+							"line": 7658,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuPosition\""
 				},
 				{
-					"id": 2352,
+					"id": 2366,
 					"name": "AxisMenuRemove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -682,14 +682,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7679,
+							"line": 7711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRemove\""
 				},
 				{
-					"id": 2348,
+					"id": 2362,
 					"name": "AxisMenuRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -710,14 +710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7636,
+							"line": 7668,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuRename\""
 				},
 				{
-					"id": 2345,
+					"id": 2359,
 					"name": "AxisMenuSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -738,14 +738,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7603,
+							"line": 7635,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuSort\""
 				},
 				{
-					"id": 2351,
+					"id": 2365,
 					"name": "AxisMenuTextWrapping",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -766,14 +766,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7667,
+							"line": 7699,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTextWrapping\""
 				},
 				{
-					"id": 2342,
+					"id": 2356,
 					"name": "AxisMenuTimeBucket",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -794,14 +794,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7569,
+							"line": 7601,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"axisMenuTimeBucket\""
 				},
 				{
-					"id": 2388,
+					"id": 2402,
 					"name": "ChangeFilterVisibilityInTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -822,14 +822,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8073,
+							"line": 8105,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changeFilterVisibilityInTab\""
 				},
 				{
-					"id": 2273,
+					"id": 2287,
 					"name": "ChooseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -846,14 +846,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6980,
+							"line": 7012,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"chooseDataSources\""
 				},
 				{
-					"id": 2272,
+					"id": 2286,
 					"name": "CollapseDataPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -874,14 +874,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6971,
+							"line": 7003,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataPanel\""
 				},
 				{
-					"id": 2271,
+					"id": 2285,
 					"name": "CollapseDataSources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -902,14 +902,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6959,
+							"line": 6991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapseDataSources\""
 				},
 				{
-					"id": 2397,
+					"id": 2411,
 					"name": "ColumnRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -930,14 +930,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8175,
+							"line": 8207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"columnRename\""
 				},
 				{
-					"id": 2270,
+					"id": 2284,
 					"name": "ConfigureFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -954,14 +954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6948,
+							"line": 6980,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"configureFilter\""
 				},
 				{
-					"id": 2320,
+					"id": 2334,
 					"name": "CopyAndEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -969,14 +969,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7361,
+							"line": 7393,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-and-edit\""
 				},
 				{
-					"id": 2263,
+					"id": 2277,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -993,14 +993,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6885,
+							"line": 6917,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2319,
+					"id": 2333,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1017,14 +1017,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7360,
+							"line": 7392,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2398,
+					"id": 2412,
 					"name": "CoverAndFilterOptionInPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1045,14 +1045,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8185,
+							"line": 8217,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"coverAndFilterOptionInPDF\""
 				},
 				{
-					"id": 2412,
+					"id": 2426,
 					"name": "CreateGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1073,14 +1073,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8349,
+							"line": 8381,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createGroup\""
 				},
 				{
-					"id": 2372,
+					"id": 2386,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1101,14 +1101,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7892,
+							"line": 7924,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2332,
+					"id": 2346,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1129,14 +1129,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7466,
+							"line": 7498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2337,
+					"id": 2351,
 					"name": "CrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1157,14 +1157,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7516,
+							"line": 7548,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-cross-filter\""
 				},
 				{
-					"id": 2390,
+					"id": 2451,
+					"name": "DataLiteracyPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Data Literacy** starter prompt pill, next to\n{@link Action.QuickSearchPill} above the Spotter chat input.",
+						"text": "Unlike the other two pills it opens no card: clicking it submits a prompt\nthat describes the data the model can answer over, helping a user who does\nnot yet know what is in the data source. The prompt text always comes from\nThoughtSpot, so only its label is customizable. Visible by default.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.DataLiteracyPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8657,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"dataLiteracyPill\""
+				},
+				{
+					"id": 2404,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1185,14 +1214,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8099,
+							"line": 8131,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2395,
+					"id": 2450,
+					"name": "DeepAnalysisPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Deep Analysis** starter prompt pill, next to\n{@link Action.QuickSearchPill} above the Spotter chat input.",
+						"text": "Clicking it opens a card of suggested investigative questions (\"why did\nrevenue drop?\"). Picking one fills the chat input in Deep Analysis mode\nrather than submitting immediately, so the user can edit it first.\nVisible by default.",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.DeepAnalysisPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8642,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"deepAnalysisPill\""
+				},
+				{
+					"id": 2409,
 					"name": "DeletePreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1213,14 +1271,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8156,
+							"line": 8188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePreviousPrompt\""
 				},
 				{
-					"id": 2385,
+					"id": 2399,
 					"name": "DeleteScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1241,14 +1299,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8042,
+							"line": 8074,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deleteScheduleHomepage\""
 				},
 				{
-					"id": 2387,
+					"id": 2401,
 					"name": "DisableChipReorder",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1269,14 +1327,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8061,
+							"line": 8093,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"disableChipReorder\""
 				},
 				{
-					"id": 2285,
+					"id": 2299,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1293,14 +1351,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7068,
+							"line": 7100,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2288,
+					"id": 2302,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1317,14 +1375,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7101,
+							"line": 7133,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2287,
+					"id": 2301,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1342,14 +1400,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7091,
+							"line": 7123,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2286,
+					"id": 2300,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1366,14 +1424,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7078,
+							"line": 7110,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2289,
+					"id": 2303,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1390,14 +1448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7111,
+							"line": 7143,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2290,
+					"id": 2304,
 					"name": "DownloadLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1418,14 +1476,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7121,
+							"line": 7153,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboard\""
 				},
 				{
-					"id": 2292,
+					"id": 2306,
 					"name": "DownloadLiveboardAsA4Pdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1446,14 +1504,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7145,
+							"line": 7177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsA4Pdf\""
 				},
 				{
-					"id": 2291,
+					"id": 2305,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1474,14 +1532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7131,
+							"line": 7163,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2294,
+					"id": 2308,
 					"name": "DownloadLiveboardAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1502,14 +1560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7165,
+							"line": 7197,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsCsv\""
 				},
 				{
-					"id": 2293,
+					"id": 2307,
 					"name": "DownloadLiveboardAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1530,14 +1588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7155,
+							"line": 7187,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsXlsx\""
 				},
 				{
-					"id": 2324,
+					"id": 2338,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1554,14 +1612,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7377,
+							"line": 7409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILL\""
 				},
 				{
-					"id": 2318,
+					"id": 2332,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1578,14 +1636,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7350,
+							"line": 7382,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2317,
+					"id": 2331,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1602,14 +1660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7341,
+							"line": 7373,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2302,
+					"id": 2316,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1626,14 +1684,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7241,
+							"line": 7273,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2262,
+					"id": 2276,
 					"name": "EditACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1650,14 +1708,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6876,
+							"line": 6908,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editACopy\""
 				},
 				{
-					"id": 2331,
+					"id": 2345,
 					"name": "EditDetails",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1678,14 +1736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7455,
+							"line": 7487,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editDetails\""
 				},
 				{
-					"id": 2260,
+					"id": 2274,
 					"name": "EditInputTable",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1699,21 +1757,21 @@
 							},
 							{
 								"tag": "version",
-								"text": "SDK: 1.51.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+								"text": "SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6854,
+							"line": 6886,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editInputTable\""
 				},
 				{
-					"id": 2322,
+					"id": 2336,
 					"name": "EditMeasure",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1721,14 +1779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7366,
+							"line": 7398,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-edit-measure\""
 				},
 				{
-					"id": 2394,
+					"id": 2408,
 					"name": "EditPreviousPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1749,14 +1807,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8145,
+							"line": 8177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editPreviousPrompt\""
 				},
 				{
-					"id": 2363,
+					"id": 2377,
 					"name": "EditSageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1777,14 +1835,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7787,
+							"line": 7819,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editSageAnswer\""
 				},
 				{
-					"id": 2380,
+					"id": 2394,
 					"name": "EditScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1805,14 +1863,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7988,
+							"line": 8020,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editScheduleHomepage\""
 				},
 				{
-					"id": 2299,
+					"id": 2313,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1829,14 +1887,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7209,
+							"line": 7241,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2303,
+					"id": 2317,
 					"name": "EditTitle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1853,14 +1911,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7249,
+							"line": 7281,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTitle\""
 				},
 				{
-					"id": 2396,
+					"id": 2410,
 					"name": "EditTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1881,14 +1939,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8166,
+							"line": 8198,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTokens\""
 				},
 				{
-					"id": 2360,
+					"id": 2374,
 					"name": "EnableContextualChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1909,14 +1967,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7753,
+							"line": 7785,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableContextualChangeAnalysis\""
 				},
 				{
-					"id": 2361,
+					"id": 2375,
 					"name": "EnableIterativeChangeAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1937,14 +1995,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7764,
+							"line": 7796,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"enableIterativeChangeAnalysis\""
 				},
 				{
-					"id": 2316,
+					"id": 2330,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1961,14 +2019,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7330,
+							"line": 7362,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2296,
+					"id": 2310,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -1986,14 +2044,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7181,
+							"line": 7213,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2297,
+					"id": 2311,
 					"name": "ImportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2010,14 +2068,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7191,
+							"line": 7223,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"importTSL\""
 				},
 				{
-					"id": 2399,
+					"id": 2413,
 					"name": "InConversationTraining",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2039,14 +2097,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8204,
+							"line": 8236,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InConversationTraining\""
 				},
 				{
-					"id": 2435,
+					"id": 2452,
 					"name": "IncludeCurrentPeriod",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2067,14 +2125,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8587,
+							"line": 8669,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"includeCurrentPeriod\""
 				},
 				{
-					"id": 2386,
+					"id": 2400,
 					"name": "KPIAnalysisCTA",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2095,14 +2153,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8052,
+							"line": 8084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"kpiAnalysisCTA\""
 				},
 				{
-					"id": 2310,
+					"id": 2324,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2119,14 +2177,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7291,
+							"line": 7323,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2405,
+					"id": 2419,
 					"name": "LiveboardStylePanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2147,14 +2205,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8270,
+							"line": 8302,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardStylePanel\""
 				},
 				{
-					"id": 2370,
+					"id": 2384,
 					"name": "LiveboardUsers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2175,14 +2233,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7860,
+							"line": 7892,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboardUsers\""
 				},
 				{
-					"id": 2261,
+					"id": 2275,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2199,14 +2257,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6867,
+							"line": 6899,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2367,
+					"id": 2381,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2223,14 +2281,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7828,
+							"line": 7860,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2336,
+					"id": 2350,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2251,14 +2309,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7506,
+							"line": 7538,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2407,
+					"id": 2421,
 					"name": "ManagePublishing",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2279,14 +2337,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8296,
+							"line": 8328,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"managePublishing\""
 				},
 				{
-					"id": 2384,
+					"id": 2398,
 					"name": "ManageTags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2307,14 +2365,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8031,
+							"line": 8063,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageTags\""
 				},
 				{
-					"id": 2358,
+					"id": 2372,
 					"name": "MarkAsVerified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2335,14 +2393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7733,
+							"line": 7765,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"markAsVerified\""
 				},
 				{
-					"id": 2365,
+					"id": 2379,
 					"name": "ModifySageAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2362,14 +2420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7808,
+							"line": 7840,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"modifySageAnswer\""
 				},
 				{
-					"id": 2411,
+					"id": 2425,
 					"name": "MoveOutOfGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2390,14 +2448,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8339,
+							"line": 8371,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveOutOfGroup\""
 				},
 				{
-					"id": 2410,
+					"id": 2424,
 					"name": "MoveToGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2418,14 +2476,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8329,
+							"line": 8361,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"moveToGroup\""
 				},
 				{
-					"id": 2366,
+					"id": 2380,
 					"name": "MoveToTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2442,14 +2500,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7817,
+							"line": 7849,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onContainerMove\""
 				},
 				{
-					"id": 2377,
+					"id": 2391,
 					"name": "OrganiseFavourites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2474,14 +2532,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7952,
+							"line": 7984,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2378,
+					"id": 2392,
 					"name": "OrganizeFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2502,14 +2560,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7964,
+							"line": 7996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"organiseFavourites\""
 				},
 				{
-					"id": 2409,
+					"id": 2423,
 					"name": "Parameterize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2530,14 +2588,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8319,
+							"line": 8351,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterise\""
 				},
 				{
-					"id": 2381,
+					"id": 2395,
 					"name": "PauseScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2558,14 +2616,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7999,
+							"line": 8031,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pauseScheduleHomepage\""
 				},
 				{
-					"id": 2368,
+					"id": 2382,
 					"name": "PersonalisedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2590,14 +2648,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7840,
+							"line": 7872,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2369,
+					"id": 2383,
 					"name": "PersonalizedViewsDropdown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2618,14 +2676,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7850,
+							"line": 7882,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"personalisedViewsDropdown\""
 				},
 				{
-					"id": 2313,
+					"id": 2327,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2642,14 +2700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7308,
+							"line": 7340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2403,
+					"id": 2417,
 					"name": "PngScreenshotInEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2666,14 +2724,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8248,
+							"line": 8280,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pngScreenshotInEmail\""
 				},
 				{
-					"id": 2300,
+					"id": 2314,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2690,14 +2748,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7219,
+							"line": 7251,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2391,
+					"id": 2405,
 					"name": "PreviewDataSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2718,14 +2776,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8111,
+							"line": 8143,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"previewDataSpotter\""
 				},
 				{
-					"id": 2406,
+					"id": 2420,
 					"name": "Publish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2746,14 +2804,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8283,
+							"line": 8315,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"publish\""
 				},
 				{
-					"id": 2326,
+					"id": 2340,
 					"name": "QueryDetailsButtons",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2771,14 +2829,43 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7402,
+							"line": 7434,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryDetailsButtons\""
 				},
 				{
-					"id": 2441,
+					"id": 2449,
+					"name": "QuickSearchPill",
+					"kind": 16,
+					"kindString": "Enumeration member",
+					"flags": {},
+					"comment": {
+						"shortText": "The **Basic Search** starter prompt pill.",
+						"text": "Starter prompt pills are the row of category buttons shown above the\nSpotter chat input before a conversation starts. They give a new user\nready-made questions to click instead of typing one from scratch, and\ndisappear once the conversation begins. There are three, one per action\nbelow.\n\nClicking this pill opens a card of suggested simple questions; picking one\nsubmits it to Spotter right away. Visible by default, and hidden along\nwith the other pills when the surface itself is off (see\n{@link SpotterChatViewConfig.starterPrompts}).",
+						"tags": [
+							{
+								"tag": "example",
+								"text": "\n```js\nhiddenActions: [Action.QuickSearchPill]\n```"
+							},
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 8627,
+							"character": 4
+						}
+					],
+					"defaultValue": "\"quickSearchPill\""
+				},
+				{
+					"id": 2458,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2799,14 +2886,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8660,
+							"line": 8742,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2304,
+					"id": 2318,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2823,14 +2910,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7259,
+							"line": 7291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2404,
+					"id": 2418,
 					"name": "RemoveAttachment",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2851,14 +2938,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8260,
+							"line": 8292,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeAttachment\""
 				},
 				{
-					"id": 2340,
+					"id": 2354,
 					"name": "RemoveCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2879,14 +2966,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7547,
+							"line": 7579,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-remove-cross-filter\""
 				},
 				{
-					"id": 2330,
+					"id": 2344,
 					"name": "RemoveFromFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2907,14 +2994,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7446,
+							"line": 7478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromFavorites\""
 				},
 				{
-					"id": 2376,
+					"id": 2390,
 					"name": "RemoveFromWatchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2935,14 +3022,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7939,
+							"line": 7971,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeFromWatchlist\""
 				},
 				{
-					"id": 2356,
+					"id": 2370,
 					"name": "RenameModalTitleDescription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2963,14 +3050,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7713,
+							"line": 7745,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"renameModalTitleDescription\""
 				},
 				{
-					"id": 2333,
+					"id": 2347,
 					"name": "ReportError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -2994,14 +3081,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7475,
+							"line": 7507,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"reportError\""
 				},
 				{
-					"id": 2325,
+					"id": 2339,
 					"name": "RequestAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3018,14 +3105,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7386,
+							"line": 7418,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestAccess\""
 				},
 				{
-					"id": 2357,
+					"id": 2371,
 					"name": "RequestVerification",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3046,14 +3133,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7723,
+							"line": 7755,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"requestVerification\""
 				},
 				{
-					"id": 2392,
+					"id": 2406,
 					"name": "ResetSpotterChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3074,14 +3161,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8123,
+							"line": 8155,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSpotterChat\""
 				},
 				{
-					"id": 2364,
+					"id": 2378,
 					"name": "SageAnswerFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3102,14 +3189,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7799,
+							"line": 7831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sageAnswerFeedback\""
 				},
 				{
-					"id": 2256,
+					"id": 2270,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3126,14 +3213,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6825,
+							"line": 6857,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2259,
+					"id": 2273,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3150,14 +3237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6843,
+							"line": 6875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2265,
+					"id": 2279,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3174,14 +3261,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6899,
+							"line": 6931,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2266,
+					"id": 2280,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3198,14 +3285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6908,
+							"line": 6940,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2436,
+					"id": 2453,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3226,14 +3313,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8599,
+							"line": 8681,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2323,
+					"id": 2337,
 					"name": "Separator",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3241,14 +3328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7367,
+							"line": 7399,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-separator\""
 				},
 				{
-					"id": 2267,
+					"id": 2281,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3265,14 +3352,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6917,
+							"line": 6949,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2282,
+					"id": 2296,
 					"name": "ShareViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3283,14 +3370,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7043,
+							"line": 7075,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"shareViz\""
 				},
 				{
-					"id": 2362,
+					"id": 2376,
 					"name": "ShowSageQuery",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3311,14 +3398,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7774,
+							"line": 7806,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showSageQuery\""
 				},
 				{
-					"id": 2284,
+					"id": 2298,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3335,14 +3422,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7058,
+							"line": 7090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2279,
+					"id": 2293,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3359,14 +3446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7031,
+							"line": 7063,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2444,
+					"id": 2461,
 					"name": "SpotterAnalystCreate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3387,14 +3474,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8693,
+							"line": 8775,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystCreate\""
 				},
 				{
-					"id": 2445,
+					"id": 2462,
 					"name": "SpotterAnalystDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3415,14 +3502,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8704,
+							"line": 8786,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystDelete\""
 				},
 				{
-					"id": 2443,
+					"id": 2460,
 					"name": "SpotterAnalystEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3443,14 +3530,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8682,
+							"line": 8764,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystEdit\""
 				},
 				{
-					"id": 2448,
+					"id": 2465,
 					"name": "SpotterAnalystList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3471,14 +3558,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8737,
+							"line": 8819,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystList\""
 				},
 				{
-					"id": 2446,
+					"id": 2463,
 					"name": "SpotterAnalystMakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3499,14 +3586,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8715,
+							"line": 8797,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystMakeACopy\""
 				},
 				{
-					"id": 2442,
+					"id": 2459,
 					"name": "SpotterAnalystShare",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3527,14 +3614,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8671,
+							"line": 8753,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystShare\""
 				},
 				{
-					"id": 2447,
+					"id": 2464,
 					"name": "SpotterAnalystSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3555,14 +3642,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8726,
+							"line": 8808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterAnalystSidebar\""
 				},
 				{
-					"id": 2432,
+					"id": 2446,
 					"name": "SpotterChatConnectorResources",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3583,14 +3670,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8553,
+							"line": 8585,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectorResources\""
 				},
 				{
-					"id": 2433,
+					"id": 2447,
 					"name": "SpotterChatConnectors",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3611,14 +3698,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8564,
+							"line": 8596,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatConnectors\""
 				},
 				{
-					"id": 2429,
+					"id": 2443,
 					"name": "SpotterChatDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3639,14 +3726,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8522,
+							"line": 8554,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatDelete\""
 				},
 				{
-					"id": 2419,
+					"id": 2433,
 					"name": "SpotterChatMenu",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3667,14 +3754,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8419,
+							"line": 8451,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatMenu\""
 				},
 				{
-					"id": 2434,
+					"id": 2448,
 					"name": "SpotterChatModeSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3695,14 +3782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8575,
+							"line": 8607,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatModeSwitcher\""
 				},
 				{
-					"id": 2430,
+					"id": 2444,
 					"name": "SpotterChatPin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3723,14 +3810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8532,
+							"line": 8564,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatPin\""
 				},
 				{
-					"id": 2420,
+					"id": 2434,
 					"name": "SpotterChatRename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3751,14 +3838,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8429,
+							"line": 8461,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterChatRename\""
 				},
 				{
-					"id": 2449,
+					"id": 2466,
 					"name": "SpotterDefaultAnalyst",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3779,14 +3866,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8748,
+							"line": 8830,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDefaultAnalyst\""
 				},
 				{
-					"id": 2431,
+					"id": 2445,
 					"name": "SpotterDocs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3807,14 +3894,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8542,
+							"line": 8574,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterDocs\""
 				},
 				{
-					"id": 2393,
+					"id": 2407,
 					"name": "SpotterFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3835,14 +3922,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8134,
+							"line": 8166,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterFeedback\""
 				},
 				{
-					"id": 2417,
+					"id": 2431,
 					"name": "SpotterNewChat",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3863,14 +3950,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8399,
+							"line": 8431,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterNewChat\""
 				},
 				{
-					"id": 2418,
+					"id": 2432,
 					"name": "SpotterPastChatBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3891,14 +3978,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8409,
+							"line": 8441,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterPastChatBanner\""
 				},
 				{
-					"id": 2421,
+					"id": 2435,
 					"name": "SpotterShareConversationButtonHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3919,14 +4006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8440,
+							"line": 8472,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeader\""
 				},
 				{
-					"id": 2422,
+					"id": 2436,
 					"name": "SpotterShareConversationMenuItemSidebar",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3947,14 +4034,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8451,
+							"line": 8483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebar\""
 				},
 				{
-					"id": 2427,
+					"id": 2441,
 					"name": "SpotterShareIncludeNewMessagesCheckbox",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -3975,14 +4062,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8502,
+							"line": 8534,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckbox\""
 				},
 				{
-					"id": 2428,
+					"id": 2442,
 					"name": "SpotterShareStaleInfoBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4003,14 +4090,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8512,
+							"line": 8544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissButton\""
 				},
 				{
-					"id": 2426,
+					"id": 2440,
 					"name": "SpotterShareUpToCurrentInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4031,14 +4118,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8492,
+							"line": 8524,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareUpToCurrentInfo\""
 				},
 				{
-					"id": 2423,
+					"id": 2437,
 					"name": "SpotterSharedConversationBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4059,14 +4146,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8461,
+							"line": 8493,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBanner\""
 				},
 				{
-					"id": 2424,
+					"id": 2438,
 					"name": "SpotterSharedConversationBannerDismissButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4087,14 +4174,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8471,
+							"line": 8503,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationBannerDismissButton\""
 				},
 				{
-					"id": 2425,
+					"id": 2439,
 					"name": "SpotterSharedConversationExitButton",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4115,14 +4202,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8482,
+							"line": 8514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButton\""
 				},
 				{
-					"id": 2415,
+					"id": 2429,
 					"name": "SpotterSidebarFooter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4143,14 +4230,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8379,
+							"line": 8411,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarFooter\""
 				},
 				{
-					"id": 2414,
+					"id": 2428,
 					"name": "SpotterSidebarHeader",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4171,14 +4258,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8369,
+							"line": 8401,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarHeader\""
 				},
 				{
-					"id": 2416,
+					"id": 2430,
 					"name": "SpotterSidebarToggle",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4199,14 +4286,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8389,
+							"line": 8421,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSidebarToggle\""
 				},
 				{
-					"id": 2402,
+					"id": 2416,
 					"name": "SpotterTokenQuickEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4227,14 +4314,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8237,
+							"line": 8269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterTokenQuickEdit\""
 				},
 				{
-					"id": 2439,
+					"id": 2456,
 					"name": "SpotterViz",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4255,14 +4342,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8635,
+							"line": 8717,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterViz\""
 				},
 				{
-					"id": 2438,
+					"id": 2455,
 					"name": "SpotterVizCheckpointRestore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4283,14 +4370,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8623,
+							"line": 8705,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizCheckpointRestore\""
 				},
 				{
-					"id": 2437,
+					"id": 2454,
 					"name": "SpotterVizFeedback",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4311,14 +4398,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8611,
+							"line": 8693,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizFeedback\""
 				},
 				{
-					"id": 2440,
+					"id": 2457,
 					"name": "SpotterVizReferenceMode",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4339,14 +4426,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8649,
+							"line": 8731,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterVizReferenceMode\""
 				},
 				{
-					"id": 2400,
+					"id": 2414,
 					"name": "SpotterWarningsBanner",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4367,14 +4454,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8215,
+							"line": 8247,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsBanner\""
 				},
 				{
-					"id": 2401,
+					"id": 2415,
 					"name": "SpotterWarningsOnTokens",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4395,14 +4482,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8226,
+							"line": 8258,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterWarningsOnTokens\""
 				},
 				{
-					"id": 2315,
+					"id": 2329,
 					"name": "Subscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4419,14 +4506,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7322,
+							"line": 7354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2335,
+					"id": 2349,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4447,14 +4534,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7496,
+							"line": 7528,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2334,
+					"id": 2348,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4475,14 +4562,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7485,
+							"line": 7517,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2338,
+					"id": 2352,
 					"name": "SyncToSlack",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4503,14 +4590,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7526,
+							"line": 7558,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToSlack\""
 				},
 				{
-					"id": 2339,
+					"id": 2353,
 					"name": "SyncToTeams",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4531,14 +4618,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7536,
+							"line": 7568,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"syncToTeams\""
 				},
 				{
-					"id": 2371,
+					"id": 2385,
 					"name": "TML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4563,14 +4650,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7879,
+							"line": 7911,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"tml\""
 				},
 				{
-					"id": 2301,
+					"id": 2315,
 					"name": "ToggleSize",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4587,14 +4674,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7231,
+							"line": 7263,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"toggleSize\""
 				},
 				{
-					"id": 2413,
+					"id": 2427,
 					"name": "UngroupLiveboardGroup",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4615,14 +4702,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8359,
+							"line": 8391,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ungroupLiveboardGroup\""
 				},
 				{
-					"id": 2408,
+					"id": 2422,
 					"name": "Unpublish",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4643,14 +4730,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8308,
+							"line": 8340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unpublish\""
 				},
 				{
-					"id": 2383,
+					"id": 2397,
 					"name": "UnsubscribeScheduleHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4671,14 +4758,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8021,
+							"line": 8053,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"unsubscribeScheduleHomepage\""
 				},
 				{
-					"id": 2298,
+					"id": 2312,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4695,14 +4782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7200,
+							"line": 7232,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2373,
+					"id": 2387,
 					"name": "VerifiedLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4723,14 +4810,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 7903,
+							"line": 7935,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"verifiedLiveboard\""
 				},
 				{
-					"id": 2382,
+					"id": 2396,
 					"name": "ViewScheduleRunHomepage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4751,7 +4838,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8010,
+							"line": 8042,
 							"character": 4
 						}
 					],
@@ -4763,195 +4850,198 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2379,
-						2276,
-						2269,
-						2268,
-						2274,
-						2275,
-						2277,
-						2359,
-						2329,
-						2375,
-						2389,
-						2328,
-						2327,
-						2374,
-						2341,
-						2353,
-						2344,
-						2349,
-						2343,
-						2346,
-						2354,
-						2350,
-						2347,
-						2352,
-						2348,
-						2345,
-						2351,
-						2342,
-						2388,
-						2273,
-						2272,
-						2271,
-						2397,
-						2270,
-						2320,
-						2263,
-						2319,
-						2398,
-						2412,
-						2372,
-						2332,
-						2337,
-						2390,
-						2395,
-						2385,
-						2387,
-						2285,
+						2393,
+						2290,
+						2283,
+						2282,
 						2288,
+						2289,
+						2291,
+						2373,
+						2343,
+						2389,
+						2403,
+						2342,
+						2341,
+						2388,
+						2355,
+						2367,
+						2358,
+						2363,
+						2357,
+						2360,
+						2368,
+						2364,
+						2361,
+						2366,
+						2362,
+						2359,
+						2365,
+						2356,
+						2402,
 						2287,
 						2286,
-						2289,
-						2290,
-						2292,
-						2291,
-						2294,
-						2293,
-						2324,
-						2318,
-						2317,
-						2302,
-						2262,
-						2331,
-						2260,
-						2322,
-						2394,
-						2363,
-						2380,
-						2299,
-						2303,
-						2396,
-						2360,
-						2361,
-						2316,
-						2296,
-						2297,
-						2399,
-						2435,
-						2386,
-						2310,
-						2405,
-						2370,
-						2261,
-						2367,
-						2336,
-						2407,
-						2384,
-						2358,
-						2365,
+						2285,
 						2411,
-						2410,
-						2366,
-						2377,
-						2378,
-						2409,
-						2381,
-						2368,
-						2369,
-						2313,
-						2403,
-						2300,
-						2391,
-						2406,
-						2326,
-						2441,
-						2304,
-						2404,
-						2340,
-						2330,
-						2376,
-						2356,
-						2333,
-						2325,
-						2357,
-						2392,
-						2364,
-						2256,
-						2259,
-						2265,
-						2266,
-						2436,
-						2323,
-						2267,
-						2282,
-						2362,
 						2284,
-						2279,
-						2444,
-						2445,
-						2443,
-						2448,
-						2446,
-						2442,
-						2447,
-						2432,
-						2433,
-						2429,
-						2419,
-						2434,
-						2430,
-						2420,
-						2449,
-						2431,
-						2393,
-						2417,
-						2418,
-						2421,
-						2422,
-						2427,
-						2428,
-						2426,
-						2423,
-						2424,
-						2425,
-						2415,
-						2414,
-						2416,
-						2402,
-						2439,
-						2438,
-						2437,
-						2440,
-						2400,
-						2401,
-						2315,
-						2335,
 						2334,
+						2277,
+						2333,
+						2412,
+						2426,
+						2386,
+						2346,
+						2351,
+						2451,
+						2404,
+						2450,
+						2409,
+						2399,
+						2401,
+						2299,
+						2302,
+						2301,
+						2300,
+						2303,
+						2304,
+						2306,
+						2305,
+						2308,
+						2307,
 						2338,
+						2332,
+						2331,
+						2316,
+						2276,
+						2345,
+						2274,
+						2336,
+						2408,
+						2377,
+						2394,
+						2313,
+						2317,
+						2410,
+						2374,
+						2375,
+						2330,
+						2310,
+						2311,
+						2413,
+						2452,
+						2400,
+						2324,
+						2419,
+						2384,
+						2275,
+						2381,
+						2350,
+						2421,
+						2398,
+						2372,
+						2379,
+						2425,
+						2424,
+						2380,
+						2391,
+						2392,
+						2423,
+						2395,
+						2382,
+						2383,
+						2327,
+						2417,
+						2314,
+						2405,
+						2420,
+						2340,
+						2449,
+						2458,
+						2318,
+						2418,
+						2354,
+						2344,
+						2390,
+						2370,
+						2347,
 						2339,
 						2371,
-						2301,
-						2413,
-						2408,
-						2383,
+						2406,
+						2378,
+						2270,
+						2273,
+						2279,
+						2280,
+						2453,
+						2337,
+						2281,
+						2296,
+						2376,
 						2298,
-						2373,
-						2382
+						2293,
+						2461,
+						2462,
+						2460,
+						2465,
+						2463,
+						2459,
+						2464,
+						2446,
+						2447,
+						2443,
+						2433,
+						2448,
+						2444,
+						2434,
+						2466,
+						2445,
+						2407,
+						2431,
+						2432,
+						2435,
+						2436,
+						2441,
+						2442,
+						2440,
+						2437,
+						2438,
+						2439,
+						2429,
+						2428,
+						2430,
+						2416,
+						2456,
+						2455,
+						2454,
+						2457,
+						2414,
+						2415,
+						2329,
+						2349,
+						2348,
+						2352,
+						2353,
+						2385,
+						2315,
+						2427,
+						2422,
+						2397,
+						2312,
+						2387,
+						2396
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6816,
+					"line": 6848,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1839,
+			"id": 1853,
 			"name": "AuthEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -4967,7 +5057,7 @@
 			},
 			"children": [
 				{
-					"id": 1840,
+					"id": 1854,
 					"name": "TRIGGER_SSO_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -4990,7 +5080,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1840
+						1854
 					]
 				}
 			],
@@ -5003,7 +5093,7 @@
 			]
 		},
 		{
-			"id": 1824,
+			"id": 1838,
 			"name": "AuthFailureType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5019,7 +5109,7 @@
 			},
 			"children": [
 				{
-					"id": 1827,
+					"id": 1841,
 					"name": "EXPIRY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5038,7 +5128,7 @@
 					"defaultValue": "\"EXPIRY\""
 				},
 				{
-					"id": 1829,
+					"id": 1843,
 					"name": "IDLE_SESSION_TIMEOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5057,7 +5147,7 @@
 					"defaultValue": "\"IDLE_SESSION_TIMEOUT\""
 				},
 				{
-					"id": 1826,
+					"id": 1840,
 					"name": "NO_COOKIE_ACCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5076,7 +5166,7 @@
 					"defaultValue": "\"NO_COOKIE_ACCESS\""
 				},
 				{
-					"id": 1828,
+					"id": 1842,
 					"name": "OTHER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5095,7 +5185,7 @@
 					"defaultValue": "\"OTHER\""
 				},
 				{
-					"id": 1825,
+					"id": 1839,
 					"name": "SDK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5114,7 +5204,7 @@
 					"defaultValue": "\"SDK\""
 				},
 				{
-					"id": 1830,
+					"id": 1844,
 					"name": "UNAUTHENTICATED_FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5138,12 +5228,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1827,
-						1829,
-						1826,
-						1828,
-						1825,
-						1830
+						1841,
+						1843,
+						1840,
+						1842,
+						1839,
+						1844
 					]
 				}
 			],
@@ -5156,7 +5246,7 @@
 			]
 		},
 		{
-			"id": 1831,
+			"id": 1845,
 			"name": "AuthStatus",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5172,7 +5262,7 @@
 			},
 			"children": [
 				{
-					"id": 1832,
+					"id": 1846,
 					"name": "FAILURE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5190,7 +5280,7 @@
 					"defaultValue": "\"FAILURE\""
 				},
 				{
-					"id": 1836,
+					"id": 1850,
 					"name": "LOGOUT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5208,7 +5298,7 @@
 					"defaultValue": "\"LOGOUT\""
 				},
 				{
-					"id": 1838,
+					"id": 1852,
 					"name": "SAML_POPUP_CLOSED_NO_AUTH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5226,7 +5316,7 @@
 					"defaultValue": "\"SAML_POPUP_CLOSED_NO_AUTH\""
 				},
 				{
-					"id": 1833,
+					"id": 1847,
 					"name": "SDK_SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5250,7 +5340,7 @@
 					"defaultValue": "\"SDK_SUCCESS\""
 				},
 				{
-					"id": 1835,
+					"id": 1849,
 					"name": "SUCCESS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5283,7 +5373,7 @@
 					"defaultValue": "\"SUCCESS\""
 				},
 				{
-					"id": 1837,
+					"id": 1851,
 					"name": "WAITING_FOR_POPUP",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5312,12 +5402,12 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1832,
-						1836,
-						1838,
-						1833,
-						1835,
-						1837
+						1846,
+						1850,
+						1852,
+						1847,
+						1849,
+						1851
 					]
 				}
 			],
@@ -5330,7 +5420,7 @@
 			]
 		},
 		{
-			"id": 1991,
+			"id": 2005,
 			"name": "AuthType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5346,7 +5436,7 @@
 			},
 			"children": [
 				{
-					"id": 2002,
+					"id": 2016,
 					"name": "Basic",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5365,7 +5455,7 @@
 					"defaultValue": "\"Basic\""
 				},
 				{
-					"id": 1993,
+					"id": 2007,
 					"name": "EmbeddedSSO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5394,7 +5484,7 @@
 					"defaultValue": "\"EmbeddedSSO\""
 				},
 				{
-					"id": 1992,
+					"id": 2006,
 					"name": "None",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5418,7 +5508,7 @@
 					"defaultValue": "\"None\""
 				},
 				{
-					"id": 1998,
+					"id": 2012,
 					"name": "OIDCRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5436,7 +5526,7 @@
 					"defaultValue": "\"SSO_OIDC\""
 				},
 				{
-					"id": 1996,
+					"id": 2010,
 					"name": "SAMLRedirect",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5469,7 +5559,7 @@
 					"defaultValue": "\"SSO_SAML\""
 				},
 				{
-					"id": 2000,
+					"id": 2014,
 					"name": "TrustedAuthToken",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5493,7 +5583,7 @@
 					"defaultValue": "\"AuthServer\""
 				},
 				{
-					"id": 2001,
+					"id": 2015,
 					"name": "TrustedAuthTokenCookieless",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5526,13 +5616,13 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2002,
-						1993,
-						1992,
-						1998,
-						1996,
-						2000,
-						2001
+						2016,
+						2007,
+						2006,
+						2012,
+						2010,
+						2014,
+						2015
 					]
 				}
 			],
@@ -5545,7 +5635,7 @@
 			]
 		},
 		{
-			"id": 3323,
+			"id": 3340,
 			"name": "BackgroundFormatType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5561,7 +5651,7 @@
 			},
 			"children": [
 				{
-					"id": 3325,
+					"id": 3342,
 					"name": "Gradient",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5572,14 +5662,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9453,
+							"line": 9535,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GRADIENT\""
 				},
 				{
-					"id": 3324,
+					"id": 3341,
 					"name": "Solid",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5590,7 +5680,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9451,
+							"line": 9533,
 							"character": 4
 						}
 					],
@@ -5602,21 +5692,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3325,
-						3324
+						3342,
+						3341
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9449,
+					"line": 9531,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3326,
+			"id": 3343,
 			"name": "ConditionalFormattingComparisonType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5632,7 +5722,7 @@
 			},
 			"children": [
 				{
-					"id": 3328,
+					"id": 3345,
 					"name": "ColumnBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5643,14 +5733,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9464,
+							"line": 9546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COLUMN_BASED\""
 				},
 				{
-					"id": 3329,
+					"id": 3346,
 					"name": "ParameterBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5661,14 +5751,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9466,
+							"line": 9548,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARAMETER_BASED\""
 				},
 				{
-					"id": 3327,
+					"id": 3344,
 					"name": "ValueBased",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5679,7 +5769,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9462,
+							"line": 9544,
 							"character": 4
 						}
 					],
@@ -5691,22 +5781,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3328,
-						3329,
-						3327
+						3345,
+						3346,
+						3344
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9460,
+					"line": 9542,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3330,
+			"id": 3347,
 			"name": "ConditionalFormattingOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -5722,7 +5812,7 @@
 			},
 			"children": [
 				{
-					"id": 3333,
+					"id": 3350,
 					"name": "Contains",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5733,14 +5823,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9418,
+							"line": 9500,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 3334,
+					"id": 3351,
 					"name": "DoesNotContain",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5751,14 +5841,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9420,
+							"line": 9502,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DOES_NOT_CONTAIN\""
 				},
 				{
-					"id": 3336,
+					"id": 3353,
 					"name": "EndsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5769,14 +5859,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9424,
+							"line": 9506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 3341,
+					"id": 3358,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5787,14 +5877,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9434,
+							"line": 9516,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3337,
+					"id": 3354,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5805,14 +5895,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9426,
+							"line": 9508,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3339,
+					"id": 3356,
 					"name": "GreaterThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5823,14 +5913,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9430,
+							"line": 9512,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3331,
+					"id": 3348,
 					"name": "Is",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5841,14 +5931,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9414,
+							"line": 9496,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS\""
 				},
 				{
-					"id": 3343,
+					"id": 3360,
 					"name": "IsBetween",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5859,14 +5949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9438,
+							"line": 9520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_BETWEEN\""
 				},
 				{
-					"id": 3332,
+					"id": 3349,
 					"name": "IsNot",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5877,14 +5967,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9416,
+							"line": 9498,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT\""
 				},
 				{
-					"id": 3345,
+					"id": 3362,
 					"name": "IsNotNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5895,14 +5985,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9442,
+							"line": 9524,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NOT_NULL\""
 				},
 				{
-					"id": 3344,
+					"id": 3361,
 					"name": "IsNull",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5913,14 +6003,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9440,
+							"line": 9522,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IS_NULL\""
 				},
 				{
-					"id": 3338,
+					"id": 3355,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5931,14 +6021,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9428,
+							"line": 9510,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3340,
+					"id": 3357,
 					"name": "LessThanEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5949,14 +6039,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9432,
+							"line": 9514,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_EQUAL_TO\""
 				},
 				{
-					"id": 3342,
+					"id": 3359,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5967,14 +6057,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9436,
+							"line": 9518,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NOT_EQUAL_TO\""
 				},
 				{
-					"id": 3335,
+					"id": 3352,
 					"name": "StartsWith",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -5985,7 +6075,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9422,
+							"line": 9504,
 							"character": 4
 						}
 					],
@@ -5997,34 +6087,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3333,
-						3334,
-						3336,
-						3341,
-						3337,
-						3339,
-						3331,
-						3343,
-						3332,
-						3345,
-						3344,
-						3338,
-						3340,
-						3342,
-						3335
+						3350,
+						3351,
+						3353,
+						3358,
+						3354,
+						3356,
+						3348,
+						3360,
+						3349,
+						3362,
+						3361,
+						3355,
+						3357,
+						3359,
+						3352
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9412,
+					"line": 9494,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2450,
+			"id": 2467,
 			"name": "ContextMenuTriggerOptions",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6034,7 +6124,7 @@
 			},
 			"children": [
 				{
-					"id": 2453,
+					"id": 2470,
 					"name": "BOTH_CLICKS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6042,14 +6132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8768,
+							"line": 8850,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"both-clicks\""
 				},
 				{
-					"id": 2451,
+					"id": 2468,
 					"name": "LEFT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6057,14 +6147,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8766,
+							"line": 8848,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left-click\""
 				},
 				{
-					"id": 2452,
+					"id": 2469,
 					"name": "RIGHT_CLICK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6072,7 +6162,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8767,
+							"line": 8849,
 							"character": 4
 						}
 					],
@@ -6084,22 +6174,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2453,
-						2451,
-						2452
+						2470,
+						2468,
+						2469
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8765,
+					"line": 8847,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2245,
+			"id": 2259,
 			"name": "ContextType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6123,7 +6213,7 @@
 			},
 			"children": [
 				{
-					"id": 2248,
+					"id": 2262,
 					"name": "Answer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6134,14 +6224,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9216,
+							"line": 9298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answer\""
 				},
 				{
-					"id": 2247,
+					"id": 2261,
 					"name": "Liveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6152,14 +6242,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9212,
+							"line": 9294,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"liveboard\""
 				},
 				{
-					"id": 2250,
+					"id": 2264,
 					"name": "Other",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6170,14 +6260,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9225,
+							"line": 9307,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"other\""
 				},
 				{
-					"id": 2246,
+					"id": 2260,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6188,14 +6278,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9208,
+							"line": 9290,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search-answer\""
 				},
 				{
-					"id": 2249,
+					"id": 2263,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6206,7 +6296,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9220,
+							"line": 9302,
 							"character": 4
 						}
 					],
@@ -6218,24 +6308,24 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2248,
-						2247,
-						2250,
-						2246,
-						2249
+						2262,
+						2261,
+						2264,
+						2260,
+						2263
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9204,
+					"line": 9286,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3277,
+			"id": 3294,
 			"name": "CustomActionTarget",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6245,7 +6335,7 @@
 			},
 			"children": [
 				{
-					"id": 3280,
+					"id": 3297,
 					"name": "ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6256,14 +6346,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8905,
+							"line": 8987,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ANSWER\""
 				},
 				{
-					"id": 3278,
+					"id": 3295,
 					"name": "LIVEBOARD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6274,14 +6364,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8878,
+							"line": 8960,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD\""
 				},
 				{
-					"id": 3281,
+					"id": 3298,
 					"name": "SPOTTER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6292,14 +6382,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8916,
+							"line": 8998,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SPOTTER\""
 				},
 				{
-					"id": 3279,
+					"id": 3296,
 					"name": "VIZ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6310,7 +6400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8892,
+							"line": 8974,
 							"character": 4
 						}
 					],
@@ -6322,23 +6412,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3280,
-						3278,
-						3281,
-						3279
+						3297,
+						3295,
+						3298,
+						3296
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8868,
+					"line": 8950,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3273,
+			"id": 3290,
 			"name": "CustomActionsPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6348,7 +6438,7 @@
 			},
 			"children": [
 				{
-					"id": 3276,
+					"id": 3293,
 					"name": "CONTEXTMENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6359,14 +6449,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8859,
+							"line": 8941,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTEXTMENU\""
 				},
 				{
-					"id": 3275,
+					"id": 3292,
 					"name": "MENU",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6377,14 +6467,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8851,
+							"line": 8933,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MENU\""
 				},
 				{
-					"id": 3274,
+					"id": 3291,
 					"name": "PRIMARY",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6395,7 +6485,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8846,
+							"line": 8928,
 							"character": 4
 						}
 					],
@@ -6407,22 +6497,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3276,
-						3275,
-						3274
+						3293,
+						3292,
+						3291
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8841,
+					"line": 8923,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3346,
+			"id": 3363,
 			"name": "DataLabelFilterOperator",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6438,7 +6528,7 @@
 			},
 			"children": [
 				{
-					"id": 3351,
+					"id": 3368,
 					"name": "EqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6449,14 +6539,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9403,
+							"line": 9485,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQUAL_TO\""
 				},
 				{
-					"id": 3347,
+					"id": 3364,
 					"name": "GreaterThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6467,14 +6557,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9395,
+							"line": 9477,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN\""
 				},
 				{
-					"id": 3349,
+					"id": 3366,
 					"name": "GreaterThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6485,14 +6575,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9399,
+							"line": 9481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GREATER_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3348,
+					"id": 3365,
 					"name": "LessThan",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6503,14 +6593,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9397,
+							"line": 9479,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN\""
 				},
 				{
-					"id": 3350,
+					"id": 3367,
 					"name": "LessThanOrEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6521,14 +6611,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9401,
+							"line": 9483,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LESS_THAN_OR_EQUAL_TO\""
 				},
 				{
-					"id": 3352,
+					"id": 3369,
 					"name": "NotEqualTo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6539,7 +6629,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9405,
+							"line": 9487,
 							"character": 4
 						}
 					],
@@ -6551,25 +6641,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3351,
-						3347,
-						3349,
-						3348,
-						3350,
-						3352
+						3368,
+						3364,
+						3366,
+						3365,
+						3367,
+						3369
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9393,
+					"line": 9475,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3269,
+			"id": 3286,
 			"name": "DataPanelCustomColumnGroupsAccordionState",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6579,7 +6669,7 @@
 			},
 			"children": [
 				{
-					"id": 3271,
+					"id": 3288,
 					"name": "COLLAPSE_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6597,7 +6687,7 @@
 					"defaultValue": "\"COLLAPSE_ALL\""
 				},
 				{
-					"id": 3270,
+					"id": 3287,
 					"name": "EXPAND_ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6615,7 +6705,7 @@
 					"defaultValue": "\"EXPAND_ALL\""
 				},
 				{
-					"id": 3272,
+					"id": 3289,
 					"name": "EXPAND_FIRST",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6638,9 +6728,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3271,
-						3270,
-						3272
+						3288,
+						3287,
+						3289
 					]
 				}
 			],
@@ -6653,7 +6743,7 @@
 			]
 		},
 		{
-			"id": 2251,
+			"id": 2265,
 			"name": "DataSourceVisualMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6663,7 +6753,7 @@
 			},
 			"children": [
 				{
-					"id": 2253,
+					"id": 2267,
 					"name": "Collapsed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6674,14 +6764,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6599,
+							"line": 6631,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"collapse\""
 				},
 				{
-					"id": 2254,
+					"id": 2268,
 					"name": "Expanded",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6692,14 +6782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6603,
+							"line": 6635,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"expand\""
 				},
 				{
-					"id": 2252,
+					"id": 2266,
 					"name": "Hidden",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6710,7 +6800,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6595,
+							"line": 6627,
 							"character": 4
 						}
 					],
@@ -6722,22 +6812,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2253,
-						2254,
-						2252
+						2267,
+						2268,
+						2266
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 6591,
+					"line": 6623,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3286,
+			"id": 3303,
 			"name": "EmbedErrorCodes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -6761,7 +6851,7 @@
 			},
 			"children": [
 				{
-					"id": 3289,
+					"id": 3306,
 					"name": "CONFLICTING_ACTIONS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6772,14 +6862,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9082,
+							"line": 9164,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_ACTIONS_CONFIG\""
 				},
 				{
-					"id": 3290,
+					"id": 3307,
 					"name": "CONFLICTING_TABS_CONFIG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6790,14 +6880,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9085,
+							"line": 9167,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONFLICTING_TABS_CONFIG\""
 				},
 				{
-					"id": 3293,
+					"id": 3310,
 					"name": "CUSTOM_ACTION_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6808,14 +6898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9094,
+							"line": 9176,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CUSTOM_ACTION_VALIDATION\""
 				},
 				{
-					"id": 3302,
+					"id": 3319,
 					"name": "DRILLDOWN_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6826,14 +6916,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9121,
+							"line": 9203,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DRILLDOWN_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3296,
+					"id": 3313,
 					"name": "HOST_EVENT_TYPE_UNDEFINED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6844,14 +6934,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9103,
+							"line": 9185,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_TYPE_UNDEFINED\""
 				},
 				{
-					"id": 3300,
+					"id": 3317,
 					"name": "HOST_EVENT_VALIDATION",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6862,14 +6952,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9115,
+							"line": 9197,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"HOST_EVENT_VALIDATION\""
 				},
 				{
-					"id": 3291,
+					"id": 3308,
 					"name": "INIT_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6880,14 +6970,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9088,
+							"line": 9170,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INIT_ERROR\""
 				},
 				{
-					"id": 3299,
+					"id": 3316,
 					"name": "INVALID_URL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6898,14 +6988,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9112,
+							"line": 9194,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INVALID_URL\""
 				},
 				{
-					"id": 3288,
+					"id": 3305,
 					"name": "LIVEBOARD_ID_MISSING",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6916,14 +7006,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9079,
+							"line": 9161,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LIVEBOARD_ID_MISSING\""
 				},
 				{
-					"id": 3294,
+					"id": 3311,
 					"name": "LOGIN_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6934,14 +7024,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9097,
+							"line": 9179,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LOGIN_FAILED\""
 				},
 				{
-					"id": 3292,
+					"id": 3309,
 					"name": "NETWORK_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6952,14 +7042,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9091,
+							"line": 9173,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK_ERROR\""
 				},
 				{
-					"id": 3297,
+					"id": 3314,
 					"name": "PARSING_API_INTERCEPT_BODY_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6970,14 +7060,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9106,
+							"line": 9188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PARSING_API_INTERCEPT_BODY_ERROR\""
 				},
 				{
-					"id": 3295,
+					"id": 3312,
 					"name": "RENDER_NOT_CALLED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -6988,14 +7078,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9100,
+							"line": 9182,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"RENDER_NOT_CALLED\""
 				},
 				{
-					"id": 3301,
+					"id": 3318,
 					"name": "UPDATEFILTERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7006,14 +7096,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9118,
+							"line": 9200,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEFILTERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3303,
+					"id": 3320,
 					"name": "UPDATEPARAMETERS_INVALID_PAYLOAD",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7024,14 +7114,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9124,
+							"line": 9206,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATEPARAMETERS_INVALID_PAYLOAD\""
 				},
 				{
-					"id": 3298,
+					"id": 3315,
 					"name": "UPDATE_PARAMS_FAILED",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7042,14 +7132,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9109,
+							"line": 9191,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UPDATE_PARAMS_FAILED\""
 				},
 				{
-					"id": 3287,
+					"id": 3304,
 					"name": "WORKSHEET_ID_NOT_FOUND",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7060,7 +7150,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9076,
+							"line": 9158,
 							"character": 4
 						}
 					],
@@ -7072,36 +7162,36 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3289,
-						3290,
-						3293,
-						3302,
-						3296,
-						3300,
-						3291,
-						3299,
-						3288,
-						3294,
-						3292,
-						3297,
-						3295,
-						3301,
-						3303,
-						3298,
-						3287
+						3306,
+						3307,
+						3310,
+						3319,
+						3313,
+						3317,
+						3308,
+						3316,
+						3305,
+						3311,
+						3309,
+						3314,
+						3312,
+						3318,
+						3320,
+						3315,
+						3304
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9074,
+					"line": 9156,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2023,
+			"id": 2037,
 			"name": "EmbedEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -7126,7 +7216,7 @@
 			},
 			"children": [
 				{
-					"id": 2060,
+					"id": 2074,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7147,14 +7237,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3021,
+							"line": 3045,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2051,
+					"id": 2065,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7175,14 +7265,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2884,
+							"line": 2908,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"*\""
 				},
 				{
-					"id": 2031,
+					"id": 2045,
 					"name": "AddRemoveColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7207,14 +7297,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2632,
+							"line": 2656,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addRemoveColumns\""
 				},
 				{
-					"id": 2113,
+					"id": 2127,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7235,14 +7325,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3687,
+							"line": 3711,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2077,
+					"id": 2091,
 					"name": "AddToFavorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7263,14 +7353,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3234,
+							"line": 3258,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToFavorites\""
 				},
 				{
-					"id": 2036,
+					"id": 2050,
 					"name": "Alert",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7295,14 +7385,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2742,
+							"line": 2766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"alert\""
 				},
 				{
-					"id": 2073,
+					"id": 2087,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7323,14 +7413,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3202,
+							"line": 3226,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2059,
+					"id": 2073,
 					"name": "AnswerDelete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7351,14 +7441,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3010,
+							"line": 3034,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerDelete\""
 				},
 				{
-					"id": 2123,
+					"id": 2137,
 					"name": "ApiIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7380,14 +7470,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3853,
+							"line": 3877,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ApiIntercept\""
 				},
 				{
-					"id": 2102,
+					"id": 2116,
 					"name": "AskSageInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7420,14 +7510,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3491,
+							"line": 3515,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSageInit\""
 				},
 				{
-					"id": 2037,
+					"id": 2051,
 					"name": "AuthExpire",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7448,14 +7538,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2755,
+							"line": 2779,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ThoughtspotAuthExpired\""
 				},
 				{
-					"id": 2025,
+					"id": 2039,
 					"name": "AuthInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7480,14 +7570,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2534,
+							"line": 2558,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"authInit\""
 				},
 				{
-					"id": 2084,
+					"id": 2098,
 					"name": "Cancel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7508,14 +7598,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3310,
+							"line": 3334,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cancel\""
 				},
 				{
-					"id": 2100,
+					"id": 2114,
 					"name": "ChangePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7552,14 +7642,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3477,
+							"line": 3501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"changePersonalisedView\""
 				},
 				{
-					"id": 2071,
+					"id": 2085,
 					"name": "CopyAEdit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7580,14 +7670,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3180,
+							"line": 3204,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"copyAEdit\""
 				},
 				{
-					"id": 2086,
+					"id": 2100,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7608,14 +7698,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3330,
+							"line": 3354,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2066,
+					"id": 2080,
 					"name": "CopyToClipboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7636,14 +7726,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3113,
+							"line": 3137,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-copy-to-clipboard\""
 				},
 				{
-					"id": 2092,
+					"id": 2106,
 					"name": "CreateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7660,14 +7750,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3389,
+							"line": 3413,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createConnection\""
 				},
 				{
-					"id": 2107,
+					"id": 2121,
 					"name": "CreateLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7685,14 +7775,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3637,
+							"line": 3661,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createLiveboard\""
 				},
 				{
-					"id": 2108,
+					"id": 2122,
 					"name": "CreateModel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7709,14 +7799,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3642,
+							"line": 3666,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createModel\""
 				},
 				{
-					"id": 2101,
+					"id": 2115,
 					"name": "CreateWorksheet",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7733,14 +7823,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3482,
+							"line": 3506,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createWorksheet\""
 				},
 				{
-					"id": 2087,
+					"id": 2101,
 					"name": "CrossFilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7761,14 +7851,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3341,
+							"line": 3365,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"cross-filter-changed\""
 				},
 				{
-					"id": 2032,
+					"id": 2046,
 					"name": "CustomAction",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7797,14 +7887,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2649,
+							"line": 2673,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"customAction\""
 				},
 				{
-					"id": 2027,
+					"id": 2041,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7833,14 +7923,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2562,
+							"line": 2586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 2114,
+					"id": 2128,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7861,14 +7951,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3698,
+							"line": 3722,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2030,
+					"id": 2044,
 					"name": "DataSourceSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7893,14 +7983,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2620,
+							"line": 2644,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dataSourceSelected\""
 				},
 				{
-					"id": 2082,
+					"id": 2096,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7921,14 +8011,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3292,
+							"line": 3316,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2098,
+					"id": 2112,
 					"name": "DeletePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7957,14 +8047,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3449,
+							"line": 3473,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2099,
+					"id": 2113,
 					"name": "DeletePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -7989,14 +8079,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3456,
+							"line": 3480,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"deletePersonalisedView\""
 				},
 				{
-					"id": 2049,
+					"id": 2063,
 					"name": "DialogClose",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8017,14 +8107,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2851,
+							"line": 2875,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-close\""
 				},
 				{
-					"id": 2048,
+					"id": 2062,
 					"name": "DialogOpen",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8045,14 +8135,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2840,
+							"line": 2864,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"dialog-open\""
 				},
 				{
-					"id": 2053,
+					"id": 2067,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8074,14 +8164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2919,
+							"line": 2943,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"download\""
 				},
 				{
-					"id": 2056,
+					"id": 2070,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8102,14 +8192,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2967,
+							"line": 2991,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCsv\""
 				},
 				{
-					"id": 2055,
+					"id": 2069,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8130,14 +8220,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2951,
+							"line": 2975,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2054,
+					"id": 2068,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8158,14 +8248,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2935,
+							"line": 2959,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2057,
+					"id": 2071,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8186,14 +8276,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2983,
+							"line": 3007,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXlsx\""
 				},
 				{
-					"id": 2058,
+					"id": 2072,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8214,14 +8304,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2994,
+							"line": 3018,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2065,
+					"id": 2079,
 					"name": "DrillExclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8242,14 +8332,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3102,
+							"line": 3126,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-exclude\""
 				},
 				{
-					"id": 2064,
+					"id": 2078,
 					"name": "DrillInclude",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8270,14 +8360,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3090,
+							"line": 3114,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"context-menu-item-include\""
 				},
 				{
-					"id": 2029,
+					"id": 2043,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8314,14 +8404,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2608,
+							"line": 2632,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 2079,
+					"id": 2093,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8342,14 +8432,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3256,
+							"line": 3280,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2068,
+					"id": 2082,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8370,14 +8460,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3136,
+							"line": 3160,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2141,
+					"id": 2155,
 					"name": "EmbedPageContextChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8398,14 +8488,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4091,
+							"line": 4115,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedPageContextChanged\""
 				},
 				{
-					"id": 2035,
+					"id": 2049,
 					"name": "Error",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8435,14 +8525,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2732,
+							"line": 2756,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Error\""
 				},
 				{
-					"id": 2085,
+					"id": 2099,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8463,14 +8553,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3320,
+							"line": 3344,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2069,
+					"id": 2083,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8491,14 +8581,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3153,
+							"line": 3177,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2090,
+					"id": 2104,
 					"name": "FilterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8519,14 +8609,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3379,
+							"line": 3403,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"filterChanged\""
 				},
 				{
-					"id": 2043,
+					"id": 2057,
 					"name": "GetDataClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8547,14 +8637,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2797,
+							"line": 2821,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getDataClick\""
 				},
 				{
-					"id": 2024,
+					"id": 2038,
 					"name": "Init",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8575,14 +8665,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2522,
+							"line": 2546,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"init\""
 				},
 				{
-					"id": 2117,
+					"id": 2131,
 					"name": "LastPromptDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8603,14 +8693,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3731,
+							"line": 3755,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptDeleted\""
 				},
 				{
-					"id": 2116,
+					"id": 2130,
 					"name": "LastPromptEdited",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8631,14 +8721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3720,
+							"line": 3744,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LastPromptEdited\""
 				},
 				{
-					"id": 2076,
+					"id": 2090,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8659,14 +8749,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3223,
+							"line": 3247,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2050,
+					"id": 2064,
 					"name": "LiveboardRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8691,14 +8781,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2873,
+							"line": 2897,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinboardRendered\""
 				},
 				{
-					"id": 2026,
+					"id": 2040,
 					"name": "Load",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8723,14 +8813,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2548,
+							"line": 2572,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"load\""
 				},
 				{
-					"id": 2080,
+					"id": 2094,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8751,14 +8841,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3267,
+							"line": 3291,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2046,
+					"id": 2060,
 					"name": "NoCookieAccess",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8779,14 +8869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2823,
+							"line": 2847,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"noCookieAccess\""
 				},
 				{
-					"id": 2104,
+					"id": 2118,
 					"name": "OnBeforeGetVizDataIntercept",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8817,14 +8907,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3562,
+							"line": 3586,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onBeforeGetVizDataIntercept\""
 				},
 				{
-					"id": 2122,
+					"id": 2136,
 					"name": "OrgSwitched",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8845,14 +8935,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3787,
+							"line": 3811,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"orgSwitched\""
 				},
 				{
-					"id": 2105,
+					"id": 2119,
 					"name": "ParameterChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8869,14 +8959,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3581,
+							"line": 3605,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"parameterChanged\""
 				},
 				{
-					"id": 2061,
+					"id": 2075,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8897,14 +8987,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3042,
+							"line": 3066,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2081,
+					"id": 2095,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8929,14 +9019,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3282,
+							"line": 3306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2112,
+					"id": 2126,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8957,14 +9047,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3676,
+							"line": 3700,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2028,
+					"id": 2042,
 					"name": "QueryChanged",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -8985,14 +9075,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2571,
+							"line": 2595,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"queryChanged\""
 				},
 				{
-					"id": 2151,
+					"id": 2165,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9013,14 +9103,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4233,
+							"line": 4257,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2103,
+					"id": 2117,
 					"name": "Rename",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9037,14 +9127,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3496,
+							"line": 3520,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"rename\""
 				},
 				{
-					"id": 2097,
+					"id": 2111,
 					"name": "ResetLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9077,14 +9167,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3440,
+							"line": 3464,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetLiveboard\""
 				},
 				{
-					"id": 2118,
+					"id": 2132,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9105,14 +9195,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3742,
+							"line": 3766,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2044,
+					"id": 2058,
 					"name": "RouteChange",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9133,14 +9223,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2807,
+							"line": 2831,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROUTE_CHANGE\""
 				},
 				{
-					"id": 2052,
+					"id": 2066,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9161,14 +9251,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2903,
+							"line": 2927,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2070,
+					"id": 2084,
 					"name": "SaveAsView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9189,14 +9279,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3164,
+							"line": 3188,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAsView\""
 				},
 				{
-					"id": 2095,
+					"id": 2109,
 					"name": "SavePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9233,14 +9323,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3422,
+							"line": 3446,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2096,
+					"id": 2110,
 					"name": "SavePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9273,14 +9363,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3431,
+							"line": 3455,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"savePersonalisedView\""
 				},
 				{
-					"id": 2078,
+					"id": 2092,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9301,14 +9391,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3245,
+							"line": 3269,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2083,
+					"id": 2097,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9329,14 +9419,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3301,
+							"line": 3325,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2143,
+					"id": 2157,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9357,14 +9447,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4130,
+							"line": 4154,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2063,
+					"id": 2077,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9385,14 +9475,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3078,
+							"line": 3102,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2072,
+					"id": 2086,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9413,14 +9503,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3191,
+							"line": 3215,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2062,
+					"id": 2076,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9441,14 +9531,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3060,
+							"line": 3084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2125,
+					"id": 2139,
 					"name": "SpotterConversationDeleted",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9469,14 +9559,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3877,
+							"line": 3901,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationDeleted\""
 				},
 				{
-					"id": 2136,
+					"id": 2150,
 					"name": "SpotterConversationPinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9497,14 +9587,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4017,
+							"line": 4041,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationPinned\""
 				},
 				{
-					"id": 2124,
+					"id": 2138,
 					"name": "SpotterConversationRenamed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9525,14 +9615,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3865,
+							"line": 3889,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationRenamed\""
 				},
 				{
-					"id": 2138,
+					"id": 2152,
 					"name": "SpotterConversationSelected",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9553,14 +9643,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4041,
+							"line": 4065,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationSelected\""
 				},
 				{
-					"id": 2129,
+					"id": 2143,
 					"name": "SpotterConversationShareRevoked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9581,14 +9671,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3932,
+							"line": 3956,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShareRevoked\""
 				},
 				{
-					"id": 2128,
+					"id": 2142,
 					"name": "SpotterConversationShared",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9609,14 +9699,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3918,
+							"line": 3942,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationShared\""
 				},
 				{
-					"id": 2137,
+					"id": 2151,
 					"name": "SpotterConversationUnpinned",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9637,14 +9727,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4029,
+							"line": 4053,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterConversationUnpinned\""
 				},
 				{
-					"id": 2111,
+					"id": 2125,
 					"name": "SpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9665,14 +9755,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3665,
+							"line": 3689,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterData\""
 				},
 				{
-					"id": 2119,
+					"id": 2133,
 					"name": "SpotterInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9693,14 +9783,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3753,
+							"line": 3777,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterInit\""
 				},
 				{
-					"id": 2120,
+					"id": 2134,
 					"name": "SpotterLoadComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9721,14 +9811,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3764,
+							"line": 3788,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterLoadComplete\""
 				},
 				{
-					"id": 2115,
+					"id": 2129,
 					"name": "SpotterQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9749,14 +9839,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3709,
+							"line": 3733,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterQueryTriggered\""
 				},
 				{
-					"id": 2139,
+					"id": 2153,
 					"name": "SpotterResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9782,14 +9872,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4066,
+							"line": 4090,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterResponseComplete\""
 				},
 				{
-					"id": 2126,
+					"id": 2140,
 					"name": "SpotterShareConversationButtonHeaderClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9810,14 +9900,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3890,
+							"line": 3914,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationButtonHeaderClicked\""
 				},
 				{
-					"id": 2127,
+					"id": 2141,
 					"name": "SpotterShareConversationMenuItemSidebarClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9838,14 +9928,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3902,
+							"line": 3926,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareConversationMenuItemSidebarClicked\""
 				},
 				{
-					"id": 2131,
+					"id": 2145,
 					"name": "SpotterShareIncludeNewMessagesCheckboxToggled",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9866,14 +9956,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3957,
+							"line": 3981,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareIncludeNewMessagesCheckboxToggled\""
 				},
 				{
-					"id": 2134,
+					"id": 2148,
 					"name": "SpotterShareModalCancelButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9894,14 +9984,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3993,
+							"line": 4017,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalCancelButtonClicked\""
 				},
 				{
-					"id": 2133,
+					"id": 2147,
 					"name": "SpotterShareModalConfirmButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9922,14 +10012,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3982,
+							"line": 4006,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareModalConfirmButtonClicked\""
 				},
 				{
-					"id": 2132,
+					"id": 2146,
 					"name": "SpotterShareStaleInfoBannerDismissed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9950,14 +10040,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3969,
+							"line": 3993,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterShareStaleInfoBannerDismissed\""
 				},
 				{
-					"id": 2135,
+					"id": 2149,
 					"name": "SpotterSharedConversationExitButtonClicked",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -9978,14 +10068,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4005,
+							"line": 4029,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationExitButtonClicked\""
 				},
 				{
-					"id": 2130,
+					"id": 2144,
 					"name": "SpotterSharedConversationViewed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10006,14 +10096,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3945,
+							"line": 3969,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotterSharedConversationViewed\""
 				},
 				{
-					"id": 2147,
+					"id": 2161,
 					"name": "SpotterVizCheckpointCreated",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10034,14 +10124,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4182,
+							"line": 4206,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointCreated\""
 				},
 				{
-					"id": 2148,
+					"id": 2162,
 					"name": "SpotterVizCheckpointRestored",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10062,14 +10152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4195,
+							"line": 4219,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizCheckpointRestored\""
 				},
 				{
-					"id": 2150,
+					"id": 2164,
 					"name": "SpotterVizClosed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10090,14 +10180,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4219,
+							"line": 4243,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizClosed\""
 				},
 				{
-					"id": 2149,
+					"id": 2163,
 					"name": "SpotterVizError",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10118,14 +10208,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4207,
+							"line": 4231,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizError\""
 				},
 				{
-					"id": 2144,
+					"id": 2158,
 					"name": "SpotterVizInit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10146,14 +10236,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4143,
+							"line": 4167,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizInit\""
 				},
 				{
-					"id": 2145,
+					"id": 2159,
 					"name": "SpotterVizQueryTriggered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10174,14 +10264,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4156,
+							"line": 4180,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizQueryTriggered\""
 				},
 				{
-					"id": 2146,
+					"id": 2160,
 					"name": "SpotterVizResponseComplete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10202,14 +10292,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4169,
+							"line": 4193,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizResponseComplete\""
 				},
 				{
-					"id": 2142,
+					"id": 2156,
 					"name": "Subscribed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10235,14 +10325,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4115,
+							"line": 4139,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Subscribed\""
 				},
 				{
-					"id": 2106,
+					"id": 2120,
 					"name": "TableVizRendered",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10264,14 +10354,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3624,
+							"line": 3648,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TableVizRendered\""
 				},
 				{
-					"id": 2091,
+					"id": 2105,
 					"name": "UpdateConnection",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10288,14 +10378,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3384,
+							"line": 3408,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateConnection\""
 				},
 				{
-					"id": 2093,
+					"id": 2107,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10332,14 +10422,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3401,
+							"line": 3425,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2094,
+					"id": 2108,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10372,14 +10462,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3411,
+							"line": 3435,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updatePersonalisedView\""
 				},
 				{
-					"id": 2067,
+					"id": 2081,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10400,14 +10490,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3124,
+							"line": 3148,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2034,
+					"id": 2048,
 					"name": "VizPointClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10436,14 +10526,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2680,
+							"line": 2704,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointClick\""
 				},
 				{
-					"id": 2033,
+					"id": 2047,
 					"name": "VizPointDoubleClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10468,14 +10558,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2661,
+							"line": 2685,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"vizPointDoubleClick\""
 				},
 				{
-					"id": 2088,
+					"id": 2102,
 					"name": "VizPointRightClick",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10496,7 +10586,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 3352,
+							"line": 3376,
 							"character": 4
 						}
 					],
@@ -10508,133 +10598,133 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2060,
-						2051,
-						2031,
-						2113,
-						2077,
-						2036,
-						2073,
-						2059,
-						2123,
-						2102,
-						2037,
-						2025,
-						2084,
-						2100,
-						2071,
-						2086,
-						2066,
-						2092,
-						2107,
-						2108,
-						2101,
-						2087,
-						2032,
-						2027,
-						2114,
-						2030,
-						2082,
-						2098,
-						2099,
-						2049,
-						2048,
-						2053,
-						2056,
-						2055,
-						2054,
-						2057,
-						2058,
+						2074,
 						2065,
-						2064,
-						2029,
-						2079,
-						2068,
-						2141,
-						2035,
-						2085,
-						2069,
-						2090,
-						2043,
-						2024,
-						2117,
-						2116,
-						2076,
-						2050,
-						2026,
-						2080,
-						2046,
-						2104,
-						2122,
-						2105,
-						2061,
-						2081,
-						2112,
-						2028,
-						2151,
-						2103,
-						2097,
-						2118,
-						2044,
-						2052,
-						2070,
-						2095,
-						2096,
-						2078,
-						2083,
-						2143,
-						2063,
-						2072,
-						2062,
-						2125,
-						2136,
-						2124,
-						2138,
-						2129,
-						2128,
-						2137,
-						2111,
-						2119,
-						2120,
-						2115,
-						2139,
-						2126,
+						2045,
 						2127,
+						2091,
+						2050,
+						2087,
+						2073,
+						2137,
+						2116,
+						2051,
+						2039,
+						2098,
+						2114,
+						2085,
+						2100,
+						2080,
+						2106,
+						2121,
+						2122,
+						2115,
+						2101,
+						2046,
+						2041,
+						2128,
+						2044,
+						2096,
+						2112,
+						2113,
+						2063,
+						2062,
+						2067,
+						2070,
+						2069,
+						2068,
+						2071,
+						2072,
+						2079,
+						2078,
+						2043,
+						2093,
+						2082,
+						2155,
+						2049,
+						2099,
+						2083,
+						2104,
+						2057,
+						2038,
 						2131,
-						2134,
-						2133,
-						2132,
-						2135,
 						2130,
-						2147,
-						2148,
+						2090,
+						2064,
+						2040,
+						2094,
+						2060,
+						2118,
+						2136,
+						2119,
+						2075,
+						2095,
+						2126,
+						2042,
+						2165,
+						2117,
+						2111,
+						2132,
+						2058,
+						2066,
+						2084,
+						2109,
+						2110,
+						2092,
+						2097,
+						2157,
+						2077,
+						2086,
+						2076,
+						2139,
 						2150,
+						2138,
+						2152,
+						2143,
+						2142,
+						2151,
+						2125,
+						2133,
+						2134,
+						2129,
+						2153,
+						2140,
+						2141,
+						2145,
+						2148,
+						2147,
+						2146,
 						2149,
 						2144,
-						2145,
-						2146,
-						2142,
-						2106,
-						2091,
-						2093,
-						2094,
-						2067,
-						2034,
-						2033,
-						2088
+						2161,
+						2162,
+						2164,
+						2163,
+						2158,
+						2159,
+						2160,
+						2156,
+						2120,
+						2105,
+						2107,
+						2108,
+						2081,
+						2048,
+						2047,
+						2102
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2509,
+					"line": 2533,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3310,
+			"id": 3327,
 			"name": "ErrorDetailsTypes",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10659,7 +10749,7 @@
 			},
 			"children": [
 				{
-					"id": 3311,
+					"id": 3328,
 					"name": "API",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10670,14 +10760,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9036,
+							"line": 9118,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"API\""
 				},
 				{
-					"id": 3313,
+					"id": 3330,
 					"name": "NETWORK",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10688,14 +10778,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9040,
+							"line": 9122,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NETWORK\""
 				},
 				{
-					"id": 3312,
+					"id": 3329,
 					"name": "VALIDATION_ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10706,7 +10796,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9038,
+							"line": 9120,
 							"character": 4
 						}
 					],
@@ -10718,22 +10808,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3311,
-						3313,
-						3312
+						3328,
+						3330,
+						3329
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9034,
+					"line": 9116,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2875,
+			"id": 2892,
 			"name": "HomeLeftNavItem",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -10743,7 +10833,7 @@
 			},
 			"children": [
 				{
-					"id": 2879,
+					"id": 2896,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10767,7 +10857,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 2886,
+					"id": 2903,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10791,7 +10881,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 2883,
+					"id": 2900,
 					"name": "Create",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10815,7 +10905,7 @@
 					"defaultValue": "\"create\""
 				},
 				{
-					"id": 2885,
+					"id": 2902,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10839,7 +10929,7 @@
 					"defaultValue": "\"favorites\""
 				},
 				{
-					"id": 2877,
+					"id": 2894,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10863,7 +10953,7 @@
 					"defaultValue": "\"insights-home\""
 				},
 				{
-					"id": 2882,
+					"id": 2899,
 					"name": "LiveboardSchedules",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10887,7 +10977,7 @@
 					"defaultValue": "\"liveboard-schedules\""
 				},
 				{
-					"id": 2878,
+					"id": 2895,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10911,7 +11001,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 2880,
+					"id": 2897,
 					"name": "MonitorSubscription",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10935,7 +11025,7 @@
 					"defaultValue": "\"monitor-alerts\""
 				},
 				{
-					"id": 2876,
+					"id": 2893,
 					"name": "SearchData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10959,7 +11049,7 @@
 					"defaultValue": "\"search-data\""
 				},
 				{
-					"id": 2881,
+					"id": 2898,
 					"name": "SpotIQAnalysis",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -10983,7 +11073,7 @@
 					"defaultValue": "\"spotiq-analysis\""
 				},
 				{
-					"id": 2884,
+					"id": 2901,
 					"name": "Spotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11012,17 +11102,17 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2879,
-						2886,
-						2883,
-						2885,
-						2877,
-						2882,
-						2878,
-						2880,
-						2876,
-						2881,
-						2884
+						2896,
+						2903,
+						2900,
+						2902,
+						2894,
+						2899,
+						2895,
+						2897,
+						2893,
+						2898,
+						2901
 					]
 				}
 			],
@@ -11035,7 +11125,7 @@
 			]
 		},
 		{
-			"id": 3213,
+			"id": 3230,
 			"name": "HomePage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11051,7 +11141,7 @@
 			},
 			"children": [
 				{
-					"id": 3216,
+					"id": 3233,
 					"name": "Focused",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11075,7 +11165,7 @@
 					"defaultValue": "\"v4\""
 				},
 				{
-					"id": 3214,
+					"id": 3231,
 					"name": "Modular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11099,7 +11189,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3215,
+					"id": 3232,
 					"name": "ModularWithStylingChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11122,9 +11212,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3216,
-						3214,
-						3215
+						3233,
+						3231,
+						3232
 					]
 				}
 			],
@@ -11137,14 +11227,14 @@
 			]
 		},
 		{
-			"id": 3207,
+			"id": 3224,
 			"name": "HomePageSearchBarMode",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3209,
+					"id": 3226,
 					"name": "AI_ANSWER",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11159,7 +11249,7 @@
 					"defaultValue": "\"aiAnswer\""
 				},
 				{
-					"id": 3210,
+					"id": 3227,
 					"name": "NONE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11174,7 +11264,7 @@
 					"defaultValue": "\"none\""
 				},
 				{
-					"id": 3208,
+					"id": 3225,
 					"name": "OBJECT_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11194,9 +11284,9 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3209,
-						3210,
-						3208
+						3226,
+						3227,
+						3225
 					]
 				}
 			],
@@ -11209,7 +11299,7 @@
 			]
 		},
 		{
-			"id": 2887,
+			"id": 2904,
 			"name": "HomepageModule",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11226,7 +11316,7 @@
 			},
 			"children": [
 				{
-					"id": 2890,
+					"id": 2907,
 					"name": "Favorite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11237,14 +11327,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2381,
+							"line": 2405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVORITE\""
 				},
 				{
-					"id": 2893,
+					"id": 2910,
 					"name": "Learning",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11255,14 +11345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2393,
+							"line": 2417,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LEARNING\""
 				},
 				{
-					"id": 2891,
+					"id": 2908,
 					"name": "MyLibrary",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11273,14 +11363,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2385,
+							"line": 2409,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"MY_LIBRARY\""
 				},
 				{
-					"id": 2888,
+					"id": 2905,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11291,14 +11381,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2373,
+							"line": 2397,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SEARCH\""
 				},
 				{
-					"id": 2892,
+					"id": 2909,
 					"name": "Trending",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11309,14 +11399,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2389,
+							"line": 2413,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRENDING\""
 				},
 				{
-					"id": 2889,
+					"id": 2906,
 					"name": "Watchlist",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11327,7 +11417,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2377,
+							"line": 2401,
 							"character": 4
 						}
 					],
@@ -11339,25 +11429,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2890,
-						2893,
-						2891,
-						2888,
-						2892,
-						2889
+						2907,
+						2910,
+						2908,
+						2905,
+						2909,
+						2906
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2369,
+					"line": 2393,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 2152,
+			"id": 2166,
 			"name": "HostEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -11390,7 +11480,7 @@
 			},
 			"children": [
 				{
-					"id": 2176,
+					"id": 2190,
 					"name": "AIHighlights",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11411,14 +11501,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4950,
+							"line": 4974,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AIHighlights\""
 				},
 				{
-					"id": 2164,
+					"id": 2178,
 					"name": "AddColumns",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11448,14 +11538,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4648,
+							"line": 4672,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addColumns\""
 				},
 				{
-					"id": 2222,
+					"id": 2236,
 					"name": "AddToCoaching",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11481,14 +11571,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6316,
+							"line": 6348,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"addToCoaching\""
 				},
 				{
-					"id": 2229,
+					"id": 2243,
 					"name": "AnswerChartSwitcher",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11514,14 +11604,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6388,
+							"line": 6420,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"answerChartSwitcher\""
 				},
 				{
-					"id": 2206,
+					"id": 2220,
 					"name": "AskSage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11542,14 +11632,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5972,
+							"line": 5996,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSage\""
 				},
 				{
-					"id": 2232,
+					"id": 2246,
 					"name": "AskSpotter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11575,14 +11665,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6426,
+							"line": 6458,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AskSpotter\""
 				},
 				{
-					"id": 2226,
+					"id": 2240,
 					"name": "CloseSpotterShareConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11603,14 +11693,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6355,
+							"line": 6387,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterShareConversation\""
 				},
 				{
-					"id": 2243,
+					"id": 2257,
 					"name": "CloseSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11631,14 +11721,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6572,
+							"line": 6604,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CloseSpotterVizPanel\""
 				},
 				{
-					"id": 2183,
+					"id": 2197,
 					"name": "CopyLink",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11680,14 +11770,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5183,
+							"line": 5207,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"embedDocument\""
 				},
 				{
-					"id": 2180,
+					"id": 2194,
 					"name": "CreateMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11725,14 +11815,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5058,
+							"line": 5082,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"createMonitor\""
 				},
 				{
-					"id": 2223,
+					"id": 2237,
 					"name": "DataModelInstructions",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11753,14 +11843,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6325,
+							"line": 6357,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DataModelInstructions\""
 				},
 				{
-					"id": 2187,
+					"id": 2201,
 					"name": "Delete",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11794,14 +11884,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5336,
+							"line": 5360,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"onDeleteAnswer\""
 				},
 				{
-					"id": 2228,
+					"id": 2242,
 					"name": "DeleteLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11822,14 +11912,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6373,
+							"line": 6405,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DeleteLastPrompt\""
 				},
 				{
-					"id": 2234,
+					"id": 2248,
 					"name": "DestroyEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11850,14 +11940,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6446,
+							"line": 6478,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EmbedDestroyed\""
 				},
 				{
-					"id": 2189,
+					"id": 2203,
 					"name": "Download",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11887,14 +11977,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5398,
+							"line": 5422,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2191,
+					"id": 2205,
 					"name": "DownloadAsCsv",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11928,14 +12018,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5468,
+							"line": 5492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsCSV\""
 				},
 				{
-					"id": 2174,
+					"id": 2188,
 					"name": "DownloadAsPdf",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -11973,14 +12063,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4928,
+							"line": 4952,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPdf\""
 				},
 				{
-					"id": 2190,
+					"id": 2204,
 					"name": "DownloadAsPng",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12005,14 +12095,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5429,
+							"line": 5453,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsPng\""
 				},
 				{
-					"id": 2192,
+					"id": 2206,
 					"name": "DownloadAsXlsx",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12046,14 +12136,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5507,
+							"line": 5531,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadAsXLSX\""
 				},
 				{
-					"id": 2175,
+					"id": 2189,
 					"name": "DownloadLiveboardAsContinuousPDF",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12074,14 +12164,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4940,
+							"line": 4964,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"downloadLiveboardAsContinuousPDF\""
 				},
 				{
-					"id": 2154,
+					"id": 2168,
 					"name": "DrillDown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12119,14 +12209,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4408,
+							"line": 4432,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"triggerDrillDown\""
 				},
 				{
-					"id": 2182,
+					"id": 2196,
 					"name": "Edit",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12165,14 +12255,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5138,
+							"line": 5162,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"edit\""
 				},
 				{
-					"id": 2220,
+					"id": 2234,
 					"name": "EditLastPrompt",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12202,14 +12292,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6290,
+							"line": 6322,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EditLastPrompt\""
 				},
 				{
-					"id": 2172,
+					"id": 2186,
 					"name": "EditTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12238,14 +12328,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4874,
+							"line": 4898,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"editTSL\""
 				},
 				{
-					"id": 2227,
+					"id": 2241,
 					"name": "ExitSpotterSharedConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12266,14 +12356,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6364,
+							"line": 6396,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ExitSpotterSharedConversation\""
 				},
 				{
-					"id": 2179,
+					"id": 2193,
 					"name": "Explore",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12303,14 +12393,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5027,
+							"line": 5051,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"explore\""
 				},
 				{
-					"id": 2171,
+					"id": 2185,
 					"name": "ExportTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12339,14 +12429,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4852,
+							"line": 4876,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"exportTSL\""
 				},
 				{
-					"id": 2205,
+					"id": 2219,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12372,14 +12462,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5962,
+							"line": 5986,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 2199,
+					"id": 2213,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12404,14 +12494,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5717,
+							"line": 5741,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 2202,
+					"id": 2216,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12436,14 +12526,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5888,
+							"line": 5912,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 2157,
+					"id": 2171,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12468,14 +12558,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4435,
+							"line": 4459,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetIframeUrl\""
 				},
 				{
-					"id": 2211,
+					"id": 2225,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12501,14 +12591,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6095,
+							"line": 6119,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GetParameters\""
 				},
 				{
-					"id": 2185,
+					"id": 2199,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12545,14 +12635,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5274,
+							"line": 5298,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 2201,
+					"id": 2215,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12577,14 +12667,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5866,
+							"line": 5890,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 2241,
+					"id": 2255,
 					"name": "InitSpotterVizConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12605,14 +12695,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6552,
+							"line": 6584,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"InitSpotterVizConversation\""
 				},
 				{
-					"id": 2168,
+					"id": 2182,
 					"name": "LiveboardInfo",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12637,14 +12727,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4800,
+							"line": 4824,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pinboardInfo\""
 				},
 				{
-					"id": 2177,
+					"id": 2191,
 					"name": "MakeACopy",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12689,14 +12779,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4995,
+							"line": 5019,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"makeACopy\""
 				},
 				{
-					"id": 2181,
+					"id": 2195,
 					"name": "ManageMonitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12738,14 +12828,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5093,
+							"line": 5117,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manageMonitor\""
 				},
 				{
-					"id": 2197,
+					"id": 2211,
 					"name": "ManagePipelines",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12779,14 +12869,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5673,
+							"line": 5697,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"manage-pipeline\""
 				},
 				{
-					"id": 2161,
+					"id": 2175,
 					"name": "Navigate",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12813,14 +12903,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4551,
+							"line": 4575,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"Navigate\""
 				},
 				{
-					"id": 2162,
+					"id": 2176,
 					"name": "OpenFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12858,14 +12948,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4598,
+							"line": 4622,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openFilter\""
 				},
 				{
-					"id": 2163,
+					"id": 2177,
 					"name": "OpenParameter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12895,14 +12985,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4630,
+							"line": 4654,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"openParameter\""
 				},
 				{
-					"id": 2242,
+					"id": 2256,
 					"name": "OpenSpotterVizPanel",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12923,14 +13013,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6562,
+							"line": 6594,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OpenSpotterVizPanel\""
 				},
 				{
-					"id": 2167,
+					"id": 2181,
 					"name": "Pin",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -12984,14 +13074,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4784,
+							"line": 4808,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"pin\""
 				},
 				{
-					"id": 2236,
+					"id": 2250,
 					"name": "PinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13013,14 +13103,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6479,
+							"line": 6511,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PinSpotterConversation\""
 				},
 				{
-					"id": 2184,
+					"id": 2198,
 					"name": "Present",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13062,14 +13152,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5228,
+							"line": 5252,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"present\""
 				},
 				{
-					"id": 2221,
+					"id": 2235,
 					"name": "PreviewSpotterData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13094,14 +13184,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6305,
+							"line": 6337,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"PreviewSpotterData\""
 				},
 				{
-					"id": 2244,
+					"id": 2258,
 					"name": "RefreshLiveboardBrowserCache",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13122,14 +13212,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6583,
+							"line": 6615,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"refreshLiveboardBrowserCache\""
 				},
 				{
-					"id": 2178,
+					"id": 2192,
 					"name": "Remove",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13158,14 +13248,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5009,
+							"line": 5033,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"delete\""
 				},
 				{
-					"id": 2165,
+					"id": 2179,
 					"name": "RemoveColumn",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13195,14 +13285,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4666,
+							"line": 4690,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"removeColumn\""
 				},
 				{
-					"id": 2208,
+					"id": 2222,
 					"name": "ResetLiveboardPersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13227,14 +13317,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5999,
+							"line": 6023,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2209,
+					"id": 2223,
 					"name": "ResetLiveboardPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13255,14 +13345,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6008,
+							"line": 6032,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetLiveboardPersonalisedView\""
 				},
 				{
-					"id": 2198,
+					"id": 2212,
 					"name": "ResetSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13287,14 +13377,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5691,
+							"line": 5715,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"resetSearch\""
 				},
 				{
-					"id": 2224,
+					"id": 2238,
 					"name": "ResetSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13315,14 +13405,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6334,
+							"line": 6366,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ResetSpotterConversation\""
 				},
 				{
-					"id": 2194,
+					"id": 2208,
 					"name": "Save",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13356,14 +13446,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5584,
+							"line": 5608,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"save\""
 				},
 				{
-					"id": 2216,
+					"id": 2230,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13405,14 +13495,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6224,
+							"line": 6256,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 2169,
+					"id": 2183,
 					"name": "Schedule",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13437,14 +13527,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4815,
+							"line": 4839,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"subscription\""
 				},
 				{
-					"id": 2170,
+					"id": 2184,
 					"name": "SchedulesList",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13469,14 +13559,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4830,
+							"line": 4854,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"schedule-list\""
 				},
 				{
-					"id": 2153,
+					"id": 2167,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13502,14 +13592,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4339,
+							"line": 4363,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 2214,
+					"id": 2228,
 					"name": "SelectPersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13538,14 +13628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6154,
+							"line": 6186,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SelectPersonalisedView\""
 				},
 				{
-					"id": 2239,
+					"id": 2253,
 					"name": "SendTestScheduleEmail",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13570,14 +13660,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6529,
+							"line": 6561,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sendTestScheduleEmail\""
 				},
 				{
-					"id": 2159,
+					"id": 2173,
 					"name": "SetActiveTab",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13607,14 +13697,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4477,
+							"line": 4501,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetActiveTab\""
 				},
 				{
-					"id": 2204,
+					"id": 2218,
 					"name": "SetHiddenTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13644,14 +13734,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5932,
+							"line": 5956,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardHiddenTabs\""
 				},
 				{
-					"id": 2203,
+					"id": 2217,
 					"name": "SetVisibleTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13681,14 +13771,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5910,
+							"line": 5934,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleTabs\""
 				},
 				{
-					"id": 2158,
+					"id": 2172,
 					"name": "SetVisibleVizs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13718,14 +13808,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4457,
+							"line": 4481,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SetPinboardVisibleVizs\""
 				},
 				{
-					"id": 2193,
+					"id": 2207,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13754,14 +13844,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5532,
+							"line": 5556,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"share\""
 				},
 				{
-					"id": 2225,
+					"id": 2239,
 					"name": "ShareSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13782,14 +13872,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6346,
+							"line": 6378,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ShareSpotterConversation\""
 				},
 				{
-					"id": 2186,
+					"id": 2200,
 					"name": "ShowUnderlyingData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13823,14 +13913,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5307,
+							"line": 5331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"showUnderlyingData\""
 				},
 				{
-					"id": 2188,
+					"id": 2202,
 					"name": "SpotIQAnalyze",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13864,14 +13954,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5370,
+							"line": 5394,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"spotIQAnalyze\""
 				},
 				{
-					"id": 2219,
+					"id": 2233,
 					"name": "SpotterSearch",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13901,14 +13991,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6274,
+							"line": 6306,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterSearch\""
 				},
 				{
-					"id": 2240,
+					"id": 2254,
 					"name": "SpotterVizSendUserMessage",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13934,14 +14024,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6542,
+							"line": 6574,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SpotterVizSendUserMessage\""
 				},
 				{
-					"id": 2235,
+					"id": 2249,
 					"name": "StartNewSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -13963,14 +14053,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6460,
+							"line": 6492,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"StartNewSpotterConversation\""
 				},
 				{
-					"id": 2196,
+					"id": 2210,
 					"name": "SyncToOtherApps",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14004,14 +14094,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5643,
+							"line": 5667,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-other-apps\""
 				},
 				{
-					"id": 2195,
+					"id": 2209,
 					"name": "SyncToSheets",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14045,14 +14135,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5613,
+							"line": 5637,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"sync-to-sheets\""
 				},
 				{
-					"id": 2218,
+					"id": 2232,
 					"name": "TransformTableVizData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14078,14 +14168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6249,
+							"line": 6281,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TransformTableVizData\""
 				},
 				{
-					"id": 2237,
+					"id": 2251,
 					"name": "UnpinSpotterConversation",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14107,14 +14197,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6497,
+							"line": 6529,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UnpinSpotterConversation\""
 				},
 				{
-					"id": 2207,
+					"id": 2221,
 					"name": "UpdateCrossFilter",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14135,14 +14225,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5988,
+							"line": 6012,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateCrossFilter\""
 				},
 				{
-					"id": 2200,
+					"id": 2214,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14188,14 +14278,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 5845,
+							"line": 5869,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateFilters\""
 				},
 				{
-					"id": 2210,
+					"id": 2224,
 					"name": "UpdateParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14229,20 +14319,20 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6058,
+							"line": 6082,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateParameters\""
 				},
 				{
-					"id": 2212,
+					"id": 2226,
 					"name": "UpdatePersonalisedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Triggers an event to update a personalized view of a Liveboard.\nThis event is deprecated. Use {@link HostEvent.UpdatePersonalizedView} instead.\n```js\nliveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})\n```",
+						"shortText": "Triggers an event to update a personalized view of a Liveboard.\nThis event is deprecated. Use {@link HostEvent.SelectPersonalizedView} instead,\nwhich additionally accepts a `viewName`, resets to the original view when\ncalled with an empty payload, and reports an error when a named view\ncannot be found.\n```js\nliveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})\n```",
 						"tags": [
 							{
 								"tag": "example",
@@ -14261,38 +14351,42 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6113,
+							"line": 6140,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2213,
+					"id": 2227,
 					"name": "UpdatePersonalizedView",
 					"kind": 16,
 					"kindString": "Enumeration member",
 					"flags": {},
 					"comment": {
-						"shortText": "Triggers an event to update a personalized view of a Liveboard.\n```js\nliveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})\n```",
+						"shortText": "Triggers an event to update a personalized view of a Liveboard.\nThis event is deprecated. Use {@link HostEvent.SelectPersonalizedView} instead,\nwhich additionally accepts a `viewName`, resets to the original view when\ncalled with an empty payload, and reports an error when a named view\ncannot be found.\n```js\nliveboardEmbed.trigger(HostEvent.UpdatePersonalisedView, {viewId: '1234'})\n```",
 						"tags": [
 							{
 								"tag": "version",
-								"text": "SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl\n"
+								"text": "SDK: 1.48.0 | ThoughtSpot: 26.5.0.cl"
+							},
+							{
+								"tag": "deprecated",
+								"text": "SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl\n"
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 6121,
+							"line": 6153,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdatePersonalisedView\""
 				},
 				{
-					"id": 2160,
+					"id": 2174,
 					"name": "UpdateRuntimeFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14327,14 +14421,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4520,
+							"line": 4544,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"UpdateRuntimeFilters\""
 				},
 				{
-					"id": 2173,
+					"id": 2187,
 					"name": "UpdateTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14359,14 +14453,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4889,
+							"line": 4913,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"updateTSL\""
 				},
 				{
-					"id": 2166,
+					"id": 2180,
 					"name": "getExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14387,7 +14481,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 4682,
+							"line": 4706,
 							"character": 4
 						}
 					],
@@ -14399,103 +14493,103 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2176,
-						2164,
-						2222,
-						2229,
-						2206,
-						2232,
-						2226,
-						2243,
-						2183,
-						2180,
-						2223,
-						2187,
-						2228,
-						2234,
-						2189,
-						2191,
-						2174,
 						2190,
-						2192,
-						2175,
-						2154,
-						2182,
-						2220,
-						2172,
-						2227,
-						2179,
-						2171,
-						2205,
-						2199,
-						2202,
-						2157,
-						2211,
-						2185,
-						2201,
-						2241,
-						2168,
-						2177,
-						2181,
-						2197,
-						2161,
-						2162,
-						2163,
-						2242,
-						2167,
-						2236,
-						2184,
-						2221,
-						2244,
 						2178,
-						2165,
-						2208,
-						2209,
-						2198,
-						2224,
-						2194,
-						2216,
-						2169,
-						2170,
-						2153,
-						2214,
-						2239,
-						2159,
-						2204,
-						2203,
-						2158,
-						2193,
-						2225,
-						2186,
-						2188,
-						2219,
+						2236,
+						2243,
+						2220,
+						2246,
 						2240,
-						2235,
-						2196,
-						2195,
-						2218,
+						2257,
+						2197,
+						2194,
 						2237,
-						2207,
-						2200,
-						2210,
-						2212,
+						2201,
+						2242,
+						2248,
+						2203,
+						2205,
+						2188,
+						2204,
+						2206,
+						2189,
+						2168,
+						2196,
+						2234,
+						2186,
+						2241,
+						2193,
+						2185,
+						2219,
 						2213,
-						2160,
+						2216,
+						2171,
+						2225,
+						2199,
+						2215,
+						2255,
+						2182,
+						2191,
+						2195,
+						2211,
+						2175,
+						2176,
+						2177,
+						2256,
+						2181,
+						2250,
+						2198,
+						2235,
+						2258,
+						2192,
+						2179,
+						2222,
+						2223,
+						2212,
+						2238,
+						2208,
+						2230,
+						2183,
+						2184,
+						2167,
+						2228,
+						2253,
 						2173,
-						2166
+						2218,
+						2217,
+						2172,
+						2207,
+						2239,
+						2200,
+						2202,
+						2233,
+						2254,
+						2249,
+						2210,
+						2209,
+						2232,
+						2251,
+						2221,
+						2214,
+						2224,
+						2226,
+						2227,
+						2174,
+						2187,
+						2180
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 4309,
+					"line": 4333,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3282,
+			"id": 3299,
 			"name": "InterceptedApiType",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14505,7 +14599,7 @@
 			},
 			"children": [
 				{
-					"id": 3284,
+					"id": 3301,
 					"name": "ALL",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14516,14 +14610,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9258,
+							"line": 9340,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ALL\""
 				},
 				{
-					"id": 3283,
+					"id": 3300,
 					"name": "AnswerData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14534,14 +14628,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9254,
+							"line": 9336,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AnswerData\""
 				},
 				{
-					"id": 3285,
+					"id": 3302,
 					"name": "LiveboardData",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14552,7 +14646,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9262,
+							"line": 9344,
 							"character": 4
 						}
 					],
@@ -14564,22 +14658,22 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3284,
-						3283,
-						3285
+						3301,
+						3300,
+						3302
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9250,
+					"line": 9332,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3318,
+			"id": 3335,
 			"name": "LegendPosition",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14595,7 +14689,7 @@
 			},
 			"children": [
 				{
-					"id": 3320,
+					"id": 3337,
 					"name": "Bottom",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14606,14 +14700,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9528,
+							"line": 9610,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"bottom\""
 				},
 				{
-					"id": 3321,
+					"id": 3338,
 					"name": "Left",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14624,14 +14718,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9530,
+							"line": 9612,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"left\""
 				},
 				{
-					"id": 3322,
+					"id": 3339,
 					"name": "Right",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14642,14 +14736,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9532,
+							"line": 9614,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"right\""
 				},
 				{
-					"id": 3319,
+					"id": 3336,
 					"name": "Top",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14660,7 +14754,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9526,
+							"line": 9608,
 							"character": 4
 						}
 					],
@@ -14672,23 +14766,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3320,
-						3321,
-						3322,
-						3319
+						3337,
+						3338,
+						3339,
+						3336
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9524,
+					"line": 9606,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3217,
+			"id": 3234,
 			"name": "ListPage",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14704,7 +14798,7 @@
 			},
 			"children": [
 				{
-					"id": 3218,
+					"id": 3235,
 					"name": "List",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14722,7 +14816,7 @@
 					"defaultValue": "\"v2\""
 				},
 				{
-					"id": 3219,
+					"id": 3236,
 					"name": "ListWithUXChanges",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14745,8 +14839,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3218,
-						3219
+						3235,
+						3236
 					]
 				}
 			],
@@ -14759,7 +14853,7 @@
 			]
 		},
 		{
-			"id": 3261,
+			"id": 3278,
 			"name": "ListPageColumns",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14775,7 +14869,7 @@
 			},
 			"children": [
 				{
-					"id": 3265,
+					"id": 3282,
 					"name": "Author",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14786,14 +14880,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2419,
+							"line": 2443,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"AUTHOR\""
 				},
 				{
-					"id": 3266,
+					"id": 3283,
 					"name": "DateSort",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14804,14 +14898,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2423,
+							"line": 2447,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DATE_SORT\""
 				},
 				{
-					"id": 3262,
+					"id": 3279,
 					"name": "Favorites",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14822,14 +14916,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2406,
+							"line": 2430,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3263,
+					"id": 3280,
 					"name": "Favourite",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14846,14 +14940,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2411,
+							"line": 2435,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FAVOURITE\""
 				},
 				{
-					"id": 3267,
+					"id": 3284,
 					"name": "Share",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14864,14 +14958,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2427,
+							"line": 2451,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SHARE\""
 				},
 				{
-					"id": 3264,
+					"id": 3281,
 					"name": "Tags",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14882,14 +14976,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2415,
+							"line": 2439,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TAGS\""
 				},
 				{
-					"id": 3268,
+					"id": 3285,
 					"name": "Verified",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14900,7 +14994,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2431,
+							"line": 2455,
 							"character": 4
 						}
 					],
@@ -14912,26 +15006,26 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3265,
-						3266,
-						3262,
-						3263,
-						3267,
-						3264,
-						3268
+						3282,
+						3283,
+						3279,
+						3280,
+						3284,
+						3281,
+						3285
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2402,
+					"line": 2426,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3180,
+			"id": 3197,
 			"name": "LogLevel",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -14941,7 +15035,7 @@
 			},
 			"children": [
 				{
-					"id": 3185,
+					"id": 3202,
 					"name": "DEBUG",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14962,14 +15056,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8990,
+							"line": 9072,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"DEBUG\""
 				},
 				{
-					"id": 3182,
+					"id": 3199,
 					"name": "ERROR",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -14990,14 +15084,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8951,
+							"line": 9033,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ERROR\""
 				},
 				{
-					"id": 3184,
+					"id": 3201,
 					"name": "INFO",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15018,14 +15112,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8976,
+							"line": 9058,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"INFO\""
 				},
 				{
-					"id": 3181,
+					"id": 3198,
 					"name": "SILENT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15046,14 +15140,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8939,
+							"line": 9021,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SILENT\""
 				},
 				{
-					"id": 3186,
+					"id": 3203,
 					"name": "TRACE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15074,14 +15168,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9002,
+							"line": 9084,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"TRACE\""
 				},
 				{
-					"id": 3183,
+					"id": 3200,
 					"name": "WARN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15102,7 +15196,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8963,
+							"line": 9045,
 							"character": 4
 						}
 					],
@@ -15114,25 +15208,25 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3185,
-						3182,
-						3184,
-						3181,
-						3186,
-						3183
+						3202,
+						3199,
+						3201,
+						3198,
+						3203,
+						3200
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8926,
+					"line": 9008,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1981,
+			"id": 1995,
 			"name": "Page",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15142,7 +15236,7 @@
 			},
 			"children": [
 				{
-					"id": 1984,
+					"id": 1998,
 					"name": "Answers",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15160,7 +15254,7 @@
 					"defaultValue": "\"answers\""
 				},
 				{
-					"id": 1990,
+					"id": 2004,
 					"name": "Collections",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15178,7 +15272,7 @@
 					"defaultValue": "\"collections\""
 				},
 				{
-					"id": 1987,
+					"id": 2001,
 					"name": "Data",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15196,7 +15290,7 @@
 					"defaultValue": "\"data\""
 				},
 				{
-					"id": 1982,
+					"id": 1996,
 					"name": "Home",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15214,7 +15308,7 @@
 					"defaultValue": "\"home\""
 				},
 				{
-					"id": 1985,
+					"id": 1999,
 					"name": "Liveboards",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15232,7 +15326,7 @@
 					"defaultValue": "\"liveboards\""
 				},
 				{
-					"id": 1989,
+					"id": 2003,
 					"name": "Monitor",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15250,7 +15344,7 @@
 					"defaultValue": "\"monitor\""
 				},
 				{
-					"id": 1983,
+					"id": 1997,
 					"name": "Search",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15268,7 +15362,7 @@
 					"defaultValue": "\"search\""
 				},
 				{
-					"id": 1988,
+					"id": 2002,
 					"name": "SpotIQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15291,14 +15385,14 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1984,
-						1990,
-						1987,
-						1982,
-						1985,
-						1989,
-						1983,
-						1988
+						1998,
+						2004,
+						2001,
+						1996,
+						1999,
+						2003,
+						1997,
+						2002
 					]
 				}
 			],
@@ -15311,14 +15405,14 @@
 			]
 		},
 		{
-			"id": 2864,
+			"id": 2881,
 			"name": "PrefetchFeatures",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 2865,
+					"id": 2882,
 					"name": "FullApp",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15326,14 +15420,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8755,
+							"line": 8837,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"FullApp\""
 				},
 				{
-					"id": 2867,
+					"id": 2884,
 					"name": "LiveboardEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15341,14 +15435,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8757,
+							"line": 8839,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LiveboardEmbed\""
 				},
 				{
-					"id": 2866,
+					"id": 2883,
 					"name": "SearchEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15356,14 +15450,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8756,
+							"line": 8838,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"SearchEmbed\""
 				},
 				{
-					"id": 2868,
+					"id": 2885,
 					"name": "VizEmbed",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15371,7 +15465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8758,
+							"line": 8840,
 							"character": 4
 						}
 					],
@@ -15383,23 +15477,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2865,
-						2867,
-						2866,
-						2868
+						2882,
+						2884,
+						2883,
+						2885
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8754,
+					"line": 8836,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3211,
+			"id": 3228,
 			"name": "PrimaryNavbarVersion",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15415,7 +15509,7 @@
 			},
 			"children": [
 				{
-					"id": 3212,
+					"id": 3229,
 					"name": "Sliding",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15438,7 +15532,7 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3212
+						3229
 					]
 				}
 			],
@@ -15451,7 +15545,7 @@
 			]
 		},
 		{
-			"id": 2007,
+			"id": 2021,
 			"name": "RuntimeFilterOp",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15461,7 +15555,7 @@
 			},
 			"children": [
 				{
-					"id": 2015,
+					"id": 2029,
 					"name": "BEGINS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15472,14 +15566,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2327,
+							"line": 2351,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BEGINS_WITH\""
 				},
 				{
-					"id": 2020,
+					"id": 2034,
 					"name": "BW",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15490,14 +15584,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2347,
+							"line": 2371,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW\""
 				},
 				{
-					"id": 2019,
+					"id": 2033,
 					"name": "BW_INC",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15508,14 +15602,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2343,
+							"line": 2367,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC\""
 				},
 				{
-					"id": 2017,
+					"id": 2031,
 					"name": "BW_INC_MAX",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15526,14 +15620,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2335,
+							"line": 2359,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MAX\""
 				},
 				{
-					"id": 2018,
+					"id": 2032,
 					"name": "BW_INC_MIN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15544,14 +15638,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2339,
+							"line": 2363,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"BW_INC_MIN\""
 				},
 				{
-					"id": 2014,
+					"id": 2028,
 					"name": "CONTAINS",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15562,14 +15656,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2323,
+							"line": 2347,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"CONTAINS\""
 				},
 				{
-					"id": 2016,
+					"id": 2030,
 					"name": "ENDS_WITH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15580,14 +15674,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2331,
+							"line": 2355,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ENDS_WITH\""
 				},
 				{
-					"id": 2008,
+					"id": 2022,
 					"name": "EQ",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15598,14 +15692,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2299,
+							"line": 2323,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"EQ\""
 				},
 				{
-					"id": 2013,
+					"id": 2027,
 					"name": "GE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15616,14 +15710,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2319,
+							"line": 2343,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GE\""
 				},
 				{
-					"id": 2012,
+					"id": 2026,
 					"name": "GT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15634,14 +15728,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2315,
+							"line": 2339,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"GT\""
 				},
 				{
-					"id": 2021,
+					"id": 2035,
 					"name": "IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15652,14 +15746,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2351,
+							"line": 2375,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"IN\""
 				},
 				{
-					"id": 2011,
+					"id": 2025,
 					"name": "LE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15670,14 +15764,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2311,
+							"line": 2335,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LE\""
 				},
 				{
-					"id": 2010,
+					"id": 2024,
 					"name": "LT",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15688,14 +15782,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2307,
+							"line": 2331,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"LT\""
 				},
 				{
-					"id": 2009,
+					"id": 2023,
 					"name": "NE",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15706,14 +15800,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2303,
+							"line": 2327,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"NE\""
 				},
 				{
-					"id": 2022,
+					"id": 2036,
 					"name": "NOT_IN",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15724,7 +15818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2355,
+							"line": 2379,
 							"character": 4
 						}
 					],
@@ -15736,34 +15830,34 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						2015,
-						2020,
-						2019,
-						2017,
-						2018,
-						2014,
-						2016,
-						2008,
-						2013,
-						2012,
-						2021,
-						2011,
-						2010,
-						2009,
-						2022
+						2029,
+						2034,
+						2033,
+						2031,
+						2032,
+						2028,
+						2030,
+						2022,
+						2027,
+						2026,
+						2035,
+						2025,
+						2024,
+						2023,
+						2036
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2295,
+					"line": 2319,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 1558,
+			"id": 1559,
 			"name": "SpotterQueryMode",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15779,7 +15873,7 @@
 			},
 			"children": [
 				{
-					"id": 1559,
+					"id": 1560,
 					"name": "FAST_SEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15794,7 +15888,7 @@
 					"defaultValue": "\"fastSearch\""
 				},
 				{
-					"id": 1560,
+					"id": 1561,
 					"name": "RESEARCH",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15814,8 +15908,8 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						1559,
-						1560
+						1560,
+						1561
 					]
 				}
 			],
@@ -15828,7 +15922,7 @@
 			]
 		},
 		{
-			"id": 3357,
+			"id": 3374,
 			"name": "TableContentDensity",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15844,7 +15938,7 @@
 			},
 			"children": [
 				{
-					"id": 3359,
+					"id": 3376,
 					"name": "Compact",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15855,14 +15949,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9556,
+							"line": 9638,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"COMPACT\""
 				},
 				{
-					"id": 3358,
+					"id": 3375,
 					"name": "Regular",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15873,7 +15967,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9554,
+							"line": 9636,
 							"character": 4
 						}
 					],
@@ -15885,21 +15979,21 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3359,
-						3358
+						3376,
+						3375
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9552,
+					"line": 9634,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3353,
+			"id": 3370,
 			"name": "TableTheme",
 			"kind": 4,
 			"kindString": "Enumeration",
@@ -15915,7 +16009,7 @@
 			},
 			"children": [
 				{
-					"id": 3354,
+					"id": 3371,
 					"name": "Outline",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15926,14 +16020,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9541,
+							"line": 9623,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"OUTLINE\""
 				},
 				{
-					"id": 3355,
+					"id": 3372,
 					"name": "Row",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15944,14 +16038,14 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9543,
+							"line": 9625,
 							"character": 4
 						}
 					],
 					"defaultValue": "\"ROW\""
 				},
 				{
-					"id": 3356,
+					"id": 3373,
 					"name": "Zebra",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -15962,7 +16056,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9545,
+							"line": 9627,
 							"character": 4
 						}
 					],
@@ -15974,29 +16068,29 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3354,
-						3355,
-						3356
+						3371,
+						3372,
+						3373
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9539,
+					"line": 9621,
 					"character": 12
 				}
 			]
 		},
 		{
-			"id": 3243,
+			"id": 3260,
 			"name": "UIPassthroughEvent",
 			"kind": 4,
 			"kindString": "Enumeration",
 			"flags": {},
 			"children": [
 				{
-					"id": 3252,
+					"id": 3269,
 					"name": "Drilldown",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16011,7 +16105,7 @@
 					"defaultValue": "\"drillDown\""
 				},
 				{
-					"id": 3248,
+					"id": 3265,
 					"name": "GetAnswerConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16026,7 +16120,7 @@
 					"defaultValue": "\"getAnswerPageConfig\""
 				},
 				{
-					"id": 3253,
+					"id": 3270,
 					"name": "GetAnswerSession",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16041,7 +16135,7 @@
 					"defaultValue": "\"getAnswerSession\""
 				},
 				{
-					"id": 3247,
+					"id": 3264,
 					"name": "GetAvailableUIPassthroughs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16056,7 +16150,7 @@
 					"defaultValue": "\"getAvailableUiPassthroughs\""
 				},
 				{
-					"id": 3246,
+					"id": 3263,
 					"name": "GetDiscoverabilityStatus",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16071,7 +16165,7 @@
 					"defaultValue": "\"getDiscoverabilityStatus\""
 				},
 				{
-					"id": 3260,
+					"id": 3277,
 					"name": "GetExportRequestForCurrentPinboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16086,7 +16180,7 @@
 					"defaultValue": "\"getExportRequestForCurrentPinboard\""
 				},
 				{
-					"id": 3254,
+					"id": 3271,
 					"name": "GetFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16101,7 +16195,7 @@
 					"defaultValue": "\"getFilters\""
 				},
 				{
-					"id": 3259,
+					"id": 3276,
 					"name": "GetGroups",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16116,7 +16210,7 @@
 					"defaultValue": "\"getGroups\""
 				},
 				{
-					"id": 3255,
+					"id": 3272,
 					"name": "GetIframeUrl",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16131,7 +16225,7 @@
 					"defaultValue": "\"getIframeUrl\""
 				},
 				{
-					"id": 3249,
+					"id": 3266,
 					"name": "GetLiveboardConfig",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16146,7 +16240,7 @@
 					"defaultValue": "\"getPinboardPageConfig\""
 				},
 				{
-					"id": 3256,
+					"id": 3273,
 					"name": "GetParameters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16161,7 +16255,7 @@
 					"defaultValue": "\"getParameters\""
 				},
 				{
-					"id": 3257,
+					"id": 3274,
 					"name": "GetTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16176,7 +16270,7 @@
 					"defaultValue": "\"getTML\""
 				},
 				{
-					"id": 3258,
+					"id": 3275,
 					"name": "GetTabs",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16191,7 +16285,7 @@
 					"defaultValue": "\"getTabs\""
 				},
 				{
-					"id": 3250,
+					"id": 3267,
 					"name": "GetUnsavedAnswerTML",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16206,7 +16300,7 @@
 					"defaultValue": "\"getUnsavedAnswerTML\""
 				},
 				{
-					"id": 3244,
+					"id": 3261,
 					"name": "PinAnswerToLiveboard",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16221,7 +16315,7 @@
 					"defaultValue": "\"addVizToPinboard\""
 				},
 				{
-					"id": 3245,
+					"id": 3262,
 					"name": "SaveAnswer",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16236,7 +16330,7 @@
 					"defaultValue": "\"saveAnswer\""
 				},
 				{
-					"id": 3251,
+					"id": 3268,
 					"name": "UpdateFilters",
 					"kind": 16,
 					"kindString": "Enumeration member",
@@ -16256,23 +16350,23 @@
 					"title": "Enumeration members",
 					"kind": 16,
 					"children": [
-						3252,
-						3248,
-						3253,
-						3247,
-						3246,
-						3260,
-						3254,
-						3259,
-						3255,
-						3249,
-						3256,
-						3257,
-						3258,
-						3250,
-						3244,
-						3245,
-						3251
+						3269,
+						3265,
+						3270,
+						3264,
+						3263,
+						3277,
+						3271,
+						3276,
+						3272,
+						3266,
+						3273,
+						3274,
+						3275,
+						3267,
+						3261,
+						3262,
+						3268
 					]
 				}
 			],
@@ -16285,7 +16379,7 @@
 			]
 		},
 		{
-			"id": 1894,
+			"id": 1908,
 			"name": "AnswerService",
 			"kind": 128,
 			"kindString": "Class",
@@ -16314,7 +16408,7 @@
 			},
 			"children": [
 				{
-					"id": 1895,
+					"id": 1909,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -16331,7 +16425,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1896,
+							"id": 1910,
 							"name": "new AnswerService",
 							"kind": 16384,
 							"kindString": "Constructor signature",
@@ -16341,7 +16435,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1897,
+									"id": 1911,
 									"name": "session",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16349,12 +16443,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1971,
+										"id": 1985,
 										"name": "SessionInterface"
 									}
 								},
 								{
-									"id": 1898,
+									"id": 1912,
 									"name": "answer",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16366,7 +16460,7 @@
 									}
 								},
 								{
-									"id": 1899,
+									"id": 1913,
 									"name": "thoughtSpotHost",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16378,7 +16472,7 @@
 									}
 								},
 								{
-									"id": 1900,
+									"id": 1914,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16392,7 +16486,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3220,
+											"id": 3237,
 											"name": "VizPoint"
 										}
 									}
@@ -16400,14 +16494,14 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1894,
+								"id": 1908,
 								"name": "AnswerService"
 							}
 						}
 					]
 				},
 				{
-					"id": 1909,
+					"id": 1923,
 					"name": "addColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16423,7 +16517,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1910,
+							"id": 1924,
 							"name": "addColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16434,7 +16528,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1911,
+									"id": 1925,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16463,7 +16557,7 @@
 					]
 				},
 				{
-					"id": 1912,
+					"id": 1926,
 					"name": "addColumnsByName",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16479,7 +16573,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1913,
+							"id": 1927,
 							"name": "addColumnsByName",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16495,7 +16589,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1914,
+									"id": 1928,
 									"name": "columnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16524,7 +16618,7 @@
 					]
 				},
 				{
-					"id": 1965,
+					"id": 1979,
 					"name": "addDisplayedVizToLiveboard",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16540,14 +16634,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1966,
+							"id": 1980,
 							"name": "addDisplayedVizToLiveboard",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1967,
+									"id": 1981,
 									"name": "liveboardId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16572,7 +16666,7 @@
 					]
 				},
 				{
-					"id": 1915,
+					"id": 1929,
 					"name": "addFilter",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16588,7 +16682,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1916,
+							"id": 1930,
 							"name": "addFilter",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16599,7 +16693,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1917,
+									"id": 1931,
 									"name": "columnName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16611,7 +16705,7 @@
 									}
 								},
 								{
-									"id": 1918,
+									"id": 1932,
 									"name": "operator",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16619,12 +16713,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 2007,
+										"id": 2021,
 										"name": "RuntimeFilterOp"
 									}
 								},
 								{
-									"id": 1919,
+									"id": 1933,
 									"name": "values",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16670,7 +16764,7 @@
 					]
 				},
 				{
-					"id": 1955,
+					"id": 1969,
 					"name": "executeQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16686,7 +16780,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1956,
+							"id": 1970,
 							"name": "executeQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16697,7 +16791,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1957,
+									"id": 1971,
 									"name": "query",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16711,7 +16805,7 @@
 									}
 								},
 								{
-									"id": 1958,
+									"id": 1972,
 									"name": "variables",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16739,7 +16833,7 @@
 					]
 				},
 				{
-					"id": 1933,
+					"id": 1947,
 					"name": "fetchCSVBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16755,7 +16849,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1934,
+							"id": 1948,
 							"name": "fetchCSVBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16766,7 +16860,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1935,
+									"id": 1949,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16779,7 +16873,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1936,
+									"id": 1950,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16808,7 +16902,7 @@
 					]
 				},
 				{
-					"id": 1926,
+					"id": 1940,
 					"name": "fetchData",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16824,7 +16918,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1927,
+							"id": 1941,
 							"name": "fetchData",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16835,7 +16929,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1928,
+									"id": 1942,
 									"name": "offset",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16848,7 +16942,7 @@
 									"defaultValue": "0"
 								},
 								{
-									"id": 1929,
+									"id": 1943,
 									"name": "size",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16867,14 +16961,14 @@
 									{
 										"type": "reflection",
 										"declaration": {
-											"id": 1930,
+											"id": 1944,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 1931,
+													"id": 1945,
 													"name": "columns",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16885,7 +16979,7 @@
 													}
 												},
 												{
-													"id": 1932,
+													"id": 1946,
 													"name": "data",
 													"kind": 1024,
 													"kindString": "Property",
@@ -16901,8 +16995,8 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														1931,
-														1932
+														1945,
+														1946
 													]
 												}
 											]
@@ -16915,7 +17009,7 @@
 					]
 				},
 				{
-					"id": 1937,
+					"id": 1951,
 					"name": "fetchPNGBlob",
 					"kind": 2048,
 					"kindString": "Method",
@@ -16931,7 +17025,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1938,
+							"id": 1952,
 							"name": "fetchPNGBlob",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -16942,7 +17036,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1939,
+									"id": 1953,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16955,7 +17049,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1940,
+									"id": 1954,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16970,7 +17064,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1941,
+									"id": 1955,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -16999,7 +17093,7 @@
 					]
 				},
 				{
-					"id": 1961,
+					"id": 1975,
 					"name": "getAnswer",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17015,7 +17109,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1962,
+							"id": 1976,
 							"name": "getAnswer",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17034,7 +17128,7 @@
 					]
 				},
 				{
-					"id": 1942,
+					"id": 1956,
 					"name": "getFetchCSVBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17050,7 +17144,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1943,
+							"id": 1957,
 							"name": "getFetchCSVBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17061,7 +17155,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1944,
+									"id": 1958,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17074,7 +17168,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1945,
+									"id": 1959,
 									"name": "includeInfo",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17095,7 +17189,7 @@
 					]
 				},
 				{
-					"id": 1946,
+					"id": 1960,
 					"name": "getFetchPNGBlobUrl",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17111,7 +17205,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1947,
+							"id": 1961,
 							"name": "getFetchPNGBlobUrl",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17121,7 +17215,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1948,
+									"id": 1962,
 									"name": "userLocale",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17134,7 +17228,7 @@
 									"defaultValue": "'en-us'"
 								},
 								{
-									"id": 1949,
+									"id": 1963,
 									"name": "omitBackground",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17147,7 +17241,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1950,
+									"id": 1964,
 									"name": "deviceScaleFactor",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17170,7 +17264,7 @@
 					]
 				},
 				{
-					"id": 1923,
+					"id": 1937,
 					"name": "getSQLQuery",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17186,14 +17280,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1924,
+							"id": 1938,
 							"name": "getSQLQuery",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1925,
+									"id": 1939,
 									"name": "fetchSQLWithAllColumns",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17219,7 +17313,7 @@
 					]
 				},
 				{
-					"id": 1959,
+					"id": 1973,
 					"name": "getSession",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17235,7 +17329,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1960,
+							"id": 1974,
 							"name": "getSession",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17246,14 +17340,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 1971,
+								"id": 1985,
 								"name": "SessionInterface"
 							}
 						}
 					]
 				},
 				{
-					"id": 1904,
+					"id": 1918,
 					"name": "getSourceDetail",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17269,7 +17363,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1905,
+							"id": 1919,
 							"name": "getSourceDetail",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17291,7 +17385,7 @@
 					]
 				},
 				{
-					"id": 1963,
+					"id": 1977,
 					"name": "getTML",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17307,7 +17401,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1964,
+							"id": 1978,
 							"name": "getTML",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17326,7 +17420,7 @@
 					]
 				},
 				{
-					"id": 1951,
+					"id": 1965,
 					"name": "getUnderlyingDataForPoint",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17342,7 +17436,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1952,
+							"id": 1966,
 							"name": "getUnderlyingDataForPoint",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17362,7 +17456,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1953,
+									"id": 1967,
 									"name": "outputColumnNames",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17377,7 +17471,7 @@
 									}
 								},
 								{
-									"id": 1954,
+									"id": 1968,
 									"name": "selectedPoints",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17389,7 +17483,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 1978,
+											"id": 1992,
 											"name": "UnderlyingDataPoint"
 										}
 									}
@@ -17400,7 +17494,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -17410,7 +17504,7 @@
 					]
 				},
 				{
-					"id": 1906,
+					"id": 1920,
 					"name": "removeColumns",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17426,7 +17520,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1907,
+							"id": 1921,
 							"name": "removeColumns",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -17437,7 +17531,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1908,
+									"id": 1922,
 									"name": "columnIds",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17466,7 +17560,7 @@
 					]
 				},
 				{
-					"id": 1968,
+					"id": 1982,
 					"name": "setTMLOverride",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17482,14 +17576,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1969,
+							"id": 1983,
 							"name": "setTMLOverride",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1970,
+									"id": 1984,
 									"name": "override",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17508,7 +17602,7 @@
 					]
 				},
 				{
-					"id": 1920,
+					"id": 1934,
 					"name": "updateDisplayMode",
 					"kind": 2048,
 					"kindString": "Method",
@@ -17524,14 +17618,14 @@
 					],
 					"signatures": [
 						{
-							"id": 1921,
+							"id": 1935,
 							"name": "updateDisplayMode",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1922,
+									"id": 1936,
 									"name": "displayMode",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -17562,32 +17656,32 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1895
+						1909
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1909,
-						1912,
-						1965,
-						1915,
-						1955,
-						1933,
-						1926,
-						1937,
-						1961,
-						1942,
-						1946,
 						1923,
-						1959,
-						1904,
-						1963,
+						1926,
+						1979,
+						1929,
+						1969,
+						1947,
+						1940,
 						1951,
-						1906,
-						1968,
-						1920
+						1975,
+						1956,
+						1960,
+						1937,
+						1973,
+						1918,
+						1977,
+						1965,
+						1920,
+						1982,
+						1934
 					]
 				}
 			],
@@ -17624,7 +17718,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1021,
+							"line": 1022,
 							"character": 4
 						}
 					],
@@ -17644,7 +17738,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2911,
 										"name": "DOMSelector"
 									}
 								},
@@ -17656,7 +17750,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2747,
+										"id": 2764,
 										"name": "AppViewConfig"
 									}
 								}
@@ -17688,7 +17782,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1539,
+							"line": 1541,
 							"character": 11
 						}
 					],
@@ -17777,7 +17871,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -17862,7 +17956,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1405,
+							"line": 1407,
 							"character": 11
 						}
 					],
@@ -18212,7 +18306,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1512,
+							"line": 1514,
 							"character": 11
 						}
 					],
@@ -18322,7 +18416,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18337,7 +18431,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -18404,7 +18498,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -18416,7 +18510,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
@@ -18428,7 +18522,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -18588,7 +18682,7 @@
 					"sources": [
 						{
 							"fileName": "embed/app.ts",
-							"line": 1595,
+							"line": 1597,
 							"character": 17
 						}
 					],
@@ -18718,12 +18812,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -18836,7 +18930,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
@@ -18855,7 +18949,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
@@ -18987,7 +19081,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -19094,7 +19188,7 @@
 			"sources": [
 				{
 					"fileName": "embed/app.ts",
-					"line": 1012,
+					"line": 1013,
 					"character": 13
 				}
 			],
@@ -19638,7 +19732,7 @@
 			]
 		},
 		{
-			"id": 1636,
+			"id": 1650,
 			"name": "ConversationEmbed",
 			"kind": 128,
 			"kindString": "Class",
@@ -19666,7 +19760,7 @@
 			},
 			"children": [
 				{
-					"id": 1637,
+					"id": 1651,
 					"name": "constructor",
 					"kind": 512,
 					"kindString": "Constructor",
@@ -19674,20 +19768,20 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 854,
+							"line": 968,
 							"character": 4
 						}
 					],
 					"signatures": [
 						{
-							"id": 1638,
+							"id": 1652,
 							"name": "new ConversationEmbed",
 							"kind": 16384,
 							"kindString": "Constructor signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1639,
+									"id": 1653,
 									"name": "container",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19698,21 +19792,21 @@
 									}
 								},
 								{
-									"id": 1640,
+									"id": 1654,
 									"name": "viewConfig",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1575,
+										"id": 1589,
 										"name": "ConversationViewConfig"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1636,
+								"id": 1650,
 								"name": "ConversationEmbed"
 							},
 							"overwrites": {
@@ -19729,7 +19823,7 @@
 					}
 				},
 				{
-					"id": 1799,
+					"id": 1813,
 					"name": "destroy",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19745,7 +19839,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1800,
+							"id": 1814,
 							"name": "destroy",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19777,7 +19871,7 @@
 					}
 				},
 				{
-					"id": 1821,
+					"id": 1835,
 					"name": "getAnswerService",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19793,7 +19887,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1822,
+							"id": 1836,
 							"name": "getAnswerService",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19809,7 +19903,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1823,
+									"id": 1837,
 									"name": "vizId",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -19830,7 +19924,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -19850,7 +19944,7 @@
 					}
 				},
 				{
-					"id": 1784,
+					"id": 1798,
 					"name": "getCurrentContext",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19866,7 +19960,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1785,
+							"id": 1799,
 							"name": "getCurrentContext",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19909,7 +20003,7 @@
 					}
 				},
 				{
-					"id": 1646,
+					"id": 1660,
 					"name": "getIframeSrc",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19919,13 +20013,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 780,
+							"line": 894,
 							"character": 11
 						}
 					],
 					"signatures": [
 						{
-							"id": 1647,
+							"id": 1661,
 							"name": "getIframeSrc",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19948,7 +20042,7 @@
 					}
 				},
 				{
-					"id": 1815,
+					"id": 1829,
 					"name": "getPreRenderIds",
 					"kind": 2048,
 					"kindString": "Method",
@@ -19964,7 +20058,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1816,
+							"id": 1830,
 							"name": "getPreRenderIds",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -19986,14 +20080,14 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 1817,
+									"id": 1831,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
 									"flags": {},
 									"children": [
 										{
-											"id": 1819,
+											"id": 1833,
 											"name": "child",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20005,7 +20099,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1820,
+											"id": 1834,
 											"name": "placeHolder",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20017,7 +20111,7 @@
 											"defaultValue": "..."
 										},
 										{
-											"id": 1818,
+											"id": 1832,
 											"name": "wrapper",
 											"kind": 1024,
 											"kindString": "Property",
@@ -20034,9 +20128,9 @@
 											"title": "Properties",
 											"kind": 1024,
 											"children": [
-												1819,
-												1820,
-												1818
+												1833,
+												1834,
+												1832
 											]
 										}
 									]
@@ -20056,7 +20150,7 @@
 					}
 				},
 				{
-					"id": 1793,
+					"id": 1807,
 					"name": "getThoughtSpotPostUrlParams",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20072,7 +20166,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1794,
+							"id": 1808,
 							"name": "getThoughtSpotPostUrlParams",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20088,7 +20182,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1795,
+									"id": 1809,
 									"name": "additionalParams",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20096,20 +20190,20 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1796,
+											"id": 1810,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"indexSignature": {
-												"id": 1797,
+												"id": 1811,
 												"name": "__index",
 												"kind": 8192,
 												"kindString": "Index signature",
 												"flags": {},
 												"parameters": [
 													{
-														"id": 1798,
+														"id": 1812,
 														"name": "key",
 														"kind": 32768,
 														"flags": {},
@@ -20156,7 +20250,7 @@
 					}
 				},
 				{
-					"id": 1801,
+					"id": 1815,
 					"name": "getUnderlyingFrameElement",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20172,7 +20266,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1802,
+							"id": 1816,
 							"name": "getUnderlyingFrameElement",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20195,7 +20289,7 @@
 					}
 				},
 				{
-					"id": 1813,
+					"id": 1827,
 					"name": "hidePreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20211,7 +20305,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1814,
+							"id": 1828,
 							"name": "hidePreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20237,7 +20331,7 @@
 					}
 				},
 				{
-					"id": 1751,
+					"id": 1765,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20253,7 +20347,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1752,
+							"id": 1766,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20269,7 +20363,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1753,
+									"id": 1767,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20279,12 +20373,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1754,
+									"id": 1768,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20294,7 +20388,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -20317,7 +20411,7 @@
 					}
 				},
 				{
-					"id": 1745,
+					"id": 1759,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20333,7 +20427,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1746,
+							"id": 1760,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20353,7 +20447,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1747,
+									"id": 1761,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20363,12 +20457,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
 								{
-									"id": 1748,
+									"id": 1762,
 									"name": "callback",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20378,12 +20472,12 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
 								{
-									"id": 1749,
+									"id": 1763,
 									"name": "options",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20393,13 +20487,13 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
 								},
 								{
-									"id": 1750,
+									"id": 1764,
 									"name": "isRegisteredBySDK",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20430,7 +20524,7 @@
 					}
 				},
 				{
-					"id": 1789,
+					"id": 1803,
 					"name": "preRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20446,7 +20540,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1790,
+							"id": 1804,
 							"name": "preRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20456,7 +20550,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1791,
+									"id": 1805,
 									"name": "showPreRenderByDefault",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20471,7 +20565,7 @@
 									"defaultValue": "false"
 								},
 								{
-									"id": 1792,
+									"id": 1806,
 									"name": "replaceExistingPreRender",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20507,7 +20601,7 @@
 					}
 				},
 				{
-					"id": 1803,
+					"id": 1817,
 					"name": "prerenderGeneric",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20523,7 +20617,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1804,
+							"id": 1818,
 							"name": "prerenderGeneric",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20562,7 +20656,7 @@
 					}
 				},
 				{
-					"id": 1648,
+					"id": 1662,
 					"name": "render",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20572,13 +20666,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 827,
+							"line": 941,
 							"character": 17
 						}
 					],
 					"signatures": [
 						{
-							"id": 1649,
+							"id": 1663,
 							"name": "render",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20608,7 +20702,7 @@
 					}
 				},
 				{
-					"id": 1807,
+					"id": 1821,
 					"name": "showPreRender",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20624,7 +20718,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1808,
+							"id": 1822,
 							"name": "showPreRender",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20656,7 +20750,7 @@
 					}
 				},
 				{
-					"id": 1786,
+					"id": 1800,
 					"name": "subscribedEvent",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20672,7 +20766,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1787,
+							"id": 1801,
 							"name": "subscribedEvent",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20690,7 +20784,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1788,
+									"id": 1802,
 									"name": "eventName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20703,12 +20797,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -20733,7 +20827,7 @@
 					}
 				},
 				{
-					"id": 1811,
+					"id": 1825,
 					"name": "syncPreRenderStyle",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20749,7 +20843,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1812,
+							"id": 1826,
 							"name": "syncPreRenderStyle",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20781,7 +20875,7 @@
 					}
 				},
 				{
-					"id": 1769,
+					"id": 1783,
 					"name": "trigger",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20797,7 +20891,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1770,
+							"id": 1784,
 							"name": "trigger",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20818,40 +20912,40 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1771,
+									"id": 1785,
 									"name": "HostEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
 								{
-									"id": 1772,
+									"id": 1786,
 									"name": "PayloadT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {}
 								},
 								{
-									"id": 1773,
+									"id": 1787,
 									"name": "ContextT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1774,
+									"id": 1788,
 									"name": "messageType",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20865,7 +20959,7 @@
 									}
 								},
 								{
-									"id": 1775,
+									"id": 1789,
 									"name": "data",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20890,7 +20984,7 @@
 									"defaultValue": "..."
 								},
 								{
-									"id": 1776,
+									"id": 1790,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20944,7 +21038,7 @@
 					}
 				},
 				{
-					"id": 1777,
+					"id": 1791,
 					"name": "triggerUIPassThrough",
 					"kind": 2048,
 					"kindString": "Method",
@@ -20960,7 +21054,7 @@
 					],
 					"signatures": [
 						{
-							"id": 1778,
+							"id": 1792,
 							"name": "triggerUIPassThrough",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -20971,21 +21065,21 @@
 							},
 							"typeParameter": [
 								{
-									"id": 1779,
+									"id": 1793,
 									"name": "UIPassthroughEventT",
 									"kind": 131072,
 									"kindString": "Type parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
 							],
 							"parameters": [
 								{
-									"id": 1780,
+									"id": 1794,
 									"name": "apiName",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -20999,7 +21093,7 @@
 									}
 								},
 								{
-									"id": 1781,
+									"id": 1795,
 									"name": "parameters",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -21054,38 +21148,38 @@
 					"title": "Constructors",
 					"kind": 512,
 					"children": [
-						1637
+						1651
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1799,
-						1821,
-						1784,
-						1646,
-						1815,
-						1793,
-						1801,
 						1813,
-						1751,
-						1745,
-						1789,
-						1803,
-						1648,
+						1835,
+						1798,
+						1660,
+						1829,
 						1807,
-						1786,
-						1811,
-						1769,
-						1777
+						1815,
+						1827,
+						1765,
+						1759,
+						1803,
+						1817,
+						1662,
+						1821,
+						1800,
+						1825,
+						1783,
+						1791
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 853,
+					"line": 967,
 					"character": 13
 				}
 			],
@@ -21126,7 +21220,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 669,
+							"line": 671,
 							"character": 4
 						}
 					],
@@ -21146,7 +21240,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2911,
 										"name": "DOMSelector"
 									}
 								},
@@ -21158,7 +21252,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2624,
+										"id": 2641,
 										"name": "LiveboardViewConfig"
 									}
 								}
@@ -21190,7 +21284,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1163,
+							"line": 1166,
 							"character": 11
 						}
 					],
@@ -21279,7 +21373,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -21401,7 +21495,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1255,
+							"line": 1258,
 							"character": 11
 						}
 					],
@@ -21715,7 +21809,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1230,
+							"line": 1233,
 							"character": 11
 						}
 					],
@@ -21828,7 +21922,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21843,7 +21937,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -21910,7 +22004,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -21922,7 +22016,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
@@ -21934,7 +22028,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -22094,7 +22188,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1219,
+							"line": 1222,
 							"character": 17
 						}
 					],
@@ -22224,12 +22318,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -22308,7 +22402,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 1144,
+							"line": 1147,
 							"character": 11
 						}
 					],
@@ -22332,7 +22426,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
@@ -22351,7 +22445,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
@@ -22480,7 +22574,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -22587,7 +22681,7 @@
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 659,
+					"line": 661,
 					"character": 13
 				}
 			],
@@ -22658,7 +22752,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2571,
+										"id": 2588,
 										"name": "SearchBarViewConfig"
 									}
 								}
@@ -22779,7 +22873,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -23214,7 +23308,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23229,7 +23323,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -23296,7 +23390,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -23311,7 +23405,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
@@ -23326,7 +23420,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -23629,12 +23723,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -23747,7 +23841,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
@@ -23766,7 +23860,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
@@ -23898,7 +23992,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -24059,7 +24153,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2894,
+										"id": 2911,
 										"name": "DOMSelector"
 									}
 								},
@@ -24071,7 +24165,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2505,
+										"id": 2522,
 										"name": "SearchViewConfig"
 									}
 								}
@@ -24192,7 +24286,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -24659,7 +24753,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24674,7 +24768,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -24741,7 +24835,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -24756,7 +24850,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
@@ -24771,7 +24865,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -25074,12 +25168,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -25192,7 +25286,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
@@ -25211,7 +25305,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
@@ -25343,7 +25437,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -25995,7 +26089,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 688,
+							"line": 801,
 							"character": 4
 						}
 					],
@@ -26147,7 +26241,7 @@
 								"typeArguments": [
 									{
 										"type": "reference",
-										"id": 1894,
+										"id": 1908,
 										"name": "AnswerService"
 									}
 								],
@@ -26232,7 +26326,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 780,
+							"line": 894,
 							"character": 11
 						}
 					],
@@ -26582,7 +26676,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26597,7 +26691,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								}
@@ -26664,7 +26758,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2023,
+										"id": 2037,
 										"name": "EmbedEvent"
 									}
 								},
@@ -26679,7 +26773,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2898,
+										"id": 2915,
 										"name": "MessageCallback"
 									}
 								},
@@ -26694,7 +26788,7 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 2895,
+										"id": 2912,
 										"name": "MessageOptions"
 									},
 									"defaultValue": "..."
@@ -26867,7 +26961,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 827,
+							"line": 941,
 							"character": 17
 						}
 					],
@@ -26994,12 +27088,12 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 2255,
+												"id": 2269,
 												"name": "Action"
 											},
 											{
 												"type": "reference",
-												"id": 2152,
+												"id": 2166,
 												"name": "HostEvent"
 											}
 										]
@@ -27112,7 +27206,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2152,
+										"id": 2166,
 										"name": "HostEvent"
 									}
 								},
@@ -27131,7 +27225,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2245,
+										"id": 2259,
 										"name": "ContextType"
 									}
 								}
@@ -27263,7 +27357,7 @@
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 3243,
+										"id": 3260,
 										"name": "UIPassthroughEvent"
 									}
 								}
@@ -27368,7 +27462,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 687,
+					"line": 800,
 					"character": 13
 				}
 			],
@@ -27381,13 +27475,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1636,
+					"id": 1650,
 					"name": "ConversationEmbed"
 				}
 			]
 		},
 		{
-			"id": 2747,
+			"id": 2764,
 			"name": "AppViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -27403,7 +27497,7 @@
 			},
 			"children": [
 				{
-					"id": 2804,
+					"id": 2821,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27427,27 +27521,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2805,
+							"id": 2822,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2806,
+								"id": 2823,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2807,
+										"id": 2824,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -27483,7 +27577,7 @@
 					}
 				},
 				{
-					"id": 2838,
+					"id": 2855,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27511,7 +27605,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -27525,7 +27619,7 @@
 					}
 				},
 				{
-					"id": 2767,
+					"id": 2784,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27562,7 +27656,7 @@
 					}
 				},
 				{
-					"id": 2835,
+					"id": 2852,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27586,13 +27680,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2467,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -27601,7 +27695,7 @@
 					}
 				},
 				{
-					"id": 2856,
+					"id": 2873,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27625,7 +27719,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2110,
+							"line": 2134,
 							"character": 4
 						}
 					],
@@ -27639,7 +27733,7 @@
 					}
 				},
 				{
-					"id": 2826,
+					"id": 2843,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27671,7 +27765,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -27688,7 +27782,7 @@
 					}
 				},
 				{
-					"id": 2808,
+					"id": 2825,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27711,13 +27805,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -27726,7 +27820,7 @@
 					}
 				},
 				{
-					"id": 2768,
+					"id": 2785,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27760,12 +27854,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3269,
+						"id": 3286,
 						"name": "DataPanelCustomColumnGroupsAccordionState"
 					}
 				},
 				{
-					"id": 2839,
+					"id": 2856,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27793,7 +27887,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -27807,7 +27901,7 @@
 					}
 				},
 				{
-					"id": 2782,
+					"id": 2799,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27841,12 +27935,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1559,
 						"name": "SpotterQueryMode"
 					}
 				},
 				{
-					"id": 2750,
+					"id": 2767,
 					"name": "disableProfileAndHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27884,7 +27978,7 @@
 					}
 				},
 				{
-					"id": 2818,
+					"id": 2835,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27908,7 +28002,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -27922,7 +28016,7 @@
 					}
 				},
 				{
-					"id": 2800,
+					"id": 2817,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27946,7 +28040,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -27960,7 +28054,7 @@
 					}
 				},
 				{
-					"id": 2799,
+					"id": 2816,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -27984,7 +28078,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -27992,7 +28086,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -28002,7 +28096,7 @@
 					}
 				},
 				{
-					"id": 2766,
+					"id": 2783,
 					"name": "discoveryExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28039,7 +28133,7 @@
 					}
 				},
 				{
-					"id": 2812,
+					"id": 2829,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28070,7 +28164,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -28084,7 +28178,7 @@
 					}
 				},
 				{
-					"id": 2850,
+					"id": 2867,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28112,7 +28206,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2006,
+							"line": 2030,
 							"character": 4
 						}
 					],
@@ -28126,7 +28220,7 @@
 					}
 				},
 				{
-					"id": 2855,
+					"id": 2872,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28154,7 +28248,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2094,
+							"line": 2118,
 							"character": 4
 						}
 					],
@@ -28168,7 +28262,7 @@
 					}
 				},
 				{
-					"id": 2840,
+					"id": 2857,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28196,7 +28290,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -28210,7 +28304,7 @@
 					}
 				},
 				{
-					"id": 2791,
+					"id": 2808,
 					"name": "enableHomepageAnnouncement",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28244,7 +28338,7 @@
 					}
 				},
 				{
-					"id": 2822,
+					"id": 2839,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28268,7 +28362,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -28282,7 +28376,7 @@
 					}
 				},
 				{
-					"id": 2792,
+					"id": 2809,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28315,7 +28409,7 @@
 					}
 				},
 				{
-					"id": 2783,
+					"id": 2800,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28353,7 +28447,7 @@
 					}
 				},
 				{
-					"id": 2751,
+					"id": 2768,
 					"name": "enablePendoHelp",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28391,7 +28485,7 @@
 					}
 				},
 				{
-					"id": 2763,
+					"id": 2780,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28429,7 +28523,7 @@
 					}
 				},
 				{
-					"id": 2789,
+					"id": 2806,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28463,7 +28557,7 @@
 					}
 				},
 				{
-					"id": 2815,
+					"id": 2832,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28487,7 +28581,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -28501,7 +28595,7 @@
 					}
 				},
 				{
-					"id": 2836,
+					"id": 2853,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28525,7 +28619,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -28539,7 +28633,7 @@
 					}
 				},
 				{
-					"id": 2837,
+					"id": 2854,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28563,7 +28657,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -28577,7 +28671,7 @@
 					}
 				},
 				{
-					"id": 2817,
+					"id": 2834,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28600,7 +28694,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -28614,7 +28708,7 @@
 					}
 				},
 				{
-					"id": 2796,
+					"id": 2813,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28638,13 +28732,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -28653,7 +28747,7 @@
 					}
 				},
 				{
-					"id": 2764,
+					"id": 2781,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28687,7 +28781,7 @@
 					}
 				},
 				{
-					"id": 2801,
+					"id": 2818,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28715,7 +28809,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -28723,7 +28817,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -28733,7 +28827,7 @@
 					}
 				},
 				{
-					"id": 2845,
+					"id": 2862,
 					"name": "hiddenHomeLeftNavItems",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28757,7 +28851,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1766,
+							"line": 1790,
 							"character": 4
 						}
 					],
@@ -28765,7 +28859,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2875,
+							"id": 2892,
 							"name": "HomeLeftNavItem"
 						}
 					},
@@ -28775,7 +28869,7 @@
 					}
 				},
 				{
-					"id": 2843,
+					"id": 2860,
 					"name": "hiddenHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28799,7 +28893,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1719,
+							"line": 1743,
 							"character": 4
 						}
 					],
@@ -28807,7 +28901,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2887,
+							"id": 2904,
 							"name": "HomepageModule"
 						}
 					},
@@ -28817,7 +28911,7 @@
 					}
 				},
 				{
-					"id": 2842,
+					"id": 2859,
 					"name": "hiddenListColumns",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28841,7 +28935,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1696,
+							"line": 1720,
 							"character": 4
 						}
 					],
@@ -28849,7 +28943,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3261,
+							"id": 3278,
 							"name": "ListPageColumns"
 						}
 					},
@@ -28859,7 +28953,7 @@
 					}
 				},
 				{
-					"id": 2755,
+					"id": 2772,
 					"name": "hideApplicationSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28897,7 +28991,7 @@
 					}
 				},
 				{
-					"id": 2752,
+					"id": 2769,
 					"name": "hideHamburger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28935,7 +29029,7 @@
 					}
 				},
 				{
-					"id": 2749,
+					"id": 2766,
 					"name": "hideHomepageLeftNav",
 					"kind": 1024,
 					"kindString": "Property",
@@ -28973,7 +29067,7 @@
 					}
 				},
 				{
-					"id": 2853,
+					"id": 2870,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29001,7 +29095,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2061,
+							"line": 2085,
 							"character": 4
 						}
 					],
@@ -29015,7 +29109,7 @@
 					}
 				},
 				{
-					"id": 2846,
+					"id": 2863,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29043,7 +29137,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1942,
+							"line": 1966,
 							"character": 4
 						}
 					],
@@ -29057,7 +29151,7 @@
 					}
 				},
 				{
-					"id": 2754,
+					"id": 2771,
 					"name": "hideNotification",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29095,7 +29189,7 @@
 					}
 				},
 				{
-					"id": 2753,
+					"id": 2770,
 					"name": "hideObjectSearch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29133,7 +29227,7 @@
 					}
 				},
 				{
-					"id": 2761,
+					"id": 2778,
 					"name": "hideObjects",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29170,7 +29264,7 @@
 					}
 				},
 				{
-					"id": 2756,
+					"id": 2773,
 					"name": "hideOrgSwitcher",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29208,7 +29302,7 @@
 					}
 				},
 				{
-					"id": 2760,
+					"id": 2777,
 					"name": "hideTagFilterChips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29242,7 +29336,7 @@
 					}
 				},
 				{
-					"id": 2769,
+					"id": 2786,
 					"name": "homePageSearchBarMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29268,12 +29362,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3207,
+						"id": 3224,
 						"name": "HomePageSearchBarMode"
 					}
 				},
 				{
-					"id": 2809,
+					"id": 2826,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29297,7 +29391,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -29311,7 +29405,7 @@
 					}
 				},
 				{
-					"id": 2832,
+					"id": 2849,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29334,7 +29428,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -29348,7 +29442,7 @@
 					}
 				},
 				{
-					"id": 2831,
+					"id": 2848,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29371,7 +29465,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -29388,7 +29482,7 @@
 					}
 				},
 				{
-					"id": 2857,
+					"id": 2874,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29412,7 +29506,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2128,
+							"line": 2152,
 							"character": 4
 						}
 					],
@@ -29426,7 +29520,7 @@
 					}
 				},
 				{
-					"id": 2774,
+					"id": 2791,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29464,7 +29558,7 @@
 					}
 				},
 				{
-					"id": 2860,
+					"id": 2877,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29488,7 +29582,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2178,
+							"line": 2202,
 							"character": 4
 						}
 					],
@@ -29502,7 +29596,7 @@
 					}
 				},
 				{
-					"id": 2776,
+					"id": 2793,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29540,7 +29634,7 @@
 					}
 				},
 				{
-					"id": 2859,
+					"id": 2876,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29564,7 +29658,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2161,
+							"line": 2185,
 							"character": 4
 						}
 					],
@@ -29578,7 +29672,7 @@
 					}
 				},
 				{
-					"id": 2851,
+					"id": 2868,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29606,7 +29700,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2023,
+							"line": 2047,
 							"character": 4
 						}
 					],
@@ -29620,7 +29714,7 @@
 					}
 				},
 				{
-					"id": 2849,
+					"id": 2866,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29644,7 +29738,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2013,
 							"character": 4
 						}
 					],
@@ -29658,7 +29752,7 @@
 					}
 				},
 				{
-					"id": 2862,
+					"id": 2879,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29686,7 +29780,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2210,
+							"line": 2234,
 							"character": 4
 						}
 					],
@@ -29700,7 +29794,7 @@
 					}
 				},
 				{
-					"id": 2772,
+					"id": 2789,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29737,7 +29831,7 @@
 					}
 				},
 				{
-					"id": 2775,
+					"id": 2792,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29775,7 +29869,7 @@
 					}
 				},
 				{
-					"id": 2830,
+					"id": 2847,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29795,7 +29889,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -29809,7 +29903,7 @@
 					}
 				},
 				{
-					"id": 2773,
+					"id": 2790,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29843,7 +29937,7 @@
 					}
 				},
 				{
-					"id": 2858,
+					"id": 2875,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29867,7 +29961,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2146,
+							"line": 2170,
 							"character": 4
 						}
 					],
@@ -29881,7 +29975,7 @@
 					}
 				},
 				{
-					"id": 2841,
+					"id": 2858,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29905,7 +29999,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -29919,7 +30013,7 @@
 					}
 				},
 				{
-					"id": 2770,
+					"id": 2787,
 					"name": "isUnifiedSearchExperienceEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29957,7 +30051,7 @@
 					}
 				},
 				{
-					"id": 2777,
+					"id": 2794,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -29994,7 +30088,7 @@
 					}
 				},
 				{
-					"id": 2779,
+					"id": 2796,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30028,7 +30122,7 @@
 					}
 				},
 				{
-					"id": 2821,
+					"id": 2838,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30052,7 +30146,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -30066,7 +30160,7 @@
 					}
 				},
 				{
-					"id": 2803,
+					"id": 2820,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30090,7 +30184,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -30104,7 +30198,7 @@
 					}
 				},
 				{
-					"id": 2790,
+					"id": 2807,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30141,7 +30235,7 @@
 					}
 				},
 				{
-					"id": 2765,
+					"id": 2782,
 					"name": "modularHomeExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30182,7 +30276,7 @@
 					}
 				},
 				{
-					"id": 2863,
+					"id": 2880,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30210,7 +30304,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2226,
+							"line": 2250,
 							"character": 4
 						}
 					],
@@ -30224,7 +30318,7 @@
 					}
 				},
 				{
-					"id": 2771,
+					"id": 2788,
 					"name": "newConnectionsExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30262,7 +30356,7 @@
 					}
 				},
 				{
-					"id": 2820,
+					"id": 2837,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30286,7 +30380,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -30300,7 +30394,7 @@
 					}
 				},
 				{
-					"id": 2819,
+					"id": 2836,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30324,7 +30418,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -30338,7 +30432,7 @@
 					}
 				},
 				{
-					"id": 2758,
+					"id": 2775,
 					"name": "pageId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30368,12 +30462,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1981,
+						"id": 1995,
 						"name": "Page"
 					}
 				},
 				{
-					"id": 2757,
+					"id": 2774,
 					"name": "path",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30407,7 +30501,7 @@
 					}
 				},
 				{
-					"id": 2814,
+					"id": 2831,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30430,7 +30524,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -30444,7 +30538,7 @@
 					}
 				},
 				{
-					"id": 2813,
+					"id": 2830,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30472,7 +30566,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -30495,7 +30589,7 @@
 					}
 				},
 				{
-					"id": 2811,
+					"id": 2828,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30523,7 +30617,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -30537,7 +30631,7 @@
 					}
 				},
 				{
-					"id": 2823,
+					"id": 2840,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30561,7 +30655,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -30575,7 +30669,7 @@
 					}
 				},
 				{
-					"id": 2827,
+					"id": 2844,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30602,7 +30696,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -30616,7 +30710,7 @@
 					}
 				},
 				{
-					"id": 2844,
+					"id": 2861,
 					"name": "reorderedHomepageModules",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30640,7 +30734,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1743,
+							"line": 1767,
 							"character": 4
 						}
 					],
@@ -30648,7 +30742,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2887,
+							"id": 2904,
 							"name": "HomepageModule"
 						}
 					},
@@ -30658,7 +30752,7 @@
 					}
 				},
 				{
-					"id": 2833,
+					"id": 2850,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30682,7 +30776,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -30690,7 +30784,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -30700,7 +30794,7 @@
 					}
 				},
 				{
-					"id": 2834,
+					"id": 2851,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30724,7 +30818,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -30732,7 +30826,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -30742,7 +30836,7 @@
 					}
 				},
 				{
-					"id": 2828,
+					"id": 2845,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30769,7 +30863,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -30783,7 +30877,7 @@
 					}
 				},
 				{
-					"id": 2825,
+					"id": 2842,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30806,7 +30900,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -30820,7 +30914,7 @@
 					}
 				},
 				{
-					"id": 2848,
+					"id": 2865,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30848,7 +30942,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1974,
+							"line": 1998,
 							"character": 4
 						}
 					],
@@ -30862,7 +30956,7 @@
 					}
 				},
 				{
-					"id": 2854,
+					"id": 2871,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30890,7 +30984,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2078,
+							"line": 2102,
 							"character": 4
 						}
 					],
@@ -30904,7 +30998,7 @@
 					}
 				},
 				{
-					"id": 2847,
+					"id": 2864,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30932,7 +31026,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1958,
+							"line": 1982,
 							"character": 4
 						}
 					],
@@ -30946,7 +31040,7 @@
 					}
 				},
 				{
-					"id": 2852,
+					"id": 2869,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -30974,7 +31068,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2040,
+							"line": 2064,
 							"character": 4
 						}
 					],
@@ -30988,7 +31082,7 @@
 					}
 				},
 				{
-					"id": 2861,
+					"id": 2878,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31016,7 +31110,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2194,
+							"line": 2218,
 							"character": 4
 						}
 					],
@@ -31030,7 +31124,7 @@
 					}
 				},
 				{
-					"id": 2748,
+					"id": 2765,
 					"name": "showPrimaryNavbar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31068,7 +31162,7 @@
 					}
 				},
 				{
-					"id": 2781,
+					"id": 2798,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31106,7 +31200,7 @@
 					}
 				},
 				{
-					"id": 2785,
+					"id": 2802,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31141,7 +31235,7 @@
 					}
 				},
 				{
-					"id": 2787,
+					"id": 2804,
 					"name": "spotterDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31178,7 +31272,7 @@
 					}
 				},
 				{
-					"id": 2786,
+					"id": 2803,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31208,12 +31302,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1562,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
 				{
-					"id": 2784,
+					"id": 2801,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31243,12 +31337,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1542,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
 				{
-					"id": 2788,
+					"id": 2805,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31278,12 +31372,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2726,
+						"id": 2743,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2759,
+					"id": 2776,
 					"name": "tag",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31317,7 +31411,7 @@
 					}
 				},
 				{
-					"id": 2780,
+					"id": 2797,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31355,7 +31449,7 @@
 					}
 				},
 				{
-					"id": 2794,
+					"id": 2811,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31393,7 +31487,7 @@
 					}
 				},
 				{
-					"id": 2829,
+					"id": 2846,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31420,7 +31514,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -31434,7 +31528,7 @@
 					}
 				},
 				{
-					"id": 2802,
+					"id": 2819,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31462,7 +31556,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -31470,7 +31564,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -31480,7 +31574,7 @@
 					}
 				},
 				{
-					"id": 2793,
+					"id": 2810,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -31505,7 +31599,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3315,
+						"id": 3332,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -31515,111 +31609,111 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2804,
-						2838,
+						2821,
+						2855,
+						2784,
+						2852,
+						2873,
+						2843,
+						2825,
+						2785,
+						2856,
+						2799,
 						2767,
 						2835,
-						2856,
-						2826,
-						2808,
-						2768,
-						2839,
-						2782,
-						2750,
-						2818,
-						2800,
-						2799,
-						2766,
-						2812,
-						2850,
-						2855,
-						2840,
-						2791,
-						2822,
-						2792,
-						2783,
-						2751,
-						2763,
-						2789,
-						2815,
-						2836,
-						2837,
 						2817,
-						2796,
-						2764,
-						2801,
-						2845,
-						2843,
-						2842,
-						2755,
-						2752,
-						2749,
-						2853,
-						2846,
-						2754,
-						2753,
-						2761,
-						2756,
-						2760,
-						2769,
-						2809,
-						2832,
-						2831,
+						2816,
+						2783,
+						2829,
+						2867,
+						2872,
 						2857,
-						2774,
-						2860,
-						2776,
-						2859,
-						2851,
-						2849,
+						2808,
+						2839,
+						2809,
+						2800,
+						2768,
+						2780,
+						2806,
+						2832,
+						2853,
+						2854,
+						2834,
+						2813,
+						2781,
+						2818,
 						2862,
+						2860,
+						2859,
 						2772,
-						2775,
-						2830,
-						2773,
-						2858,
-						2841,
-						2770,
-						2777,
-						2779,
-						2821,
-						2803,
-						2790,
-						2765,
+						2769,
+						2766,
+						2870,
 						2863,
 						2771,
-						2820,
-						2819,
-						2758,
-						2757,
-						2814,
-						2813,
-						2811,
-						2823,
-						2827,
-						2844,
-						2833,
-						2834,
-						2828,
-						2825,
-						2848,
-						2854,
-						2847,
-						2852,
-						2861,
-						2748,
-						2781,
-						2785,
-						2787,
+						2770,
+						2778,
+						2773,
+						2777,
 						2786,
-						2784,
-						2788,
-						2759,
-						2780,
+						2826,
+						2849,
+						2848,
+						2874,
+						2791,
+						2877,
+						2793,
+						2876,
+						2868,
+						2866,
+						2879,
+						2789,
+						2792,
+						2847,
+						2790,
+						2875,
+						2858,
+						2787,
 						2794,
-						2829,
+						2796,
+						2838,
+						2820,
+						2807,
+						2782,
+						2880,
+						2788,
+						2837,
+						2836,
+						2775,
+						2774,
+						2831,
+						2830,
+						2828,
+						2840,
+						2844,
+						2861,
+						2850,
+						2851,
+						2845,
+						2842,
+						2865,
+						2871,
+						2864,
+						2869,
+						2878,
+						2765,
+						2798,
 						2802,
-						2793
+						2804,
+						2803,
+						2801,
+						2805,
+						2776,
+						2797,
+						2811,
+						2846,
+						2819,
+						2810
 					]
 				}
 			],
@@ -31638,7 +31732,7 @@
 			]
 		},
 		{
-			"id": 1841,
+			"id": 1855,
 			"name": "AuthEventEmitter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -31654,14 +31748,14 @@
 			},
 			"children": [
 				{
-					"id": 1878,
+					"id": 1892,
 					"name": "emit",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1879,
+							"id": 1893,
 							"name": "emit",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31671,19 +31765,19 @@
 							},
 							"parameters": [
 								{
-									"id": 1880,
+									"id": 1894,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1840,
+										"id": 1854,
 										"name": "TRIGGER_SSO_POPUP"
 									}
 								},
 								{
-									"id": 1881,
+									"id": 1895,
 									"name": "args",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31707,14 +31801,14 @@
 					]
 				},
 				{
-					"id": 1882,
+					"id": 1896,
 					"name": "off",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1883,
+							"id": 1897,
 							"name": "off",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31724,7 +31818,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1884,
+									"id": 1898,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31732,12 +31826,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1831,
+										"id": 1845,
 										"name": "AuthStatus"
 									}
 								},
 								{
-									"id": 1885,
+									"id": 1899,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31746,21 +31840,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1886,
+											"id": 1900,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1887,
+													"id": 1901,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1888,
+															"id": 1902,
 															"name": "args",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -31786,7 +31880,7 @@
 									}
 								},
 								{
-									"id": 1889,
+									"id": 1903,
 									"name": "context",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31798,7 +31892,7 @@
 									}
 								},
 								{
-									"id": 1890,
+									"id": 1904,
 									"name": "once",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31814,21 +31908,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1842,
+					"id": 1856,
 					"name": "on",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1843,
+							"id": 1857,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31838,7 +31932,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1844,
+									"id": 1858,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31846,12 +31940,12 @@
 									"comment": {},
 									"type": {
 										"type": "reference",
-										"id": 1832,
+										"id": 1846,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1845,
+									"id": 1859,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31862,28 +31956,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1846,
+											"id": 1860,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1847,
+													"id": 1861,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1848,
+															"id": 1862,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1824,
+																"id": 1838,
 																"name": "AuthFailureType"
 															}
 														}
@@ -31900,12 +31994,12 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1849,
+							"id": 1863,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -31915,7 +32009,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1850,
+									"id": 1864,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31926,29 +32020,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1833,
+												"id": 1847,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1850,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1837,
+												"id": 1851,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1838,
+												"id": 1852,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1851,
+									"id": 1865,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -31959,14 +32053,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1852,
+											"id": 1866,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1853,
+													"id": 1867,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -31983,31 +32077,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1854,
+							"id": 1868,
 							"name": "on",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1855,
+									"id": 1869,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1835,
+										"id": 1849,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1856,
+									"id": 1870,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32015,21 +32109,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1857,
+											"id": 1871,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1858,
+													"id": 1872,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1859,
+															"id": 1873,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32052,40 +32146,40 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1860,
+					"id": 1874,
 					"name": "once",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1861,
+							"id": 1875,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1862,
+									"id": 1876,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1832,
+										"id": 1846,
 										"name": "FAILURE"
 									}
 								},
 								{
-									"id": 1863,
+									"id": 1877,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32093,28 +32187,28 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1864,
+											"id": 1878,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1865,
+													"id": 1879,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1866,
+															"id": 1880,
 															"name": "failureType",
 															"kind": 32768,
 															"kindString": "Parameter",
 															"flags": {},
 															"type": {
 																"type": "reference",
-																"id": 1824,
+																"id": 1838,
 																"name": "AuthFailureType"
 															}
 														}
@@ -32131,19 +32225,19 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1867,
+							"id": 1881,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1868,
+									"id": 1882,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32153,29 +32247,29 @@
 										"types": [
 											{
 												"type": "reference",
-												"id": 1833,
+												"id": 1847,
 												"name": "SDK_SUCCESS"
 											},
 											{
 												"type": "reference",
-												"id": 1836,
+												"id": 1850,
 												"name": "LOGOUT"
 											},
 											{
 												"type": "reference",
-												"id": 1837,
+												"id": 1851,
 												"name": "WAITING_FOR_POPUP"
 											},
 											{
 												"type": "reference",
-												"id": 1838,
+												"id": 1852,
 												"name": "SAML_POPUP_CLOSED_NO_AUTH"
 											}
 										]
 									}
 								},
 								{
-									"id": 1869,
+									"id": 1883,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32183,14 +32277,14 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1870,
+											"id": 1884,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1871,
+													"id": 1885,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -32207,31 +32301,31 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						},
 						{
-							"id": 1872,
+							"id": 1886,
 							"name": "once",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 1873,
+									"id": 1887,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 1835,
+										"id": 1849,
 										"name": "SUCCESS"
 									}
 								},
 								{
-									"id": 1874,
+									"id": 1888,
 									"name": "listener",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32239,21 +32333,21 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 1875,
+											"id": 1889,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"signatures": [
 												{
-													"id": 1876,
+													"id": 1890,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
 													"flags": {},
 													"parameters": [
 														{
-															"id": 1877,
+															"id": 1891,
 															"name": "sessionInfo",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -32276,21 +32370,21 @@
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						}
 					]
 				},
 				{
-					"id": 1891,
+					"id": 1905,
 					"name": "removeAllListeners",
 					"kind": 2048,
 					"kindString": "Method",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 1892,
+							"id": 1906,
 							"name": "removeAllListeners",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -32300,7 +32394,7 @@
 							},
 							"parameters": [
 								{
-									"id": 1893,
+									"id": 1907,
 									"name": "event",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -32310,14 +32404,14 @@
 									},
 									"type": {
 										"type": "reference",
-										"id": 1831,
+										"id": 1845,
 										"name": "AuthStatus"
 									}
 								}
 							],
 							"type": {
 								"type": "reference",
-								"id": 1841,
+								"id": 1855,
 								"name": "AuthEventEmitter"
 							}
 						}
@@ -32329,11 +32423,11 @@
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						1878,
-						1882,
-						1842,
-						1860,
-						1891
+						1892,
+						1896,
+						1856,
+						1874,
+						1905
 					]
 				}
 			],
@@ -32390,7 +32484,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -32479,7 +32573,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -32520,13 +32614,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -32560,7 +32654,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -32599,7 +32693,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -32638,7 +32732,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -32646,7 +32740,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -32688,7 +32782,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -32727,7 +32821,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -32766,7 +32860,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -32804,7 +32898,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -32843,13 +32937,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -32887,7 +32981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -32895,7 +32989,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -32930,7 +33024,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -32968,7 +33062,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -33006,7 +33100,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -33044,7 +33138,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -33083,7 +33177,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -33122,7 +33216,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -33161,7 +33255,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -33200,7 +33294,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -33238,7 +33332,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -33281,7 +33375,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -33333,7 +33427,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -33375,7 +33469,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -33417,7 +33511,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -33455,7 +33549,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -33497,7 +33591,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -33540,7 +33634,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -33548,7 +33642,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -33638,7 +33732,7 @@
 			]
 		},
 		{
-			"id": 1575,
+			"id": 1589,
 			"name": "ConversationViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -33658,7 +33752,7 @@
 			},
 			"children": [
 				{
-					"id": 1608,
+					"id": 1622,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33682,27 +33776,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1609,
+							"id": 1623,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 1610,
+								"id": 1624,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 1611,
+										"id": 1625,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -33739,7 +33833,7 @@
 					}
 				},
 				{
-					"id": 1629,
+					"id": 1643,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33771,7 +33865,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -33789,7 +33883,7 @@
 					}
 				},
 				{
-					"id": 1612,
+					"id": 1626,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33812,13 +33906,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -33828,7 +33922,7 @@
 					}
 				},
 				{
-					"id": 1582,
+					"id": 1596,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33856,7 +33950,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 394,
+							"line": 506,
 							"character": 4
 						}
 					],
@@ -33871,7 +33965,7 @@
 					}
 				},
 				{
-					"id": 1577,
+					"id": 1591,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33895,7 +33989,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 329,
+							"line": 441,
 							"character": 4
 						}
 					],
@@ -33913,7 +34007,7 @@
 					}
 				},
 				{
-					"id": 1591,
+					"id": 1605,
 					"name": "defaultQueryMode",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33941,13 +34035,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 649,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1559,
 						"name": "SpotterQueryMode"
 					},
 					"inheritedFrom": {
@@ -33957,7 +34051,7 @@
 					}
 				},
 				{
-					"id": 1622,
+					"id": 1636,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -33981,7 +34075,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -33996,7 +34090,7 @@
 					}
 				},
 				{
-					"id": 1580,
+					"id": 1594,
 					"name": "disableSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34020,7 +34114,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 364,
+							"line": 476,
 							"character": 4
 						}
 					],
@@ -34035,7 +34129,7 @@
 					}
 				},
 				{
-					"id": 1604,
+					"id": 1618,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34059,7 +34153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -34074,7 +34168,7 @@
 					}
 				},
 				{
-					"id": 1603,
+					"id": 1617,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34098,7 +34192,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -34106,7 +34200,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -34117,7 +34211,7 @@
 					}
 				},
 				{
-					"id": 1616,
+					"id": 1630,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34148,7 +34242,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -34163,7 +34257,7 @@
 					}
 				},
 				{
-					"id": 1626,
+					"id": 1640,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34187,7 +34281,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -34202,7 +34296,7 @@
 					}
 				},
 				{
-					"id": 1593,
+					"id": 1607,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34230,7 +34324,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 556,
+							"line": 668,
 							"character": 4
 						}
 					],
@@ -34245,7 +34339,7 @@
 					}
 				},
 				{
-					"id": 1592,
+					"id": 1606,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34269,7 +34363,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 546,
+							"line": 658,
 							"character": 4
 						}
 					],
@@ -34284,7 +34378,7 @@
 					}
 				},
 				{
-					"id": 1619,
+					"id": 1633,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34308,7 +34402,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -34323,7 +34417,7 @@
 					}
 				},
 				{
-					"id": 1586,
+					"id": 1600,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34347,7 +34441,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 458,
+							"line": 570,
 							"character": 4
 						}
 					],
@@ -34362,7 +34456,7 @@
 					}
 				},
 				{
-					"id": 1588,
+					"id": 1602,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34386,7 +34480,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 489,
+							"line": 601,
 							"character": 4
 						}
 					],
@@ -34401,7 +34495,7 @@
 					}
 				},
 				{
-					"id": 1621,
+					"id": 1635,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34424,7 +34518,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -34439,7 +34533,7 @@
 					}
 				},
 				{
-					"id": 1600,
+					"id": 1614,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34463,13 +34557,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -34479,7 +34573,7 @@
 					}
 				},
 				{
-					"id": 1605,
+					"id": 1619,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34507,7 +34601,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -34515,7 +34609,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -34526,7 +34620,7 @@
 					}
 				},
 				{
-					"id": 1584,
+					"id": 1598,
 					"name": "hideSampleQuestions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34550,7 +34644,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 425,
+							"line": 537,
 							"character": 4
 						}
 					],
@@ -34565,7 +34659,7 @@
 					}
 				},
 				{
-					"id": 1581,
+					"id": 1595,
 					"name": "hideSourceSelection",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34589,7 +34683,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 378,
+							"line": 490,
 							"character": 4
 						}
 					],
@@ -34604,7 +34698,7 @@
 					}
 				},
 				{
-					"id": 1613,
+					"id": 1627,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34628,7 +34722,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -34643,7 +34737,7 @@
 					}
 				},
 				{
-					"id": 1635,
+					"id": 1649,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34666,7 +34760,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -34681,7 +34775,7 @@
 					}
 				},
 				{
-					"id": 1634,
+					"id": 1648,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34704,7 +34798,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -34722,7 +34816,7 @@
 					}
 				},
 				{
-					"id": 1633,
+					"id": 1647,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34742,7 +34836,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -34757,7 +34851,7 @@
 					}
 				},
 				{
-					"id": 1625,
+					"id": 1639,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34781,7 +34875,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -34796,7 +34890,7 @@
 					}
 				},
 				{
-					"id": 1607,
+					"id": 1621,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34820,7 +34914,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -34835,7 +34929,7 @@
 					}
 				},
 				{
-					"id": 1624,
+					"id": 1638,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34859,7 +34953,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -34874,7 +34968,7 @@
 					}
 				},
 				{
-					"id": 1623,
+					"id": 1637,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34898,7 +34992,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -34913,7 +35007,7 @@
 					}
 				},
 				{
-					"id": 1618,
+					"id": 1632,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34936,7 +35030,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -34951,7 +35045,7 @@
 					}
 				},
 				{
-					"id": 1617,
+					"id": 1631,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -34979,7 +35073,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -35003,7 +35097,7 @@
 					}
 				},
 				{
-					"id": 1615,
+					"id": 1629,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35031,7 +35125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -35046,7 +35140,7 @@
 					}
 				},
 				{
-					"id": 1630,
+					"id": 1644,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35073,7 +35167,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -35088,7 +35182,7 @@
 					}
 				},
 				{
-					"id": 1585,
+					"id": 1599,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35112,7 +35206,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 446,
+							"line": 558,
 							"character": 4
 						}
 					],
@@ -35120,7 +35214,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -35131,7 +35225,7 @@
 					}
 				},
 				{
-					"id": 1587,
+					"id": 1601,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35155,7 +35249,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 477,
+							"line": 589,
 							"character": 4
 						}
 					],
@@ -35163,7 +35257,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -35174,7 +35268,7 @@
 					}
 				},
 				{
-					"id": 1579,
+					"id": 1593,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35187,7 +35281,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 349,
+							"line": 461,
 							"character": 4
 						}
 					],
@@ -35202,7 +35296,7 @@
 					}
 				},
 				{
-					"id": 1597,
+					"id": 1611,
 					"name": "sharedConversationId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35226,7 +35320,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 633,
+							"line": 745,
 							"character": 4
 						}
 					],
@@ -35241,7 +35335,7 @@
 					}
 				},
 				{
-					"id": 1631,
+					"id": 1645,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35268,7 +35362,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -35283,7 +35377,7 @@
 					}
 				},
 				{
-					"id": 1628,
+					"id": 1642,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35306,7 +35400,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -35321,7 +35415,7 @@
 					}
 				},
 				{
-					"id": 1583,
+					"id": 1597,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35345,7 +35439,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 410,
+							"line": 522,
 							"character": 4
 						}
 					],
@@ -35360,7 +35454,7 @@
 					}
 				},
 				{
-					"id": 1590,
+					"id": 1604,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35388,7 +35482,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 519,
+							"line": 631,
 							"character": 4
 						}
 					],
@@ -35403,7 +35497,7 @@
 					}
 				},
 				{
-					"id": 1578,
+					"id": 1592,
 					"name": "spotterAnalystConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35427,13 +35521,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 345,
+							"line": 457,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1557,
 						"name": "SpotterAnalystConfig"
 					},
 					"inheritedFrom": {
@@ -35443,7 +35537,7 @@
 					}
 				},
 				{
-					"id": 1595,
+					"id": 1609,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35467,7 +35561,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 595,
+							"line": 707,
 							"character": 4
 						}
 					],
@@ -35483,7 +35577,7 @@
 					}
 				},
 				{
-					"id": 1596,
+					"id": 1610,
 					"name": "spotterShareConversationConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35507,13 +35601,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 611,
+							"line": 723,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1562,
 						"name": "SpotterShareConversationConfig"
 					},
 					"inheritedFrom": {
@@ -35523,7 +35617,7 @@
 					}
 				},
 				{
-					"id": 1594,
+					"id": 1608,
 					"name": "spotterSidebarConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35547,13 +35641,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 577,
+							"line": 689,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1542,
 						"name": "SpotterSidebarViewConfig"
 					},
 					"inheritedFrom": {
@@ -35563,7 +35657,7 @@
 					}
 				},
 				{
-					"id": 1589,
+					"id": 1603,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35591,7 +35685,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 504,
+							"line": 616,
 							"character": 4
 						}
 					],
@@ -35606,7 +35700,7 @@
 					}
 				},
 				{
-					"id": 1598,
+					"id": 1612,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35634,7 +35728,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 648,
+							"line": 760,
 							"character": 4
 						}
 					],
@@ -35649,7 +35743,7 @@
 					}
 				},
 				{
-					"id": 1632,
+					"id": 1646,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35676,7 +35770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -35691,7 +35785,7 @@
 					}
 				},
 				{
-					"id": 1606,
+					"id": 1620,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35719,7 +35813,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -35727,7 +35821,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -35738,7 +35832,7 @@
 					}
 				},
 				{
-					"id": 1576,
+					"id": 1590,
 					"name": "worksheetId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35751,7 +35845,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 312,
+							"line": 424,
 							"character": 4
 						}
 					],
@@ -35771,64 +35865,64 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1608,
-						1629,
-						1612,
-						1582,
-						1577,
-						1591,
 						1622,
-						1580,
-						1604,
-						1603,
-						1616,
+						1643,
 						1626,
-						1593,
-						1592,
-						1619,
-						1586,
-						1588,
-						1621,
-						1600,
+						1596,
+						1591,
 						1605,
-						1584,
-						1581,
-						1613,
-						1635,
-						1634,
-						1633,
-						1625,
-						1607,
-						1624,
-						1623,
+						1636,
+						1594,
 						1618,
 						1617,
-						1615,
 						1630,
-						1585,
-						1587,
-						1579,
-						1597,
-						1631,
-						1628,
-						1583,
-						1590,
-						1578,
-						1595,
-						1596,
-						1594,
-						1589,
-						1598,
-						1632,
+						1640,
+						1607,
 						1606,
-						1576
+						1633,
+						1600,
+						1602,
+						1635,
+						1614,
+						1619,
+						1598,
+						1595,
+						1627,
+						1649,
+						1648,
+						1647,
+						1639,
+						1621,
+						1638,
+						1637,
+						1632,
+						1631,
+						1629,
+						1644,
+						1599,
+						1601,
+						1593,
+						1611,
+						1645,
+						1642,
+						1597,
+						1604,
+						1592,
+						1609,
+						1610,
+						1608,
+						1603,
+						1612,
+						1646,
+						1620,
+						1590
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 658,
+					"line": 770,
 					"character": 17
 				}
 			],
@@ -35841,7 +35935,7 @@
 			]
 		},
 		{
-			"id": 3223,
+			"id": 3240,
 			"name": "CustomActionPayload",
 			"kind": 256,
 			"kindString": "Interface",
@@ -35856,7 +35950,7 @@
 			},
 			"children": [
 				{
-					"id": 3224,
+					"id": 3241,
 					"name": "contextMenuPoints",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35866,21 +35960,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8799,
+							"line": 8881,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3225,
+							"id": 3242,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3226,
+									"id": 3243,
 									"name": "clickedPoint",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35888,18 +35982,18 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8800,
+											"line": 8882,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reference",
-										"id": 3220,
+										"id": 3237,
 										"name": "VizPoint"
 									}
 								},
 								{
-									"id": 3227,
+									"id": 3244,
 									"name": "selectedPoints",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35907,7 +36001,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8801,
+											"line": 8883,
 											"character": 8
 										}
 									],
@@ -35915,7 +36009,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"id": 3220,
+											"id": 3237,
 											"name": "VizPoint"
 										}
 									}
@@ -35926,8 +36020,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3226,
-										3227
+										3243,
+										3244
 									]
 								}
 							]
@@ -35935,7 +36029,7 @@
 					}
 				},
 				{
-					"id": 3228,
+					"id": 3245,
 					"name": "embedAnswerData",
 					"kind": 1024,
 					"kindString": "Property",
@@ -35943,21 +36037,21 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8803,
+							"line": 8885,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 3229,
+							"id": 3246,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 3237,
+									"id": 3254,
 									"name": "columns",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35965,7 +36059,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8811,
+											"line": 8893,
 											"character": 8
 										}
 									],
@@ -35978,7 +36072,7 @@
 									}
 								},
 								{
-									"id": 3238,
+									"id": 3255,
 									"name": "data",
 									"kind": 1024,
 									"kindString": "Property",
@@ -35986,7 +36080,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8812,
+											"line": 8894,
 											"character": 8
 										}
 									],
@@ -35999,7 +36093,7 @@
 									}
 								},
 								{
-									"id": 3231,
+									"id": 3248,
 									"name": "id",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36007,7 +36101,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8805,
+											"line": 8887,
 											"character": 8
 										}
 									],
@@ -36017,7 +36111,7 @@
 									}
 								},
 								{
-									"id": 3230,
+									"id": 3247,
 									"name": "name",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36025,7 +36119,7 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8804,
+											"line": 8886,
 											"character": 8
 										}
 									],
@@ -36035,7 +36129,7 @@
 									}
 								},
 								{
-									"id": 3232,
+									"id": 3249,
 									"name": "sources",
 									"kind": 1024,
 									"kindString": "Property",
@@ -36043,21 +36137,21 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 8806,
+											"line": 8888,
 											"character": 8
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 3233,
+											"id": 3250,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
 											"flags": {},
 											"children": [
 												{
-													"id": 3234,
+													"id": 3251,
 													"name": "header",
 													"kind": 1024,
 													"kindString": "Property",
@@ -36065,21 +36159,21 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 8807,
+															"line": 8889,
 															"character": 12
 														}
 													],
 													"type": {
 														"type": "reflection",
 														"declaration": {
-															"id": 3235,
+															"id": 3252,
 															"name": "__type",
 															"kind": 65536,
 															"kindString": "Type literal",
 															"flags": {},
 															"children": [
 																{
-																	"id": 3236,
+																	"id": 3253,
 																	"name": "guid",
 																	"kind": 1024,
 																	"kindString": "Property",
@@ -36087,7 +36181,7 @@
 																	"sources": [
 																		{
 																			"fileName": "types.ts",
-																			"line": 8808,
+																			"line": 8890,
 																			"character": 16
 																		}
 																	],
@@ -36102,7 +36196,7 @@
 																	"title": "Properties",
 																	"kind": 1024,
 																	"children": [
-																		3236
+																		3253
 																	]
 																}
 															]
@@ -36115,7 +36209,7 @@
 													"title": "Properties",
 													"kind": 1024,
 													"children": [
-														3234
+														3251
 													]
 												}
 											]
@@ -36128,23 +36222,23 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										3237,
-										3238,
-										3231,
-										3230,
-										3232
+										3254,
+										3255,
+										3248,
+										3247,
+										3249
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 3239,
+								"id": 3256,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 3240,
+										"id": 3257,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -36163,7 +36257,7 @@
 					}
 				},
 				{
-					"id": 3241,
+					"id": 3258,
 					"name": "session",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36171,18 +36265,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8815,
+							"line": 8897,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1971,
+						"id": 1985,
 						"name": "SessionInterface"
 					}
 				},
 				{
-					"id": 3242,
+					"id": 3259,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36192,7 +36286,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8816,
+							"line": 8898,
 							"character": 4
 						}
 					],
@@ -36207,23 +36301,23 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3224,
-						3228,
 						3241,
-						3242
+						3245,
+						3258,
+						3259
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8798,
+					"line": 8880,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2933,
+			"id": 2950,
 			"name": "CustomCssVariables",
 			"kind": 256,
 			"kindString": "Interface",
@@ -36233,7 +36327,7 @@
 			},
 			"children": [
 				{
-					"id": 2996,
+					"id": 3013,
 					"name": "--ts-var-answer-chart-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36256,7 +36350,7 @@
 					}
 				},
 				{
-					"id": 2995,
+					"id": 3012,
 					"name": "--ts-var-answer-chart-select-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36279,7 +36373,7 @@
 					}
 				},
 				{
-					"id": 2965,
+					"id": 2982,
 					"name": "--ts-var-answer-data-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36302,7 +36396,7 @@
 					}
 				},
 				{
-					"id": 2966,
+					"id": 2983,
 					"name": "--ts-var-answer-edit-panel-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36325,7 +36419,7 @@
 					}
 				},
 				{
-					"id": 2968,
+					"id": 2985,
 					"name": "--ts-var-answer-view-table-chart-switcher-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36348,7 +36442,7 @@
 					}
 				},
 				{
-					"id": 2967,
+					"id": 2984,
 					"name": "--ts-var-answer-view-table-chart-switcher-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36371,7 +36465,7 @@
 					}
 				},
 				{
-					"id": 2938,
+					"id": 2955,
 					"name": "--ts-var-application-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36394,7 +36488,7 @@
 					}
 				},
 				{
-					"id": 3008,
+					"id": 3025,
 					"name": "--ts-var-axis-data-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36417,7 +36511,7 @@
 					}
 				},
 				{
-					"id": 3009,
+					"id": 3026,
 					"name": "--ts-var-axis-data-label-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36440,7 +36534,7 @@
 					}
 				},
 				{
-					"id": 3006,
+					"id": 3023,
 					"name": "--ts-var-axis-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36463,7 +36557,7 @@
 					}
 				},
 				{
-					"id": 3007,
+					"id": 3024,
 					"name": "--ts-var-axis-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36486,7 +36580,7 @@
 					}
 				},
 				{
-					"id": 2970,
+					"id": 2987,
 					"name": "--ts-var-button--icon-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36509,7 +36603,7 @@
 					}
 				},
 				{
-					"id": 2975,
+					"id": 2992,
 					"name": "--ts-var-button--primary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36532,7 +36626,7 @@
 					}
 				},
 				{
-					"id": 2972,
+					"id": 2989,
 					"name": "--ts-var-button--primary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36555,7 +36649,7 @@
 					}
 				},
 				{
-					"id": 2974,
+					"id": 2991,
 					"name": "--ts-var-button--primary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36578,7 +36672,7 @@
 					}
 				},
 				{
-					"id": 2973,
+					"id": 2990,
 					"name": "--ts-var-button--primary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36601,7 +36695,7 @@
 					}
 				},
 				{
-					"id": 2971,
+					"id": 2988,
 					"name": "--ts-var-button--primary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36624,7 +36718,7 @@
 					}
 				},
 				{
-					"id": 2980,
+					"id": 2997,
 					"name": "--ts-var-button--secondary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36647,7 +36741,7 @@
 					}
 				},
 				{
-					"id": 2977,
+					"id": 2994,
 					"name": "--ts-var-button--secondary--font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36670,7 +36764,7 @@
 					}
 				},
 				{
-					"id": 2979,
+					"id": 2996,
 					"name": "--ts-var-button--secondary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36693,7 +36787,7 @@
 					}
 				},
 				{
-					"id": 2978,
+					"id": 2995,
 					"name": "--ts-var-button--secondary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36716,7 +36810,7 @@
 					}
 				},
 				{
-					"id": 2976,
+					"id": 2993,
 					"name": "--ts-var-button--secondary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36739,7 +36833,7 @@
 					}
 				},
 				{
-					"id": 2984,
+					"id": 3001,
 					"name": "--ts-var-button--tertiary--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36762,7 +36856,7 @@
 					}
 				},
 				{
-					"id": 2983,
+					"id": 3000,
 					"name": "--ts-var-button--tertiary--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36785,7 +36879,7 @@
 					}
 				},
 				{
-					"id": 2982,
+					"id": 2999,
 					"name": "--ts-var-button--tertiary-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36808,7 +36902,7 @@
 					}
 				},
 				{
-					"id": 2981,
+					"id": 2998,
 					"name": "--ts-var-button--tertiary-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36831,7 +36925,7 @@
 					}
 				},
 				{
-					"id": 2969,
+					"id": 2986,
 					"name": "--ts-var-button-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36854,7 +36948,7 @@
 					}
 				},
 				{
-					"id": 3105,
+					"id": 3122,
 					"name": "--ts-var-cca-modal-summary-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36877,7 +36971,7 @@
 					}
 				},
 				{
-					"id": 3100,
+					"id": 3117,
 					"name": "--ts-var-change-analysis-insights-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36900,7 +36994,7 @@
 					}
 				},
 				{
-					"id": 3095,
+					"id": 3112,
 					"name": "--ts-var-chart-heatmap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36923,7 +37017,7 @@
 					}
 				},
 				{
-					"id": 3094,
+					"id": 3111,
 					"name": "--ts-var-chart-heatmap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36946,7 +37040,7 @@
 					}
 				},
 				{
-					"id": 3097,
+					"id": 3114,
 					"name": "--ts-var-chart-treemap-legend-label-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36969,7 +37063,7 @@
 					}
 				},
 				{
-					"id": 3096,
+					"id": 3113,
 					"name": "--ts-var-chart-treemap-legend-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -36992,7 +37086,7 @@
 					}
 				},
 				{
-					"id": 3031,
+					"id": 3048,
 					"name": "--ts-var-checkbox-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37015,7 +37109,7 @@
 					}
 				},
 				{
-					"id": 3034,
+					"id": 3051,
 					"name": "--ts-var-checkbox-background-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37038,7 +37132,7 @@
 					}
 				},
 				{
-					"id": 3029,
+					"id": 3046,
 					"name": "--ts-var-checkbox-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37061,7 +37155,7 @@
 					}
 				},
 				{
-					"id": 3032,
+					"id": 3049,
 					"name": "--ts-var-checkbox-checked-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37084,7 +37178,7 @@
 					}
 				},
 				{
-					"id": 3033,
+					"id": 3050,
 					"name": "--ts-var-checkbox-checked-disabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37107,7 +37201,7 @@
 					}
 				},
 				{
-					"id": 3028,
+					"id": 3045,
 					"name": "--ts-var-checkbox-error-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37130,7 +37224,7 @@
 					}
 				},
 				{
-					"id": 3030,
+					"id": 3047,
 					"name": "--ts-var-checkbox-hover-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37153,7 +37247,7 @@
 					}
 				},
 				{
-					"id": 3001,
+					"id": 3018,
 					"name": "--ts-var-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37176,7 +37270,7 @@
 					}
 				},
 				{
-					"id": 3000,
+					"id": 3017,
 					"name": "--ts-var-chip--active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37199,7 +37293,7 @@
 					}
 				},
 				{
-					"id": 3003,
+					"id": 3020,
 					"name": "--ts-var-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37222,7 +37316,7 @@
 					}
 				},
 				{
-					"id": 3002,
+					"id": 3019,
 					"name": "--ts-var-chip--hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37245,7 +37339,7 @@
 					}
 				},
 				{
-					"id": 2999,
+					"id": 3016,
 					"name": "--ts-var-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37268,7 +37362,7 @@
 					}
 				},
 				{
-					"id": 2997,
+					"id": 3014,
 					"name": "--ts-var-chip-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37291,7 +37385,7 @@
 					}
 				},
 				{
-					"id": 2998,
+					"id": 3015,
 					"name": "--ts-var-chip-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37314,7 +37408,7 @@
 					}
 				},
 				{
-					"id": 3004,
+					"id": 3021,
 					"name": "--ts-var-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37337,7 +37431,7 @@
 					}
 				},
 				{
-					"id": 3005,
+					"id": 3022,
 					"name": "--ts-var-chip-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37360,7 +37454,7 @@
 					}
 				},
 				{
-					"id": 3016,
+					"id": 3033,
 					"name": "--ts-var-dialog-body-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37383,7 +37477,7 @@
 					}
 				},
 				{
-					"id": 3017,
+					"id": 3034,
 					"name": "--ts-var-dialog-body-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37406,7 +37500,7 @@
 					}
 				},
 				{
-					"id": 3020,
+					"id": 3037,
 					"name": "--ts-var-dialog-footer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37429,7 +37523,7 @@
 					}
 				},
 				{
-					"id": 3018,
+					"id": 3035,
 					"name": "--ts-var-dialog-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37452,7 +37546,7 @@
 					}
 				},
 				{
-					"id": 3019,
+					"id": 3036,
 					"name": "--ts-var-dialog-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37475,7 +37569,7 @@
 					}
 				},
 				{
-					"id": 3027,
+					"id": 3044,
 					"name": "--ts-var-home-favorite-suggestion-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37498,7 +37592,7 @@
 					}
 				},
 				{
-					"id": 3026,
+					"id": 3043,
 					"name": "--ts-var-home-favorite-suggestion-card-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37521,7 +37615,7 @@
 					}
 				},
 				{
-					"id": 3025,
+					"id": 3042,
 					"name": "--ts-var-home-favorite-suggestion-card-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37544,7 +37638,7 @@
 					}
 				},
 				{
-					"id": 3024,
+					"id": 3041,
 					"name": "--ts-var-home-watchlist-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37567,7 +37661,7 @@
 					}
 				},
 				{
-					"id": 3093,
+					"id": 3110,
 					"name": "--ts-var-kpi-analyze-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37590,7 +37684,7 @@
 					}
 				},
 				{
-					"id": 3092,
+					"id": 3109,
 					"name": "--ts-var-kpi-comparison-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37613,7 +37707,7 @@
 					}
 				},
 				{
-					"id": 3091,
+					"id": 3108,
 					"name": "--ts-var-kpi-hero-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37636,7 +37730,7 @@
 					}
 				},
 				{
-					"id": 3099,
+					"id": 3116,
 					"name": "--ts-var-kpi-negative-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37659,7 +37753,7 @@
 					}
 				},
 				{
-					"id": 3098,
+					"id": 3115,
 					"name": "--ts-var-kpi-positive-change-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37682,7 +37776,7 @@
 					}
 				},
 				{
-					"id": 2942,
+					"id": 2959,
 					"name": "--ts-var-left-nav-active-tab-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37705,7 +37799,7 @@
 					}
 				},
 				{
-					"id": 2943,
+					"id": 2960,
 					"name": "--ts-var-left-nav-active-tab-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37728,7 +37822,7 @@
 					}
 				},
 				{
-					"id": 2941,
+					"id": 2958,
 					"name": "--ts-var-left-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37751,7 +37845,7 @@
 					}
 				},
 				{
-					"id": 2945,
+					"id": 2962,
 					"name": "--ts-var-left-nav-item-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37774,7 +37868,7 @@
 					}
 				},
 				{
-					"id": 2947,
+					"id": 2964,
 					"name": "--ts-var-left-nav-item-selection-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37797,7 +37891,7 @@
 					}
 				},
 				{
-					"id": 2946,
+					"id": 2963,
 					"name": "--ts-var-left-nav-item-selection-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37820,7 +37914,7 @@
 					}
 				},
 				{
-					"id": 2944,
+					"id": 2961,
 					"name": "--ts-var-left-nav-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37843,7 +37937,7 @@
 					}
 				},
 				{
-					"id": 2948,
+					"id": 2965,
 					"name": "--ts-var-left-nav-tab-icon-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37866,7 +37960,7 @@
 					}
 				},
 				{
-					"id": 2949,
+					"id": 2966,
 					"name": "--ts-var-left-nav-tab-icon-inactive-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37889,7 +37983,7 @@
 					}
 				},
 				{
-					"id": 3022,
+					"id": 3039,
 					"name": "--ts-var-list-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37912,7 +38006,7 @@
 					}
 				},
 				{
-					"id": 3021,
+					"id": 3038,
 					"name": "--ts-var-list-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37935,7 +38029,7 @@
 					}
 				},
 				{
-					"id": 3051,
+					"id": 3068,
 					"name": "--ts-var-liveboard-answer-viz-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37958,7 +38052,7 @@
 					}
 				},
 				{
-					"id": 3064,
+					"id": 3081,
 					"name": "--ts-var-liveboard-chip--active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -37982,7 +38076,7 @@
 					}
 				},
 				{
-					"id": 3063,
+					"id": 3080,
 					"name": "--ts-var-liveboard-chip--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38006,7 +38100,7 @@
 					}
 				},
 				{
-					"id": 3061,
+					"id": 3078,
 					"name": "--ts-var-liveboard-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38030,7 +38124,7 @@
 					}
 				},
 				{
-					"id": 3062,
+					"id": 3079,
 					"name": "--ts-var-liveboard-chip-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38054,7 +38148,7 @@
 					}
 				},
 				{
-					"id": 3069,
+					"id": 3086,
 					"name": "--ts-var-liveboard-cross-filter-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38077,7 +38171,7 @@
 					}
 				},
 				{
-					"id": 3067,
+					"id": 3084,
 					"name": "--ts-var-liveboard-dual-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38100,7 +38194,7 @@
 					}
 				},
 				{
-					"id": 3066,
+					"id": 3083,
 					"name": "--ts-var-liveboard-edit-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38123,7 +38217,7 @@
 					}
 				},
 				{
-					"id": 3154,
+					"id": 3171,
 					"name": "--ts-var-liveboard-edit-toolbar-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38146,7 +38240,7 @@
 					}
 				},
 				{
-					"id": 3158,
+					"id": 3175,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38169,7 +38263,7 @@
 					}
 				},
 				{
-					"id": 3159,
+					"id": 3176,
 					"name": "--ts-var-liveboard-edit-toolbar-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38192,7 +38286,7 @@
 					}
 				},
 				{
-					"id": 3155,
+					"id": 3172,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38215,7 +38309,7 @@
 					}
 				},
 				{
-					"id": 3156,
+					"id": 3173,
 					"name": "--ts-var-liveboard-edit-toolbar-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38238,7 +38332,7 @@
 					}
 				},
 				{
-					"id": 3157,
+					"id": 3174,
 					"name": "--ts-var-liveboard-edit-toolbar-text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38261,7 +38355,7 @@
 					}
 				},
 				{
-					"id": 3052,
+					"id": 3069,
 					"name": "--ts-var-liveboard-group-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38285,7 +38379,7 @@
 					}
 				},
 				{
-					"id": 3053,
+					"id": 3070,
 					"name": "--ts-var-liveboard-group-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38309,7 +38403,7 @@
 					}
 				},
 				{
-					"id": 3057,
+					"id": 3074,
 					"name": "--ts-var-liveboard-group-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38333,7 +38427,7 @@
 					}
 				},
 				{
-					"id": 3045,
+					"id": 3062,
 					"name": "--ts-var-liveboard-group-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38357,7 +38451,7 @@
 					}
 				},
 				{
-					"id": 3060,
+					"id": 3077,
 					"name": "--ts-var-liveboard-group-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38381,7 +38475,7 @@
 					}
 				},
 				{
-					"id": 3059,
+					"id": 3076,
 					"name": "--ts-var-liveboard-group-tile-description-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38405,7 +38499,7 @@
 					}
 				},
 				{
-					"id": 3050,
+					"id": 3067,
 					"name": "--ts-var-liveboard-group-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38429,7 +38523,7 @@
 					}
 				},
 				{
-					"id": 3058,
+					"id": 3075,
 					"name": "--ts-var-liveboard-group-tile-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38453,7 +38547,7 @@
 					}
 				},
 				{
-					"id": 3048,
+					"id": 3065,
 					"name": "--ts-var-liveboard-group-tile-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38477,7 +38571,7 @@
 					}
 				},
 				{
-					"id": 3049,
+					"id": 3066,
 					"name": "--ts-var-liveboard-group-tile-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38501,7 +38595,7 @@
 					}
 				},
 				{
-					"id": 3056,
+					"id": 3073,
 					"name": "--ts-var-liveboard-group-title-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38525,7 +38619,7 @@
 					}
 				},
 				{
-					"id": 3046,
+					"id": 3063,
 					"name": "--ts-var-liveboard-group-title-font-size",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38549,7 +38643,7 @@
 					}
 				},
 				{
-					"id": 3047,
+					"id": 3064,
 					"name": "--ts-var-liveboard-group-title-font-weight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38573,7 +38667,7 @@
 					}
 				},
 				{
-					"id": 3084,
+					"id": 3101,
 					"name": "--ts-var-liveboard-header-action-button-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38596,7 +38690,7 @@
 					}
 				},
 				{
-					"id": 3081,
+					"id": 3098,
 					"name": "--ts-var-liveboard-header-action-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38619,7 +38713,7 @@
 					}
 				},
 				{
-					"id": 3082,
+					"id": 3099,
 					"name": "--ts-var-liveboard-header-action-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38642,7 +38736,7 @@
 					}
 				},
 				{
-					"id": 3083,
+					"id": 3100,
 					"name": "--ts-var-liveboard-header-action-button-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38665,7 +38759,7 @@
 					}
 				},
 				{
-					"id": 3036,
+					"id": 3053,
 					"name": "--ts-var-liveboard-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38688,7 +38782,7 @@
 					}
 				},
 				{
-					"id": 3090,
+					"id": 3107,
 					"name": "--ts-var-liveboard-header-badge-active-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38711,7 +38805,7 @@
 					}
 				},
 				{
-					"id": 3085,
+					"id": 3102,
 					"name": "--ts-var-liveboard-header-badge-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38734,7 +38828,7 @@
 					}
 				},
 				{
-					"id": 3086,
+					"id": 3103,
 					"name": "--ts-var-liveboard-header-badge-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38757,7 +38851,7 @@
 					}
 				},
 				{
-					"id": 3089,
+					"id": 3106,
 					"name": "--ts-var-liveboard-header-badge-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38780,7 +38874,7 @@
 					}
 				},
 				{
-					"id": 3087,
+					"id": 3104,
 					"name": "--ts-var-liveboard-header-badge-modified-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38803,7 +38897,7 @@
 					}
 				},
 				{
-					"id": 3088,
+					"id": 3105,
 					"name": "--ts-var-liveboard-header-badge-modified-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38826,7 +38920,7 @@
 					}
 				},
 				{
-					"id": 3037,
+					"id": 3054,
 					"name": "--ts-var-liveboard-header-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38849,7 +38943,7 @@
 					}
 				},
 				{
-					"id": 3041,
+					"id": 3058,
 					"name": "--ts-var-liveboard-insight-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38872,7 +38966,7 @@
 					}
 				},
 				{
-					"id": 3040,
+					"id": 3057,
 					"name": "--ts-var-liveboard-insight-tile-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38895,7 +38989,7 @@
 					}
 				},
 				{
-					"id": 3035,
+					"id": 3052,
 					"name": "--ts-var-liveboard-layout-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38918,7 +39012,7 @@
 					}
 				},
 				{
-					"id": 3055,
+					"id": 3072,
 					"name": "--ts-var-liveboard-notetitle-body-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38941,7 +39035,7 @@
 					}
 				},
 				{
-					"id": 3054,
+					"id": 3071,
 					"name": "--ts-var-liveboard-notetitle-heading-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38964,7 +39058,7 @@
 					}
 				},
 				{
-					"id": 3068,
+					"id": 3085,
 					"name": "--ts-var-liveboard-single-column-breakpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -38987,7 +39081,7 @@
 					}
 				},
 				{
-					"id": 3124,
+					"id": 3141,
 					"name": "--ts-var-liveboard-styling-button-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39010,7 +39104,7 @@
 					}
 				},
 				{
-					"id": 3121,
+					"id": 3138,
 					"name": "--ts-var-liveboard-styling-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39033,7 +39127,7 @@
 					}
 				},
 				{
-					"id": 3123,
+					"id": 3140,
 					"name": "--ts-var-liveboard-styling-button-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39056,7 +39150,7 @@
 					}
 				},
 				{
-					"id": 3125,
+					"id": 3142,
 					"name": "--ts-var-liveboard-styling-button-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39079,7 +39173,7 @@
 					}
 				},
 				{
-					"id": 3126,
+					"id": 3143,
 					"name": "--ts-var-liveboard-styling-button-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39102,7 +39196,7 @@
 					}
 				},
 				{
-					"id": 3122,
+					"id": 3139,
 					"name": "--ts-var-liveboard-styling-button-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39125,7 +39219,7 @@
 					}
 				},
 				{
-					"id": 3127,
+					"id": 3144,
 					"name": "--ts-var-liveboard-styling-color-palette-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39148,7 +39242,7 @@
 					}
 				},
 				{
-					"id": 3120,
+					"id": 3137,
 					"name": "--ts-var-liveboard-styling-panel-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39171,7 +39265,7 @@
 					}
 				},
 				{
-					"id": 3119,
+					"id": 3136,
 					"name": "--ts-var-liveboard-styling-panel-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39194,7 +39288,7 @@
 					}
 				},
 				{
-					"id": 3070,
+					"id": 3087,
 					"name": "--ts-var-liveboard-tab-active-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39217,7 +39311,7 @@
 					}
 				},
 				{
-					"id": 3071,
+					"id": 3088,
 					"name": "--ts-var-liveboard-tab-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39240,7 +39334,7 @@
 					}
 				},
 				{
-					"id": 3039,
+					"id": 3056,
 					"name": "--ts-var-liveboard-tile-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39263,7 +39357,7 @@
 					}
 				},
 				{
-					"id": 3038,
+					"id": 3055,
 					"name": "--ts-var-liveboard-tile-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39286,7 +39380,7 @@
 					}
 				},
 				{
-					"id": 3042,
+					"id": 3059,
 					"name": "--ts-var-liveboard-tile-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39309,7 +39403,7 @@
 					}
 				},
 				{
-					"id": 3043,
+					"id": 3060,
 					"name": "--ts-var-liveboard-tile-padding",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39332,7 +39426,7 @@
 					}
 				},
 				{
-					"id": 3044,
+					"id": 3061,
 					"name": "--ts-var-liveboard-tile-table-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39355,7 +39449,7 @@
 					}
 				},
 				{
-					"id": 3072,
+					"id": 3089,
 					"name": "--ts-var-liveboard-tile-title-fontsize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39378,7 +39472,7 @@
 					}
 				},
 				{
-					"id": 3073,
+					"id": 3090,
 					"name": "--ts-var-liveboard-tile-title-fontweight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39401,7 +39495,7 @@
 					}
 				},
 				{
-					"id": 3014,
+					"id": 3031,
 					"name": "--ts-var-menu--hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39424,7 +39518,7 @@
 					}
 				},
 				{
-					"id": 3011,
+					"id": 3028,
 					"name": "--ts-var-menu-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39447,7 +39541,7 @@
 					}
 				},
 				{
-					"id": 3010,
+					"id": 3027,
 					"name": "--ts-var-menu-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39470,7 +39564,7 @@
 					}
 				},
 				{
-					"id": 3012,
+					"id": 3029,
 					"name": "--ts-var-menu-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39493,7 +39587,7 @@
 					}
 				},
 				{
-					"id": 3015,
+					"id": 3032,
 					"name": "--ts-var-menu-selected-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39516,7 +39610,7 @@
 					}
 				},
 				{
-					"id": 3013,
+					"id": 3030,
 					"name": "--ts-var-menu-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39539,7 +39633,7 @@
 					}
 				},
 				{
-					"id": 2939,
+					"id": 2956,
 					"name": "--ts-var-nav-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39562,7 +39656,7 @@
 					}
 				},
 				{
-					"id": 2940,
+					"id": 2957,
 					"name": "--ts-var-nav-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39585,7 +39679,7 @@
 					}
 				},
 				{
-					"id": 3078,
+					"id": 3095,
 					"name": "--ts-var-parameter-chip-active-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39608,7 +39702,7 @@
 					}
 				},
 				{
-					"id": 3079,
+					"id": 3096,
 					"name": "--ts-var-parameter-chip-active-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39631,7 +39725,7 @@
 					}
 				},
 				{
-					"id": 3074,
+					"id": 3091,
 					"name": "--ts-var-parameter-chip-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39654,7 +39748,7 @@
 					}
 				},
 				{
-					"id": 3076,
+					"id": 3093,
 					"name": "--ts-var-parameter-chip-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39677,7 +39771,7 @@
 					}
 				},
 				{
-					"id": 3077,
+					"id": 3094,
 					"name": "--ts-var-parameter-chip-hover-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39700,7 +39794,7 @@
 					}
 				},
 				{
-					"id": 3075,
+					"id": 3092,
 					"name": "--ts-var-parameter-chip-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39723,7 +39817,7 @@
 					}
 				},
 				{
-					"id": 2934,
+					"id": 2951,
 					"name": "--ts-var-root-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39746,7 +39840,7 @@
 					}
 				},
 				{
-					"id": 2935,
+					"id": 2952,
 					"name": "--ts-var-root-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39769,7 +39863,7 @@
 					}
 				},
 				{
-					"id": 2936,
+					"id": 2953,
 					"name": "--ts-var-root-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39792,7 +39886,7 @@
 					}
 				},
 				{
-					"id": 2937,
+					"id": 2954,
 					"name": "--ts-var-root-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39815,7 +39909,7 @@
 					}
 				},
 				{
-					"id": 3108,
+					"id": 3125,
 					"name": "--ts-var-saved-chats-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39838,7 +39932,7 @@
 					}
 				},
 				{
-					"id": 3107,
+					"id": 3124,
 					"name": "--ts-var-saved-chats-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39861,7 +39955,7 @@
 					}
 				},
 				{
-					"id": 3112,
+					"id": 3129,
 					"name": "--ts-var-saved-chats-btn-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39884,7 +39978,7 @@
 					}
 				},
 				{
-					"id": 3113,
+					"id": 3130,
 					"name": "--ts-var-saved-chats-btn-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39907,7 +40001,7 @@
 					}
 				},
 				{
-					"id": 3116,
+					"id": 3133,
 					"name": "--ts-var-saved-chats-conv-active-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39930,7 +40024,7 @@
 					}
 				},
 				{
-					"id": 3115,
+					"id": 3132,
 					"name": "--ts-var-saved-chats-conv-hover-bg",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39953,7 +40047,7 @@
 					}
 				},
 				{
-					"id": 3114,
+					"id": 3131,
 					"name": "--ts-var-saved-chats-conv-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39976,7 +40070,7 @@
 					}
 				},
 				{
-					"id": 3117,
+					"id": 3134,
 					"name": "--ts-var-saved-chats-footer-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -39999,7 +40093,7 @@
 					}
 				},
 				{
-					"id": 3110,
+					"id": 3127,
 					"name": "--ts-var-saved-chats-header-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40022,7 +40116,7 @@
 					}
 				},
 				{
-					"id": 3118,
+					"id": 3135,
 					"name": "--ts-var-saved-chats-section-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40045,7 +40139,7 @@
 					}
 				},
 				{
-					"id": 3109,
+					"id": 3126,
 					"name": "--ts-var-saved-chats-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40068,7 +40162,7 @@
 					}
 				},
 				{
-					"id": 3111,
+					"id": 3128,
 					"name": "--ts-var-saved-chats-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40091,7 +40185,7 @@
 					}
 				},
 				{
-					"id": 2957,
+					"id": 2974,
 					"name": "--ts-var-search-auto-complete-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40114,7 +40208,7 @@
 					}
 				},
 				{
-					"id": 2961,
+					"id": 2978,
 					"name": "--ts-var-search-auto-complete-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40137,7 +40231,7 @@
 					}
 				},
 				{
-					"id": 2962,
+					"id": 2979,
 					"name": "--ts-var-search-auto-complete-subtext-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40160,7 +40254,7 @@
 					}
 				},
 				{
-					"id": 2960,
+					"id": 2977,
 					"name": "--ts-var-search-bar-auto-complete-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40183,7 +40277,7 @@
 					}
 				},
 				{
-					"id": 2956,
+					"id": 2973,
 					"name": "--ts-var-search-bar-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40206,7 +40300,7 @@
 					}
 				},
 				{
-					"id": 2959,
+					"id": 2976,
 					"name": "--ts-var-search-bar-navigation-help-text-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40229,7 +40323,7 @@
 					}
 				},
 				{
-					"id": 2953,
+					"id": 2970,
 					"name": "--ts-var-search-bar-text-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40252,7 +40346,7 @@
 					}
 				},
 				{
-					"id": 2954,
+					"id": 2971,
 					"name": "--ts-var-search-bar-text-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40275,7 +40369,7 @@
 					}
 				},
 				{
-					"id": 2955,
+					"id": 2972,
 					"name": "--ts-var-search-bar-text-font-style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40298,7 +40392,7 @@
 					}
 				},
 				{
-					"id": 2950,
+					"id": 2967,
 					"name": "--ts-var-search-data-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40321,7 +40415,7 @@
 					}
 				},
 				{
-					"id": 2951,
+					"id": 2968,
 					"name": "--ts-var-search-data-button-font-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40344,7 +40438,7 @@
 					}
 				},
 				{
-					"id": 2952,
+					"id": 2969,
 					"name": "--ts-var-search-data-button-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40367,7 +40461,7 @@
 					}
 				},
 				{
-					"id": 2958,
+					"id": 2975,
 					"name": "--ts-var-search-navigation-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40390,7 +40484,7 @@
 					}
 				},
 				{
-					"id": 3023,
+					"id": 3040,
 					"name": "--ts-var-segment-control-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40413,7 +40507,7 @@
 					}
 				},
 				{
-					"id": 3170,
+					"id": 3187,
 					"name": "--ts-var-share-chat-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40436,7 +40530,7 @@
 					}
 				},
 				{
-					"id": 3169,
+					"id": 3186,
 					"name": "--ts-var-share-chat-header-container-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40459,7 +40553,7 @@
 					}
 				},
 				{
-					"id": 3173,
+					"id": 3190,
 					"name": "--ts-var-share-chat-header-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40482,7 +40576,7 @@
 					}
 				},
 				{
-					"id": 3174,
+					"id": 3191,
 					"name": "--ts-var-share-chat-header-input-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40505,7 +40599,7 @@
 					}
 				},
 				{
-					"id": 3172,
+					"id": 3189,
 					"name": "--ts-var-share-chat-header-input-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40528,7 +40622,7 @@
 					}
 				},
 				{
-					"id": 3171,
+					"id": 3188,
 					"name": "--ts-var-share-chat-header-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40551,7 +40645,7 @@
 					}
 				},
 				{
-					"id": 3166,
+					"id": 3183,
 					"name": "--ts-var-shared-conv-header-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40574,7 +40668,7 @@
 					}
 				},
 				{
-					"id": 3167,
+					"id": 3184,
 					"name": "--ts-var-shared-conv-header-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40597,7 +40691,7 @@
 					}
 				},
 				{
-					"id": 3168,
+					"id": 3185,
 					"name": "--ts-var-shared-conv-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40620,7 +40714,7 @@
 					}
 				},
 				{
-					"id": 3175,
+					"id": 3192,
 					"name": "--ts-var-shimmer-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40643,7 +40737,7 @@
 					}
 				},
 				{
-					"id": 3176,
+					"id": 3193,
 					"name": "--ts-var-shimmer-sweep-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40666,7 +40760,7 @@
 					}
 				},
 				{
-					"id": 3065,
+					"id": 3082,
 					"name": "--ts-var-side-panel-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40689,7 +40783,7 @@
 					}
 				},
 				{
-					"id": 3104,
+					"id": 3121,
 					"name": "--ts-var-spotiq-analyze-crosscorrelation-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40712,7 +40806,7 @@
 					}
 				},
 				{
-					"id": 3101,
+					"id": 3118,
 					"name": "--ts-var-spotiq-analyze-forecasting-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40735,7 +40829,7 @@
 					}
 				},
 				{
-					"id": 3102,
+					"id": 3119,
 					"name": "--ts-var-spotiq-analyze-outlier-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40758,7 +40852,7 @@
 					}
 				},
 				{
-					"id": 3103,
+					"id": 3120,
 					"name": "--ts-var-spotiq-analyze-trend-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40781,7 +40875,7 @@
 					}
 				},
 				{
-					"id": 3106,
+					"id": 3123,
 					"name": "--ts-var-spotter-chat-width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40804,7 +40898,7 @@
 					}
 				},
 				{
-					"id": 2963,
+					"id": 2980,
 					"name": "--ts-var-spotter-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40827,7 +40921,7 @@
 					}
 				},
 				{
-					"id": 2964,
+					"id": 2981,
 					"name": "--ts-var-spotter-prompt-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40850,7 +40944,7 @@
 					}
 				},
 				{
-					"id": 3161,
+					"id": 3178,
 					"name": "--ts-var-spotterviz-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40873,7 +40967,7 @@
 					}
 				},
 				{
-					"id": 3133,
+					"id": 3150,
 					"name": "--ts-var-spotterviz-emptystate-spotterviz-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40896,7 +40990,7 @@
 					}
 				},
 				{
-					"id": 3162,
+					"id": 3179,
 					"name": "--ts-var-spotterviz-expanded-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40919,7 +41013,7 @@
 					}
 				},
 				{
-					"id": 3160,
+					"id": 3177,
 					"name": "--ts-var-spotterviz-footer-text-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40942,7 +41036,7 @@
 					}
 				},
 				{
-					"id": 3129,
+					"id": 3146,
 					"name": "--ts-var-spotterviz-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40965,7 +41059,7 @@
 					}
 				},
 				{
-					"id": 3131,
+					"id": 3148,
 					"name": "--ts-var-spotterviz-input-cta-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -40988,7 +41082,7 @@
 					}
 				},
 				{
-					"id": 3132,
+					"id": 3149,
 					"name": "--ts-var-spotterviz-input-cta-hover-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41011,7 +41105,7 @@
 					}
 				},
 				{
-					"id": 3130,
+					"id": 3147,
 					"name": "--ts-var-spotterviz-input-placeholder-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41034,7 +41128,7 @@
 					}
 				},
 				{
-					"id": 3152,
+					"id": 3169,
 					"name": "--ts-var-spotterviz-last-checkpoint-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41057,7 +41151,7 @@
 					}
 				},
 				{
-					"id": 3153,
+					"id": 3170,
 					"name": "--ts-var-spotterviz-last-checkpoint-border",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41080,7 +41174,7 @@
 					}
 				},
 				{
-					"id": 3138,
+					"id": 3155,
 					"name": "--ts-var-spotterviz-message-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41103,7 +41197,7 @@
 					}
 				},
 				{
-					"id": 3128,
+					"id": 3145,
 					"name": "--ts-var-spotterviz-panel-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41126,7 +41220,7 @@
 					}
 				},
 				{
-					"id": 3134,
+					"id": 3151,
 					"name": "--ts-var-spotterviz-prompt-card-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41149,7 +41243,7 @@
 					}
 				},
 				{
-					"id": 3135,
+					"id": 3152,
 					"name": "--ts-var-spotterviz-prompt-card-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41172,7 +41266,7 @@
 					}
 				},
 				{
-					"id": 3163,
+					"id": 3180,
 					"name": "--ts-var-spotterviz-reference-icon-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41195,7 +41289,7 @@
 					}
 				},
 				{
-					"id": 3165,
+					"id": 3182,
 					"name": "--ts-var-spotterviz-reference-icon-selected-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41218,7 +41312,7 @@
 					}
 				},
 				{
-					"id": 3164,
+					"id": 3181,
 					"name": "--ts-var-spotterviz-reference-icon-selected-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41241,7 +41335,7 @@
 					}
 				},
 				{
-					"id": 3136,
+					"id": 3153,
 					"name": "--ts-var-spotterviz-text-primary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41264,7 +41358,7 @@
 					}
 				},
 				{
-					"id": 3137,
+					"id": 3154,
 					"name": "--ts-var-spotterviz-text-secondary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41287,7 +41381,7 @@
 					}
 				},
 				{
-					"id": 3142,
+					"id": 3159,
 					"name": "--ts-var-spotterviz-thinking-completed-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41310,7 +41404,7 @@
 					}
 				},
 				{
-					"id": 3144,
+					"id": 3161,
 					"name": "--ts-var-spotterviz-thinking-cta-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41333,7 +41427,7 @@
 					}
 				},
 				{
-					"id": 3141,
+					"id": 3158,
 					"name": "--ts-var-spotterviz-thinking-inprogress-header-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41356,7 +41450,7 @@
 					}
 				},
 				{
-					"id": 3143,
+					"id": 3160,
 					"name": "--ts-var-spotterviz-thinking-work-done-icon-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41379,7 +41473,7 @@
 					}
 				},
 				{
-					"id": 3147,
+					"id": 3164,
 					"name": "--ts-var-spotterviz-tool-border-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41402,7 +41496,7 @@
 					}
 				},
 				{
-					"id": 3145,
+					"id": 3162,
 					"name": "--ts-var-spotterviz-tool-call-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41425,7 +41519,7 @@
 					}
 				},
 				{
-					"id": 3149,
+					"id": 3166,
 					"name": "--ts-var-spotterviz-tool-feedback-button-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41448,7 +41542,7 @@
 					}
 				},
 				{
-					"id": 3150,
+					"id": 3167,
 					"name": "--ts-var-spotterviz-tool-feedback-button-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41471,7 +41565,7 @@
 					}
 				},
 				{
-					"id": 3148,
+					"id": 3165,
 					"name": "--ts-var-spotterviz-tool-json-input-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41494,7 +41588,7 @@
 					}
 				},
 				{
-					"id": 3151,
+					"id": 3168,
 					"name": "--ts-var-spotterviz-tool-json-input-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41517,7 +41611,7 @@
 					}
 				},
 				{
-					"id": 3146,
+					"id": 3163,
 					"name": "--ts-var-spotterviz-tool-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41540,7 +41634,7 @@
 					}
 				},
 				{
-					"id": 3140,
+					"id": 3157,
 					"name": "--ts-var-spotterviz-usermessage-icon-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41563,7 +41657,7 @@
 					}
 				},
 				{
-					"id": 3139,
+					"id": 3156,
 					"name": "--ts-var-spotterviz-usermessage-icon-hover",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41586,7 +41680,7 @@
 					}
 				},
 				{
-					"id": 3080,
+					"id": 3097,
 					"name": "--ts-var-unsaved-filter-indicator-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41615,7 +41709,7 @@
 					}
 				},
 				{
-					"id": 2993,
+					"id": 3010,
 					"name": "--ts-var-viz-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41638,7 +41732,7 @@
 					}
 				},
 				{
-					"id": 2991,
+					"id": 3008,
 					"name": "--ts-var-viz-border-radius",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41661,7 +41755,7 @@
 					}
 				},
 				{
-					"id": 2992,
+					"id": 3009,
 					"name": "--ts-var-viz-box-shadow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41684,7 +41778,7 @@
 					}
 				},
 				{
-					"id": 2988,
+					"id": 3005,
 					"name": "--ts-var-viz-description-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41707,7 +41801,7 @@
 					}
 				},
 				{
-					"id": 2989,
+					"id": 3006,
 					"name": "--ts-var-viz-description-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41730,7 +41824,7 @@
 					}
 				},
 				{
-					"id": 2990,
+					"id": 3007,
 					"name": "--ts-var-viz-description-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41753,7 +41847,7 @@
 					}
 				},
 				{
-					"id": 2994,
+					"id": 3011,
 					"name": "--ts-var-viz-legend-hover-background",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41776,7 +41870,7 @@
 					}
 				},
 				{
-					"id": 2985,
+					"id": 3002,
 					"name": "--ts-var-viz-title-color",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41799,7 +41893,7 @@
 					}
 				},
 				{
-					"id": 2986,
+					"id": 3003,
 					"name": "--ts-var-viz-title-font-family",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41822,7 +41916,7 @@
 					}
 				},
 				{
-					"id": 2987,
+					"id": 3004,
 					"name": "--ts-var-viz-title-text-transform",
 					"kind": 1024,
 					"kindString": "Property",
@@ -41850,249 +41944,249 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
+						3013,
+						3012,
+						2982,
+						2983,
+						2985,
+						2984,
+						2955,
+						3025,
+						3026,
+						3023,
+						3024,
+						2987,
+						2992,
+						2989,
+						2991,
+						2990,
+						2988,
+						2997,
+						2994,
 						2996,
 						2995,
-						2965,
-						2966,
-						2968,
-						2967,
-						2938,
-						3008,
-						3009,
-						3006,
-						3007,
-						2970,
-						2975,
-						2972,
-						2974,
-						2973,
-						2971,
-						2980,
-						2977,
-						2979,
-						2978,
-						2976,
-						2984,
-						2983,
-						2982,
-						2981,
-						2969,
-						3105,
-						3100,
-						3095,
-						3094,
-						3097,
-						3096,
-						3031,
-						3034,
-						3029,
-						3032,
-						3033,
-						3028,
-						3030,
+						2993,
 						3001,
 						3000,
-						3003,
-						3002,
 						2999,
-						2997,
 						2998,
-						3004,
-						3005,
-						3016,
+						2986,
+						3122,
+						3117,
+						3112,
+						3111,
+						3114,
+						3113,
+						3048,
+						3051,
+						3046,
+						3049,
+						3050,
+						3045,
+						3047,
+						3018,
 						3017,
 						3020,
-						3018,
 						3019,
-						3027,
-						3026,
-						3025,
-						3024,
-						3093,
-						3092,
-						3091,
-						3099,
-						3098,
-						2942,
-						2943,
-						2941,
-						2945,
-						2947,
-						2946,
-						2944,
-						2948,
-						2949,
-						3022,
-						3021,
-						3051,
-						3064,
-						3063,
-						3061,
-						3062,
-						3069,
-						3067,
-						3066,
-						3154,
-						3158,
-						3159,
-						3155,
-						3156,
-						3157,
-						3052,
-						3053,
-						3057,
-						3045,
-						3060,
-						3059,
-						3050,
-						3058,
-						3048,
-						3049,
-						3056,
-						3046,
-						3047,
-						3084,
-						3081,
-						3082,
-						3083,
-						3036,
-						3090,
-						3085,
-						3086,
-						3089,
-						3087,
-						3088,
-						3037,
-						3041,
-						3040,
-						3035,
-						3055,
-						3054,
-						3068,
-						3124,
-						3121,
-						3123,
-						3125,
-						3126,
-						3122,
-						3127,
-						3120,
-						3119,
-						3070,
-						3071,
-						3039,
-						3038,
-						3042,
-						3043,
-						3044,
-						3072,
-						3073,
+						3016,
 						3014,
-						3011,
-						3010,
-						3012,
 						3015,
-						3013,
-						2939,
-						2940,
-						3078,
-						3079,
-						3074,
-						3076,
-						3077,
-						3075,
-						2934,
-						2935,
-						2936,
-						2937,
+						3021,
+						3022,
+						3033,
+						3034,
+						3037,
+						3035,
+						3036,
+						3044,
+						3043,
+						3042,
+						3041,
+						3110,
+						3109,
 						3108,
-						3107,
-						3112,
-						3113,
 						3116,
 						3115,
-						3114,
-						3117,
-						3110,
-						3118,
-						3109,
-						3111,
-						2957,
-						2961,
-						2962,
-						2960,
-						2956,
 						2959,
-						2953,
-						2954,
-						2955,
-						2950,
-						2951,
-						2952,
+						2960,
 						2958,
-						3023,
-						3170,
-						3169,
-						3173,
-						3174,
-						3172,
+						2962,
+						2964,
+						2963,
+						2961,
+						2965,
+						2966,
+						3039,
+						3038,
+						3068,
+						3081,
+						3080,
+						3078,
+						3079,
+						3086,
+						3084,
+						3083,
 						3171,
-						3166,
-						3167,
-						3168,
 						3175,
 						3176,
+						3172,
+						3173,
+						3174,
+						3069,
+						3070,
+						3074,
+						3062,
+						3077,
+						3076,
+						3067,
+						3075,
 						3065,
-						3104,
+						3066,
+						3073,
+						3063,
+						3064,
 						3101,
+						3098,
+						3099,
+						3100,
+						3053,
+						3107,
 						3102,
 						3103,
 						3106,
-						2963,
-						2964,
-						3161,
-						3133,
-						3162,
-						3160,
-						3129,
-						3131,
-						3132,
-						3130,
-						3152,
-						3153,
-						3138,
-						3128,
-						3134,
-						3135,
-						3163,
-						3165,
-						3164,
-						3136,
-						3137,
-						3142,
-						3144,
+						3104,
+						3105,
+						3054,
+						3058,
+						3057,
+						3052,
+						3072,
+						3071,
+						3085,
 						3141,
-						3143,
-						3147,
-						3145,
-						3149,
-						3150,
-						3148,
-						3151,
-						3146,
+						3138,
 						3140,
+						3142,
+						3143,
 						3139,
-						3080,
-						2993,
-						2991,
-						2992,
-						2988,
-						2989,
-						2990,
-						2994,
-						2985,
-						2986,
-						2987
+						3144,
+						3137,
+						3136,
+						3087,
+						3088,
+						3056,
+						3055,
+						3059,
+						3060,
+						3061,
+						3089,
+						3090,
+						3031,
+						3028,
+						3027,
+						3029,
+						3032,
+						3030,
+						2956,
+						2957,
+						3095,
+						3096,
+						3091,
+						3093,
+						3094,
+						3092,
+						2951,
+						2952,
+						2953,
+						2954,
+						3125,
+						3124,
+						3129,
+						3130,
+						3133,
+						3132,
+						3131,
+						3134,
+						3127,
+						3135,
+						3126,
+						3128,
+						2974,
+						2978,
+						2979,
+						2977,
+						2973,
+						2976,
+						2970,
+						2971,
+						2972,
+						2967,
+						2968,
+						2969,
+						2975,
+						3040,
+						3187,
+						3186,
+						3190,
+						3191,
+						3189,
+						3188,
+						3183,
+						3184,
+						3185,
+						3192,
+						3193,
+						3082,
+						3121,
+						3118,
+						3119,
+						3120,
+						3123,
+						2980,
+						2981,
+						3178,
+						3150,
+						3179,
+						3177,
+						3146,
+						3148,
+						3149,
+						3147,
+						3169,
+						3170,
+						3155,
+						3145,
+						3151,
+						3152,
+						3180,
+						3182,
+						3181,
+						3153,
+						3154,
+						3159,
+						3161,
+						3158,
+						3160,
+						3164,
+						3162,
+						3166,
+						3167,
+						3165,
+						3168,
+						3163,
+						3157,
+						3156,
+						3097,
+						3010,
+						3008,
+						3009,
+						3005,
+						3006,
+						3007,
+						3011,
+						3002,
+						3003,
+						3004
 					]
 				}
 			],
@@ -42105,7 +42199,7 @@
 			]
 		},
 		{
-			"id": 2921,
+			"id": 2938,
 			"name": "CustomStyles",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42115,7 +42209,7 @@
 			},
 			"children": [
 				{
-					"id": 2923,
+					"id": 2940,
 					"name": "customCSS",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42131,12 +42225,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2924,
+						"id": 2941,
 						"name": "customCssInterface"
 					}
 				},
 				{
-					"id": 2922,
+					"id": 2939,
 					"name": "customCSSUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42161,8 +42255,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2923,
-						2922
+						2940,
+						2939
 					]
 				}
 			],
@@ -42175,7 +42269,7 @@
 			]
 		},
 		{
-			"id": 2911,
+			"id": 2928,
 			"name": "CustomisationsInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42191,7 +42285,7 @@
 			},
 			"children": [
 				{
-					"id": 2913,
+					"id": 2930,
 					"name": "content",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42208,14 +42302,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2914,
+							"id": 2931,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 2916,
+									"id": 2933,
 									"name": "stringIDs",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42245,7 +42339,7 @@
 									}
 								},
 								{
-									"id": 2917,
+									"id": 2934,
 									"name": "stringIDsUrl",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42265,7 +42359,7 @@
 									}
 								},
 								{
-									"id": 2915,
+									"id": 2932,
 									"name": "strings",
 									"kind": 1024,
 									"kindString": "Property",
@@ -42308,21 +42402,21 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										2916,
-										2917,
-										2915
+										2933,
+										2934,
+										2932
 									]
 								}
 							],
 							"indexSignature": {
-								"id": 2918,
+								"id": 2935,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2919,
+										"id": 2936,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42341,7 +42435,7 @@
 					}
 				},
 				{
-					"id": 2920,
+					"id": 2937,
 					"name": "iconSpriteUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42361,7 +42455,7 @@
 					}
 				},
 				{
-					"id": 2912,
+					"id": 2929,
 					"name": "style",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42377,7 +42471,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2921,
+						"id": 2938,
 						"name": "CustomStyles"
 					}
 				}
@@ -42387,9 +42481,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2913,
-						2920,
-						2912
+						2930,
+						2937,
+						2929
 					]
 				}
 			],
@@ -42402,7 +42496,7 @@
 			]
 		},
 		{
-			"id": 2454,
+			"id": 2471,
 			"name": "EmbedConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -42418,7 +42512,7 @@
 			},
 			"children": [
 				{
-					"id": 2495,
+					"id": 2512,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42448,20 +42542,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2496,
+							"id": 2513,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2497,
+								"id": 2514,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2498,
+										"id": 2515,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -42493,7 +42587,7 @@
 					}
 				},
 				{
-					"id": 2457,
+					"id": 2474,
 					"name": "authEndpoint",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42516,7 +42610,7 @@
 					}
 				},
 				{
-					"id": 2477,
+					"id": 2494,
 					"name": "authTriggerContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42558,7 +42652,7 @@
 					}
 				},
 				{
-					"id": 2479,
+					"id": 2496,
 					"name": "authTriggerText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42587,7 +42681,7 @@
 					}
 				},
 				{
-					"id": 2456,
+					"id": 2473,
 					"name": "authType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42604,12 +42698,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 1991,
+						"id": 2005,
 						"name": "AuthType"
 					}
 				},
 				{
-					"id": 2469,
+					"id": 2486,
 					"name": "autoLogin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42638,7 +42732,7 @@
 					}
 				},
 				{
-					"id": 2480,
+					"id": 2497,
 					"name": "blockNonEmbedFullAppAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42671,7 +42765,7 @@
 					}
 				},
 				{
-					"id": 2472,
+					"id": 2489,
 					"name": "callPrefetch",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42700,7 +42794,7 @@
 					}
 				},
 				{
-					"id": 2504,
+					"id": 2521,
 					"name": "cleanupTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42733,7 +42827,7 @@
 					}
 				},
 				{
-					"id": 2492,
+					"id": 2509,
 					"name": "currencyFormat",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42762,7 +42856,7 @@
 					}
 				},
 				{
-					"id": 2502,
+					"id": 2519,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42806,7 +42900,7 @@
 					}
 				},
 				{
-					"id": 2499,
+					"id": 2516,
 					"name": "customVariablesForThirdPartyTools",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42849,7 +42943,7 @@
 					}
 				},
 				{
-					"id": 2476,
+					"id": 2493,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42874,12 +42968,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					}
 				},
 				{
-					"id": 2490,
+					"id": 2507,
 					"name": "dateFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42908,7 +43002,7 @@
 					}
 				},
 				{
-					"id": 2474,
+					"id": 2491,
 					"name": "detectCookieAccessSlow",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42938,7 +43032,7 @@
 					}
 				},
 				{
-					"id": 2501,
+					"id": 2518,
 					"name": "disableFullscreenPresentation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -42975,7 +43069,7 @@
 					}
 				},
 				{
-					"id": 2494,
+					"id": 2511,
 					"name": "disableLoginFailurePage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43004,7 +43098,7 @@
 					}
 				},
 				{
-					"id": 2470,
+					"id": 2487,
 					"name": "disableLoginRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43037,7 +43131,7 @@
 					}
 				},
 				{
-					"id": 2500,
+					"id": 2517,
 					"name": "disablePreauthCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43057,7 +43151,7 @@
 					}
 				},
 				{
-					"id": 2468,
+					"id": 2485,
 					"name": "ignoreNoCookieAccess",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43086,7 +43180,7 @@
 					}
 				},
 				{
-					"id": 2463,
+					"id": 2480,
 					"name": "inPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43120,7 +43214,7 @@
 					}
 				},
 				{
-					"id": 2488,
+					"id": 2505,
 					"name": "logLevel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43153,12 +43247,12 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3180,
+						"id": 3197,
 						"name": "LogLevel"
 					}
 				},
 				{
-					"id": 2471,
+					"id": 2488,
 					"name": "loginFailedMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43187,7 +43281,7 @@
 					}
 				},
 				{
-					"id": 2462,
+					"id": 2479,
 					"name": "noRedirect",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43220,7 +43314,7 @@
 					}
 				},
 				{
-					"id": 2491,
+					"id": 2508,
 					"name": "numberFormatLocale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43249,7 +43343,7 @@
 					}
 				},
 				{
-					"id": 2461,
+					"id": 2478,
 					"name": "password",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43273,7 +43367,7 @@
 					}
 				},
 				{
-					"id": 2486,
+					"id": 2503,
 					"name": "pendoTrackingKey",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43302,7 +43396,7 @@
 					}
 				},
 				{
-					"id": 2473,
+					"id": 2490,
 					"name": "queueMultiRenders",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43335,7 +43429,7 @@
 					}
 				},
 				{
-					"id": 2464,
+					"id": 2481,
 					"name": "redirectPath",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43365,7 +43459,7 @@
 					}
 				},
 				{
-					"id": 2466,
+					"id": 2483,
 					"name": "shouldEncodeUrlQueryParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43394,7 +43488,7 @@
 					}
 				},
 				{
-					"id": 2487,
+					"id": 2504,
 					"name": "suppressErrorAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43423,7 +43517,7 @@
 					}
 				},
 				{
-					"id": 2467,
+					"id": 2484,
 					"name": "suppressNoCookieAccessAlert",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43452,7 +43546,7 @@
 					}
 				},
 				{
-					"id": 2475,
+					"id": 2492,
 					"name": "suppressSearchEmbedBetaWarning",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43481,7 +43575,7 @@
 					}
 				},
 				{
-					"id": 2455,
+					"id": 2472,
 					"name": "thoughtSpotHost",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43502,7 +43596,7 @@
 					}
 				},
 				{
-					"id": 2478,
+					"id": 2495,
 					"name": "useEventForSAMLPopup",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43525,7 +43619,7 @@
 					}
 				},
 				{
-					"id": 2460,
+					"id": 2477,
 					"name": "username",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43548,7 +43642,7 @@
 					}
 				},
 				{
-					"id": 2503,
+					"id": 2520,
 					"name": "waitForCleanupOnDestroy",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43581,7 +43675,7 @@
 					}
 				},
 				{
-					"id": 2458,
+					"id": 2475,
 					"name": "getAuthToken",
 					"kind": 2048,
 					"kindString": "Method",
@@ -43597,7 +43691,7 @@
 					],
 					"signatures": [
 						{
-							"id": 2459,
+							"id": 2476,
 							"name": "getAuthToken",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -43625,50 +43719,50 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2495,
-						2457,
-						2477,
-						2479,
-						2456,
-						2469,
-						2480,
-						2472,
-						2504,
-						2492,
-						2502,
-						2499,
-						2476,
-						2490,
+						2512,
 						2474,
-						2501,
 						2494,
-						2470,
-						2500,
-						2468,
-						2463,
-						2488,
-						2471,
-						2462,
-						2491,
-						2461,
-						2486,
+						2496,
 						2473,
-						2464,
-						2466,
+						2486,
+						2497,
+						2489,
+						2521,
+						2509,
+						2519,
+						2516,
+						2493,
+						2507,
+						2491,
+						2518,
+						2511,
 						2487,
-						2467,
-						2475,
-						2455,
+						2517,
+						2485,
+						2480,
+						2505,
+						2488,
+						2479,
+						2508,
 						2478,
-						2460,
-						2503
+						2503,
+						2490,
+						2481,
+						2483,
+						2504,
+						2484,
+						2492,
+						2472,
+						2495,
+						2477,
+						2520
 					]
 				},
 				{
 					"title": "Methods",
 					"kind": 2048,
 					"children": [
-						2458
+						2475
 					]
 				}
 			],
@@ -43681,7 +43775,7 @@
 			]
 		},
 		{
-			"id": 3304,
+			"id": 3321,
 			"name": "EmbedErrorDetailsEvent",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43710,7 +43804,7 @@
 			},
 			"children": [
 				{
-					"id": 3307,
+					"id": 3324,
 					"name": "code",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43721,18 +43815,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9183,
+							"line": 9265,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3286,
+						"id": 3303,
 						"name": "EmbedErrorCodes"
 					}
 				},
 				{
-					"id": 3305,
+					"id": 3322,
 					"name": "errorType",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43743,18 +43837,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9179,
+							"line": 9261,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 3310,
+						"id": 3327,
 						"name": "ErrorDetailsTypes"
 					}
 				},
 				{
-					"id": 3306,
+					"id": 3323,
 					"name": "message",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43765,7 +43859,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9181,
+							"line": 9263,
 							"character": 4
 						}
 					],
@@ -43792,21 +43886,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3307,
-						3305,
-						3306
+						3324,
+						3322,
+						3323
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9177,
+					"line": 9259,
 					"character": 17
 				}
 			],
 			"indexSignature": {
-				"id": 3308,
+				"id": 3325,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43816,7 +43910,7 @@
 				},
 				"parameters": [
 					{
-						"id": 3309,
+						"id": 3326,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -43833,7 +43927,7 @@
 			}
 		},
 		{
-			"id": 2869,
+			"id": 2886,
 			"name": "FrameParams",
 			"kind": 256,
 			"kindString": "Interface",
@@ -43849,7 +43943,7 @@
 			},
 			"children": [
 				{
-					"id": 2871,
+					"id": 2888,
 					"name": "height",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43881,7 +43975,7 @@
 					}
 				},
 				{
-					"id": 2872,
+					"id": 2889,
 					"name": "loading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43917,7 +44011,7 @@
 					}
 				},
 				{
-					"id": 2870,
+					"id": 2887,
 					"name": "width",
 					"kind": 1024,
 					"kindString": "Property",
@@ -43954,9 +44048,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2871,
-						2872,
-						2870
+						2888,
+						2889,
+						2887
 					]
 				}
 			],
@@ -43968,7 +44062,7 @@
 				}
 			],
 			"indexSignature": {
-				"id": 2873,
+				"id": 2890,
 				"name": "__index",
 				"kind": 8192,
 				"kindString": "Index signature",
@@ -43978,7 +44072,7 @@
 				},
 				"parameters": [
 					{
-						"id": 2874,
+						"id": 2891,
 						"name": "key",
 						"kind": 32768,
 						"flags": {},
@@ -44012,7 +44106,7 @@
 			}
 		},
 		{
-			"id": 2624,
+			"id": 2641,
 			"name": "LiveboardViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -44028,7 +44122,7 @@
 			},
 			"children": [
 				{
-					"id": 2636,
+					"id": 2653,
 					"name": "activeTabId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44052,7 +44146,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 227,
+							"line": 229,
 							"character": 4
 						}
 					],
@@ -44062,7 +44156,7 @@
 					}
 				},
 				{
-					"id": 2670,
+					"id": 2687,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44086,27 +44180,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2671,
+							"id": 2688,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2672,
+								"id": 2689,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2673,
+										"id": 2690,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -44142,7 +44236,7 @@
 					}
 				},
 				{
-					"id": 2704,
+					"id": 2721,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44170,7 +44264,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -44184,7 +44278,7 @@
 					}
 				},
 				{
-					"id": 2701,
+					"id": 2718,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44208,13 +44302,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2467,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -44223,7 +44317,7 @@
 					}
 				},
 				{
-					"id": 2718,
+					"id": 2735,
 					"name": "coverAndFilterOptionInPDF",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44247,7 +44341,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2110,
+							"line": 2134,
 							"character": 4
 						}
 					],
@@ -44261,7 +44355,7 @@
 					}
 				},
 				{
-					"id": 2692,
+					"id": 2709,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44293,7 +44387,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -44310,7 +44404,7 @@
 					}
 				},
 				{
-					"id": 2674,
+					"id": 2691,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44333,13 +44427,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -44348,7 +44442,7 @@
 					}
 				},
 				{
-					"id": 2705,
+					"id": 2722,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44376,7 +44470,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -44390,7 +44484,7 @@
 					}
 				},
 				{
-					"id": 2626,
+					"id": 2643,
 					"name": "defaultHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44422,7 +44516,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 94,
+							"line": 96,
 							"character": 4
 						}
 					],
@@ -44432,7 +44526,7 @@
 					}
 				},
 				{
-					"id": 2684,
+					"id": 2701,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44456,7 +44550,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -44470,7 +44564,7 @@
 					}
 				},
 				{
-					"id": 2666,
+					"id": 2683,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44494,7 +44588,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -44508,7 +44602,7 @@
 					}
 				},
 				{
-					"id": 2665,
+					"id": 2682,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44532,7 +44626,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -44540,7 +44634,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -44550,7 +44644,7 @@
 					}
 				},
 				{
-					"id": 2678,
+					"id": 2695,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44581,7 +44675,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -44595,7 +44689,7 @@
 					}
 				},
 				{
-					"id": 2712,
+					"id": 2729,
 					"name": "enable2ColumnLayout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44623,7 +44717,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2006,
+							"line": 2030,
 							"character": 4
 						}
 					],
@@ -44637,7 +44731,7 @@
 					}
 				},
 				{
-					"id": 2717,
+					"id": 2734,
 					"name": "enableAskSage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44665,7 +44759,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2094,
+							"line": 2118,
 							"character": 4
 						}
 					],
@@ -44679,7 +44773,7 @@
 					}
 				},
 				{
-					"id": 2706,
+					"id": 2723,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44707,7 +44801,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -44721,7 +44815,7 @@
 					}
 				},
 				{
-					"id": 2688,
+					"id": 2705,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44745,7 +44839,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -44759,7 +44853,7 @@
 					}
 				},
 				{
-					"id": 2659,
+					"id": 2676,
 					"name": "enableLiveboardDataCache",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44782,7 +44876,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 626,
+							"line": 628,
 							"character": 4
 						}
 					],
@@ -44792,7 +44886,7 @@
 					}
 				},
 				{
-					"id": 2651,
+					"id": 2668,
 					"name": "enableScrollableContainerLazyLoading",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44812,7 +44906,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 482,
+							"line": 484,
 							"character": 4
 						}
 					],
@@ -44822,7 +44916,7 @@
 					}
 				},
 				{
-					"id": 2656,
+					"id": 2673,
 					"name": "enableStopAnswerGenerationEmbed",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44846,7 +44940,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 560,
+							"line": 562,
 							"character": 4
 						}
 					],
@@ -44856,7 +44950,7 @@
 					}
 				},
 				{
-					"id": 2681,
+					"id": 2698,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44880,7 +44974,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -44894,7 +44988,7 @@
 					}
 				},
 				{
-					"id": 2628,
+					"id": 2645,
 					"name": "enableVizTransformations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44921,7 +45015,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 124,
+							"line": 126,
 							"character": 4
 						}
 					],
@@ -44931,7 +45025,7 @@
 					}
 				},
 				{
-					"id": 2702,
+					"id": 2719,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44955,7 +45049,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -44969,7 +45063,7 @@
 					}
 				},
 				{
-					"id": 2703,
+					"id": 2720,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -44993,7 +45087,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -45007,7 +45101,7 @@
 					}
 				},
 				{
-					"id": 2683,
+					"id": 2700,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45030,7 +45124,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -45044,7 +45138,7 @@
 					}
 				},
 				{
-					"id": 2662,
+					"id": 2679,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45068,13 +45162,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -45083,7 +45177,7 @@
 					}
 				},
 				{
-					"id": 2625,
+					"id": 2642,
 					"name": "fullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45107,7 +45201,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 75,
+							"line": 77,
 							"character": 4
 						}
 					],
@@ -45117,7 +45211,7 @@
 					}
 				},
 				{
-					"id": 2667,
+					"id": 2684,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45145,7 +45239,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -45153,7 +45247,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -45163,7 +45257,7 @@
 					}
 				},
 				{
-					"id": 2643,
+					"id": 2660,
 					"name": "hiddenTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45187,7 +45281,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 347,
+							"line": 349,
 							"character": 4
 						}
 					],
@@ -45200,7 +45294,7 @@
 					}
 				},
 				{
-					"id": 2715,
+					"id": 2732,
 					"name": "hideIrrelevantChipsInLiveboardTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45228,7 +45322,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2061,
+							"line": 2085,
 							"character": 4
 						}
 					],
@@ -45242,7 +45336,7 @@
 					}
 				},
 				{
-					"id": 2708,
+					"id": 2725,
 					"name": "hideLiveboardHeader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45270,7 +45364,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1942,
+							"line": 1966,
 							"character": 4
 						}
 					],
@@ -45284,7 +45378,7 @@
 					}
 				},
 				{
-					"id": 2638,
+					"id": 2655,
 					"name": "hideTabPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45308,7 +45402,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 258,
+							"line": 260,
 							"character": 4
 						}
 					],
@@ -45318,7 +45412,7 @@
 					}
 				},
 				{
-					"id": 2675,
+					"id": 2692,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45342,7 +45436,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -45356,7 +45450,7 @@
 					}
 				},
 				{
-					"id": 2698,
+					"id": 2715,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45379,7 +45473,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -45393,7 +45487,7 @@
 					}
 				},
 				{
-					"id": 2697,
+					"id": 2714,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45416,7 +45510,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -45433,7 +45527,7 @@
 					}
 				},
 				{
-					"id": 2719,
+					"id": 2736,
 					"name": "isCentralizedLiveboardFilterUXEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45457,7 +45551,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2128,
+							"line": 2152,
 							"character": 4
 						}
 					],
@@ -45471,7 +45565,7 @@
 					}
 				},
 				{
-					"id": 2647,
+					"id": 2664,
 					"name": "isContinuousLiveboardPDFEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45499,7 +45593,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 420,
+							"line": 422,
 							"character": 4
 						}
 					],
@@ -45509,7 +45603,7 @@
 					}
 				},
 				{
-					"id": 2722,
+					"id": 2739,
 					"name": "isEnhancedFilterInteractivityEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45533,7 +45627,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2178,
+							"line": 2202,
 							"character": 4
 						}
 					],
@@ -45547,7 +45641,7 @@
 					}
 				},
 				{
-					"id": 2649,
+					"id": 2666,
 					"name": "isGranularXLSXCSVSchedulesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45575,7 +45669,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 456,
+							"line": 458,
 							"character": 4
 						}
 					],
@@ -45585,7 +45679,7 @@
 					}
 				},
 				{
-					"id": 2721,
+					"id": 2738,
 					"name": "isLinkParametersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45609,7 +45703,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2161,
+							"line": 2185,
 							"character": 4
 						}
 					],
@@ -45623,7 +45717,7 @@
 					}
 				},
 				{
-					"id": 2713,
+					"id": 2730,
 					"name": "isLiveboardCompactHeaderEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45651,7 +45745,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2023,
+							"line": 2047,
 							"character": 4
 						}
 					],
@@ -45665,7 +45759,7 @@
 					}
 				},
 				{
-					"id": 2711,
+					"id": 2728,
 					"name": "isLiveboardHeaderSticky",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45689,7 +45783,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1989,
+							"line": 2013,
 							"character": 4
 						}
 					],
@@ -45703,7 +45797,7 @@
 					}
 				},
 				{
-					"id": 2724,
+					"id": 2741,
 					"name": "isLiveboardMasterpiecesEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45731,7 +45825,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2210,
+							"line": 2234,
 							"character": 4
 						}
 					],
@@ -45745,7 +45839,7 @@
 					}
 				},
 				{
-					"id": 2645,
+					"id": 2662,
 					"name": "isLiveboardStylingAndGroupingEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45772,7 +45866,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 384,
+							"line": 386,
 							"character": 4
 						}
 					],
@@ -45782,7 +45876,7 @@
 					}
 				},
 				{
-					"id": 2648,
+					"id": 2665,
 					"name": "isLiveboardXLSXCSVDownloadEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45810,7 +45904,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 438,
+							"line": 440,
 							"character": 4
 						}
 					],
@@ -45820,7 +45914,7 @@
 					}
 				},
 				{
-					"id": 2696,
+					"id": 2713,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45840,7 +45934,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -45854,7 +45948,7 @@
 					}
 				},
 				{
-					"id": 2646,
+					"id": 2663,
 					"name": "isPNGInScheduledEmailsEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45878,7 +45972,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 401,
+							"line": 403,
 							"character": 4
 						}
 					],
@@ -45888,7 +45982,7 @@
 					}
 				},
 				{
-					"id": 2720,
+					"id": 2737,
 					"name": "isScopedLiveboardFilteringEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45912,7 +46006,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2146,
+							"line": 2170,
 							"character": 4
 						}
 					],
@@ -45926,7 +46020,7 @@
 					}
 				},
 				{
-					"id": 2707,
+					"id": 2724,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45950,7 +46044,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -45964,7 +46058,7 @@
 					}
 				},
 				{
-					"id": 2650,
+					"id": 2667,
 					"name": "lazyLoadingForFullHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -45991,7 +46085,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 472,
+							"line": 474,
 							"character": 4
 						}
 					],
@@ -46001,7 +46095,7 @@
 					}
 				},
 				{
-					"id": 2652,
+					"id": 2669,
 					"name": "lazyLoadingMargin",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46025,7 +46119,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 505,
+							"line": 507,
 							"character": 4
 						}
 					],
@@ -46035,7 +46129,7 @@
 					}
 				},
 				{
-					"id": 2687,
+					"id": 2704,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46059,7 +46153,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -46073,7 +46167,7 @@
 					}
 				},
 				{
-					"id": 2629,
+					"id": 2646,
 					"name": "liveboardId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46097,7 +46191,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 139,
+							"line": 141,
 							"character": 4
 						}
 					],
@@ -46107,7 +46201,7 @@
 					}
 				},
 				{
-					"id": 2635,
+					"id": 2652,
 					"name": "liveboardV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46131,7 +46225,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 212,
+							"line": 214,
 							"character": 4
 						}
 					],
@@ -46141,7 +46235,7 @@
 					}
 				},
 				{
-					"id": 2669,
+					"id": 2686,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46165,7 +46259,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -46179,7 +46273,7 @@
 					}
 				},
 				{
-					"id": 2627,
+					"id": 2644,
 					"name": "minimumHeight",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46206,7 +46300,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 111,
+							"line": 113,
 							"character": 4
 						}
 					],
@@ -46216,7 +46310,7 @@
 					}
 				},
 				{
-					"id": 2725,
+					"id": 2742,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46244,7 +46338,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2226,
+							"line": 2250,
 							"character": 4
 						}
 					],
@@ -46258,7 +46352,7 @@
 					}
 				},
 				{
-					"id": 2686,
+					"id": 2703,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46282,7 +46376,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -46296,7 +46390,7 @@
 					}
 				},
 				{
-					"id": 2685,
+					"id": 2702,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46320,7 +46414,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -46334,7 +46428,7 @@
 					}
 				},
 				{
-					"id": 2637,
+					"id": 2654,
 					"name": "personalizedViewId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46358,7 +46452,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 244,
+							"line": 246,
 							"character": 4
 						}
 					],
@@ -46368,7 +46462,7 @@
 					}
 				},
 				{
-					"id": 2680,
+					"id": 2697,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46391,7 +46485,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -46405,7 +46499,7 @@
 					}
 				},
 				{
-					"id": 2679,
+					"id": 2696,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46433,7 +46527,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -46456,7 +46550,7 @@
 					}
 				},
 				{
-					"id": 2677,
+					"id": 2694,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46484,7 +46578,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -46498,7 +46592,7 @@
 					}
 				},
 				{
-					"id": 2632,
+					"id": 2649,
 					"name": "preventLiveboardFilterRemoval",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46522,7 +46616,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 173,
+							"line": 175,
 							"character": 4
 						}
 					],
@@ -46532,7 +46626,7 @@
 					}
 				},
 				{
-					"id": 2689,
+					"id": 2706,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46556,7 +46650,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -46570,7 +46664,7 @@
 					}
 				},
 				{
-					"id": 2693,
+					"id": 2710,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46597,7 +46691,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -46611,7 +46705,7 @@
 					}
 				},
 				{
-					"id": 2699,
+					"id": 2716,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46635,7 +46729,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -46643,7 +46737,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -46653,7 +46747,7 @@
 					}
 				},
 				{
-					"id": 2700,
+					"id": 2717,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46677,7 +46771,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -46685,7 +46779,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -46695,7 +46789,7 @@
 					}
 				},
 				{
-					"id": 2694,
+					"id": 2711,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46722,7 +46816,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -46736,7 +46830,7 @@
 					}
 				},
 				{
-					"id": 2691,
+					"id": 2708,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46759,7 +46853,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -46773,7 +46867,7 @@
 					}
 				},
 				{
-					"id": 2710,
+					"id": 2727,
 					"name": "showLiveboardDescription",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46801,7 +46895,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1974,
+							"line": 1998,
 							"character": 4
 						}
 					],
@@ -46815,7 +46909,7 @@
 					}
 				},
 				{
-					"id": 2716,
+					"id": 2733,
 					"name": "showLiveboardReverifyBanner",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46843,7 +46937,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2078,
+							"line": 2102,
 							"character": 4
 						}
 					],
@@ -46857,7 +46951,7 @@
 					}
 				},
 				{
-					"id": 2709,
+					"id": 2726,
 					"name": "showLiveboardTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46885,7 +46979,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1958,
+							"line": 1982,
 							"character": 4
 						}
 					],
@@ -46899,7 +46993,7 @@
 					}
 				},
 				{
-					"id": 2714,
+					"id": 2731,
 					"name": "showLiveboardVerifiedBadge",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46927,7 +47021,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2040,
+							"line": 2064,
 							"character": 4
 						}
 					],
@@ -46941,7 +47035,7 @@
 					}
 				},
 				{
-					"id": 2723,
+					"id": 2740,
 					"name": "showMaskedFilterChip",
 					"kind": 1024,
 					"kindString": "Property",
@@ -46969,7 +47063,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2194,
+							"line": 2218,
 							"character": 4
 						}
 					],
@@ -46983,7 +47077,7 @@
 					}
 				},
 				{
-					"id": 2639,
+					"id": 2656,
 					"name": "showPreviewLoader",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47007,7 +47101,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 281,
+							"line": 283,
 							"character": 4
 						}
 					],
@@ -47017,7 +47111,7 @@
 					}
 				},
 				{
-					"id": 2653,
+					"id": 2670,
 					"name": "showSpotterLimitations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47040,7 +47134,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 521,
+							"line": 523,
 							"character": 4
 						}
 					],
@@ -47050,7 +47144,7 @@
 					}
 				},
 				{
-					"id": 2655,
+					"id": 2672,
 					"name": "showSpotterRadiance",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47078,7 +47172,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 551,
+							"line": 553,
 							"character": 4
 						}
 					],
@@ -47088,7 +47182,7 @@
 					}
 				},
 				{
-					"id": 2657,
+					"id": 2674,
 					"name": "spotterChatConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47112,7 +47206,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 578,
+							"line": 580,
 							"character": 4
 						}
 					],
@@ -47123,7 +47217,7 @@
 					}
 				},
 				{
-					"id": 2658,
+					"id": 2675,
 					"name": "spotterViz",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47147,18 +47241,18 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 613,
+							"line": 615,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2726,
+						"id": 2743,
 						"name": "SpotterVizConfig"
 					}
 				},
 				{
-					"id": 2654,
+					"id": 2671,
 					"name": "updatedSpotterChatPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47186,7 +47280,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 536,
+							"line": 538,
 							"character": 4
 						}
 					],
@@ -47196,7 +47290,7 @@
 					}
 				},
 				{
-					"id": 2660,
+					"id": 2677,
 					"name": "updatedSpotterExperience",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47224,7 +47318,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 641,
+							"line": 643,
 							"character": 4
 						}
 					],
@@ -47234,7 +47328,7 @@
 					}
 				},
 				{
-					"id": 2695,
+					"id": 2712,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47261,7 +47355,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -47275,7 +47369,7 @@
 					}
 				},
 				{
-					"id": 2668,
+					"id": 2685,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47303,7 +47397,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -47311,7 +47405,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -47321,7 +47415,7 @@
 					}
 				},
 				{
-					"id": 2644,
+					"id": 2661,
 					"name": "visibleTabs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47345,7 +47439,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 367,
+							"line": 369,
 							"character": 4
 						}
 					],
@@ -47358,7 +47452,7 @@
 					}
 				},
 				{
-					"id": 2633,
+					"id": 2650,
 					"name": "visibleVizs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47382,7 +47476,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 192,
+							"line": 194,
 							"character": 4
 						}
 					],
@@ -47395,7 +47489,7 @@
 					}
 				},
 				{
-					"id": 2631,
+					"id": 2648,
 					"name": "vizId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47419,7 +47513,7 @@
 					"sources": [
 						{
 							"fileName": "embed/liveboard.ts",
-							"line": 158,
+							"line": 160,
 							"character": 4
 						}
 					],
@@ -47434,100 +47528,100 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2636,
-						2670,
-						2704,
-						2701,
-						2718,
-						2692,
-						2674,
-						2705,
-						2626,
-						2684,
-						2666,
-						2665,
-						2678,
-						2712,
-						2717,
-						2706,
-						2688,
-						2659,
-						2651,
-						2656,
-						2681,
-						2628,
-						2702,
-						2703,
-						2683,
-						2662,
-						2625,
-						2667,
-						2643,
-						2715,
-						2708,
-						2638,
-						2675,
-						2698,
-						2697,
-						2719,
-						2647,
-						2722,
-						2649,
-						2721,
-						2713,
-						2711,
-						2724,
-						2645,
-						2648,
-						2696,
-						2646,
-						2720,
-						2707,
-						2650,
-						2652,
+						2653,
 						2687,
-						2629,
-						2635,
-						2669,
-						2627,
-						2725,
-						2686,
-						2685,
-						2637,
-						2680,
-						2679,
-						2677,
-						2632,
-						2689,
-						2693,
-						2699,
-						2700,
-						2694,
+						2721,
+						2718,
+						2735,
+						2709,
 						2691,
+						2722,
+						2643,
+						2701,
+						2683,
+						2682,
+						2695,
+						2729,
+						2734,
+						2723,
+						2705,
+						2676,
+						2668,
+						2673,
+						2698,
+						2645,
+						2719,
+						2720,
+						2700,
+						2679,
+						2642,
+						2684,
+						2660,
+						2732,
+						2725,
+						2655,
+						2692,
+						2715,
+						2714,
+						2736,
+						2664,
+						2739,
+						2666,
+						2738,
+						2730,
+						2728,
+						2741,
+						2662,
+						2665,
+						2713,
+						2663,
+						2737,
+						2724,
+						2667,
+						2669,
+						2704,
+						2646,
+						2652,
+						2686,
+						2644,
+						2742,
+						2703,
+						2702,
+						2654,
+						2697,
+						2696,
+						2694,
+						2649,
+						2706,
 						2710,
 						2716,
-						2709,
-						2714,
-						2723,
-						2639,
-						2653,
-						2655,
-						2657,
-						2658,
-						2654,
-						2660,
-						2695,
-						2668,
-						2644,
-						2633,
-						2631
+						2717,
+						2711,
+						2708,
+						2727,
+						2733,
+						2726,
+						2731,
+						2740,
+						2656,
+						2670,
+						2672,
+						2674,
+						2675,
+						2671,
+						2677,
+						2712,
+						2685,
+						2661,
+						2650,
+						2648
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/liveboard.ts",
-					"line": 52,
+					"line": 54,
 					"character": 17
 				}
 			],
@@ -47547,7 +47641,7 @@
 			]
 		},
 		{
-			"id": 2003,
+			"id": 2017,
 			"name": "RuntimeFilter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47557,7 +47651,7 @@
 			},
 			"children": [
 				{
-					"id": 2004,
+					"id": 2018,
 					"name": "columnName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47568,7 +47662,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2442,
+							"line": 2466,
 							"character": 4
 						}
 					],
@@ -47578,7 +47672,7 @@
 					}
 				},
 				{
-					"id": 2005,
+					"id": 2019,
 					"name": "operator",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47589,18 +47683,18 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2446,
+							"line": 2470,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2007,
+						"id": 2021,
 						"name": "RuntimeFilterOp"
 					}
 				},
 				{
-					"id": 2006,
+					"id": 2020,
 					"name": "values",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47611,7 +47705,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2452,
+							"line": 2476,
 							"character": 4
 						}
 					],
@@ -47646,22 +47740,22 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2004,
-						2005,
-						2006
+						2018,
+						2019,
+						2020
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2438,
+					"line": 2462,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3177,
+			"id": 3194,
 			"name": "RuntimeParameter",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47671,7 +47765,7 @@
 			},
 			"children": [
 				{
-					"id": 3178,
+					"id": 3195,
 					"name": "name",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47682,7 +47776,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2462,
+							"line": 2486,
 							"character": 4
 						}
 					],
@@ -47692,7 +47786,7 @@
 					}
 				},
 				{
-					"id": 3179,
+					"id": 3196,
 					"name": "value",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47703,7 +47797,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2466,
+							"line": 2490,
 							"character": 4
 						}
 					],
@@ -47731,21 +47825,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3178,
-						3179
+						3195,
+						3196
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2458,
+					"line": 2482,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2571,
+			"id": 2588,
 			"name": "SearchBarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -47760,7 +47854,7 @@
 			},
 			"children": [
 				{
-					"id": 2586,
+					"id": 2603,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47784,27 +47878,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2587,
+							"id": 2604,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2588,
+								"id": 2605,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2589,
+										"id": 2606,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -47840,7 +47934,7 @@
 					}
 				},
 				{
-					"id": 2620,
+					"id": 2637,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47868,7 +47962,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -47882,7 +47976,7 @@
 					}
 				},
 				{
-					"id": 2617,
+					"id": 2634,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47906,13 +48000,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2467,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -47921,7 +48015,7 @@
 					}
 				},
 				{
-					"id": 2608,
+					"id": 2625,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47953,7 +48047,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -47970,7 +48064,7 @@
 					}
 				},
 				{
-					"id": 2590,
+					"id": 2607,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -47993,13 +48087,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -48008,7 +48102,7 @@
 					}
 				},
 				{
-					"id": 2621,
+					"id": 2638,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48036,7 +48130,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -48050,7 +48144,7 @@
 					}
 				},
 				{
-					"id": 2573,
+					"id": 2590,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48084,7 +48178,7 @@
 					}
 				},
 				{
-					"id": 2572,
+					"id": 2589,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48125,7 +48219,7 @@
 					}
 				},
 				{
-					"id": 2600,
+					"id": 2617,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48149,7 +48243,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -48163,7 +48257,7 @@
 					}
 				},
 				{
-					"id": 2582,
+					"id": 2599,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48187,7 +48281,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -48201,7 +48295,7 @@
 					}
 				},
 				{
-					"id": 2581,
+					"id": 2598,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48225,7 +48319,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -48233,7 +48327,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -48243,7 +48337,7 @@
 					}
 				},
 				{
-					"id": 2594,
+					"id": 2611,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48274,7 +48368,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -48288,7 +48382,7 @@
 					}
 				},
 				{
-					"id": 2622,
+					"id": 2639,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48316,7 +48410,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -48330,7 +48424,7 @@
 					}
 				},
 				{
-					"id": 2604,
+					"id": 2621,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48354,7 +48448,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -48368,7 +48462,7 @@
 					}
 				},
 				{
-					"id": 2597,
+					"id": 2614,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48392,7 +48486,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -48406,7 +48500,7 @@
 					}
 				},
 				{
-					"id": 2618,
+					"id": 2635,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48430,7 +48524,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -48444,7 +48538,7 @@
 					}
 				},
 				{
-					"id": 2619,
+					"id": 2636,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48468,7 +48562,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -48482,7 +48576,7 @@
 					}
 				},
 				{
-					"id": 2576,
+					"id": 2593,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48516,7 +48610,7 @@
 					}
 				},
 				{
-					"id": 2599,
+					"id": 2616,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48539,7 +48633,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -48553,7 +48647,7 @@
 					}
 				},
 				{
-					"id": 2578,
+					"id": 2595,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48577,13 +48671,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -48592,7 +48686,7 @@
 					}
 				},
 				{
-					"id": 2583,
+					"id": 2600,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48620,7 +48714,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -48628,7 +48722,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -48638,7 +48732,7 @@
 					}
 				},
 				{
-					"id": 2591,
+					"id": 2608,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48662,7 +48756,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -48676,7 +48770,7 @@
 					}
 				},
 				{
-					"id": 2614,
+					"id": 2631,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48699,7 +48793,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -48713,7 +48807,7 @@
 					}
 				},
 				{
-					"id": 2613,
+					"id": 2630,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48736,7 +48830,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -48753,7 +48847,7 @@
 					}
 				},
 				{
-					"id": 2612,
+					"id": 2629,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48773,7 +48867,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -48787,7 +48881,7 @@
 					}
 				},
 				{
-					"id": 2623,
+					"id": 2640,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48811,7 +48905,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -48825,7 +48919,7 @@
 					}
 				},
 				{
-					"id": 2603,
+					"id": 2620,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48849,7 +48943,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -48863,7 +48957,7 @@
 					}
 				},
 				{
-					"id": 2585,
+					"id": 2602,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48887,7 +48981,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -48901,7 +48995,7 @@
 					}
 				},
 				{
-					"id": 2602,
+					"id": 2619,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48925,7 +49019,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -48939,7 +49033,7 @@
 					}
 				},
 				{
-					"id": 2601,
+					"id": 2618,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -48963,7 +49057,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -48977,7 +49071,7 @@
 					}
 				},
 				{
-					"id": 2596,
+					"id": 2613,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49000,7 +49094,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -49014,7 +49108,7 @@
 					}
 				},
 				{
-					"id": 2595,
+					"id": 2612,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49042,7 +49136,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -49065,7 +49159,7 @@
 					}
 				},
 				{
-					"id": 2593,
+					"id": 2610,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49093,7 +49187,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -49107,7 +49201,7 @@
 					}
 				},
 				{
-					"id": 2605,
+					"id": 2622,
 					"name": "primaryAction",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49131,7 +49225,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1403,
+							"line": 1427,
 							"character": 4
 						}
 					],
@@ -49145,7 +49239,7 @@
 					}
 				},
 				{
-					"id": 2609,
+					"id": 2626,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49172,7 +49266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -49186,7 +49280,7 @@
 					}
 				},
 				{
-					"id": 2615,
+					"id": 2632,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49210,7 +49304,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -49218,7 +49312,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -49228,7 +49322,7 @@
 					}
 				},
 				{
-					"id": 2616,
+					"id": 2633,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49252,7 +49346,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -49260,7 +49354,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -49270,7 +49364,7 @@
 					}
 				},
 				{
-					"id": 2575,
+					"id": 2592,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49304,7 +49398,7 @@
 					}
 				},
 				{
-					"id": 2610,
+					"id": 2627,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49331,7 +49425,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -49345,7 +49439,7 @@
 					}
 				},
 				{
-					"id": 2607,
+					"id": 2624,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49368,7 +49462,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -49382,7 +49476,7 @@
 					}
 				},
 				{
-					"id": 2611,
+					"id": 2628,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49409,7 +49503,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -49423,7 +49517,7 @@
 					}
 				},
 				{
-					"id": 2574,
+					"id": 2591,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49457,7 +49551,7 @@
 					}
 				},
 				{
-					"id": 2584,
+					"id": 2601,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49485,7 +49579,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -49493,7 +49587,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -49508,49 +49602,49 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2586,
-						2620,
-						2617,
-						2608,
+						2603,
+						2637,
+						2634,
+						2625,
+						2607,
+						2638,
 						2590,
-						2621,
-						2573,
-						2572,
-						2600,
-						2582,
-						2581,
-						2594,
-						2622,
-						2604,
-						2597,
-						2618,
-						2619,
-						2576,
+						2589,
+						2617,
 						2599,
-						2578,
-						2583,
-						2591,
+						2598,
+						2611,
+						2639,
+						2621,
 						2614,
+						2635,
+						2636,
+						2593,
+						2616,
+						2595,
+						2600,
+						2608,
+						2631,
+						2630,
+						2629,
+						2640,
+						2620,
+						2602,
+						2619,
+						2618,
 						2613,
 						2612,
-						2623,
-						2603,
-						2585,
-						2602,
-						2601,
-						2596,
-						2595,
-						2593,
-						2605,
-						2609,
-						2615,
-						2616,
-						2575,
 						2610,
-						2607,
-						2611,
-						2574,
-						2584
+						2622,
+						2626,
+						2632,
+						2633,
+						2592,
+						2627,
+						2624,
+						2628,
+						2591,
+						2601
 					]
 				}
 			],
@@ -49573,7 +49667,7 @@
 			]
 		},
 		{
-			"id": 2505,
+			"id": 2522,
 			"name": "SearchViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -49589,7 +49683,7 @@
 			},
 			"children": [
 				{
-					"id": 2543,
+					"id": 2560,
 					"name": "additionalFlags",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49613,27 +49707,27 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2544,
+							"id": 2561,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2545,
+								"id": 2562,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2546,
+										"id": 2563,
 										"name": "key",
 										"kind": 32768,
 										"flags": {},
@@ -49669,7 +49763,7 @@
 					}
 				},
 				{
-					"id": 2517,
+					"id": 2534,
 					"name": "answerId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49703,7 +49797,7 @@
 					}
 				},
 				{
-					"id": 2507,
+					"id": 2524,
 					"name": "collapseDataPanel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49737,7 +49831,7 @@
 					}
 				},
 				{
-					"id": 2506,
+					"id": 2523,
 					"name": "collapseDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49771,7 +49865,7 @@
 					}
 				},
 				{
-					"id": 2530,
+					"id": 2547,
 					"name": "collapseSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49799,7 +49893,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1872,
+							"line": 1896,
 							"character": 4
 						}
 					],
@@ -49813,7 +49907,7 @@
 					}
 				},
 				{
-					"id": 2520,
+					"id": 2537,
 					"name": "collapseSearchBarInitially",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49850,7 +49944,7 @@
 					}
 				},
 				{
-					"id": 2527,
+					"id": 2544,
 					"name": "contextMenuTrigger",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49874,13 +49968,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1830,
+							"line": 1854,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2450,
+						"id": 2467,
 						"name": "ContextMenuTriggerOptions"
 					},
 					"inheritedFrom": {
@@ -49889,7 +49983,7 @@
 					}
 				},
 				{
-					"id": 2564,
+					"id": 2581,
 					"name": "customActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49921,7 +50015,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -49938,7 +50032,7 @@
 					}
 				},
 				{
-					"id": 2547,
+					"id": 2564,
 					"name": "customizations",
 					"kind": 1024,
 					"kindString": "Property",
@@ -49961,13 +50055,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -49976,7 +50070,7 @@
 					}
 				},
 				{
-					"id": 2521,
+					"id": 2538,
 					"name": "dataPanelCustomGroupsAccordionInitialState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50014,7 +50108,7 @@
 					}
 				},
 				{
-					"id": 2531,
+					"id": 2548,
 					"name": "dataPanelV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50042,7 +50136,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1888,
+							"line": 1912,
 							"character": 4
 						}
 					],
@@ -50056,7 +50150,7 @@
 					}
 				},
 				{
-					"id": 2513,
+					"id": 2530,
 					"name": "dataSource",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50090,7 +50184,7 @@
 					}
 				},
 				{
-					"id": 2512,
+					"id": 2529,
 					"name": "dataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50126,7 +50220,7 @@
 					}
 				},
 				{
-					"id": 2557,
+					"id": 2574,
 					"name": "disableRedirectionLinksInNewTab",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50150,7 +50244,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -50164,7 +50258,7 @@
 					}
 				},
 				{
-					"id": 2539,
+					"id": 2556,
 					"name": "disabledActionReason",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50188,7 +50282,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -50202,7 +50296,7 @@
 					}
 				},
 				{
-					"id": 2538,
+					"id": 2555,
 					"name": "disabledActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50226,7 +50320,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -50234,7 +50328,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -50244,7 +50338,7 @@
 					}
 				},
 				{
-					"id": 2551,
+					"id": 2568,
 					"name": "doNotTrackPreRenderSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50275,7 +50369,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -50289,7 +50383,7 @@
 					}
 				},
 				{
-					"id": 2532,
+					"id": 2549,
 					"name": "enableCustomColumnGroups",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50317,7 +50411,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1904,
+							"line": 1928,
 							"character": 4
 						}
 					],
@@ -50331,7 +50425,7 @@
 					}
 				},
 				{
-					"id": 2561,
+					"id": 2578,
 					"name": "enableLinkOverridesV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50355,7 +50449,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -50369,7 +50463,7 @@
 					}
 				},
 				{
-					"id": 2510,
+					"id": 2527,
 					"name": "enableSearchAssist",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50403,7 +50497,7 @@
 					}
 				},
 				{
-					"id": 2554,
+					"id": 2571,
 					"name": "enableV2Shell_experimental",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50427,7 +50521,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -50441,7 +50535,7 @@
 					}
 				},
 				{
-					"id": 2528,
+					"id": 2545,
 					"name": "excludeRuntimeFiltersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50465,7 +50559,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1843,
+							"line": 1867,
 							"character": 4
 						}
 					],
@@ -50479,7 +50573,7 @@
 					}
 				},
 				{
-					"id": 2529,
+					"id": 2546,
 					"name": "excludeRuntimeParametersfromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50503,7 +50597,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1856,
+							"line": 1880,
 							"character": 4
 						}
 					],
@@ -50517,7 +50611,7 @@
 					}
 				},
 				{
-					"id": 2516,
+					"id": 2533,
 					"name": "excludeSearchTokenStringFromURL",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50551,7 +50645,7 @@
 					}
 				},
 				{
-					"id": 2556,
+					"id": 2573,
 					"name": "exposeTranslationIDs",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50574,7 +50668,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -50588,7 +50682,7 @@
 					}
 				},
 				{
-					"id": 2522,
+					"id": 2539,
 					"name": "focusSearchBarOnRender",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50626,7 +50720,7 @@
 					}
 				},
 				{
-					"id": 2511,
+					"id": 2528,
 					"name": "forceTable",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50660,7 +50754,7 @@
 					}
 				},
 				{
-					"id": 2535,
+					"id": 2552,
 					"name": "frameParams",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50684,13 +50778,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -50699,7 +50793,7 @@
 					}
 				},
 				{
-					"id": 2540,
+					"id": 2557,
 					"name": "hiddenActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50727,7 +50821,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -50735,7 +50829,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -50745,7 +50839,7 @@
 					}
 				},
 				{
-					"id": 2508,
+					"id": 2525,
 					"name": "hideDataSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50779,7 +50873,7 @@
 					}
 				},
 				{
-					"id": 2509,
+					"id": 2526,
 					"name": "hideResults",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50813,7 +50907,7 @@
 					}
 				},
 				{
-					"id": 2518,
+					"id": 2535,
 					"name": "hideSearchBar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50847,7 +50941,7 @@
 					}
 				},
 				{
-					"id": 2548,
+					"id": 2565,
 					"name": "insertAsSibling",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50871,7 +50965,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -50885,7 +50979,7 @@
 					}
 				},
 				{
-					"id": 2570,
+					"id": 2587,
 					"name": "interceptTimeout",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50908,7 +51002,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -50922,7 +51016,7 @@
 					}
 				},
 				{
-					"id": 2569,
+					"id": 2586,
 					"name": "interceptUrls",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50945,7 +51039,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -50962,7 +51056,7 @@
 					}
 				},
 				{
-					"id": 2568,
+					"id": 2585,
 					"name": "isOnBeforeGetVizDataInterceptEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -50982,7 +51076,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -50996,7 +51090,7 @@
 					}
 				},
 				{
-					"id": 2533,
+					"id": 2550,
 					"name": "isThisPeriodInDateFiltersEnabled",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51020,7 +51114,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1920,
+							"line": 1944,
 							"character": 4
 						}
 					],
@@ -51034,7 +51128,7 @@
 					}
 				},
 				{
-					"id": 2560,
+					"id": 2577,
 					"name": "linkOverride",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51058,7 +51152,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -51072,7 +51166,7 @@
 					}
 				},
 				{
-					"id": 2542,
+					"id": 2559,
 					"name": "locale",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51096,7 +51190,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -51110,7 +51204,7 @@
 					}
 				},
 				{
-					"id": 2523,
+					"id": 2540,
 					"name": "newChartsLibrary",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51148,7 +51242,7 @@
 					}
 				},
 				{
-					"id": 2559,
+					"id": 2576,
 					"name": "overrideHistoryState",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51172,7 +51266,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -51186,7 +51280,7 @@
 					}
 				},
 				{
-					"id": 2558,
+					"id": 2575,
 					"name": "overrideOrgId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51210,7 +51304,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -51224,7 +51318,7 @@
 					}
 				},
 				{
-					"id": 2553,
+					"id": 2570,
 					"name": "preRenderConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51247,7 +51341,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -51261,7 +51355,7 @@
 					}
 				},
 				{
-					"id": 2552,
+					"id": 2569,
 					"name": "preRenderContainer",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51289,7 +51383,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -51312,7 +51406,7 @@
 					}
 				},
 				{
-					"id": 2550,
+					"id": 2567,
 					"name": "preRenderId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51340,7 +51434,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -51354,7 +51448,7 @@
 					}
 				},
 				{
-					"id": 2565,
+					"id": 2582,
 					"name": "refreshAuthTokenOnNearExpiry",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51381,7 +51475,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -51395,7 +51489,7 @@
 					}
 				},
 				{
-					"id": 2525,
+					"id": 2542,
 					"name": "runtimeFilters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51419,7 +51513,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1794,
+							"line": 1818,
 							"character": 4
 						}
 					],
@@ -51427,7 +51521,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					},
@@ -51437,7 +51531,7 @@
 					}
 				},
 				{
-					"id": 2526,
+					"id": 2543,
 					"name": "runtimeParameters",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51461,7 +51555,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1815,
+							"line": 1839,
 							"character": 4
 						}
 					],
@@ -51469,7 +51563,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					},
@@ -51479,7 +51573,7 @@
 					}
 				},
 				{
-					"id": 2515,
+					"id": 2532,
 					"name": "searchOptions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51509,7 +51603,7 @@
 					}
 				},
 				{
-					"id": 2514,
+					"id": 2531,
 					"name": "searchQuery",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51538,7 +51632,7 @@
 					}
 				},
 				{
-					"id": 2566,
+					"id": 2583,
 					"name": "shouldBypassPayloadValidation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51565,7 +51659,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -51579,7 +51673,7 @@
 					}
 				},
 				{
-					"id": 2563,
+					"id": 2580,
 					"name": "showAlerts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51602,7 +51696,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -51616,7 +51710,7 @@
 					}
 				},
 				{
-					"id": 2567,
+					"id": 2584,
 					"name": "useHostEventsV2",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51643,7 +51737,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -51657,7 +51751,7 @@
 					}
 				},
 				{
-					"id": 2519,
+					"id": 2536,
 					"name": "useLastSelectedSources",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51687,7 +51781,7 @@
 					}
 				},
 				{
-					"id": 2541,
+					"id": 2558,
 					"name": "visibleActions",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51715,7 +51809,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -51723,7 +51817,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -51733,7 +51827,7 @@
 					}
 				},
 				{
-					"id": 2524,
+					"id": 2541,
 					"name": "visualOverrides",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51758,7 +51852,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 3315,
+						"id": 3332,
 						"name": "VisualizationOverrides"
 					}
 				}
@@ -51768,62 +51862,62 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2543,
-						2517,
-						2507,
-						2506,
-						2530,
-						2520,
-						2527,
-						2564,
-						2547,
-						2521,
-						2531,
-						2513,
-						2512,
-						2557,
-						2539,
-						2538,
-						2551,
-						2532,
-						2561,
-						2510,
-						2554,
-						2528,
-						2529,
-						2516,
-						2556,
-						2522,
-						2511,
-						2535,
-						2540,
-						2508,
-						2509,
-						2518,
-						2548,
-						2570,
-						2569,
-						2568,
-						2533,
 						2560,
-						2542,
+						2534,
+						2524,
 						2523,
-						2559,
-						2558,
-						2553,
+						2547,
+						2537,
+						2544,
+						2581,
+						2564,
+						2538,
+						2548,
+						2530,
+						2529,
+						2574,
+						2556,
+						2555,
+						2568,
+						2549,
+						2578,
+						2527,
+						2571,
+						2545,
+						2546,
+						2533,
+						2573,
+						2539,
+						2528,
 						2552,
-						2550,
-						2565,
+						2557,
 						2525,
 						2526,
-						2515,
-						2514,
-						2566,
-						2563,
+						2535,
+						2565,
+						2587,
+						2586,
+						2585,
+						2550,
+						2577,
+						2559,
+						2540,
+						2576,
+						2575,
+						2570,
+						2569,
 						2567,
-						2519,
-						2541,
-						2524
+						2582,
+						2542,
+						2543,
+						2532,
+						2531,
+						2583,
+						2580,
+						2584,
+						2536,
+						2558,
+						2541
 					]
 				}
 			],
@@ -51856,14 +51950,14 @@
 			]
 		},
 		{
-			"id": 1971,
+			"id": 1985,
 			"name": "SessionInterface",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1974,
+					"id": 1988,
 					"name": "acSession",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51878,14 +51972,14 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 1975,
+							"id": 1989,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 1977,
+									"id": 1991,
 									"name": "genNo",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51903,7 +51997,7 @@
 									}
 								},
 								{
-									"id": 1976,
+									"id": 1990,
 									"name": "sessionId",
 									"kind": 1024,
 									"kindString": "Property",
@@ -51926,8 +52020,8 @@
 									"title": "Properties",
 									"kind": 1024,
 									"children": [
-										1977,
-										1976
+										1991,
+										1990
 									]
 								}
 							]
@@ -51935,7 +52029,7 @@
 					}
 				},
 				{
-					"id": 1973,
+					"id": 1987,
 					"name": "genNo",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51953,7 +52047,7 @@
 					}
 				},
 				{
-					"id": 1972,
+					"id": 1986,
 					"name": "sessionId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -51976,9 +52070,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1974,
-						1973,
-						1972
+						1988,
+						1987,
+						1986
 					]
 				}
 			],
@@ -52031,7 +52125,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -52119,7 +52213,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -52159,13 +52253,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -52198,7 +52292,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -52236,7 +52330,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -52274,7 +52368,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -52282,7 +52376,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -52323,7 +52417,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -52361,7 +52455,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -52399,7 +52493,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -52436,7 +52530,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -52474,13 +52568,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -52517,7 +52611,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -52525,7 +52619,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -52559,7 +52653,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -52596,7 +52690,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -52633,7 +52727,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -52670,7 +52764,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -52708,7 +52802,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -52746,7 +52840,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -52784,7 +52878,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -52822,7 +52916,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -52859,7 +52953,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -52901,7 +52995,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -52952,7 +53046,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -52993,7 +53087,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -53034,7 +53128,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -53071,7 +53165,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -53112,7 +53206,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -53154,7 +53248,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -53162,7 +53256,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -53262,7 +53356,7 @@
 			]
 		},
 		{
-			"id": 1556,
+			"id": 1557,
 			"name": "SpotterAnalystConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -53286,7 +53380,7 @@
 			},
 			"children": [
 				{
-					"id": 1557,
+					"id": 1558,
 					"name": "analystId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -53305,7 +53399,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 298,
+							"line": 410,
 							"character": 4
 						}
 					],
@@ -53320,14 +53414,14 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1557
+						1558
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 292,
+					"line": 404,
 					"character": 17
 				}
 			]
@@ -53362,7 +53456,7 @@
 					},
 					"comment": {
 						"shortText": "Enables starter prompts in the Spotter chat interface.",
-						"text": "Supported embed types: SpotterEmbed, LiveboardEmbed, AppEmbed",
+						"text": "Either this or `starterPrompts.enable` turns the surface on, so it stays\non while this is `true` even if `starterPrompts.enable` is `false`.\n\nSupported embed types: `SpotterEmbed`, `LiveboardEmbed`, `AppEmbed`",
 						"tags": [
 							{
 								"tag": "version",
@@ -53377,7 +53471,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 274,
+							"line": 357,
 							"character": 4
 						}
 					],
@@ -53406,7 +53500,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 243,
+							"line": 323,
 							"character": 4
 						}
 					],
@@ -53440,7 +53534,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 259,
+							"line": 339,
 							"character": 4
 						}
 					],
@@ -53470,13 +53564,48 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 266,
+							"line": 346,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
 						"name": "SpotterFileUploadFileTypes"
+					}
+				},
+				{
+					"id": 1541,
+					"name": "starterPrompts",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Customizes the labels and questions of the Spotter starter prompts.\nIndividual pills are hidden or shown with `hiddenActions` /\n`visibleActions` using `Action.QuickSearchPill`,\n`Action.DeepAnalysisPill` and `Action.DataLiteracyPill`.",
+						"text": "Supported embed types: `SpotterEmbed`, `LiveboardEmbed`, `AppEmbed`",
+						"tags": [
+							{
+								"tag": "version",
+								"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+							},
+							{
+								"tag": "example",
+								"text": "\n```js\nconst embed = new SpotterEmbed('#tsEmbed', {\n   worksheetId: 'worksheet-id',\n   hiddenActions: [Action.DeepAnalysisPill],\n   spotterChatConfig: {\n       starterPrompts: {\n           enable: true,\n           quick: {\n               label: 'Quick questions',\n               questions: [\n                   { label: 'Top products', prompt: 'What are the top products by revenue?' },\n               ],\n           },\n           previewData: { label: 'Explore your data' },\n       },\n   },\n})\n```\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 386,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1576,
+						"name": "StarterPromptsConfig"
 					}
 				},
 				{
@@ -53493,7 +53622,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 251,
+							"line": 331,
 							"character": 4
 						}
 					],
@@ -53512,6 +53641,7 @@
 						1536,
 						1538,
 						1539,
+						1541,
 						1537
 					]
 				}
@@ -53519,7 +53649,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 235,
+					"line": 315,
 					"character": 17
 				}
 			]
@@ -53565,7 +53695,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1106,
+							"line": 1130,
 							"character": 4
 						}
 					],
@@ -53653,7 +53783,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1602,
+							"line": 1626,
 							"character": 4
 						}
 					],
@@ -53693,13 +53823,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1113,
+							"line": 1137,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2911,
+						"id": 2928,
 						"name": "CustomisationsInterface"
 					},
 					"inheritedFrom": {
@@ -53736,7 +53866,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 394,
+							"line": 506,
 							"character": 4
 						}
 					],
@@ -53770,7 +53900,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 329,
+							"line": 441,
 							"character": 4
 						}
 					],
@@ -53811,13 +53941,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 537,
+							"line": 649,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1558,
+						"id": 1559,
 						"name": "SpotterQueryMode"
 					}
 				},
@@ -53846,7 +53976,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1292,
+							"line": 1316,
 							"character": 4
 						}
 					],
@@ -53884,7 +54014,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 364,
+							"line": 476,
 							"character": 4
 						}
 					],
@@ -53918,7 +54048,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1026,
+							"line": 1050,
 							"character": 4
 						}
 					],
@@ -53956,7 +54086,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1010,
+							"line": 1034,
 							"character": 4
 						}
 					],
@@ -53964,7 +54094,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -54005,7 +54135,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1179,
+							"line": 1203,
 							"character": 4
 						}
 					],
@@ -54043,7 +54173,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1387,
+							"line": 1411,
 							"character": 4
 						}
 					],
@@ -54085,7 +54215,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 556,
+							"line": 668,
 							"character": 4
 						}
 					],
@@ -54119,7 +54249,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 546,
+							"line": 658,
 							"character": 4
 						}
 					],
@@ -54153,7 +54283,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1257,
+							"line": 1281,
 							"character": 4
 						}
 					],
@@ -54191,7 +54321,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 458,
+							"line": 570,
 							"character": 4
 						}
 					],
@@ -54225,7 +54355,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 489,
+							"line": 601,
 							"character": 4
 						}
 					],
@@ -54258,7 +54388,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1268,
+							"line": 1292,
 							"character": 4
 						}
 					],
@@ -54296,13 +54426,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 982,
+							"line": 1006,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 2869,
+						"id": 2886,
 						"name": "FrameParams"
 					},
 					"inheritedFrom": {
@@ -54339,7 +54469,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1046,
+							"line": 1070,
 							"character": 4
 						}
 					],
@@ -54347,7 +54477,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -54381,7 +54511,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 425,
+							"line": 537,
 							"character": 4
 						}
 					],
@@ -54415,7 +54545,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 378,
+							"line": 490,
 							"character": 4
 						}
 					],
@@ -54449,7 +54579,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1129,
+							"line": 1153,
 							"character": 4
 						}
 					],
@@ -54486,7 +54616,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9306,
+							"line": 9388,
 							"character": 4
 						}
 					],
@@ -54523,7 +54653,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9289,
+							"line": 9371,
 							"character": 4
 						}
 					],
@@ -54560,7 +54690,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9273,
+							"line": 9355,
 							"character": 4
 						}
 					],
@@ -54598,7 +54728,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1356,
+							"line": 1380,
 							"character": 4
 						}
 					],
@@ -54636,7 +54766,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1082,
+							"line": 1106,
 							"character": 4
 						}
 					],
@@ -54674,7 +54804,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1331,
+							"line": 1355,
 							"character": 4
 						}
 					],
@@ -54712,7 +54842,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1311,
+							"line": 1335,
 							"character": 4
 						}
 					],
@@ -54749,7 +54879,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1240,
+							"line": 1264,
 							"character": 4
 						}
 					],
@@ -54791,7 +54921,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1219,
+							"line": 1243,
 							"character": 4
 						}
 					],
@@ -54842,7 +54972,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1157,
+							"line": 1181,
 							"character": 4
 						}
 					],
@@ -54883,7 +55013,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1616,
+							"line": 1640,
 							"character": 4
 						}
 					],
@@ -54921,7 +55051,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 446,
+							"line": 558,
 							"character": 4
 						}
 					],
@@ -54929,7 +55059,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2003,
+							"id": 2017,
 							"name": "RuntimeFilter"
 						}
 					}
@@ -54959,7 +55089,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 477,
+							"line": 589,
 							"character": 4
 						}
 					],
@@ -54967,7 +55097,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 3177,
+							"id": 3194,
 							"name": "RuntimeParameter"
 						}
 					}
@@ -54986,7 +55116,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 349,
+							"line": 461,
 							"character": 4
 						}
 					],
@@ -55020,7 +55150,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 633,
+							"line": 745,
 							"character": 4
 						}
 					],
@@ -55057,7 +55187,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1629,
+							"line": 1653,
 							"character": 4
 						}
 					],
@@ -55094,7 +55224,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1423,
+							"line": 1447,
 							"character": 4
 						}
 					],
@@ -55132,7 +55262,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 410,
+							"line": 522,
 							"character": 4
 						}
 					],
@@ -55170,7 +55300,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 519,
+							"line": 631,
 							"character": 4
 						}
 					],
@@ -55204,13 +55334,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 345,
+							"line": 457,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1556,
+						"id": 1557,
 						"name": "SpotterAnalystConfig"
 					}
 				},
@@ -55239,7 +55369,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 595,
+							"line": 707,
 							"character": 4
 						}
 					],
@@ -55274,13 +55404,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 611,
+							"line": 723,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1561,
+						"id": 1562,
 						"name": "SpotterShareConversationConfig"
 					}
 				},
@@ -55309,13 +55439,13 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 577,
+							"line": 689,
 							"character": 4
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1541,
+						"id": 1542,
 						"name": "SpotterSidebarViewConfig"
 					}
 				},
@@ -55348,7 +55478,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 504,
+							"line": 616,
 							"character": 4
 						}
 					],
@@ -55386,7 +55516,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 648,
+							"line": 760,
 							"character": 4
 						}
 					],
@@ -55423,7 +55553,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1643,
+							"line": 1667,
 							"character": 4
 						}
 					],
@@ -55465,7 +55595,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 1067,
+							"line": 1091,
 							"character": 4
 						}
 					],
@@ -55473,7 +55603,7 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2255,
+							"id": 2269,
 							"name": "Action"
 						}
 					},
@@ -55496,7 +55626,7 @@
 					"sources": [
 						{
 							"fileName": "embed/conversation.ts",
-							"line": 312,
+							"line": 424,
 							"character": 4
 						}
 					],
@@ -55568,7 +55698,7 @@
 			"sources": [
 				{
 					"fileName": "embed/conversation.ts",
-					"line": 305,
+					"line": 417,
 					"character": 17
 				}
 			],
@@ -55591,13 +55721,13 @@
 			"extendedBy": [
 				{
 					"type": "reference",
-					"id": 1575,
+					"id": 1589,
 					"name": "ConversationViewConfig"
 				}
 			]
 		},
 		{
-			"id": 1561,
+			"id": 1562,
 			"name": "SpotterShareConversationConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -55617,7 +55747,7 @@
 			},
 			"children": [
 				{
-					"id": 1562,
+					"id": 1563,
 					"name": "enableShareConversation",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55650,7 +55780,7 @@
 					}
 				},
 				{
-					"id": 1567,
+					"id": 1568,
 					"name": "spotterShareAddUsersLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55679,7 +55809,7 @@
 					}
 				},
 				{
-					"id": 1566,
+					"id": 1567,
 					"name": "spotterShareCancelLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55712,7 +55842,7 @@
 					}
 				},
 				{
-					"id": 1565,
+					"id": 1566,
 					"name": "spotterShareConfirmLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55745,7 +55875,7 @@
 					}
 				},
 				{
-					"id": 1569,
+					"id": 1570,
 					"name": "spotterShareEmptySubtitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55774,7 +55904,7 @@
 					}
 				},
 				{
-					"id": 1568,
+					"id": 1569,
 					"name": "spotterShareEmptyTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55803,7 +55933,7 @@
 					}
 				},
 				{
-					"id": 1570,
+					"id": 1571,
 					"name": "spotterShareIncludeNewMessagesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55832,7 +55962,7 @@
 					}
 				},
 				{
-					"id": 1563,
+					"id": 1564,
 					"name": "spotterShareLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55865,7 +55995,7 @@
 					}
 				},
 				{
-					"id": 1564,
+					"id": 1565,
 					"name": "spotterShareModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55894,7 +56024,7 @@
 					}
 				},
 				{
-					"id": 1572,
+					"id": 1573,
 					"name": "spotterShareStaleInfoLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55923,7 +56053,7 @@
 					}
 				},
 				{
-					"id": 1571,
+					"id": 1572,
 					"name": "spotterShareUpToCurrentLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55952,7 +56082,7 @@
 					}
 				},
 				{
-					"id": 1573,
+					"id": 1574,
 					"name": "spotterSharedConversationBannerMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -55981,7 +56111,7 @@
 					}
 				},
 				{
-					"id": 1574,
+					"id": 1575,
 					"name": "spotterSharedConversationExitLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56019,19 +56149,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1562,
+						1563,
+						1568,
 						1567,
 						1566,
-						1565,
-						1569,
-						1568,
 						1570,
-						1563,
-						1564,
-						1572,
+						1569,
 						1571,
+						1564,
+						1565,
 						1573,
-						1574
+						1572,
+						1574,
+						1575
 					]
 				}
 			],
@@ -56044,7 +56174,7 @@
 			]
 		},
 		{
-			"id": 1541,
+			"id": 1542,
 			"name": "SpotterSidebarViewConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56064,7 +56194,7 @@
 			},
 			"children": [
 				{
-					"id": 1542,
+					"id": 1543,
 					"name": "enablePastConversationsSidebar",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56097,7 +56227,7 @@
 					}
 				},
 				{
-					"id": 1554,
+					"id": 1555,
 					"name": "spotterAnalystLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56130,7 +56260,7 @@
 					}
 				},
 				{
-					"id": 1555,
+					"id": 1556,
 					"name": "spotterAnalystsLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56163,7 +56293,7 @@
 					}
 				},
 				{
-					"id": 1551,
+					"id": 1552,
 					"name": "spotterBestPracticesLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56192,7 +56322,7 @@
 					}
 				},
 				{
-					"id": 1546,
+					"id": 1547,
 					"name": "spotterChatDeleteLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56221,7 +56351,7 @@
 					}
 				},
 				{
-					"id": 1547,
+					"id": 1548,
 					"name": "spotterChatPinConfig",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56250,7 +56380,7 @@
 					}
 				},
 				{
-					"id": 1545,
+					"id": 1546,
 					"name": "spotterChatRenameLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56279,7 +56409,7 @@
 					}
 				},
 				{
-					"id": 1552,
+					"id": 1553,
 					"name": "spotterConversationsBatchSize",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56312,7 +56442,7 @@
 					}
 				},
 				{
-					"id": 1548,
+					"id": 1549,
 					"name": "spotterDeleteConversationModalTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56341,7 +56471,7 @@
 					}
 				},
 				{
-					"id": 1550,
+					"id": 1551,
 					"name": "spotterDocumentationUrl",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56370,7 +56500,7 @@
 					}
 				},
 				{
-					"id": 1553,
+					"id": 1554,
 					"name": "spotterNewChatButtonTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56399,7 +56529,7 @@
 					}
 				},
 				{
-					"id": 1549,
+					"id": 1550,
 					"name": "spotterPastConversationAlertMessage",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56428,7 +56558,7 @@
 					}
 				},
 				{
-					"id": 1544,
+					"id": 1545,
 					"name": "spotterSidebarDefaultExpanded",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56461,7 +56591,7 @@
 					}
 				},
 				{
-					"id": 1543,
+					"id": 1544,
 					"name": "spotterSidebarTitle",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56495,20 +56625,20 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1542,
-						1554,
+						1543,
 						1555,
-						1551,
-						1546,
-						1547,
-						1545,
+						1556,
 						1552,
+						1547,
 						1548,
-						1550,
+						1546,
 						1553,
 						1549,
-						1544,
-						1543
+						1551,
+						1554,
+						1550,
+						1545,
+						1544
 					]
 				}
 			],
@@ -56521,7 +56651,7 @@
 			]
 		},
 		{
-			"id": 2726,
+			"id": 2743,
 			"name": "SpotterVizConfig",
 			"kind": 256,
 			"kindString": "Interface",
@@ -56545,7 +56675,7 @@
 			},
 			"children": [
 				{
-					"id": 2728,
+					"id": 2745,
 					"name": "brandHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56578,7 +56708,7 @@
 					}
 				},
 				{
-					"id": 2727,
+					"id": 2744,
 					"name": "brandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56611,7 +56741,7 @@
 					}
 				},
 				{
-					"id": 2730,
+					"id": 2747,
 					"name": "customStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56638,13 +56768,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2740,
+							"id": 2757,
 							"name": "SpotterVizStarterPrompt"
 						}
 					}
 				},
 				{
-					"id": 2731,
+					"id": 2748,
 					"name": "description",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56673,7 +56803,7 @@
 					}
 				},
 				{
-					"id": 2729,
+					"id": 2746,
 					"name": "hideStarterPrompts",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56706,7 +56836,7 @@
 					}
 				},
 				{
-					"id": 2732,
+					"id": 2749,
 					"name": "inputChatPlaceholder",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56735,7 +56865,7 @@
 					}
 				},
 				{
-					"id": 2737,
+					"id": 2754,
 					"name": "insightTileBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56768,7 +56898,7 @@
 					}
 				},
 				{
-					"id": 2739,
+					"id": 2756,
 					"name": "insightTileLoaderText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56797,7 +56927,7 @@
 					}
 				},
 				{
-					"id": 2738,
+					"id": 2755,
 					"name": "insightTileViewPlanLabel",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56826,7 +56956,7 @@
 					}
 				},
 				{
-					"id": 2735,
+					"id": 2752,
 					"name": "liveboardBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56859,7 +56989,7 @@
 					}
 				},
 				{
-					"id": 2733,
+					"id": 2750,
 					"name": "loaderHeadline",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56888,7 +57018,7 @@
 					}
 				},
 				{
-					"id": 2734,
+					"id": 2751,
 					"name": "loaderTips",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56915,13 +57045,13 @@
 						"type": "array",
 						"elementType": {
 							"type": "reference",
-							"id": 2744,
+							"id": 2761,
 							"name": "SpotterVizLoaderTip"
 						}
 					}
 				},
 				{
-					"id": 2736,
+					"id": 2753,
 					"name": "spotterBrandName",
 					"kind": 1024,
 					"kindString": "Property",
@@ -56959,19 +57089,19 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2728,
-						2727,
-						2730,
-						2731,
-						2729,
-						2732,
-						2737,
-						2739,
-						2738,
-						2735,
-						2733,
-						2734,
-						2736
+						2745,
+						2744,
+						2747,
+						2748,
+						2746,
+						2749,
+						2754,
+						2756,
+						2755,
+						2752,
+						2750,
+						2751,
+						2753
 					]
 				}
 			],
@@ -56984,7 +57114,7 @@
 			]
 		},
 		{
-			"id": 2744,
+			"id": 2761,
 			"name": "SpotterVizLoaderTip",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57004,7 +57134,7 @@
 			},
 			"children": [
 				{
-					"id": 2745,
+					"id": 2762,
 					"name": "label",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57025,7 +57155,7 @@
 					}
 				},
 				{
-					"id": 2746,
+					"id": 2763,
 					"name": "text",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57051,8 +57181,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2745,
-						2746
+						2762,
+						2763
 					]
 				}
 			],
@@ -57065,7 +57195,7 @@
 			]
 		},
 		{
-			"id": 2740,
+			"id": 2757,
 			"name": "SpotterVizStarterPrompt",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57085,7 +57215,7 @@
 			},
 			"children": [
 				{
-					"id": 2742,
+					"id": 2759,
 					"name": "displayText",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57106,7 +57236,7 @@
 					}
 				},
 				{
-					"id": 2743,
+					"id": 2760,
 					"name": "fullPrompt",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57127,7 +57257,7 @@
 					}
 				},
 				{
-					"id": 2741,
+					"id": 2758,
 					"name": "id",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57153,9 +57283,9 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2742,
-						2743,
-						2741
+						2759,
+						2760,
+						2758
 					]
 				}
 			],
@@ -57168,14 +57298,391 @@
 			]
 		},
 		{
-			"id": 1978,
+			"id": 1584,
+			"name": "StarterPreviewDataCategory",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for the Data Literacy starter prompt category.\nOnly the label is customizable; the prompt text comes from the backend.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1585,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Overrides the default category pill label. ThoughtSpot truncates it\nbeyond 30 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 278,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1585
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 273,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1581,
+			"name": "StarterPromptCategory",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Configuration for a starter prompt category with questions\n(`quick` and `research`).",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1582,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Overrides the default category pill label. ThoughtSpot truncates it\nbeyond 30 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 259,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1583,
+					"name": "questions",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Replaces the backend-generated prompts. ThoughtSpot renders the first 4\nand drops any entry without a `prompt`."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 264,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reference",
+							"id": 1586,
+							"name": "StarterPromptQuestion"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1582,
+						1583
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 254,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1586,
+			"name": "StarterPromptQuestion",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "A single starter prompt question shown under a category pill.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1587,
+					"name": "label",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Short label shown as a clickable suggestion. Falls back to `prompt` when\nomitted. ThoughtSpot truncates it beyond 80 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 240,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1588,
+					"name": "prompt",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {},
+					"comment": {
+						"shortText": "Prompt text sent to Spotter on click. ThoughtSpot truncates it beyond\n300 characters."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 245,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1587,
+						1588
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 235,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1576,
+			"name": "StarterPromptsConfig",
+			"kind": 256,
+			"kindString": "Interface",
+			"flags": {},
+			"comment": {
+				"shortText": "Content configuration for the Spotter starter prompts.\nCategory keys are fixed: `quick` (Basic Search), `research` (Deep Analysis)\nand `previewData` (Data Literacy).",
+				"text": "Note: this controls the Spotter chat interface only. The starter prompts on\nthe Liveboard SpotterViz surface are configured separately through\n{@link SpotterVizConfig.customStarterPrompts}.",
+				"tags": [
+					{
+						"tag": "version",
+						"text": "SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl"
+					},
+					{
+						"tag": "group",
+						"text": "Embed components\n"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1577,
+					"name": "enable",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Turns the starter prompts surface on. Must be set explicitly, an\nunset flag leaves the surface off.",
+						"text": "Either this or `enableStarterPrompts` turns the surface on, so `false`\nhere does not switch it off while `enableStarterPrompts` is `true`.",
+						"tags": [
+							{
+								"tag": "default",
+								"text": "false\n"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 301,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1580,
+					"name": "previewData",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Data Literacy category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 307,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1584,
+						"name": "StarterPreviewDataCategory"
+					}
+				},
+				{
+					"id": 1578,
+					"name": "quick",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Basic Search category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 303,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1581,
+						"name": "StarterPromptCategory"
+					}
+				},
+				{
+					"id": 1579,
+					"name": "research",
+					"kind": 1024,
+					"kindString": "Property",
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"shortText": "Deep Analysis category configuration."
+					},
+					"sources": [
+						{
+							"fileName": "embed/conversation.ts",
+							"line": 305,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"id": 1581,
+						"name": "StarterPromptCategory"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"kind": 1024,
+					"children": [
+						1577,
+						1580,
+						1578,
+						1579
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "embed/conversation.ts",
+					"line": 292,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 1992,
 			"name": "UnderlyingDataPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 1979,
+					"id": 1993,
 					"name": "columnId",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57193,7 +57700,7 @@
 					}
 				},
 				{
-					"id": 1980,
+					"id": 1994,
 					"name": "dataValue",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57216,8 +57723,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						1979,
-						1980
+						1993,
+						1994
 					]
 				}
 			],
@@ -57230,7 +57737,7 @@
 			]
 		},
 		{
-			"id": 3315,
+			"id": 3332,
 			"name": "VisualizationOverrides",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57250,7 +57757,7 @@
 			},
 			"children": [
 				{
-					"id": 3316,
+					"id": 3333,
 					"name": "chart",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57263,7 +57770,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9799,
+							"line": 9881,
 							"character": 4
 						}
 					],
@@ -57273,7 +57780,7 @@
 					}
 				},
 				{
-					"id": 3317,
+					"id": 3334,
 					"name": "table",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57286,7 +57793,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 9801,
+							"line": 9883,
 							"character": 4
 						}
 					],
@@ -57301,28 +57808,28 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3316,
-						3317
+						3333,
+						3334
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 9797,
+					"line": 9879,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 3220,
+			"id": 3237,
 			"name": "VizPoint",
 			"kind": 256,
 			"kindString": "Interface",
 			"flags": {},
 			"children": [
 				{
-					"id": 3221,
+					"id": 3238,
 					"name": "selectedAttributes",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57330,7 +57837,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8791,
+							"line": 8873,
 							"character": 4
 						}
 					],
@@ -57343,7 +57850,7 @@
 					}
 				},
 				{
-					"id": 3222,
+					"id": 3239,
 					"name": "selectedMeasures",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57351,7 +57858,7 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 8792,
+							"line": 8874,
 							"character": 4
 						}
 					],
@@ -57369,21 +57876,21 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						3221,
-						3222
+						3238,
+						3239
 					]
 				}
 			],
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 8790,
+					"line": 8872,
 					"character": 17
 				}
 			]
 		},
 		{
-			"id": 2924,
+			"id": 2941,
 			"name": "customCssInterface",
 			"kind": 256,
 			"kindString": "Interface",
@@ -57393,7 +57900,7 @@
 			},
 			"children": [
 				{
-					"id": 2926,
+					"id": 2943,
 					"name": "rules_UNSTABLE",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57423,20 +57930,20 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 2927,
+							"id": 2944,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"indexSignature": {
-								"id": 2928,
+								"id": 2945,
 								"name": "__index",
 								"kind": 8192,
 								"kindString": "Index signature",
 								"flags": {},
 								"parameters": [
 									{
-										"id": 2929,
+										"id": 2946,
 										"name": "selector",
 										"kind": 32768,
 										"flags": {},
@@ -57449,7 +57956,7 @@
 								"type": {
 									"type": "reflection",
 									"declaration": {
-										"id": 2930,
+										"id": 2947,
 										"name": "__type",
 										"kind": 65536,
 										"kindString": "Type literal",
@@ -57462,14 +57969,14 @@
 											}
 										],
 										"indexSignature": {
-											"id": 2931,
+											"id": 2948,
 											"name": "__index",
 											"kind": 8192,
 											"kindString": "Index signature",
 											"flags": {},
 											"parameters": [
 												{
-													"id": 2932,
+													"id": 2949,
 													"name": "declaration",
 													"kind": 32768,
 													"flags": {},
@@ -57491,7 +57998,7 @@
 					}
 				},
 				{
-					"id": 2925,
+					"id": 2942,
 					"name": "variables",
 					"kind": 1024,
 					"kindString": "Property",
@@ -57510,7 +58017,7 @@
 					],
 					"type": {
 						"type": "reference",
-						"id": 2933,
+						"id": 2950,
 						"name": "CustomCssVariables"
 					}
 				}
@@ -57520,8 +58027,8 @@
 					"title": "Properties",
 					"kind": 1024,
 					"children": [
-						2926,
-						2925
+						2943,
+						2942
 					]
 				}
 			],
@@ -57826,7 +58333,7 @@
 			]
 		},
 		{
-			"id": 3314,
+			"id": 3331,
 			"name": "AutoMCPFrameRendererViewConfig",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57838,7 +58345,7 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 1660,
+					"line": 1684,
 					"character": 12
 				}
 			],
@@ -57883,7 +58390,7 @@
 			}
 		},
 		{
-			"id": 2894,
+			"id": 2911,
 			"name": "DOMSelector",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57910,7 +58417,7 @@
 			}
 		},
 		{
-			"id": 2898,
+			"id": 2915,
 			"name": "MessageCallback",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -57918,14 +58425,14 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2263,
+					"line": 2287,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2899,
+					"id": 2916,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
@@ -57942,13 +58449,13 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2263,
+							"line": 2287,
 							"character": 30
 						}
 					],
 					"signatures": [
 						{
-							"id": 2900,
+							"id": 2917,
 							"name": "__type",
 							"kind": 4096,
 							"kindString": "Call signature",
@@ -57958,19 +58465,19 @@
 							},
 							"parameters": [
 								{
-									"id": 2901,
+									"id": 2918,
 									"name": "payload",
 									"kind": 32768,
 									"kindString": "Parameter",
 									"flags": {},
 									"type": {
 										"type": "reference",
-										"id": 2906,
+										"id": 2923,
 										"name": "MessagePayload"
 									}
 								},
 								{
-									"id": 2902,
+									"id": 2919,
 									"name": "responder",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -57980,7 +58487,7 @@
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 2903,
+											"id": 2920,
 											"name": "__type",
 											"kind": 65536,
 											"kindString": "Type literal",
@@ -57988,13 +58495,13 @@
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 2270,
+													"line": 2294,
 													"character": 16
 												}
 											],
 											"signatures": [
 												{
-													"id": 2904,
+													"id": 2921,
 													"name": "__type",
 													"kind": 4096,
 													"kindString": "Call signature",
@@ -58004,7 +58511,7 @@
 													},
 													"parameters": [
 														{
-															"id": 2905,
+															"id": 2922,
 															"name": "data",
 															"kind": 32768,
 															"kindString": "Parameter",
@@ -58035,7 +58542,7 @@
 			}
 		},
 		{
-			"id": 2895,
+			"id": 2912,
 			"name": "MessageOptions",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -58052,21 +58559,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2252,
+					"line": 2276,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2896,
+					"id": 2913,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2897,
+							"id": 2914,
 							"name": "start",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58079,7 +58586,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2257,
+									"line": 2281,
 									"character": 4
 								}
 							],
@@ -58094,14 +58601,14 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2897
+								2914
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2252,
+							"line": 2276,
 							"character": 29
 						}
 					]
@@ -58109,7 +58616,7 @@
 			}
 		},
 		{
-			"id": 2906,
+			"id": 2923,
 			"name": "MessagePayload",
 			"kind": 4194304,
 			"kindString": "Type alias",
@@ -58126,21 +58633,21 @@
 			"sources": [
 				{
 					"fileName": "types.ts",
-					"line": 2239,
+					"line": 2263,
 					"character": 12
 				}
 			],
 			"type": {
 				"type": "reflection",
 				"declaration": {
-					"id": 2907,
+					"id": 2924,
 					"name": "__type",
 					"kind": 65536,
 					"kindString": "Type literal",
 					"flags": {},
 					"children": [
 						{
-							"id": 2909,
+							"id": 2926,
 							"name": "data",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58148,7 +58655,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2243,
+									"line": 2267,
 									"character": 4
 								}
 							],
@@ -58158,7 +58665,7 @@
 							}
 						},
 						{
-							"id": 2910,
+							"id": 2927,
 							"name": "status",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58168,7 +58675,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2245,
+									"line": 2269,
 									"character": 4
 								}
 							],
@@ -58178,7 +58685,7 @@
 							}
 						},
 						{
-							"id": 2908,
+							"id": 2925,
 							"name": "type",
 							"kind": 1024,
 							"kindString": "Property",
@@ -58186,7 +58693,7 @@
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 2241,
+									"line": 2265,
 									"character": 4
 								}
 							],
@@ -58201,16 +58708,16 @@
 							"title": "Properties",
 							"kind": 1024,
 							"children": [
-								2909,
-								2910,
-								2908
+								2926,
+								2927,
+								2925
 							]
 						}
 					],
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 2239,
+							"line": 2263,
 							"character": 29
 						}
 					]
@@ -58268,7 +58775,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 1894,
+									"id": 1908,
 									"name": "AnswerService"
 								}
 							}
@@ -58530,7 +59037,7 @@
 											],
 											"type": {
 												"type": "reference",
-												"id": 1894,
+												"id": 1908,
 												"name": "AnswerService"
 											}
 										},
@@ -58617,7 +59124,7 @@
 					},
 					"type": {
 						"type": "reference",
-						"id": 2454,
+						"id": 2471,
 						"name": "EmbedConfig"
 					}
 				}
@@ -58717,14 +59224,14 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 2454,
+								"id": 2471,
 								"name": "EmbedConfig"
 							}
 						}
 					],
 					"type": {
 						"type": "reference",
-						"id": 1841,
+						"id": 1855,
 						"name": "AuthEventEmitter"
 					}
 				}
@@ -58864,7 +59371,7 @@
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"id": 2864,
+									"id": 2881,
 									"name": "PrefetchFeatures"
 								}
 							}
@@ -58992,7 +59499,7 @@
 			]
 		},
 		{
-			"id": 3360,
+			"id": 3377,
 			"name": "resetCachedAuthToken",
 			"kind": 64,
 			"kindString": "Function",
@@ -59008,7 +59515,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3361,
+					"id": 3378,
 					"name": "resetCachedAuthToken",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59038,7 +59545,7 @@
 			]
 		},
 		{
-			"id": 3362,
+			"id": 3379,
 			"name": "startAutoMCPFrameRenderer",
 			"kind": 64,
 			"kindString": "Function",
@@ -59052,7 +59559,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3363,
+					"id": 3380,
 					"name": "startAutoMCPFrameRenderer",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59074,7 +59581,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3364,
+							"id": 3381,
 							"name": "viewConfig",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59084,7 +59591,7 @@
 							},
 							"type": {
 								"type": "reference",
-								"id": 3314,
+								"id": 3331,
 								"name": "AutoMCPFrameRendererViewConfig"
 							},
 							"defaultValue": "{}"
@@ -59262,7 +59769,7 @@
 			]
 		},
 		{
-			"id": 3187,
+			"id": 3204,
 			"name": "uploadMixpanelEvent",
 			"kind": 64,
 			"kindString": "Function",
@@ -59276,7 +59783,7 @@
 			],
 			"signatures": [
 				{
-					"id": 3188,
+					"id": 3205,
 					"name": "uploadMixpanelEvent",
 					"kind": 4096,
 					"kindString": "Call signature",
@@ -59286,7 +59793,7 @@
 					},
 					"parameters": [
 						{
-							"id": 3189,
+							"id": 3206,
 							"name": "eventId",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59298,7 +59805,7 @@
 							}
 						},
 						{
-							"id": 3190,
+							"id": 3207,
 							"name": "eventProps",
 							"kind": 32768,
 							"kindString": "Parameter",
@@ -59309,7 +59816,7 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 3191,
+									"id": 3208,
 									"name": "__type",
 									"kind": 65536,
 									"kindString": "Type literal",
@@ -59332,52 +59839,52 @@
 			"title": "Enumerations",
 			"kind": 4,
 			"children": [
-				2255,
-				1839,
-				1824,
-				1831,
-				1991,
-				3323,
-				3326,
-				3330,
-				2450,
-				2245,
-				3277,
-				3273,
-				3346,
-				3269,
-				2251,
+				2269,
+				1853,
+				1838,
+				1845,
+				2005,
+				3340,
+				3343,
+				3347,
+				2467,
+				2259,
+				3294,
+				3290,
+				3363,
 				3286,
-				2023,
-				3310,
-				2875,
-				3213,
-				3207,
-				2887,
-				2152,
-				3282,
-				3318,
-				3217,
-				3261,
-				3180,
-				1981,
-				2864,
-				3211,
-				2007,
-				1558,
-				3357,
-				3353,
-				3243
+				2265,
+				3303,
+				2037,
+				3327,
+				2892,
+				3230,
+				3224,
+				2904,
+				2166,
+				3299,
+				3335,
+				3234,
+				3278,
+				3197,
+				1995,
+				2881,
+				3228,
+				2021,
+				1559,
+				3374,
+				3370,
+				3260
 			]
 		},
 		{
 			"title": "Classes",
 			"kind": 128,
 			"children": [
-				1894,
+				1908,
 				911,
 				1255,
-				1636,
+				1650,
 				661,
 				256,
 				58,
@@ -59389,36 +59896,40 @@
 			"title": "Interfaces",
 			"kind": 256,
 			"children": [
-				2747,
-				1841,
+				2764,
+				1855,
 				1216,
-				1575,
-				3223,
-				2933,
-				2921,
-				2911,
-				2454,
-				3304,
-				2869,
-				2624,
-				2003,
-				3177,
-				2571,
-				2505,
-				1971,
+				1589,
+				3240,
+				2950,
+				2938,
+				2928,
+				2471,
+				3321,
+				2886,
+				2641,
+				2017,
+				3194,
+				2588,
+				2522,
+				1985,
 				1177,
-				1556,
+				1557,
 				1535,
 				1474,
-				1561,
-				1541,
-				2726,
-				2744,
-				2740,
-				1978,
-				3315,
-				3220,
-				2924,
+				1562,
+				1542,
+				2743,
+				2761,
+				2757,
+				1584,
+				1581,
+				1586,
+				1576,
+				1992,
+				3332,
+				3237,
+				2941,
 				21,
 				28
 			]
@@ -59427,11 +59938,11 @@
 			"title": "Type aliases",
 			"kind": 4194304,
 			"children": [
-				3314,
-				2894,
-				2898,
-				2895,
-				2906
+				3331,
+				2911,
+				2915,
+				2912,
+				2923
 			]
 		},
 		{
@@ -59448,10 +59959,10 @@
 				4,
 				7,
 				25,
-				3360,
-				3362,
+				3377,
+				3379,
 				40,
-				3187
+				3204
 			]
 		}
 	],


### PR DESCRIPTION
JIRA: https://thoughtspot.atlassian.net/browse/SCAL-330172

Marks `HostEvent.UpdatePersonalizedView` / `UpdatePersonalisedView` as deprecated and points to `HostEvent.SelectPersonalizedView`.

Docs-only change 