### PR TITLE
[SCAL-332993] Add liveboardGutter view config prop

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -538,7 +538,7 @@ export interface CustomCssVariables {
      * Left and right margin of the header and the tab/filter section of an
      * embedded Liveboard. Use alongside the `liveboardGutter` view config to
      * keep the header aligned with a custom tile-grid gutter.
-     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     '--ts-var-liveboard-header-horizontal-margin'?: string;
 

--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -538,7 +538,7 @@ export interface CustomCssVariables {
      * Left and right margin of the header and the tab/filter section of an
      * embedded Liveboard. Use alongside the `liveboardGutter` view config to
      * keep the header aligned with a custom tile-grid gutter.
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
      */
     '--ts-var-liveboard-header-horizontal-margin'?: string;
 

--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -538,7 +538,7 @@ export interface CustomCssVariables {
      * Left and right margin of the header and the tab/filter section of an
      * embedded Liveboard. Use alongside the `liveboardGutter` view config to
      * keep the header aligned with a custom tile-grid gutter.
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     '--ts-var-liveboard-header-horizontal-margin'?: string;
 

--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -535,6 +535,14 @@ export interface CustomCssVariables {
     '--ts-var-liveboard-header-font-color'?: string;
 
     /**
+     * Left and right margin of the header and the tab/filter section of an
+     * embedded Liveboard. Use alongside the `liveboardGutter` view config to
+     * keep the header aligned with a custom tile-grid gutter.
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     */
+    '--ts-var-liveboard-header-horizontal-margin'?: string;
+
+    /**
      * Border color of the tiles in the Liveboard.
      */
     '--ts-var-liveboard-tile-border-color'?: string;

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -416,6 +416,20 @@ describe('App embed tests', () => {
         });
     });
 
+    test('should set liveboardGutter in url', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardGutter: 8,
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&liveboardGutter=8&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('should set isThisPeriodInDateFiltersEnabled to true in url', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -608,26 +608,6 @@ export interface AppViewConfig extends AllEmbedViewConfig {
     isLiveboardStylingAndGroupingEnabled?: boolean;
 
     /**
-     * Sets the gutter space (in pixels) between the visualization tiles of
-     * Liveboard grid layouts rendered in the embedded app. Accepts a
-     * non-negative integer; `0` renders the tiles without any gap and removes
-     * the outer layout padding. When omitted, the gutter saved in each
-     * Liveboard's styling settings (or the ThoughtSpot default) applies.
-     *
-     * Supported embed types: `AppEmbed`, `LiveboardEmbed`
-     * @type {number}
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
-     * @example
-     * ```js
-     * const embed = new AppEmbed('#tsEmbed', {
-     *    ... // other embed view config
-     *    liveboardGutter: 8,
-     * })
-     * ```
-     */
-    liveboardGutter?: number;
-
-    /**
      * This flag is used to enable/disable the png embedding of liveboard in scheduled
      * mails
      *

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -608,6 +608,26 @@ export interface AppViewConfig extends AllEmbedViewConfig {
     isLiveboardStylingAndGroupingEnabled?: boolean;
 
     /**
+     * Sets the gutter space (in pixels) between the visualization tiles of
+     * Liveboard grid layouts rendered in the embedded app. Accepts a
+     * non-negative integer; `0` renders the tiles without any gap and removes
+     * the outer layout padding. When omitted, the gutter saved in each
+     * Liveboard's styling settings (or the ThoughtSpot default) applies.
+     *
+     * Supported embed types: `AppEmbed`, `LiveboardEmbed`
+     * @type {number}
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#tsEmbed', {
+     *    ... // other embed view config
+     *    liveboardGutter: 8,
+     * })
+     * ```
+     */
+    liveboardGutter?: number;
+
+    /**
      * This flag is used to enable/disable the png embedding of liveboard in scheduled
      * mails
      *
@@ -1110,6 +1130,7 @@ export class AppEmbed extends V1Embed {
             discoveryExperience,
             coverAndFilterOptionInPDF,
             isLiveboardStylingAndGroupingEnabled,
+            liveboardGutter,
             isPNGInScheduledEmailsEnabled = false,
             isLiveboardXLSXCSVDownloadEnabled,
             isGranularXLSXCSVSchedulesEnabled,
@@ -1271,6 +1292,10 @@ export class AppEmbed extends V1Embed {
             params[
                 Param.IsLiveboardStylingAndGroupingEnabled
             ] = isLiveboardStylingAndGroupingEnabled;
+        }
+
+        if (liveboardGutter !== undefined) {
+            params[Param.LiveboardGutter] = liveboardGutter;
         }
 
         if (isPNGInScheduledEmailsEnabled !== undefined) {

--- a/src/embed/host-events.spec.ts
+++ b/src/embed/host-events.spec.ts
@@ -181,6 +181,30 @@ describe('HostEvent.OpenParameter', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 10c – OpenAddFilterModal
+// ---------------------------------------------------------------------------
+describe('HostEvent.OpenAddFilterModal', () => {
+    test('postMessage type is openAddFilterModal (camelCase, no payload)', async () => {
+        mockMessageChannel();
+        const { lb, iframe } = await renderLiveboard();
+        await executeAfterWait(() => {
+            lb.trigger(HostEvent.OpenAddFilterModal);
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'openAddFilterModal' }),
+                thoughtSpotHost,
+                expect.anything(),
+            );
+        });
+    });
+
+    test('returns null when !isRendered', async () => {
+        const lb = unrenderedLiveboard();
+        const result = await lb.trigger(HostEvent.OpenAddFilterModal);
+        expect(result).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
 // 11 – AddColumns
 // ---------------------------------------------------------------------------
 describe('HostEvent.AddColumns', () => {

--- a/src/embed/host-events.spec.ts
+++ b/src/embed/host-events.spec.ts
@@ -205,6 +205,30 @@ describe('HostEvent.OpenAddFilterModal', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 10d – OpenAddParameterModal
+// ---------------------------------------------------------------------------
+describe('HostEvent.OpenAddParameterModal', () => {
+    test('postMessage type is openAddParameterModal (camelCase, no payload)', async () => {
+        mockMessageChannel();
+        const { lb, iframe } = await renderLiveboard();
+        await executeAfterWait(() => {
+            lb.trigger(HostEvent.OpenAddParameterModal);
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'openAddParameterModal' }),
+                thoughtSpotHost,
+                expect.anything(),
+            );
+        });
+    });
+
+    test('returns null when !isRendered', async () => {
+        const lb = unrenderedLiveboard();
+        const result = await lb.trigger(HostEvent.OpenAddParameterModal);
+        expect(result).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
 // 11 – AddColumns
 // ---------------------------------------------------------------------------
 describe('HostEvent.AddColumns', () => {

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -215,6 +215,36 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
+    test('should set liveboardGutter in url', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            liveboardGutter: 8,
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&liveboardGutter=8${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
+    test('should set liveboardGutter to 0 in url', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            liveboardId,
+            liveboardGutter: 0,
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&liveboardGutter=0${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
     test('should set isThisPeriodInDateFiltersEnabled to true in url', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -385,25 +385,6 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      */
     isLiveboardStylingAndGroupingEnabled?: boolean;
     /**
-     * Sets the gutter space (in pixels) between the visualization tiles of
-     * the embedded Liveboard grid layout. Accepts a non-negative integer;
-     * `0` renders the tiles without any gap and removes the outer layout
-     * padding. When omitted, the gutter saved in the Liveboard's styling
-     * settings (or the ThoughtSpot default) applies.
-     *
-     * Supported embed types: `LiveboardEmbed`, `AppEmbed`
-     * @type {number}
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
-     * @example
-     * ```js
-     * const embed = new LiveboardEmbed('#tsEmbed', {
-     *    ... // other embed view config
-     *    liveboardGutter: 8,
-     * })
-     * ```
-     */
-    liveboardGutter?: number;
-    /**
      * This flag is used to enable/disable the png embedding of liveboard in scheduled
      * mails
      *

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -385,6 +385,25 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      */
     isLiveboardStylingAndGroupingEnabled?: boolean;
     /**
+     * Sets the gutter space (in pixels) between the visualization tiles of
+     * the embedded Liveboard grid layout. Accepts a non-negative integer;
+     * `0` renders the tiles without any gap and removes the outer layout
+     * padding. When omitted, the gutter saved in the Liveboard's styling
+     * settings (or the ThoughtSpot default) applies.
+     *
+     * Supported embed types: `LiveboardEmbed`, `AppEmbed`
+     * @type {number}
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#tsEmbed', {
+     *    ... // other embed view config
+     *    liveboardGutter: 8,
+     * })
+     * ```
+     */
+    liveboardGutter?: number;
+    /**
      * This flag is used to enable/disable the png embedding of liveboard in scheduled
      * mails
      *
@@ -735,6 +754,7 @@ export class LiveboardEmbed extends V1Embed {
             dataSourceId,
             coverAndFilterOptionInPDF,
             isLiveboardStylingAndGroupingEnabled,
+            liveboardGutter,
             isPNGInScheduledEmailsEnabled = false,
             isLiveboardXLSXCSVDownloadEnabled,
             isGranularXLSXCSVSchedulesEnabled,
@@ -822,6 +842,10 @@ export class LiveboardEmbed extends V1Embed {
 
         if (isLiveboardStylingAndGroupingEnabled !== undefined) {
             params[Param.IsLiveboardStylingAndGroupingEnabled] = isLiveboardStylingAndGroupingEnabled;
+        }
+
+        if (liveboardGutter !== undefined) {
+            params[Param.LiveboardGutter] = liveboardGutter;
         }
 
         if (isPNGInScheduledEmailsEnabled !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2141,7 +2141,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {number}
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
@@ -4657,7 +4657,7 @@ export enum HostEvent {
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
      */
     OpenAddFilterModal = 'openAddFilterModal',
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -4653,11 +4653,11 @@ export enum HostEvent {
      *
      * Unlike {@link HostEvent.OpenFilter}, which opens the panel of an
      * existing filter, this event starts the creation of a new filter.
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
      * ```
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     OpenAddFilterModal = 'openAddFilterModal',
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2141,7 +2141,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {number}
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
@@ -4657,7 +4657,7 @@ export enum HostEvent {
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
      */
     OpenAddFilterModal = 'openAddFilterModal',
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6791,6 +6791,7 @@ export enum Param {
     PrimaryAction = 'primaryAction',
     isSpotterAgentEmbed = 'isSpotterAgentEmbed',
     IsLiveboardStylingAndGroupingEnabled = 'isLiveboardStylingAndGroupingEnabled',
+    LiveboardGutter = 'liveboardGutter',
     IsLazyLoadingForEmbedEnabled = 'isLazyLoadingForEmbedEnabled',
     RootMarginForLazyLoad = 'rootMarginForLazyLoad',
     isPNGInScheduledEmailsEnabled = 'isPNGInScheduledEmailsEnabled',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2133,6 +2133,26 @@ export interface LiveboardAppEmbedViewConfig {
      */
     coverAndFilterOptionInPDF?: boolean;
     /**
+     * Sets the gutter space (in pixels) between the visualization tiles of
+     * an embedded Liveboard grid layout and its outer layout padding.
+     * Accepts a non-negative integer; `0` renders the tiles without any gap
+     * and removes the outer padding. When omitted, the gutter saved in the
+     * Liveboard's styling settings (or the ThoughtSpot default) applies.
+     *
+     * Supported embed types: `AppEmbed`, `LiveboardEmbed`
+     * @type {number}
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     * @example
+     * ```js
+     * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
+     * const embed = new <EmbedComponent>('#tsEmbed', {
+     *    ... // other embed view config
+     *    liveboardGutter: 8,
+     * })
+     * ```
+     */
+    liveboardGutter?: number;
+    /**
      * This flag is used to enable or disable the new centralized Liveboard filter UX
      * (v2). When enabled, a unified modal is used to manage and update multiple filters
      * at once, replacing the older individual filter interactions.
@@ -4621,6 +4641,25 @@ export enum HostEvent {
      * @version SDK: 1.21.0 | ThoughtSpot: 9.2.0.cl
      */
     OpenFilter = 'openFilter',
+    /**
+     * Open the add-filter modal of a Liveboard, the same dialog that the
+     * *Add filter* button in the Liveboard edit header opens, so the host
+     * app can start the add-filter flow from its own UI.
+     *
+     * The Liveboard must be in edit mode; the event is ignored otherwise.
+     * Hiding the *Add filter* button with `hiddenActions:
+     * [Action.AddFilter]` does not block this event, but disabling it with
+     * `disabledActions` does.
+     *
+     * Unlike {@link HostEvent.OpenFilter}, which opens the panel of an
+     * existing filter, this event starts the creation of a new filter.
+     * @example
+     * ```js
+     * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
+     * ```
+     * @version SDK: 1.52.0 | ThoughtSpot: 26.8.0.cl
+     */
+    OpenAddFilterModal = 'openAddFilterModal',
     /**
      * Open the parameter panel for a particular parameter on a Liveboard.
      * Mirrors {@link HostEvent.OpenFilter} for parameters.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2141,7 +2141,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {number}
-     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
@@ -4657,7 +4657,7 @@ export enum HostEvent {
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
      * ```
-     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     OpenAddFilterModal = 'openAddFilterModal',
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -4661,6 +4661,22 @@ export enum HostEvent {
      */
     OpenAddFilterModal = 'openAddFilterModal',
     /**
+     * Open the add-parameter panel of a Liveboard, the same panel that the
+     * *Add parameter* button in the Liveboard edit header opens.
+     * Mirrors {@link HostEvent.OpenAddFilterModal} for parameters.
+     *
+     * The Liveboard must be in edit mode; the event is ignored otherwise.
+     * Hiding the *Add parameter* button with `hiddenActions:
+     * [Action.AddParameter]` does not block this event, but disabling it
+     * with `disabledActions` does.
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * liveboardEmbed.trigger(HostEvent.OpenAddParameterModal);
+     * ```
+     */
+    OpenAddParameterModal = 'openAddParameterModal',
+    /**
      * Open the parameter panel for a particular parameter on a Liveboard.
      * Mirrors {@link HostEvent.OpenFilter} for parameters.
      * @param - Includes the following keys:


### PR DESCRIPTION
Adds a liveboardGutter prop to LiveboardViewConfig and AppViewConfig that sets the gutter (in px) between the visualization tiles of an embedded Liveboard grid and its outer layout padding. Maps to the liveboardGutter URL param consumed by the app (main-repo PR #67765). 0 renders tiles flush.

Also documents the new customCSS variable
--ts-var-liveboard-header-horizontal-margin, which controls the left/right margins of the embedded Liveboard header and tab/filter section independently of the gutter.