### PR TITLE
[SCAL-332931] Add isLiveboardAlwaysOn12ColLayout to the Liveboard embed view config

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -758,11 +758,6 @@ export interface CustomCssVariables {
     '--ts-var-liveboard-single-column-breakpoint'?: string;
 
     /**
-     * Minimum width of the Liveboard before it scrolls horizontally.
-     */
-    '--ts-var-liveboard-min-width'?: string;
-
-    /**
      * Background color of the cross filter layout in the Liveboard.
      */
     '--ts-var-liveboard-cross-filter-layout-background'?: string;

--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -758,6 +758,11 @@ export interface CustomCssVariables {
     '--ts-var-liveboard-single-column-breakpoint'?: string;
 
     /**
+     * Minimum width of the Liveboard before it scrolls horizontally.
+     */
+    '--ts-var-liveboard-min-width'?: string;
+
+    /**
      * Background color of the cross filter layout in the Liveboard.
      */
     '--ts-var-liveboard-cross-filter-layout-background'?: string;

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -388,17 +388,17 @@ describe('App embed tests', () => {
         });
     });
 
-    test('should set force12ColLayout to true in url', async () => {
+    test('should set isLiveboardAlwaysOn12ColLayout to true in url', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,
-            force12ColLayout: true,
+            isLiveboardAlwaysOn12ColLayout: true,
         } as AppViewConfig);
 
         appEmbed.render();
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&force12ColLayout=true&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&isLiveboardAlwaysOn12ColLayout=true&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
             );
         });
     });

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -388,6 +388,21 @@ describe('App embed tests', () => {
         });
     });
 
+    test('should set isResponsiveLayoutDisabled to true in url', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            isResponsiveLayoutDisabled: true,
+        } as AppViewConfig);
+
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&isResponsiveLayoutDisabled=true&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
+            );
+        });
+    });
+
     test('should set coverAndFilterOptionInPDF to false in url', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -388,17 +388,17 @@ describe('App embed tests', () => {
         });
     });
 
-    test('should set isResponsiveLayoutDisabled to true in url', async () => {
+    test('should set force12ColLayout to true in url', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,
-            isResponsiveLayoutDisabled: true,
+            force12ColLayout: true,
         } as AppViewConfig);
 
         appEmbed.render();
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&isResponsiveLayoutDisabled=true&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
+                `http://${thoughtSpotHost}/?embedApp=true&profileAndHelpInNavBarHidden=false&force12ColLayout=true&navigationVersion=v3&homepageVersion=v3${defaultParamsPost}#/home`,
             );
         });
     });

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1096,7 +1096,7 @@ export class AppEmbed extends V1Embed {
             enableAskSage,
             collapseSearchBarInitially = false,
             enable2ColumnLayout,
-            isResponsiveLayoutDisabled,
+            force12ColLayout,
             enableCustomColumnGroups = false,
             dataPanelCustomGroupsAccordionInitialState = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL,
             collapseSearchBar = true,
@@ -1256,8 +1256,8 @@ export class AppEmbed extends V1Embed {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
         // Only when true: a false reaches the app as the string 'false'.
-        if (isResponsiveLayoutDisabled) {
-            params[Param.IsResponsiveLayoutDisabled] = isResponsiveLayoutDisabled;
+        if (force12ColLayout) {
+            params[Param.Force12ColLayout] = force12ColLayout;
         }
 
         if (enableAskSage) {

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1255,8 +1255,7 @@ export class AppEmbed extends V1Embed {
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
-        // Only when true: a false reaches the app as the string 'false'.
-        if (force12ColLayout) {
+        if (force12ColLayout !== undefined) {
             params[Param.Force12ColLayout] = force12ColLayout;
         }
 

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1096,7 +1096,7 @@ export class AppEmbed extends V1Embed {
             enableAskSage,
             collapseSearchBarInitially = false,
             enable2ColumnLayout,
-            force12ColLayout,
+            isLiveboardAlwaysOn12ColLayout,
             enableCustomColumnGroups = false,
             dataPanelCustomGroupsAccordionInitialState = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL,
             collapseSearchBar = true,
@@ -1255,8 +1255,8 @@ export class AppEmbed extends V1Embed {
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
-        if (force12ColLayout !== undefined) {
-            params[Param.Force12ColLayout] = force12ColLayout;
+        if (isLiveboardAlwaysOn12ColLayout !== undefined) {
+            params[Param.IsLiveboardAlwaysOn12ColLayout] = isLiveboardAlwaysOn12ColLayout;
         }
 
         if (enableAskSage) {

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1096,6 +1096,7 @@ export class AppEmbed extends V1Embed {
             enableAskSage,
             collapseSearchBarInitially = false,
             enable2ColumnLayout,
+            isResponsiveLayoutDisabled,
             enableCustomColumnGroups = false,
             dataPanelCustomGroupsAccordionInitialState = DataPanelCustomColumnGroupsAccordionState.EXPAND_ALL,
             collapseSearchBar = true,
@@ -1253,6 +1254,10 @@ export class AppEmbed extends V1Embed {
 
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
+        }
+        // Only when true: a false reaches the app as the string 'false'.
+        if (isResponsiveLayoutDisabled) {
+            params[Param.IsResponsiveLayoutDisabled] = isResponsiveLayoutDisabled;
         }
 
         if (enableAskSage) {

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -200,9 +200,9 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
-    test('should set isResponsiveLayoutDisabled to true in url', async () => {
+    test('should set force12ColLayout to true in url', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
-            isResponsiveLayoutDisabled: true,
+            force12ColLayout: true,
             ...defaultViewConfig,
             liveboardId,
         } as LiveboardViewConfig);
@@ -210,7 +210,7 @@ describe('Liveboard/viz embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&isResponsiveLayoutDisabled=true${prefixParams}#/embed/viz/${liveboardId}`,
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&force12ColLayout=true${prefixParams}#/embed/viz/${liveboardId}`,
             );
         });
     });

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -200,6 +200,21 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
+    test('should set isResponsiveLayoutDisabled to true in url', async () => {
+        const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+            isResponsiveLayoutDisabled: true,
+            ...defaultViewConfig,
+            liveboardId,
+        } as LiveboardViewConfig);
+        liveboardEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&isResponsiveLayoutDisabled=true${prefixParams}#/embed/viz/${liveboardId}`,
+            );
+        });
+    });
+
     test('should set isLiveboardStylingAndGroupingEnabled to true in url (deprecated, use isLiveboardMasterpiecesEnabled)', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             isLiveboardStylingAndGroupingEnabled: true,

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -200,9 +200,9 @@ describe('Liveboard/viz embed tests', () => {
         });
     });
 
-    test('should set force12ColLayout to true in url', async () => {
+    test('should set isLiveboardAlwaysOn12ColLayout to true in url', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
-            force12ColLayout: true,
+            isLiveboardAlwaysOn12ColLayout: true,
             ...defaultViewConfig,
             liveboardId,
         } as LiveboardViewConfig);
@@ -210,7 +210,7 @@ describe('Liveboard/viz embed tests', () => {
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
-                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&force12ColLayout=true${prefixParams}#/embed/viz/${liveboardId}`,
+                `http://${thoughtSpotHost}/?embedApp=true${defaultParams}&isLiveboardAlwaysOn12ColLayout=true${prefixParams}#/embed/viz/${liveboardId}`,
             );
         });
     });

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -727,7 +727,7 @@ export class LiveboardEmbed extends V1Embed {
             isEnhancedFilterInteractivityEnabled,
             enableAskSage,
             enable2ColumnLayout,
-            force12ColLayout,
+            isLiveboardAlwaysOn12ColLayout,
             dataPanelV2 = true,
             updatedSpotterExperience,
             enableCustomColumnGroups = false,
@@ -793,8 +793,8 @@ export class LiveboardEmbed extends V1Embed {
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
-        if (force12ColLayout !== undefined) {
-            params[Param.Force12ColLayout] = force12ColLayout;
+        if (isLiveboardAlwaysOn12ColLayout !== undefined) {
+            params[Param.IsLiveboardAlwaysOn12ColLayout] = isLiveboardAlwaysOn12ColLayout;
         }
         if (hideTabPanel) {
             params[Param.HideTabPanel] = hideTabPanel;

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -727,6 +727,7 @@ export class LiveboardEmbed extends V1Embed {
             isEnhancedFilterInteractivityEnabled,
             enableAskSage,
             enable2ColumnLayout,
+            isResponsiveLayoutDisabled,
             dataPanelV2 = true,
             updatedSpotterExperience,
             enableCustomColumnGroups = false,
@@ -791,6 +792,10 @@ export class LiveboardEmbed extends V1Embed {
         }
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
+        }
+        // Only when true: a false reaches the app as the string 'false'.
+        if (isResponsiveLayoutDisabled) {
+            params[Param.IsResponsiveLayoutDisabled] = isResponsiveLayoutDisabled;
         }
         if (hideTabPanel) {
             params[Param.HideTabPanel] = hideTabPanel;

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -727,7 +727,7 @@ export class LiveboardEmbed extends V1Embed {
             isEnhancedFilterInteractivityEnabled,
             enableAskSage,
             enable2ColumnLayout,
-            isResponsiveLayoutDisabled,
+            force12ColLayout,
             dataPanelV2 = true,
             updatedSpotterExperience,
             enableCustomColumnGroups = false,
@@ -794,8 +794,8 @@ export class LiveboardEmbed extends V1Embed {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
         // Only when true: a false reaches the app as the string 'false'.
-        if (isResponsiveLayoutDisabled) {
-            params[Param.IsResponsiveLayoutDisabled] = isResponsiveLayoutDisabled;
+        if (force12ColLayout) {
+            params[Param.Force12ColLayout] = force12ColLayout;
         }
         if (hideTabPanel) {
             params[Param.HideTabPanel] = hideTabPanel;

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -793,8 +793,7 @@ export class LiveboardEmbed extends V1Embed {
         if (enable2ColumnLayout !== undefined) {
             params[Param.Enable2ColumnLayout] = enable2ColumnLayout;
         }
-        // Only when true: a false reaches the app as the string 'false'.
-        if (force12ColLayout) {
+        if (force12ColLayout !== undefined) {
             params[Param.Force12ColLayout] = force12ColLayout;
         }
         if (hideTabPanel) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2042,11 +2042,11 @@ export interface LiveboardAppEmbedViewConfig {
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
      * const embed = new <EmbedComponent>('#tsEmbed', {
      *    ... // other embed view config
-     *    force12ColLayout: true,
+     *    isLiveboardAlwaysOn12ColLayout: true,
      * })
      * ```
      */
-    force12ColLayout?: boolean;
+    isLiveboardAlwaysOn12ColLayout?: boolean;
     /**
      * This flag can be used to enable the compact header in Liveboard
      *
@@ -6787,7 +6787,7 @@ export enum Param {
     NumberFormatLocale = 'numberFormatLocale',
     CurrencyFormat = 'currencyFormat',
     Enable2ColumnLayout = 'enable2ColumnLayout',
-    Force12ColLayout = 'force12ColLayout',
+    IsLiveboardAlwaysOn12ColLayout = 'isLiveboardAlwaysOn12ColLayout',
     IsFullAppEmbed = 'isFullAppEmbed',
     IsOnBeforeGetVizDataInterceptEnabled = 'isOnBeforeGetVizDataInterceptEnabled',
     FocusSearchBarOnRender = 'focusSearchBarOnRender',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2029,6 +2029,26 @@ export interface LiveboardAppEmbedViewConfig {
      */
     enable2ColumnLayout?: boolean;
     /**
+     * This attribute keeps an embedded Liveboard on the 12-column layout at
+     * every width, instead of switching to the two-column or single-column
+     * layout as the container narrows. The Liveboard also has no minimum width
+     * unless `--ts-var-liveboard-min-width` is set.
+     *
+     * Supported embed types: `AppEmbed`, `LiveboardEmbed`
+     * @type {boolean}
+     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
+     * @default false
+     * @example
+     * ```js
+     * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
+     * const embed = new <EmbedComponent>('#tsEmbed', {
+     *    ... // other embed view config
+     *    isResponsiveLayoutDisabled: true,
+     * })
+     * ```
+     */
+    isResponsiveLayoutDisabled?: boolean;
+    /**
      * This flag can be used to enable the compact header in Liveboard
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
@@ -6768,6 +6788,7 @@ export enum Param {
     NumberFormatLocale = 'numberFormatLocale',
     CurrencyFormat = 'currencyFormat',
     Enable2ColumnLayout = 'enable2ColumnLayout',
+    IsResponsiveLayoutDisabled = 'isResponsiveLayoutDisabled',
     IsFullAppEmbed = 'isFullAppEmbed',
     IsOnBeforeGetVizDataInterceptEnabled = 'isOnBeforeGetVizDataInterceptEnabled',
     FocusSearchBarOnRender = 'focusSearchBarOnRender',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2036,7 +2036,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {boolean}
-     * @version SDK: 1.53.0 | ThoughtSpot: 26.10.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @default false
      * @example
      * ```js

--- a/src/types.ts
+++ b/src/types.ts
@@ -2031,8 +2031,7 @@ export interface LiveboardAppEmbedViewConfig {
     /**
      * This attribute keeps an embedded Liveboard on the 12-column layout at
      * every width, instead of switching to the two-column or single-column
-     * layout as the container narrows. The Liveboard also has no minimum width
-     * unless `--ts-var-liveboard-min-width` is set.
+     * layout as the container narrows.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {boolean}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2043,11 +2043,11 @@ export interface LiveboardAppEmbedViewConfig {
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
      * const embed = new <EmbedComponent>('#tsEmbed', {
      *    ... // other embed view config
-     *    isResponsiveLayoutDisabled: true,
+     *    force12ColLayout: true,
      * })
      * ```
      */
-    isResponsiveLayoutDisabled?: boolean;
+    force12ColLayout?: boolean;
     /**
      * This flag can be used to enable the compact header in Liveboard
      *
@@ -6788,7 +6788,7 @@ export enum Param {
     NumberFormatLocale = 'numberFormatLocale',
     CurrencyFormat = 'currencyFormat',
     Enable2ColumnLayout = 'enable2ColumnLayout',
-    IsResponsiveLayoutDisabled = 'isResponsiveLayoutDisabled',
+    Force12ColLayout = 'force12ColLayout',
     IsFullAppEmbed = 'isFullAppEmbed',
     IsOnBeforeGetVizDataInterceptEnabled = 'isOnBeforeGetVizDataInterceptEnabled',
     FocusSearchBarOnRender = 'focusSearchBarOnRender',


### PR DESCRIPTION
## Summary

Embedded Liveboards collapse as the container narrows: to a 2-column layout at
`<= 1024px` and a single column at `<= 630px`. Customers asked for a way to keep
the 12-column layout at every width, and there is currently no opt-out. The
existing `--ts-var-liveboard-dual-column-breakpoint` and
`--ts-var-liveboard-single-column-breakpoint` variables only move the
thresholds and are clamped to a minimum of 500, so the collapse cannot be
switched off.

This PR adds an `isLiveboardAlwaysOn12ColLayout` view config option that turns
it off. The app side reads the param and pins the layout (link below); this PR
only adds the option and puts it on the iframe URL.

```js
new LiveboardEmbed('#tsEmbed', {
    liveboardId: '...',
    isLiveboardAlwaysOn12ColLayout: true,
});
```

## Changes

- `isLiveboardAlwaysOn12ColLayout` on `LiveboardAppEmbedViewConfig`, so it
  covers both `LiveboardEmbed` and `AppEmbed`, with the usual doc block and
  `@version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl`.
- `Param.IsLiveboardAlwaysOn12ColLayout` and serialisation into the iframe URL
  in `liveboard.ts` and `app.ts`, using the same `!== undefined` check as the
  neighbouring params.
- URL param tests for both embed types.

## Testing

- [ ] `yarn test` passes
- [ ] Coverage threshold met
- [ ] Manual verification against a cluster

Tests added:

- `liveboard.spec.ts` - asserts `isLiveboardAlwaysOn12ColLayout=true` reaches
  the iframe URL.
- `app.spec.ts` - the same for `AppEmbed`.

Both mirror the existing `enable2ColumnLayout` cases.

## Additional Notes

- Companion app PR: `<link>`. The option has no effect until that ships.
- Because the param is serialised whenever it is defined, an explicit `false`
  reaches the app as the string `'false'`. The app side compares against `true`
  and `'true'` so that reads as disabled. Worth knowing if the check there is
  ever simplified.
- Please confirm the `@version` tag. `1.53.0 | 26.10.0.cl` matches the newest
  in-flight version in `types.ts`, but `package.json` is on 1.51.0, so the
  target release needs checking before merge.
- No `CHANGELOG.md` entry: the file has not been maintained since 1.14.x and
  defers to the developer docs for the change list.
- A customer-settable minimum width for the Liveboard is deliberately out of
  scope. With `isLiveboardAlwaysOn12ColLayout` set there is no floor, so tiles
  keep shrinking however narrow the container gets.
