### PR TITLE
SCAL-333657: report how a host event resolved and how long it took (PR 2)

### DIFF
--- a/src/embed/host-event-telemetry.spec.ts
+++ b/src/embed/host-event-telemetry.spec.ts
@@ -12,6 +12,7 @@ import * as authInstance from '../auth';
 import * as mixpanelInstance from '../mixpanel-service';
 import { MIXPANEL_EVENT } from '../mixpanel-service';
 import * as processTriggerInstance from '../utils/processTrigger';
+import * as telemetryInstance from '../utils/hostEventTelemetry';
 
 describe('Host event parameter telemetry', () => {
     let mockUploadMixpanelEvent: jest.SpyInstance;
@@ -69,6 +70,18 @@ describe('Host event parameter telemetry', () => {
                 hostEventId: expect.stringMatching(/^he-\d+$/),
             }),
         );
+    });
+
+    test('telemetry that throws cannot reach the host application', async () => {
+        const embed = await renderLiveboard();
+        mockUploadMixpanelEvent.mockClear();
+        jest.spyOn(telemetryInstance, 'reportHostEventOutcome').mockImplementation(() => {
+            throw new Error('telemetry exploded');
+        });
+
+        await expect(
+            embed.trigger(HostEvent.DownloadAsCsv, { vizId: 'd0a1' }),
+        ).resolves.toEqual({ session: 'ok' });
     });
 
     test('gives every trigger its own id', async () => {

--- a/src/embed/host-event-telemetry.spec.ts
+++ b/src/embed/host-event-telemetry.spec.ts
@@ -2,6 +2,8 @@ import {
     init, AuthType, LiveboardEmbed, HostEvent, RuntimeFilterOp,
 } from '../index';
 import { getDocumentBody, getRootEl } from '../test/test-utils';
+import { ERROR_MESSAGE } from '../errors';
+import { logger } from '../utils/logger';
 import * as authInstance from '../auth';
 import * as mixpanelInstance from '../mixpanel-service';
 import { MIXPANEL_EVENT } from '../mixpanel-service';
@@ -9,13 +11,16 @@ import * as processTriggerInstance from '../utils/processTrigger';
 
 describe('Host event parameter telemetry', () => {
     let mockUploadMixpanelEvent: jest.SpyInstance;
+    let mockProcessTrigger: jest.SpyInstance;
 
     beforeEach(() => {
         document.body.innerHTML = getDocumentBody();
         jest.spyOn(authInstance, 'postLoginService').mockImplementation(
             () => Promise.resolve(true as any),
         );
-        jest.spyOn(processTriggerInstance, 'processTrigger').mockResolvedValue({ session: 'ok' });
+        mockProcessTrigger = jest
+            .spyOn(processTriggerInstance, 'processTrigger')
+            .mockResolvedValue({ session: 'ok' });
         mockUploadMixpanelEvent = jest.spyOn(mixpanelInstance, 'uploadMixpanelEvent');
     });
 
@@ -54,8 +59,46 @@ describe('Host event parameter telemetry', () => {
                 contextType: 'none',
                 params: { vizId: 'string' },
                 paramKeys: ['vizId'],
+                status: 'success',
+                durationMs: expect.any(Number),
             }),
         );
+    });
+
+    test('reports a trigger the embedded app never answered as timed out', async () => {
+        mockProcessTrigger.mockResolvedValue(new Error(ERROR_MESSAGE.TRIGGER_TIMED_OUT));
+        const embed = await renderLiveboard();
+        mockUploadMixpanelEvent.mockClear();
+
+        await embed.trigger(HostEvent.DownloadAsCsv, { vizId: 'd0a1' });
+
+        expect(triggerProps(HostEvent.DownloadAsCsv).status).toBe('timed-out');
+    });
+
+    test('reports a failed trigger without its error message', async () => {
+        mockProcessTrigger.mockRejectedValue(new Error('Answer 4c8a1b2e not found'));
+        const embed = await renderLiveboard();
+        mockUploadMixpanelEvent.mockClear();
+
+        await expect(embed.trigger(HostEvent.DownloadAsCsv, { vizId: 'd0a1' })).rejects.toThrow();
+
+        const props = triggerProps(HostEvent.DownloadAsCsv);
+        expect(props.status).toBe('error');
+        expect(JSON.stringify(props)).not.toContain('4c8a1b2e');
+    });
+
+    test('reports a trigger called before render', async () => {
+        jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+        init({ thoughtSpotHost: 'https://tshost', authType: AuthType.None });
+        const embed = new LiveboardEmbed(getRootEl(), {
+            frameParams: { width: '100%', height: '100%' },
+            liveboardId: '4c8a1b2e-0000-0000-0000-000000000001',
+        });
+        mockUploadMixpanelEvent.mockClear();
+
+        await embed.trigger(HostEvent.DownloadAsCsv, { vizId: 'd0a1' });
+
+        expect(triggerProps(HostEvent.DownloadAsCsv).status).toBe('render-not-called');
     });
 
     test('keeps the existing event name, so existing reports still work', async () => {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -71,7 +71,8 @@ import {
     BaseViewConfig,
 } from '../types';
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
-import { getHostEventTelemetryProps } from '../utils/hostEventTelemetry';
+import { getHostEventTelemetryProps, HostEventStatus } from '../utils/hostEventTelemetry';
+import { isTriggerTimeout } from '../utils/processTrigger';
 import { processEventData, processAuthFailure } from '../utils/processData';
 import { version } from '../utils/sdk-version';
 import {
@@ -1680,17 +1681,23 @@ export class TsEmbed {
         data: TriggerPayload<PayloadT, HostEventT> = {} as any,
         context?: ContextT,
     ): Promise<TriggerResponse<PayloadT, HostEventT, ContextT>> {
-        uploadMixpanelEvent(
-            `${MIXPANEL_EVENT.VISUAL_SDK_TRIGGER}-${messageType}`,
-            getHostEventTelemetryProps({
-                hostEvent: messageType,
-                payload: data,
-                context,
-                embedComponentType: this.viewConfig?.embedComponentType,
-            }),
-        );
+        const triggerStartedAt = Date.now();
+        const reportHostEvent = (status: HostEventStatus) => {
+            uploadMixpanelEvent(
+                `${MIXPANEL_EVENT.VISUAL_SDK_TRIGGER}-${messageType}`,
+                getHostEventTelemetryProps({
+                    hostEvent: messageType,
+                    payload: data,
+                    context,
+                    embedComponentType: this.viewConfig?.embedComponentType,
+                    status,
+                    durationMs: Date.now() - triggerStartedAt,
+                }),
+            );
+        };
 
         if (!this.isRendered) {
+            reportHostEvent('render-not-called');
             this.handleError({
                 errorType: ErrorDetailsTypes.VALIDATION_ERROR,
                 message: ERROR_MESSAGE.RENDER_BEFORE_EVENTS_REQUIRED,
@@ -1701,6 +1708,7 @@ export class TsEmbed {
         }
 
         if (!messageType) {
+            reportHostEvent('host-event-undefined');
             this.handleError({
                 errorType: ErrorDetailsTypes.VALIDATION_ERROR,
                 message: ERROR_MESSAGE.HOST_EVENT_TYPE_UNDEFINED,
@@ -1716,11 +1724,17 @@ export class TsEmbed {
             logger.debug(
                 `Cannot trigger ${messageType} - iframe not available (likely due to auth failure)`,
             );
+            reportHostEvent('no-iframe');
             return null;
         }
 
         // send an empty object, this is needed for liveboard default handlers
-        return this.hostEventClient.triggerHostEvent(messageType, data, context).catch(
+        return this.hostEventClient.triggerHostEvent(messageType, data, context).then(
+            (response) => {
+                reportHostEvent(isTriggerTimeout(response) ? 'timed-out' : 'success');
+                return response;
+            },
+        ).catch(
             (
                 err: Error & {
                     isValidationError?: boolean;
@@ -1741,6 +1755,7 @@ export class TsEmbed {
                     };
                     this.handleError(errorDetails);
                 }
+                reportHostEvent('error');
                 throw err;
             },
         );

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -1721,15 +1721,7 @@ export class TsEmbed {
         }
 
         // send an empty object, this is needed for liveboard default handlers
-        return this.hostEventClient.triggerHostEvent(messageType, data, context).then(
-            (response) => {
-                reportHostEventOutcome(
-                    hostEventId,
-                    isTriggerTimeout(response) ? 'timed-out' : 'success',
-                );
-                return response;
-            },
-        ).catch(
+        const triggered = this.hostEventClient.triggerHostEvent(messageType, data, context).catch(
             (
                 err: Error & {
                     isValidationError?: boolean;
@@ -1750,10 +1742,22 @@ export class TsEmbed {
                     };
                     this.handleError(errorDetails);
                 }
-                reportHostEventOutcome(hostEventId, 'error');
                 throw err;
             },
         );
+
+        // Observed, not chained: the promise handed back is the one the host
+        // application would have got without telemetry, so nothing reported
+        // here can change what it sees.
+        triggered.then(
+            (response) => reportHostEventOutcome(
+                hostEventId,
+                isTriggerTimeout(response) ? 'timed-out' : 'success',
+            ),
+            () => reportHostEventOutcome(hostEventId, 'error'),
+        ).catch((e) => logger.debug('Could not report host event outcome', e));
+
+        return triggered;
     }
 
     /**

--- a/src/utils/hostEventTelemetry.ts
+++ b/src/utils/hostEventTelemetry.ts
@@ -41,16 +41,28 @@ export const describeParams = (payload: unknown): Record<string, string> => {
     return mapKeys(mapValues(params as object, paramType), (_type, key) => paramName(key));
 };
 
+export type HostEventStatus =
+    | 'success'
+    | 'error'
+    | 'timed-out'
+    | 'render-not-called'
+    | 'host-event-undefined'
+    | 'no-iframe';
+
 export const getHostEventTelemetryProps = ({
     hostEvent,
     payload,
     context,
     embedComponentType,
+    status,
+    durationMs,
 }: {
     hostEvent: HostEvent;
     payload?: unknown;
     context?: ContextType;
     embedComponentType?: string;
+    status?: HostEventStatus;
+    durationMs?: number;
 }) => {
     const params = describeParams(payload);
     return {
@@ -60,5 +72,7 @@ export const getHostEventTelemetryProps = ({
         sdkVersion,
         params,
         paramKeys: Object.keys(params),
+        ...(status ? { status } : {}),
+        ...(durationMs === undefined ? {} : { durationMs }),
     };
 };

--- a/src/utils/processTrigger.ts
+++ b/src/utils/processTrigger.ts
@@ -37,6 +37,9 @@ function postIframeMessage(
 
 export const TRIGGER_TIMEOUT = 30000;
 
+export const isTriggerTimeout = (value: unknown): boolean => value instanceof Error
+    && value.message === ERROR_MESSAGE.TRIGGER_TIMED_OUT;
+
 /**
  *
  * @param iFrame


### PR DESCRIPTION
[SCAL-333657](https://thoughtspot.atlassian.net/browse/SCAL-333657) · epic [SCAL-325536](https://thoughtspot.atlassian.net/browse/SCAL-325536)

> **PR 2, stacked on #635.** Base is `SCAL-333657`, not `main` — review #635 first, and this diff shows only what PR 2 adds.

**Did the host event work, and how long did it take.**

PR 1 answers *which host event, with which parameters*. It says nothing about whether the trigger succeeded, so a host event that times out for 30 seconds looks exactly like one that works.

## What this adds

Two properties on the same upload:

| | |
|---|---|
| `status` | `success` · `error` · `timed-out` · `render-not-called` · `host-event-undefined` · `no-iframe` |
| `durationMs` | how long the trigger took to settle |

The three non-dispatch statuses matter on their own: `render-not-called` and `no-iframe` are integration mistakes in the host application that are currently invisible, and `no-iframe` in particular happens after an auth failure.

## `timed-out` needs saying out loud

`processTrigger` **resolves** — it does not reject — with `Error(TRIGGER_TIMED_OUT)` after 30 seconds. So without a check for that sentinel, a trigger the embedded app never answered reports as a **success**. That is the single most misleading thing telemetry could say here, which is why the check is in this PR rather than a later one.

`isTriggerTimeout` is a new export in `processTrigger`; it changes no behaviour.

An error's *message* is never uploaded — only the status — because it can echo customer data back. There is a test asserting a GUID from an error message does not appear in the properties.

## One behaviour change, on purpose

The upload moves from **call time to settle time**, because neither the outcome nor the duration exists until the trigger finishes. Same event name, same properties as PR 1, just later by the round trip.

That is the trade this PR asks for: outcome data in exchange for a delayed event. If you would rather keep the call-time event and add a second one at settle, say so — it is a small change, but it doubles the upload count per trigger.

## Testing

Four new cases in `src/embed/host-event-telemetry.spec.ts`: a successful trigger carrying `status` and `durationMs`, a trigger the app never answered reported as `timed-out`, a failed trigger with its error message asserted absent, and a trigger before `render()`.

Full suite **1707 passed** (47 files), `tsc` clean, lint 0 errors.

## Still to come

- **PR 3** — the response story, both directions: whether the trigger was answered and with what shape, and the same for an embed event handed a responder via `on(ApiIntercept, responder)`.
- **PR 4** — embed event tracking: which embed events arrive, their payload shape, how many handlers each dispatch ran.
- **PR 5** — the bug fixes: the same 30s timeout is lost entirely for `Pin`/`SaveAnswer`/`UpdateFilters`/`DrillDown`, where a custom handler turns it into a generic error; and the pre-init Mixpanel queue is unbounded when `disableSDKTracking` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCAL-333657]: https://thoughtspot.atlassian.net/browse/SCAL-333657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCAL-325536]: https://thoughtspot.atlassian.net/browse/SCAL-325536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ