### PR TITLE
SCAL-333385 Default lazy loading on for full-height embeds

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -76,3 +76,4 @@ export const URL_MAX_LENGTH = 2000;
  */
 export const DEFAULT_EMBED_WIDTH = '100%';
 export const DEFAULT_EMBED_HEIGHT = '100%';
+export const DEFAULT_LAZY_LOADING_MARGIN = '500px 0px';

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -2159,6 +2159,238 @@ describe('App embed tests', () => {
             }, 100);
         });
 
+        test('should default lazy loading flags to true when fullHeight is enabled', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+            } as AppViewConfig);
+
+            expect((appEmbed as any).viewConfig.lazyLoadingForFullHeight).toBe(true);
+            expect((appEmbed as any).viewConfig.enableScrollableContainerLazyLoading).toBe(true);
+            expect((appEmbed as any).viewConfig.lazyLoadingMargin).toBe('500px 0px');
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('isLazyLoadingForEmbedEnabled=true');
+                expect(iframeSrc).toContain('isFullHeightPinboard=true');
+                expect(iframeSrc).toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should not default lazy loading flags when fullHeight is not enabled', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+            } as AppViewConfig);
+
+            expect((appEmbed as any).viewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(
+                (appEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBeUndefined();
+            expect((appEmbed as any).viewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should not write the defaults back onto the caller view config', async () => {
+            const callerViewConfig = {
+                ...defaultViewConfig,
+                fullHeight: true,
+            } as AppViewConfig;
+
+            new AppEmbed(getRootEl(), callerViewConfig);
+
+            expect(callerViewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(callerViewConfig.enableScrollableContainerLazyLoading).toBeUndefined();
+            expect(callerViewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should not default lazy loading flags when fullHeight is explicitly false', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: false,
+            } as AppViewConfig);
+
+            expect((appEmbed as any).viewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(
+                (appEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBeUndefined();
+            expect((appEmbed as any).viewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should default lazyLoadingMargin when lazyLoadingForFullHeight is set explicitly', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+                lazyLoadingForFullHeight: true,
+            } as AppViewConfig);
+
+            expect((appEmbed as any).viewConfig.lazyLoadingMargin).toBe(
+                config.DEFAULT_LAZY_LOADING_MARGIN,
+            );
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(getIFrameSrc()).toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should let an explicit lazyLoadingMargin win over the default', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+                lazyLoadingMargin: '250px',
+            } as AppViewConfig);
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('rootMarginForLazyLoad=250px');
+                expect(iframeSrc).not.toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should drop an invalid lazyLoadingMargin and log an error', async () => {
+            const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+                lazyLoadingMargin: 'not-a-margin',
+            } as AppViewConfig);
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('isLazyLoadingForEmbedEnabled=true');
+                expect(iframeSrc).not.toContain('rootMarginForLazyLoad');
+                expect(loggerErrorSpy).toHaveBeenCalledWith(
+                    'Please provide a valid lazyLoadingMargin value (e.g., "10px")',
+                );
+            }, 100);
+        });
+
+        test('should track scrollable ancestors by default when only fullHeight is set', async () => {
+            const scrollContainer = getRootEl();
+            scrollContainer.style.overflow = 'auto';
+
+            const scrollContainerSpy = jest.spyOn(scrollContainer, 'addEventListener');
+            const resizeObserveSpy = jest.fn();
+            const resizeDisconnectSpy = jest.fn();
+            (window as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+                observe: resizeObserveSpy,
+                disconnect: resizeDisconnectSpy,
+            }));
+
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+            } as AppViewConfig);
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(scrollContainerSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+                expect(resizeObserveSpy).toHaveBeenCalledWith(scrollContainer);
+            }, 100);
+
+            appEmbed.destroy();
+            expect(resizeDisconnectSpy).toHaveBeenCalled();
+
+            scrollContainer.style.overflow = '';
+            (window as any).ResizeObserver = originalResizeObserver;
+        });
+
+        test('should skip ancestor tracking when enableScrollableContainerLazyLoading is false', async () => {
+            const scrollContainer = getRootEl();
+            scrollContainer.style.overflow = 'auto';
+
+            const scrollContainerSpy = jest.spyOn(scrollContainer, 'addEventListener');
+            const windowSpy = jest.spyOn(window, 'addEventListener');
+
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+                enableScrollableContainerLazyLoading: false,
+            } as AppViewConfig);
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(windowSpy).toHaveBeenCalledWith('scroll', expect.anything(), true);
+                expect(scrollContainerSpy).not.toHaveBeenCalledWith('scroll', expect.any(Function));
+            }, 100);
+
+            appEmbed.destroy();
+            scrollContainer.style.overflow = '';
+        });
+
+        test('should wire the window scroll listener to the coordinates sender by default', async () => {
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+            } as AppViewConfig);
+
+            const mockTrigger = jest
+                .spyOn(appEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+
+            await appEmbed.render();
+
+            await executeAfterWait(() => {
+                const scrollCall = addEventListenerSpy.mock.calls.find(
+                    ([eventName, , capture]) => eventName === 'scroll' && capture === true,
+                );
+                expect(scrollCall).toBeDefined();
+
+                // Call the handler the way a real scroll event would.
+                (scrollCall as any)[1]();
+
+                expect(mockTrigger).toHaveBeenCalledWith(
+                    HostEvent.VisibleEmbedCoordinates,
+                    expect.objectContaining({ top: expect.any(Number) }),
+                );
+            }, 100);
+
+            appEmbed.destroy();
+            addEventListenerSpy.mockRestore();
+        });
+
+        test('should remove listeners on destroy when the flags come from defaults', async () => {
+            const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+            } as AppViewConfig);
+
+            await appEmbed.render();
+            appEmbed.destroy();
+
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.anything());
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.anything(), true);
+
+            removeEventListenerSpy.mockRestore();
+        });
+
+        test('should keep an explicit false for the lazy loading flags', async () => {
+            const appEmbed = new AppEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                fullHeight: true,
+                lazyLoadingForFullHeight: false,
+                enableScrollableContainerLazyLoading: false,
+                lazyLoadingMargin: '0px',
+            } as AppViewConfig);
+
+            expect((appEmbed as any).viewConfig.lazyLoadingForFullHeight).toBe(false);
+            expect((appEmbed as any).viewConfig.enableScrollableContainerLazyLoading).toBe(false);
+            expect((appEmbed as any).viewConfig.lazyLoadingMargin).toBe('0px');
+        });
+
         test('should not set lazyLoadingForEmbed when lazyLoadingForFullHeight is enabled but fullHeight is false', async () => {
             const appEmbed = new AppEmbed(getRootEl(), {
                 ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -10,6 +10,7 @@
 
 import { logger } from '../utils/logger';
 import { calculateVisibleElementData, getEffectiveClippingAncestors, getQueryParamString, getScrollableAncestors, isUndefined, isValidCssMargin, setParamIfDefined } from '../utils';
+import { DEFAULT_LAZY_LOADING_MARGIN } from '../config';
 import {
     Param,
     DOMSelector,
@@ -475,6 +476,11 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      * `false` fetches visualizations incrementally as
      * users scroll the page to view the charts and tables.
      *
+     * From SDK 1.52.0, enabling `fullHeight` also turns on
+     * {@link lazyLoadingForFullHeight} and
+     * {@link enableScrollableContainerLazyLoading}, so visualizations load as
+     * they scroll into view. Set either flag to `false` to opt out.
+     *
      * Supported embed types: `AppEmbed`
      * @version SDK: 1.21.0 | ThoughtSpot: 9.4.0.cl, 9.4.0-sw
      * @example
@@ -688,11 +694,17 @@ export interface AppViewConfig extends AllEmbedViewConfig {
     isGranularXLSXCSVSchedulesEnabled?: boolean;
 
     /**
-     * This flag is used to enable the full height lazy load data.
+     * Loads visualizations only as they scroll into the viewport, instead of
+     * loading the whole full-height Liveboard at once.
+     *
+     * From SDK 1.52.0 this is enabled automatically whenever `fullHeight` is
+     * `true`. On SDK 1.51.0 and earlier it defaulted to `false` and had to be
+     * set explicitly. Set it to `false` to load every visualization upfront.
+     * The flag has no effect unless `fullHeight` is enabled.
      *
      * @type {boolean}
      * @version SDK: 1.40.0 | ThoughtSpot: 10.12.0.cl
-     * @default false
+     * @default true when `fullHeight` is enabled, from SDK 1.52.0
      * @example
      * ```js
      * const embed = new AppEmbed('#embed-container', {
@@ -704,28 +716,44 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      */
     lazyLoadingForFullHeight?: boolean;
     /**
-     * This flag is used to enable container-aware full height lazy loading.
+     * Computes the visible region of the embed against its scrollable and
+     * clipping ancestors, instead of treating the browser window as the only
+     * viewport, and tracks scroll and resize on those ancestors.
      *
-     * Use this when the embed is rendered inside a scrollable or clipping
-     * container instead of relying on the browser window as the only viewport.
+     * From SDK 1.52.0 this is enabled automatically whenever `fullHeight` is
+     * `true`. On SDK 1.51.0 and earlier it defaulted to `false` and had to be
+     * set explicitly. Set it to `false` when the page scrolls with the window
+     * and the embed has no clipping ancestor, to skip the extra ancestor
+     * tracking.
      *
      * @type {boolean}
-     * @default false
+     * @default true when `fullHeight` is enabled, from SDK 1.52.0
      * @hidden
      */
     enableScrollableContainerLazyLoading?: boolean;
 
     /**
-     * The margin to be used for lazy loading.
+     * How far outside the viewport a visualization starts loading, when
+     * {@link lazyLoadingForFullHeight} is enabled.
      *
      * For example, if the margin is set to '10px',
      * the visualization will be loaded 10px before its top edge is visible in the
      * viewport.
      *
-     * The format is similar to CSS margin.
+     * The format is similar to CSS margin, so `'500px 0px'` extends the
+     * prefetch 500px above and below the viewport and not sideways. Accepted
+     * units are `px`, `em`, `rem`, `%`, `vh` and `vw`, plus bare `0` and
+     * `auto`; an invalid value is logged and ignored.
+     *
+     * From SDK 1.52.0 this defaults to `'500px 0px'` — roughly one
+     * visualization ahead of the scroll position, so a chart has usually
+     * finished loading by the time it scrolls into view. Use a smaller margin
+     * to cut warehouse queries further, or `'0px'` to load a visualization
+     * only once it is actually visible.
      *
      * @type {string}
      * @version SDK: 1.40.0 | ThoughtSpot: 10.12.0.cl
+     * @default '500px 0px' when `fullHeight` is enabled, from SDK 1.52.0
      * @example
      * ```js
      * const embed = new AppEmbed('#embed-container', {
@@ -1026,6 +1054,16 @@ export class AppEmbed extends V1Embed {
         viewConfig.embedComponentType = 'AppEmbed';
         super(domSelector, viewConfig);
         if (this.viewConfig.fullHeight === true) {
+            if (this.viewConfig.lazyLoadingForFullHeight === undefined) {
+                this.viewConfig.lazyLoadingForFullHeight = true;
+            }
+            if (this.viewConfig.enableScrollableContainerLazyLoading === undefined) {
+                this.viewConfig.enableScrollableContainerLazyLoading = true;
+            }
+            if (this.viewConfig.lazyLoadingMargin === undefined) {
+                this.viewConfig.lazyLoadingMargin = DEFAULT_LAZY_LOADING_MARGIN;
+            }
+
             this.on(EmbedEvent.RouteChange, this.setIframeHeightForNonEmbedLiveboard);
             this.on(EmbedEvent.EmbedHeight, this.updateIFrameHeight);
             this.on(EmbedEvent.EmbedIframeCenter, this.embedIframeCenter);

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -28,6 +28,7 @@ import * as auth from '../auth';
 import * as previewService from '../utils/graphql/preview-service';
 import * as SessionInfoService from '../utils/sessionInfoService';
 import { logger } from '../utils/logger';
+import { DEFAULT_LAZY_LOADING_MARGIN } from '../config';
 
 const defaultViewConfig = {
     frameParams: {
@@ -2051,6 +2052,255 @@ describe('Liveboard/viz embed tests', () => {
             }, 100);
         });
 
+        test('should default lazy loading flags to true when fullHeight is enabled', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+            } as LiveboardViewConfig);
+
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingForFullHeight).toBe(true);
+            expect(
+                (liveboardEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBe(true);
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingMargin).toBe('500px 0px');
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('isLazyLoadingForEmbedEnabled=true');
+                expect(iframeSrc).toContain('isFullHeightPinboard=true');
+                expect(iframeSrc).toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should not default lazy loading flags when fullHeight is not enabled', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+            } as LiveboardViewConfig);
+
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(
+                (liveboardEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBeUndefined();
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should not write the defaults back onto the caller view config', async () => {
+            const callerViewConfig = {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+            } as LiveboardViewConfig;
+
+            new LiveboardEmbed(getRootEl(), callerViewConfig);
+
+            expect(callerViewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(callerViewConfig.enableScrollableContainerLazyLoading).toBeUndefined();
+            expect(callerViewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should not default lazy loading flags when fullHeight is explicitly false', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: false,
+            } as LiveboardViewConfig);
+
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingForFullHeight).toBeUndefined();
+            expect(
+                (liveboardEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBeUndefined();
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingMargin).toBeUndefined();
+        });
+
+        test('should default lazyLoadingMargin when lazyLoadingForFullHeight is set explicitly', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+                lazyLoadingForFullHeight: true,
+            } as LiveboardViewConfig);
+
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingMargin).toBe(
+                DEFAULT_LAZY_LOADING_MARGIN,
+            );
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(getIFrameSrc()).toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should let an explicit lazyLoadingMargin win over the default', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+                lazyLoadingMargin: '250px',
+            } as LiveboardViewConfig);
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('rootMarginForLazyLoad=250px');
+                expect(iframeSrc).not.toContain('rootMarginForLazyLoad=500px%200px');
+            }, 100);
+        });
+
+        test('should drop an invalid lazyLoadingMargin and log an error', async () => {
+            const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+                lazyLoadingMargin: 'not-a-margin',
+            } as LiveboardViewConfig);
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                const iframeSrc = getIFrameSrc();
+                expect(iframeSrc).toContain('isLazyLoadingForEmbedEnabled=true');
+                expect(iframeSrc).not.toContain('rootMarginForLazyLoad');
+                expect(loggerErrorSpy).toHaveBeenCalledWith(
+                    'Please provide a valid lazyLoadingMargin value (e.g., "10px")',
+                );
+            }, 100);
+        });
+
+        test('should track scrollable ancestors by default when only fullHeight is set', async () => {
+            const scrollContainer = getRootEl();
+            scrollContainer.style.overflow = 'auto';
+
+            const scrollContainerSpy = jest.spyOn(scrollContainer, 'addEventListener');
+            const resizeObserveSpy = jest.fn();
+            const resizeDisconnectSpy = jest.fn();
+            const originalResizeObserver = (window as any).ResizeObserver;
+            (window as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+                observe: resizeObserveSpy,
+                disconnect: resizeDisconnectSpy,
+            }));
+
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+            } as LiveboardViewConfig);
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(scrollContainerSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+                expect(resizeObserveSpy).toHaveBeenCalledWith(scrollContainer);
+            }, 100);
+
+            liveboardEmbed.destroy();
+            expect(resizeDisconnectSpy).toHaveBeenCalled();
+
+            scrollContainer.style.overflow = '';
+            (window as any).ResizeObserver = originalResizeObserver;
+        });
+
+        test('should skip ancestor tracking when enableScrollableContainerLazyLoading is false', async () => {
+            const scrollContainer = getRootEl();
+            scrollContainer.style.overflow = 'auto';
+
+            const scrollContainerSpy = jest.spyOn(scrollContainer, 'addEventListener');
+            const windowSpy = jest.spyOn(window, 'addEventListener');
+
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+                enableScrollableContainerLazyLoading: false,
+            } as LiveboardViewConfig);
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                expect(windowSpy).toHaveBeenCalledWith('scroll', expect.anything(), true);
+                expect(scrollContainerSpy).not.toHaveBeenCalledWith('scroll', expect.any(Function));
+            }, 100);
+
+            liveboardEmbed.destroy();
+            scrollContainer.style.overflow = '';
+        });
+
+        test('should wire the window scroll listener to the coordinates sender by default', async () => {
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+            } as LiveboardViewConfig);
+
+            const mockTrigger = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+
+            await liveboardEmbed.render();
+
+            await executeAfterWait(() => {
+                const scrollCall = addEventListenerSpy.mock.calls.find(
+                    ([eventName, , capture]) => eventName === 'scroll' && capture === true,
+                );
+                expect(scrollCall).toBeDefined();
+
+                // Call the handler the way a real scroll event would.
+                (scrollCall as any)[1]();
+
+                expect(mockTrigger).toHaveBeenCalledWith(
+                    HostEvent.VisibleEmbedCoordinates,
+                    expect.objectContaining({ top: expect.any(Number) }),
+                );
+            }, 100);
+
+            liveboardEmbed.destroy();
+            addEventListenerSpy.mockRestore();
+        });
+
+        test('should remove listeners on destroy when the flags come from defaults', async () => {
+            const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+            } as LiveboardViewConfig);
+
+            await liveboardEmbed.render();
+            liveboardEmbed.destroy();
+
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.anything());
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.anything(), true);
+
+            removeEventListenerSpy.mockRestore();
+        });
+
+        test('should keep an explicit false for the lazy loading flags', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                ...defaultViewConfig,
+                liveboardId,
+                fullHeight: true,
+                lazyLoadingForFullHeight: false,
+                enableScrollableContainerLazyLoading: false,
+                lazyLoadingMargin: '0px',
+            } as LiveboardViewConfig);
+
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingForFullHeight).toBe(false);
+            expect(
+                (liveboardEmbed as any).viewConfig.enableScrollableContainerLazyLoading,
+            ).toBe(false);
+            expect((liveboardEmbed as any).viewConfig.lazyLoadingMargin).toBe('0px');
+        });
+
         test('should not set lazyLoadingForEmbed when lazyLoadingForFullHeight is enabled but fullHeight is false', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 ...defaultViewConfig,
@@ -2130,7 +2380,7 @@ describe('Liveboard/viz embed tests', () => {
             });
         });
 
-        test('should send correct visible data when RequestVisibleEmbedCoordinates is triggered', async () => {
+        test('should send visible data when fullHeight is enabled and lazyLoadingForFullHeight is omitted', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 ...defaultViewConfig,
                 liveboardId,
@@ -2145,7 +2395,7 @@ describe('Liveboard/viz embed tests', () => {
             // Trigger the lazy load data calculation
             (liveboardEmbed as any).sendFullHeightLazyLoadData();
 
-            expect(mockTrigger).not.toHaveBeenCalledWith(HostEvent.VisibleEmbedCoordinates, {
+            expect(mockTrigger).toHaveBeenCalledWith(HostEvent.VisibleEmbedCoordinates, {
                 top: 0,
                 height: 500,
                 left: 0,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -26,6 +26,7 @@ import {
     DefaultAppInitData,
 } from '../types';
 import { calculateVisibleElementData, getEffectiveClippingAncestors, getQueryParamString, getScrollableAncestors, isUndefined, isValidCssMargin, setParamIfDefined } from '../utils';
+import { DEFAULT_LAZY_LOADING_MARGIN } from '../config';
 import { getAuthPromise } from './base';
 import { TsEmbed, V1Embed } from './ts-embed';
 import { addPreviewStylesIfNotPresent } from '../utils/global-styles';
@@ -62,6 +63,11 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      * visualizations to display on the screen.
      * Setting `fullHeight` to `false` fetches visualizations
      * incrementally as users scroll the page to view the charts and tables.
+     *
+     * From SDK 1.52.0, enabling `fullHeight` also turns on
+     * {@link lazyLoadingForFullHeight} and
+     * {@link enableScrollableContainerLazyLoading}, so visualizations load as
+     * they scroll into view. Set either flag to `false` to opt out.
      *
      *
      * Supported embed types: `LiveboardEmbed`
@@ -457,11 +463,17 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      */
     isGranularXLSXCSVSchedulesEnabled?: boolean;
     /**
-     * This flag is used to enable the full height lazy load data.
+     * Loads visualizations only as they scroll into the viewport, instead of
+     * loading the whole full-height Liveboard at once.
+     *
+     * From SDK 1.52.0 this is enabled automatically whenever `fullHeight` is
+     * `true`. On SDK 1.51.0 and earlier it defaulted to `false` and had to be
+     * set explicitly. Set it to `false` to load every visualization upfront.
+     * The flag has no effect unless `fullHeight` is enabled.
      *
      * @type {boolean}
      * @version SDK: 1.40.0 | ThoughtSpot: 10.12.0.cl
-     * @default false
+     * @default true when `fullHeight` is enabled, from SDK 1.52.0
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#embed-container', {
@@ -473,26 +485,42 @@ export interface LiveboardViewConfig extends BaseViewConfig, LiveboardOtherViewC
      */
     lazyLoadingForFullHeight?: boolean;
     /**
-     * This flag is used to enable container-aware full height lazy loading.
+     * Computes the visible region of the embed against its scrollable and
+     * clipping ancestors, instead of treating the browser window as the only
+     * viewport, and tracks scroll and resize on those ancestors.
      *
-     * Use this when the embed is rendered inside a scrollable or clipping
-     * container instead of relying on the browser window as the only viewport.
+     * From SDK 1.52.0 this is enabled automatically whenever `fullHeight` is
+     * `true`. On SDK 1.51.0 and earlier it defaulted to `false` and had to be
+     * set explicitly. Set it to `false` when the page scrolls with the window
+     * and the embed has no clipping ancestor, to skip the extra ancestor
+     * tracking.
      *
      * @type {boolean}
-     * @default false
+     * @default true when `fullHeight` is enabled, from SDK 1.52.0
      */
     enableScrollableContainerLazyLoading?: boolean;
     /**
-     * The margin to be used for lazy loading.
+     * How far outside the viewport a visualization starts loading, when
+     * {@link lazyLoadingForFullHeight} is enabled.
      *
      * For example, if the margin is set to '10px',
      * the visualization will be loaded 10px before its top edge is visible in the
      * viewport.
      *
-     * The format is similar to CSS margin.
+     * The format is similar to CSS margin, so `'500px 0px'` extends the
+     * prefetch 500px above and below the viewport and not sideways. Accepted
+     * units are `px`, `em`, `rem`, `%`, `vh` and `vw`, plus bare `0` and
+     * `auto`; an invalid value is logged and ignored.
+     *
+     * From SDK 1.52.0 this defaults to `'500px 0px'` — roughly one
+     * visualization ahead of the scroll position, so a chart has usually
+     * finished loading by the time it scrolls into view. Use a smaller margin
+     * to cut warehouse queries further, or `'0px'` to load a visualization
+     * only once it is actually visible.
      *
      * @type {string}
      * @version SDK: 1.40.0 | ThoughtSpot: 10.12.0.cl
+     * @default '500px 0px' when `fullHeight` is enabled, from SDK 1.52.0
      * @example
      * ```js
      * const embed = new LiveboardEmbed('#embed-container', {
@@ -674,6 +702,16 @@ export class LiveboardEmbed extends V1Embed {
             if (this.viewConfig.vizId) {
                 logger.warn('Full height is currently only supported for Liveboard embeds.' +
                     'Using full height with vizId might lead to unexpected behavior.');
+            }
+
+            if (this.viewConfig.lazyLoadingForFullHeight === undefined) {
+                this.viewConfig.lazyLoadingForFullHeight = true;
+            }
+            if (this.viewConfig.enableScrollableContainerLazyLoading === undefined) {
+                this.viewConfig.enableScrollableContainerLazyLoading = true;
+            }
+            if (this.viewConfig.lazyLoadingMargin === undefined) {
+                this.viewConfig.lazyLoadingMargin = DEFAULT_LAZY_LOADING_MARGIN;
             }
 
             this.on(EmbedEvent.RouteChange, this.setIframeHeightForNonEmbedLiveboard);

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -37,6 +37,7 @@ import {
 } from './utils';
 import { RuntimeFilterOp } from './types';
 import { logger } from './utils/logger';
+import { DEFAULT_LAZY_LOADING_MARGIN } from './config';
 import { ERROR_MESSAGE } from './errors';
 
 // Mock logger
@@ -1027,6 +1028,10 @@ describe('isValidCssMargin', () => {
         expect(isValidCssMargin('   ')).toBe(false);
         expect(isValidCssMargin('invalid')).toBe(false);
         expect(isValidCssMargin('10')).toBe(false); // missing unit
+    });
+
+    it('should accept DEFAULT_LAZY_LOADING_MARGIN', () => {
+        expect(isValidCssMargin(DEFAULT_LAZY_LOADING_MARGIN)).toBe(true);
     });
 
     it('should return false and log error when value is not a string (non-string type)', () => {


### PR DESCRIPTION
## What

When `fullHeight` is enabled on `LiveboardEmbed` or `AppEmbed`, three lazy-loading
options now default to on instead of having to be set by hand:

| Option | New default |
|---|---|
| `lazyLoadingForFullHeight` | `true` |
| `enableScrollableContainerLazyLoading` | `true` |
| `lazyLoadingMargin` | `'500px 0px'` |

Applied in both constructors, guarded on `=== undefined`, so an explicit value —
including an explicit `false` — always wins. Nothing changes when `fullHeight` is
off or absent.

## Why

`fullHeight` loads every visualization on a Liveboard at once, which fans out into
one warehouse query per viz and delays the charts the user can actually see.
`lazyLoadingForFullHeight` has existed since 1.40.0 to fix exactly that, but it
was opt-in, so the default configuration was the slow one.

`500px 0px` for the margin is roughly one visualization ahead of the scroll
position, so a chart has usually finished loading by the time it scrolls into
view. The horizontal component is `0` because a Liveboard scrolls vertically —
and with container-aware tracking now on by default, a sideways margin could
preload off-axis content in a horizontally scrollable host container.

## Behavior change

This changes runtime behavior for existing integrations on upgrade: hosts already
passing `fullHeight: true` without these flags will start lazy-loading, so
visualizations below the fold wait for scroll rather than rendering upfront. That
is the intended win, but it is visible.
