### PR TITLE
SCAL-331290: Add Page.LiveboardSchedules for full app embed

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -211,6 +211,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'insights/results',
             [Page.Monitor]: 'insights/monitor-alerts',
             [Page.Collections]: 'collections',
+            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
         };
 
         const pageIds = Object.keys(pageRouteMap);
@@ -245,6 +246,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'home/spotiq-analysis',
             [Page.Monitor]: 'home/monitor-alerts',
             [Page.Collections]: 'collections',
+            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
         };
 
         const pageIdsForModularHomes = Object.keys(pageRouteMapForModularHome);

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -67,6 +67,10 @@ export enum Page {
      * Collections listing page
      */
     Collections = 'collections',
+    /**
+     * Liveboard schedules listing page
+     */
+    LiveboardSchedules = 'liveboard-schedules',
 }
 
 /**
@@ -1474,6 +1478,8 @@ export class AppEmbed extends V1Embed {
                 return modularHomeExperience ? 'home/monitor-alerts' : 'insights/monitor-alerts';
             case Page.Collections:
                 return 'collections';
+            case Page.LiveboardSchedules:
+                return 'home/liveboard-schedules';
             case Page.Home:
             default:
                 return 'home';


### PR DESCRIPTION
Add a pageId for the Insights > Liveboard schedules listing page, so embedders can open the app directly to it the way Page.Monitor does for Monitor alerts. Needed now that Data > Utilities > Liveboard schedules is being deprecated in 26.10.0.cl, leaving the Insights page as the only schedules listing.

The route is returned as insights/home/liveboard-schedules regardless of modularHomeExperience. Unlike its neighbouring routes, the app registers this page at an exact path with no optional segments, so the usual home/<page> form for the modular experience would not resolve.

- Add Page.LiveboardSchedules to the Page enum
- Map it in AppEmbed.getPageRoute
- Cover it in both page route maps in app.spec.ts