### PR TITLE
SCAL-331290 - Add Page.LiveboardSchedules for full app embed

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -211,6 +211,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'insights/results',
             [Page.Monitor]: 'insights/monitor-alerts',
             [Page.Collections]: 'collections',
+            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
         };
 
         const pageIds = Object.keys(pageRouteMap);
@@ -245,6 +246,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'home/spotiq-analysis',
             [Page.Monitor]: 'home/monitor-alerts',
             [Page.Collections]: 'collections',
+            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
         };
 
         const pageIdsForModularHomes = Object.keys(pageRouteMapForModularHome);

--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -211,7 +211,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'insights/results',
             [Page.Monitor]: 'insights/monitor-alerts',
             [Page.Collections]: 'collections',
-            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
+            [Page.LiveboardSchedules]: 'home/liveboard-schedules',
         };
 
         const pageIds = Object.keys(pageRouteMap);
@@ -246,7 +246,7 @@ describe('App embed tests', () => {
             [Page.SpotIQ]: 'home/spotiq-analysis',
             [Page.Monitor]: 'home/monitor-alerts',
             [Page.Collections]: 'collections',
-            [Page.LiveboardSchedules]: 'insights/home/liveboard-schedules',
+            [Page.LiveboardSchedules]: 'home/liveboard-schedules',
         };
 
         const pageIdsForModularHomes = Object.keys(pageRouteMapForModularHome);

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -67,6 +67,10 @@ export enum Page {
      * Collections listing page
      */
     Collections = 'collections',
+    /**
+     * Liveboard schedules listing page
+     */
+    LiveboardSchedules = 'liveboard-schedules',
 }
 
 /**
@@ -1474,6 +1478,8 @@ export class AppEmbed extends V1Embed {
                 return modularHomeExperience ? 'home/monitor-alerts' : 'insights/monitor-alerts';
             case Page.Collections:
                 return 'collections';
+            case Page.LiveboardSchedules:
+                return 'home/liveboard-schedules';
             case Page.Home:
             default:
                 return 'home';


### PR DESCRIPTION
## Changes
- Add `Page.LiveboardSchedules` to the `Page` enum in `src/embed/app.ts`.
- Map it in `AppEmbed.getPageRoute` to `home/liveboard-schedules`.
- Add it to both page route maps in `src/embed/app.spec.ts`.

No breaking changes, no new dependencies
