### PR TITLE
SCAL-334713 Deserialize URL-encoded params in UpdateEmbedParams payload

### DIFF
--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -101,6 +101,20 @@ describe('Search embed tests', () => {
         expect(singleParams.dataSources).toEqual([
             '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
         ]);
+
+        // The normalization is general (mirrors the app's URL parser):
+        // URI-encoded values are decoded, non-JSON strings stay strings,
+        // and already-structured values pass through untouched.
+        const tokenEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            dataSource: '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
+            searchOptions: {
+                searchTokenString: '[commit date][revenue]',
+            },
+        });
+        const tokenParams = await (tokenEmbed as any).getUpdateEmbedParamsObject();
+        expect(tokenParams.searchTokenString).toBe('[commit date][revenue]');
+        expect(tokenParams.embedApp).toBe(true);
     });
 
     test('should pass in search query', async () => {

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -102,19 +102,10 @@ describe('Search embed tests', () => {
             '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
         ]);
 
-        // The normalization is general (mirrors the app's URL parser):
-        // URI-encoded values are decoded, non-JSON strings stay strings,
-        // and already-structured values pass through untouched.
-        const tokenEmbed = new SearchEmbed(getRootEl(), {
-            ...defaultViewConfig,
-            dataSource: '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
-            searchOptions: {
-                searchTokenString: '[commit date][revenue]',
-            },
-        });
-        const tokenParams = await (tokenEmbed as any).getUpdateEmbedParamsObject();
-        expect(tokenParams.searchTokenString).toBe('[commit date][revenue]');
-        expect(tokenParams.embedApp).toBe(true);
+        // The normalization only reverses JSON serialization: non-JSON
+        // strings and already-structured values pass through untouched.
+        expect(singleParams.embedApp).toBe(true);
+        expect(singleParams.authType).toBe('None');
     });
 
     test('should pass in search query', async () => {

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -77,6 +77,32 @@ describe('Search embed tests', () => {
         });
     });
 
+    test('getUpdateEmbedParamsObject sends dataSources as a real ARRAY, not the URL-encoded string', async () => {
+        // The iframe URL correctly carries dataSources as a JSON-encoded
+        // string (asserted above), but the UpdateEmbedParams postMessage
+        // payload is spread into app state unparsed — a string there reaches
+        // the $sources GraphQL variable ([GUID!]) and fails GUID coercion
+        // (SCAL-334713, fired from beforePrerenderVisible on prerender-show).
+        const dataSources = ['4dd30af7-9ed7-4847-8f28-b65b44a841d8'];
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            dataSources,
+        });
+        const params = await (searchEmbed as any).getUpdateEmbedParamsObject();
+        expect(params.dataSources).toEqual(dataSources);
+
+        // Single-GUID `dataSource` prop (the customer's shape) normalizes to
+        // a one-element array the same way the app's URL parser would.
+        const singleSourceEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            dataSource: '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
+        });
+        const singleParams = await (singleSourceEmbed as any).getUpdateEmbedParamsObject();
+        expect(singleParams.dataSources).toEqual([
+            '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
+        ]);
+    });
+
     test('should pass in search query', async () => {
         const dataSources = ['data-source-1'];
         const searchOptions = {

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -24,7 +24,6 @@ import {
     getRuntimeParameters,
 } from '../utils';
 import { TsEmbed } from './ts-embed';
-import { logger } from '../utils/logger';
 import { ERROR_MESSAGE } from '../errors';
 import { getAuthPromise } from './base';
 import { getReleaseVersion } from '../auth';
@@ -453,8 +452,6 @@ export class SearchEmbed extends TsEmbed {
         ];
 
         if (dataSources && dataSources.length) {
-            // eslint-disable-next-line max-len
-            logger.warn('SearchViewConfig.dataSources is deprecated (only a single data source is supported) — use `dataSource` instead.');
             queryParams[Param.DataSources] = JSON.stringify(dataSources);
         }
         if (dataSource) {

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -24,6 +24,7 @@ import {
     getRuntimeParameters,
 } from '../utils';
 import { TsEmbed } from './ts-embed';
+import { logger } from '../utils/logger';
 import { ERROR_MESSAGE } from '../errors';
 import { getAuthPromise } from './base';
 import { getReleaseVersion } from '../auth';
@@ -452,6 +453,8 @@ export class SearchEmbed extends TsEmbed {
         ];
 
         if (dataSources && dataSources.length) {
+            // eslint-disable-next-line max-len
+            logger.warn('SearchViewConfig.dataSources is deprecated (only a single data source is supported) — use `dataSource` instead.');
             queryParams[Param.DataSources] = JSON.stringify(dataSources);
         }
         if (dataSource) {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -710,6 +710,19 @@ export class TsEmbed {
         const appInitData = await this.getAppInitData();
         queryParams = { ...this.viewConfig, ...queryParams, ...appInitData };
 
+        // getEmbedParamsObject() serializes for the iframe URL, so
+        // dataSources is a JSON-encoded STRING ('["guid"]'). The app parses
+        // URL params on boot but stores this event payload as-is — a string
+        // here reaches the $sources GraphQL variable ([GUID!]) and fails
+        // coercion with 'Expected type GUID' (SCAL-334713). Send the array.
+        if (typeof queryParams[Param.DataSources] === 'string') {
+            try {
+                queryParams[Param.DataSources] = JSON.parse(queryParams[Param.DataSources]);
+            } catch (e) {
+                logger.warn('UpdateEmbedParams: could not parse dataSources', e);
+            }
+        }
+
         return queryParams;
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -38,6 +38,7 @@ import {
     isUndefined,
     getHostEventsConfig,
     getValueFromWindow,
+    deserializeParam,
 } from '../utils';
 import { getCustomActions } from '../utils/custom-actions';
 import {
@@ -706,24 +707,14 @@ export class TsEmbed {
     }
 
     protected async getUpdateEmbedParamsObject() {
-        let queryParams = this.getEmbedParamsObject();
+        const queryParams = this.getEmbedParamsObject();
+        // Values are URL-serialized (e.g. dataSources as '["guid"]'); parse
+        // them back so the event payload matches a URL load (SCAL-334713).
+        Object.keys(queryParams).forEach((key) => {
+            queryParams[key] = deserializeParam(queryParams[key]);
+        });
         const appInitData = await this.getAppInitData();
-        queryParams = { ...this.viewConfig, ...queryParams, ...appInitData };
-
-        // getEmbedParamsObject() serializes for the iframe URL, so
-        // dataSources is a JSON-encoded STRING ('["guid"]'). The app parses
-        // URL params on boot but stores this event payload as-is — a string
-        // here reaches the $sources GraphQL variable ([GUID!]) and fails
-        // coercion with 'Expected type GUID' (SCAL-334713). Send the array.
-        if (typeof queryParams[Param.DataSources] === 'string') {
-            try {
-                queryParams[Param.DataSources] = JSON.parse(queryParams[Param.DataSources]);
-            } catch (e) {
-                logger.warn('UpdateEmbedParams: could not parse dataSources', e);
-            }
-        }
-
-        return queryParams;
+        return { ...this.viewConfig, ...queryParams, ...appInitData };
     }
 
     /**

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -357,9 +357,9 @@ describe('deserializeParam', () => {
         ]);
     });
 
-    test('decodes URI-encoded strings (e.g. searchTokenString)', () => {
+    test('does not URI-decode strings — raw %xx content must survive', () => {
         expect(deserializeParam('%5Bcommit%20date%5D%5Brevenue%5D')).toBe(
-            '[commit date][revenue]',
+            '%5Bcommit%20date%5D%5Brevenue%5D',
         );
     });
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,6 @@
 import {
     getQueryParamString,
+    deserializeParam,
     getFilterQuery,
     getCssDimension,
     getEncodedQueryParamsString,
@@ -348,7 +349,50 @@ describe('unit test for utils', () => {
     });
 });
 
+describe('deserializeParam', () => {
+    // Inverse of URL param serialization — must mirror the app's URL parser.
+    test('parses a JSON-string array back to a real array (SCAL-334713)', () => {
+        expect(deserializeParam('["4dd30af7-9ed7-4847-8f28-b65b44a841d8"]')).toEqual([
+            '4dd30af7-9ed7-4847-8f28-b65b44a841d8',
+        ]);
+    });
+
+    test('decodes URI-encoded strings (e.g. searchTokenString)', () => {
+        expect(deserializeParam('%5Bcommit%20date%5D%5Brevenue%5D')).toBe(
+            '[commit date][revenue]',
+        );
+    });
+
+    test('parses JSON objects and booleans', () => {
+        expect(deserializeParam('{"a":1}')).toEqual({ a: 1 });
+        expect(deserializeParam('true')).toBe(true);
+    });
+
+    test('keeps numeric strings as strings, matching the app URL parser', () => {
+        expect(deserializeParam('123')).toBe('123');
+        expect(deserializeParam('1.5')).toBe('1.5');
+    });
+
+    test('keeps plain non-JSON strings unchanged', () => {
+        expect(deserializeParam('local-host')).toBe('local-host');
+        expect(deserializeParam('AuthServerCookieless')).toBe('AuthServerCookieless');
+    });
+
+    test('keeps a malformed percent-sequence string as-is', () => {
+        expect(deserializeParam('100% legit')).toBe('100% legit');
+    });
+
+    test('passes non-string values through untouched', () => {
+        const arr = ['a'];
+        expect(deserializeParam(arr)).toBe(arr);
+        expect(deserializeParam(true)).toBe(true);
+        expect(deserializeParam(42)).toBe(42);
+        expect(deserializeParam(undefined)).toBeUndefined();
+    });
+});
+
 describe('Fullscreen Utility Functions', () => {
+
     let originalExitFullscreen: any;
     let mockIframe: HTMLIFrameElement;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,26 @@ const serializeParam = (value: any) => {
 };
 
 /**
+ * Inverse of URL param serialization, mirroring the app's own URL parser:
+ * decode + JSON.parse with fallback; numeric strings stay strings.
+ */
+export const deserializeParam = (value: unknown): unknown => {
+    if (typeof value !== 'string') return value;
+    let decoded = value;
+    try {
+        decoded = decodeURIComponent(value);
+    } catch (e) {
+        // not URI-encoded; keep as-is
+    }
+    try {
+        const parsed = JSON.parse(decoded);
+        return typeof parsed === 'number' ? decoded : parsed;
+    } catch (e) {
+        return decoded;
+    }
+};
+
+/**
  * Convert a value to a string:
  * in case of an array, we convert it to CSV.
  * in case of any other type, we directly return the value.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,22 +86,18 @@ const serializeParam = (value: any) => {
 };
 
 /**
- * Inverse of URL param serialization, mirroring the app's own URL parser:
- * decode + JSON.parse with fallback; numeric strings stay strings.
+ * Inverse of serializeParam: JSON.parse with fallback to the raw string,
+ * matching how the app parses the same values from the iframe URL.
  */
 export const deserializeParam = (value: unknown): unknown => {
     if (typeof value !== 'string') return value;
-    let decoded = value;
     try {
-        decoded = decodeURIComponent(value);
+        const parsed = JSON.parse(value);
+        // Numeric strings stay strings ('123' !== 123), same as the app's
+        // URL parser — param consumers expect string ids/versions.
+        return typeof parsed === 'number' ? value : parsed;
     } catch (e) {
-        // not URI-encoded; keep as-is
-    }
-    try {
-        const parsed = JSON.parse(decoded);
-        return typeof parsed === 'number' ? decoded : parsed;
-    } catch (e) {
-        return decoded;
+        return value;
     }
 };
 


### PR DESCRIPTION
The UpdateEmbedParams payload was built by the URL serializer but delivered as a postMessage — so values like dataSources arrived as JSON-encoded strings that the app stores unparsed, while the same values from an actual URL load get parsed on boot. This change adds deserializeParam (the previously-missing inverse of serializeParam) and applies it to the payload, guaranteeing the event delivers exactly what a URL load would — fixing the $sources GUID coercion failure (SCAL-334713) and the latent searchTokenString double-encoding with one mechanism instead of per-field patches.