### PR TITLE
SCAL-336112: Support chat history for the Spotter MCP server

### DIFF
--- a/src/embed/auto-frame-renderer.spec.ts
+++ b/src/embed/auto-frame-renderer.spec.ts
@@ -798,6 +798,80 @@ describe('startAutoMCPFrameRenderer', () => {
             expect(frame.dataset.tsStaleAnswer).toBeUndefined();
         });
 
+        test.each([
+            ['a null messages body', null],
+            ['a messages body that is not an object', 'nope'],
+            ['messages that is not an array', { messages: null }],
+        ])('falls back on %s instead of throwing', async (_label, body) => {
+            fetchMock.mockImplementation(async (input: any) => {
+                const url = typeof input === 'string' ? input : input.url;
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => (url.includes('/details') ? detailsPayload : body),
+                } as any;
+            });
+            const { renderedSrc, frame } = await renderReplayFrame();
+
+            expect(renderedSrc).not.toContain('sessionId=');
+            expect(frame.dataset.tsStaleAnswer).toBeUndefined();
+        });
+
+        test('falls back on a null details body instead of throwing', async () => {
+            fetchMock.mockImplementation(async (input: any) => {
+                const url = typeof input === 'string' ? input : input.url;
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => (url.includes('/details') ? null : messagesPayload),
+                } as any;
+            });
+            const { renderedSrc } = await renderReplayFrame();
+
+            expect(renderedSrc).not.toContain('sessionId=');
+        });
+
+        test.each([
+            ['answer.generation_number', { ...detailsPayload.answer, generation_number: null }],
+            [
+                'ac_state.generation_number',
+                { ...detailsPayload.answer, ac_state: { transaction_identifier: 'fresh-ac', generation_number: null } },
+            ],
+        ])('treats a null %s as unresolvable', async (_label, answer) => {
+            fetchMock.mockImplementation(async (input: any) => {
+                const url = typeof input === 'string' ? input : input.url;
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => (url.includes('/details') ? { answer } : messagesPayload),
+                } as any;
+            });
+            const { renderedSrc, frame } = await renderReplayFrame();
+
+            // Never emit a literal "null" generation into the hash.
+            expect(renderedSrc).not.toContain('genNo=null');
+            expect(renderedSrc).not.toContain('acGenNo=null');
+            expect(renderedSrc).not.toContain('sessionId=');
+            expect(frame.dataset.tsStaleAnswer).toBeUndefined();
+        });
+
+        test.each([
+            ['a fractional index', '1.5'],
+            ['a negative index', '-1'],
+            ['a malformed index', 'abc'],
+            ['a trailing-junk index', '1abc'],
+        ])('%s falls back to the first answer', async (_label, value) => {
+            const src = `https://${thoughtSpotHost}/v2/?${Param.Tsmcp}=true`
+                + `&${Param.TsmcpConversationId}=${CONVERSATION_ID}`
+                + `&${Param.TsmcpAnswerIndex}=${value}`;
+            await renderReplayFrame({}, src);
+
+            const detailsCall = fetchMock.mock.calls
+                .map(([input]: any) => (typeof input === 'string' ? input : input.url))
+                .find((url: string) => url.includes('/details'));
+            expect(detailsCall).toContain('/answers/ans_first/details');
+        });
+
         test('a frame without a conversation id makes no API calls and is unmarked', async () => {
             const { renderedSrc, frame } = await renderReplayFrame({}, TSMCP_SRC);
 

--- a/src/embed/auto-frame-renderer.spec.ts
+++ b/src/embed/auto-frame-renderer.spec.ts
@@ -662,4 +662,148 @@ describe('startAutoMCPFrameRenderer', () => {
             expect(JSON.parse(autoValue)).toEqual(JSON.parse(liveboardValue));
         });
     });
+
+    // ─── replaying a stored conversation ──────────────────────────────────────
+
+    describe('stored conversation replay', () => {
+        const CONVERSATION_ID = 'U0Tfqmjlz6WT';
+        const REPLAY_SRC =
+            `https://${thoughtSpotHost}/v2/?${Param.Tsmcp}=true`
+            + `&${Param.TsmcpConversationId}=${CONVERSATION_ID}`
+            + `&${Param.TsmcpAnswerIndex}=1`;
+
+        /** getConversation shape: two real answers around a thinking one. */
+        const messagesPayload = {
+            messages: [
+                {
+                    message_id: 'm1',
+                    response_items: [
+                        { type: 'tool_call', is_thinking: false },
+                        { type: 'answer', answer_id: 'ans_first', is_thinking: false },
+                    ],
+                },
+                {
+                    message_id: 'm2',
+                    response_items: [
+                        { type: 'answer', answer_id: 'ans_thinking', is_thinking: true },
+                        { type: 'answer', answer_id: 'ans_second', is_thinking: false },
+                    ],
+                },
+            ],
+        };
+
+        const detailsPayload = {
+            answer: {
+                session_identifier: 'fresh-session',
+                generation_number: 3,
+                ac_state: { transaction_identifier: 'fresh-ac', generation_number: 2 },
+            },
+        };
+
+        let fetchMock: jest.SpyInstance;
+
+        /** Renders one replay iframe and returns the src plus the frame element. */
+        async function renderReplayFrame(
+            viewConfig: AutoMCPFrameRendererViewConfig = {},
+            src: string = REPLAY_SRC,
+        ): Promise<{ renderedSrc: string; frame: HTMLIFrameElement }> {
+            let renderedSrc = '';
+            let frame: HTMLIFrameElement;
+            renderIFrameSpy.mockRestore();
+            renderIFrameSpy = jest.spyOn(TsEmbed.prototype as any, 'renderIFrame')
+                .mockImplementation(async function (this: any, capturedSrc: string) {
+                    renderedSrc = capturedSrc;
+                    // Stand in for the real iframe the notice attaches to.
+                    frame = document.createElement('iframe');
+                    this.iFrame = frame;
+                });
+
+            const observer = startAutoMCPFrameRenderer(viewConfig);
+            const iframe = document.createElement('iframe');
+            iframe.src = src;
+            document.body.appendChild(iframe);
+            await new Promise((r) => setTimeout(r, 100));
+            observer.disconnect();
+            return { renderedSrc, frame: frame! };
+        }
+
+        beforeEach(() => {
+            fetchMock = jest.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+                const url = typeof input === 'string' ? input : input.url;
+                const body = url.includes('/details') ? detailsPayload : messagesPayload;
+                return { ok: true, status: 200, json: async () => body } as any;
+            });
+        });
+
+        afterEach(() => {
+            fetchMock.mockRestore();
+        });
+
+        test('resolves session params from the conversation and answer APIs', async () => {
+            const { renderedSrc } = await renderReplayFrame();
+
+            expect(renderedSrc).toContain('sessionId=fresh-session');
+            expect(renderedSrc).toContain('genNo=3');
+            expect(renderedSrc).toContain('acSessionId=fresh-ac');
+            expect(renderedSrc).toContain('acGenNo=2');
+        });
+
+        test('picks the answer at the requested index, skipping thinking items', async () => {
+            await renderReplayFrame();
+
+            const detailsCall = fetchMock.mock.calls
+                .map(([input]: any) => (typeof input === 'string' ? input : input.url))
+                .find((url: string) => url.includes('/details'));
+            // index 1 = second non-thinking answer; ans_thinking must not count.
+            expect(detailsCall).toContain('/answers/ans_second/details');
+        });
+
+        test('defaults to the conversational answer route when none is given', async () => {
+            const { renderedSrc } = await renderReplayFrame();
+            expect(renderedSrc).toContain('/embed/conv-assist-answer');
+        });
+
+        test('strips the replay markers from the URL sent to ThoughtSpot', async () => {
+            const { renderedSrc } = await renderReplayFrame();
+            expect(renderedSrc).not.toContain(Param.TsmcpConversationId);
+            expect(renderedSrc).not.toContain(Param.TsmcpAnswerIndex);
+            expect(renderedSrc).not.toContain(`${Param.Tsmcp}=true`);
+        });
+
+        test('marks a replayed answer with the stale-data notice', async () => {
+            const { frame } = await renderReplayFrame();
+            expect(frame.dataset.tsStaleAnswer).toBe('true');
+            expect(frame.title).toBe(
+                'This data may have changed since the last time you had a chat.',
+            );
+        });
+
+        test('suppressStaleAnswerNotice leaves the frame unmarked', async () => {
+            const { frame } = await renderReplayFrame({ suppressStaleAnswerNotice: true });
+            expect(frame.dataset.tsStaleAnswer).toBeUndefined();
+            expect(frame.title).toBe('');
+        });
+
+        test('staleAnswerNoticeText overrides the default copy', async () => {
+            const { frame } = await renderReplayFrame({ staleAnswerNoticeText: 'Numbers may differ.' });
+            expect(frame.title).toBe('Numbers may differ.');
+        });
+
+        test('falls back to the source URL when resolution fails', async () => {
+            fetchMock.mockImplementation(async () => ({ ok: false, status: 500 } as any));
+            const { renderedSrc, frame } = await renderReplayFrame();
+
+            // No invented params, and no notice claiming a successful refresh.
+            expect(renderedSrc).not.toContain('sessionId=');
+            expect(frame.dataset.tsStaleAnswer).toBeUndefined();
+        });
+
+        test('a frame without a conversation id makes no API calls and is unmarked', async () => {
+            const { renderedSrc, frame } = await renderReplayFrame({}, TSMCP_SRC);
+
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(renderedSrc).toContain('/embed/viz/lb1');
+            expect(frame.dataset.tsStaleAnswer).toBeUndefined();
+        });
+    });
 });

--- a/src/embed/auto-frame-renderer.ts
+++ b/src/embed/auto-frame-renderer.ts
@@ -1,6 +1,30 @@
 import { AutoMCPFrameRendererViewConfig, Param } from "../types";
 import { TsEmbed } from "./ts-embed";
 import { getQueryParamString } from "../utils";
+import { tokenizedFetch } from "../tokenizedFetch";
+import { logger } from "../utils/logger";
+
+/**
+ * Route the ThoughtSpot application uses to render a single conversational
+ * answer. Used when a replayed frame carries no route of its own.
+ */
+const CONV_ASSIST_ANSWER_ROUTE = '/embed/conv-assist-answer';
+
+const DEFAULT_STALE_ANSWER_NOTICE =
+    'This data may have changed since the last time you had a chat.';
+
+/**
+ * Hash parameters that locate a specific answer generation. These expire with
+ * the answer object (roughly 8 hours), which is why a host app replaying a
+ * stored conversation must not persist them - it stores the conversation
+ * identifier instead and lets the renderer resolve these afresh.
+ */
+interface AnswerSessionParams {
+    sessionId: string;
+    genNo: string;
+    acSessionId: string;
+    acGenNo: string;
+}
 
 
 /**
@@ -70,6 +94,22 @@ export function startAutoMCPFrameRenderer(viewConfig: AutoMCPFrameRendererViewCo
     return observer;
 }
 
+/**
+ * Writes resolved session parameters into the route's hash query string,
+ * preserving the route and any other hash params the source URL carried.
+ *
+ * @param sourceHash - The source URL's hash, with or without a leading `#`.
+ *   Falls back to the conversational-answer route when empty, so a host app
+ *   replaying a chat need only supply the conversation identifier.
+ */
+function buildAnswerHash(sourceHash: string, resolved: AnswerSessionParams): string {
+    const withoutHash = (sourceHash || '').replace('#', '');
+    const [route, existingQuery] = withoutHash.split('?');
+    const params = new URLSearchParams(existingQuery || '');
+    Object.entries(resolved).forEach(([key, value]) => params.set(key, value));
+    return `${route || CONV_ASSIST_ANSWER_ROUTE}?${params.toString()}`;
+}
+
 function isTSMCPIframe(iframe: HTMLIFrameElement) {
     try {
         const url = new URL(iframe.src);
@@ -107,18 +147,108 @@ class AutoFrameRenderer extends TsEmbed {
      * @param sourceSrc - The original iframe's `src` URL string.
      * @returns The constructed URL to use for the ThoughtSpot embed iframe.
      */
-    private getMCPIframeSrc(sourceSrc: string) {
+    private getMCPIframeSrc(sourceSrc: string, resolved?: AnswerSessionParams) {
         const queryParams = this.getEmbedParamsObject();
         const sourceURL = new URL(sourceSrc);
         const existingQueryParams = sourceURL.searchParams;
         const existingQueryParamsObject = Object.fromEntries(existingQueryParams);
         delete existingQueryParamsObject[Param.Tsmcp];
+        // Replay markers address the SDK, not the ThoughtSpot application.
+        delete existingQueryParamsObject[Param.TsmcpConversationId];
+        delete existingQueryParamsObject[Param.TsmcpAnswerIndex];
 
         const mergedQueryParams = { ...queryParams, ...existingQueryParamsObject };
         const mergedQueryParamsString = getQueryParamString(mergedQueryParams, true);
         const queryString = mergedQueryParamsString ? `?${mergedQueryParamsString}` : '';
-        const frameSrc = `${this.getEmbedBasePath(queryString)}${sourceURL.hash.replace('#', '')}`;
+        const hash = resolved
+            ? buildAnswerHash(sourceURL.hash, resolved)
+            : sourceURL.hash.replace('#', '');
+        const frameSrc = `${this.getEmbedBasePath(queryString)}${hash}`;
         return frameSrc;
+    }
+
+    /**
+     * Resolves the current session parameters for an answer stored only as a
+     * conversation identifier plus an ordinal position.
+     *
+     * The answer object behind `sessionId`/`genNo` expires (roughly 8 hours),
+     * so a host app replaying a stored chat cannot persist those values. It
+     * persists the conversation identifier instead, and this walks the two
+     * public APIs to rebuild them:
+     *
+     * 1. `getConversation` lists the conversation's messages; the non-thinking
+     *    `answer` items, in message order, give the answer ids.
+     * 2. `loadAnswer` turns the answer id at `answerIndex` into a live
+     *    session identifier, generation number and agent-context state.
+     *
+     * @returns The resolved parameters, or `null` when resolution fails - the
+     *   caller then falls back to whatever the source URL already carried.
+     */
+    private async resolveAnswerSessionParams(
+        conversationId: string,
+        answerIndex: number,
+    ): Promise<AnswerSessionParams | null> {
+        const base = `${this.thoughtSpotHost}/api/rest/2.0/ai/agent/conversations/${encodeURIComponent(conversationId)}`;
+        try {
+            const messagesResponse = await tokenizedFetch(`${base}/messages`, {
+                headers: { Accept: 'application/json' },
+            });
+            if (!messagesResponse.ok) {
+                logger.warn(
+                    `[AutoFrameRenderer] getConversation failed for ${conversationId}: ${messagesResponse.status}`,
+                );
+                return null;
+            }
+            const { messages = [] } = await messagesResponse.json();
+
+            // Ordinal match: the host app counts answers the same way, so the
+            // Nth non-thinking answer item here is the Nth stored answer.
+            const answerIds: string[] = [];
+            for (const message of messages) {
+                for (const item of message?.response_items || []) {
+                    if (item?.type === 'answer' && item?.is_thinking === false && item?.answer_id) {
+                        answerIds.push(item.answer_id);
+                    }
+                }
+            }
+
+            const answerId = answerIds[answerIndex];
+            if (!answerId) {
+                logger.warn(
+                    `[AutoFrameRenderer] No answer at index ${answerIndex} in conversation ${conversationId} (found ${answerIds.length}).`,
+                );
+                return null;
+            }
+
+            const detailsResponse = await tokenizedFetch(
+                `${base}/answers/${encodeURIComponent(answerId)}/details`,
+                { headers: { Accept: 'application/json' } },
+            );
+            if (!detailsResponse.ok) {
+                logger.warn(
+                    `[AutoFrameRenderer] loadAnswer failed for ${answerId}: ${detailsResponse.status}`,
+                );
+                return null;
+            }
+            const { answer } = await detailsResponse.json();
+            const acState = answer?.ac_state;
+            if (!answer?.session_identifier || !acState?.transaction_identifier) {
+                logger.warn(
+                    `[AutoFrameRenderer] loadAnswer returned no session state for ${answerId}.`,
+                );
+                return null;
+            }
+
+            return {
+                sessionId: answer.session_identifier,
+                genNo: String(answer.generation_number),
+                acSessionId: acState.transaction_identifier,
+                acGenNo: String(acState.generation_number),
+            };
+        } catch (e) {
+            logger.warn(`[AutoFrameRenderer] Failed to resolve stored answer: ${e}`);
+            return null;
+        }
     }
 
     /**
@@ -149,9 +279,44 @@ class AutoFrameRenderer extends TsEmbed {
         if (this.shouldWaitForRenderPromise) {
             await this.isReadyForRenderPromise;
         }
-        const src = this.getMCPIframeSrc(iframe.src);
+
+        // Only frames that ask for it take the replay path. A frame straight
+        // from the MCP server carries its own session params and no
+        // conversation id, so it renders exactly as it always has.
+        const sourceParams = new URL(iframe.src).searchParams;
+        const conversationId = sourceParams.get(Param.TsmcpConversationId);
+        let resolved: AnswerSessionParams | null = null;
+        if (conversationId) {
+            const answerIndex = Number(sourceParams.get(Param.TsmcpAnswerIndex) || 0);
+            resolved = await this.resolveAnswerSessionParams(
+                conversationId,
+                Number.isFinite(answerIndex) ? answerIndex : 0,
+            );
+        }
+
+        const src = this.getMCPIframeSrc(iframe.src, resolved ?? undefined);
         await this.renderIFrame(src);
+
+        // Mark only answers actually re-resolved: their numbers were computed
+        // now, not when the conversation happened.
+        if (resolved && !this.viewConfig.suppressStaleAnswerNotice) {
+            this.markAsStaleAnswer();
+        }
         this.isRendered = true;
+    }
+
+    /**
+     * Adds the "data may have changed" notice to the rendered frame as a
+     * native tooltip, so it needs no stylesheet and cannot disturb the host
+     * app's layout.
+     */
+    private markAsStaleAnswer(): void {
+        if (!this.iFrame) {
+            return;
+        }
+        this.iFrame.title = this.viewConfig.staleAnswerNoticeText || DEFAULT_STALE_ANSWER_NOTICE;
+        // Exposed so a host app can style or replace the native tooltip.
+        this.iFrame.dataset.tsStaleAnswer = 'true';
     }
 }
 

--- a/src/embed/auto-frame-renderer.ts
+++ b/src/embed/auto-frame-renderer.ts
@@ -110,6 +110,17 @@ function buildAnswerHash(sourceHash: string, resolved: AnswerSessionParams): str
     return `${route || CONV_ASSIST_ANSWER_ROUTE}?${params.toString()}`;
 }
 
+/**
+ * Reads {@link Param.TsmcpAnswerIndex} as a whole, non-negative array index.
+ *
+ * Anything else - absent, malformed, fractional, negative - falls back to the
+ * first answer rather than indexing with a value that can never match.
+ */
+function answerIndexFromParam(raw: string | null): number {
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
 function isTSMCPIframe(iframe: HTMLIFrameElement) {
     try {
         const url = new URL(iframe.src);
@@ -199,12 +210,13 @@ class AutoFrameRenderer extends TsEmbed {
                 );
                 return null;
             }
-            const { messages = [] } = await messagesResponse.json();
+            const messagesBody = await messagesResponse.json();
+            const messages = messagesBody?.messages;
 
             // Ordinal match: the host app counts answers the same way, so the
             // Nth non-thinking answer item here is the Nth stored answer.
             const answerIds: string[] = [];
-            for (const message of messages) {
+            for (const message of Array.isArray(messages) ? messages : []) {
                 for (const item of message?.response_items || []) {
                     if (item?.type === 'answer' && item?.is_thinking === false && item?.answer_id) {
                         answerIds.push(item.answer_id);
@@ -230,11 +242,21 @@ class AutoFrameRenderer extends TsEmbed {
                 );
                 return null;
             }
-            const { answer } = await detailsResponse.json();
+            const detailsBody = await detailsResponse.json();
+            const answer = detailsBody?.answer;
             const acState = answer?.ac_state;
-            if (!answer?.session_identifier || !acState?.transaction_identifier) {
+            // All four are nullable in the loadAnswer response. A missing
+            // generation number is as unusable as a missing session id:
+            // stringifying it would put a literal "null" in the hash. Fail
+            // the resolve instead and let the caller fall back.
+            if (
+                !answer?.session_identifier
+                || !acState?.transaction_identifier
+                || !(Number.isInteger(answer.generation_number) && answer.generation_number > 0)
+                || !(Number.isInteger(acState.generation_number) && acState.generation_number > 0)
+            ) {
                 logger.warn(
-                    `[AutoFrameRenderer] loadAnswer returned no session state for ${answerId}.`,
+                    `[AutoFrameRenderer] loadAnswer returned incomplete session state for ${answerId}.`,
                 );
                 return null;
             }
@@ -287,10 +309,9 @@ class AutoFrameRenderer extends TsEmbed {
         const conversationId = sourceParams.get(Param.TsmcpConversationId);
         let resolved: AnswerSessionParams | null = null;
         if (conversationId) {
-            const answerIndex = Number(sourceParams.get(Param.TsmcpAnswerIndex) || 0);
             resolved = await this.resolveAnswerSessionParams(
                 conversationId,
-                Number.isFinite(answerIndex) ? answerIndex : 0,
+                answerIndexFromParam(sourceParams.get(Param.TsmcpAnswerIndex)),
             );
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1689,7 +1689,32 @@ export type AutoMCPFrameRendererViewConfig = Omit<
     | 'insertAsSibling'
     | 'primaryAction'
     | 'enableV2Shell_experimental'
->;
+> & {
+    /**
+     * Suppress the notice shown on answers re-resolved from a stored
+     * conversation. Those answers are re-run against current data, so by
+     * default the renderer marks them with a tooltip explaining that the
+     * numbers may differ from what the user originally saw. Set this to
+     * `true` to render them without any notice.
+     *
+     * Only affects frames carrying {@link Param.TsmcpConversationId}; frames
+     * that already contain their own session parameters are never marked.
+     * @default false
+     * @version SDK: 1.51.3
+     * @example
+     * ```js
+     * startAutoMCPFrameRenderer({ suppressStaleAnswerNotice: true });
+     * ```
+     */
+    suppressStaleAnswerNotice?: boolean;
+    /**
+     * Text of the notice described in {@link suppressStaleAnswerNotice}.
+     * Override it to translate the message or match your own product voice.
+     * @default 'This data may have changed since the last time you had a chat.'
+     * @version SDK: 1.51.3
+     */
+    staleAnswerNoticeText?: string;
+};
 
 /**
  * The configuration object for Home page embeds configs.
@@ -6741,6 +6766,20 @@ export enum DataSourceVisualMode {
 
 export enum Param {
     Tsmcp = 'tsmcp',
+    /**
+     * Marker added by a host app replaying a stored conversation. Carries the
+     * analytical session (conversation) identifier, from which the renderer
+     * resolves the answer's current session parameters. Stripped before the
+     * URL reaches the ThoughtSpot application.
+     */
+    TsmcpConversationId = 'tsmcpConversationId',
+    /**
+     * Zero-based position of the answer within the conversation, counting only
+     * non-thinking answer items in message order. Accompanies
+     * {@link TsmcpConversationId}; defaults to 0 when absent. Stripped before
+     * the URL reaches the ThoughtSpot application.
+     */
+    TsmcpAnswerIndex = 'tsmcpAnswerIndex',
     EmbedApp = 'embedApp',
     DataSources = 'dataSources',
     DataSourceMode = 'dataSourceMode',


### PR DESCRIPTION
## Problem

A host app replaying a stored conversation cannot persist an answer's embed URL. The
`sessionId` / `genNo` / `acSessionId` / `acGenNo` parameters point at an answer object
that expires after roughly 8 hours, so a reopened chat renders dead frames.

## Change

`startAutoMCPFrameRenderer` can now rebuild those parameters at render time. A host app
stores only the conversation identifier and the answer's position, and marks the
placeholder iframe with two new params:

<iframe src="…/v2/?tsmcp=true&tsmcpConversationId=<id>&tsmcpAnswerIndex=<n>">

The renderer then resolves the answer through two public APIs:

1. `GET /api/rest/2.0/ai/agent/conversations/{id}/messages` — the non-thinking `answer`
   items, in message order, give the answer ids.
2. `GET …/answers/{answer_id}/details` — turns the id at `tsmcpAnswerIndex` into a live
   `session_identifier`, `generation_number` and `ac_state`.

Those are written into the route's hash, the replay markers are stripped before the URL
reaches the application, and the frame is tagged with a tooltip:
*"This data may have changed since the last time you had a chat."* — since the chart is
re-run against current data. Suppress or reword it with `suppressStaleAnswerNotice` /
`staleAnswerNoticeText`.

Calls go through `tokenizedFetch`, so cookieless auth is handled. If resolution fails
for any reason, the renderer falls back to whatever the source URL carried and logs a
warning — the frame degrades rather than disappearing, and is not marked as refreshed.

## Backwards compatibility

Fully additive. The replay path runs only when `tsmcpConversationId` is present. A frame
straight from the MCP server carries its own session params and no conversation id, so
it takes the existing code path, makes no API calls, and is left unmarked. Covered by a
regression test.

## API added

- `Param.TsmcpConversationId`, `Param.TsmcpAnswerIndex`
- `AutoMCPFrameRendererViewConfig.suppressStaleAnswerNotice` (default `false`)
- `AutoMCPFrameRendererViewConfig.staleAnswerNoticeText`

## Testing

`auto-frame-renderer.spec.ts`: 62 tests pass — 53 pre-existing (no regressions) plus 9
new covering resolution, index selection skipping thinking items, the default route,
marker stripping, the notice and both of its config flags, resolution failure, and the
untouched non-replay path. `tsc --noEmit` and `eslint` clean.

Not verified against a live expired conversation — the test cluster's REST layer was
returning 502 while this was written, so the two API calls are covered by mocks only.