### PR TITLE
SCAL-320498 Correct @version tags on starter prompts configuration

### DIFF
--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -229,7 +229,7 @@ export interface SpotterShareConversationConfig {
 
 /**
  * A single starter prompt question shown under a category pill.
- * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
  * @group Embed components
  */
 export interface StarterPromptQuestion {
@@ -248,7 +248,7 @@ export interface StarterPromptQuestion {
 /**
  * Configuration for a starter prompt category with questions
  * (`quick` and `research`).
- * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
  * @group Embed components
  */
 export interface StarterPromptCategory {
@@ -267,7 +267,7 @@ export interface StarterPromptCategory {
 /**
  * Configuration for the Data Literacy starter prompt category.
  * Only the label is customizable; the prompt text comes from the backend.
- * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
  * @group Embed components
  */
 export interface StarterPreviewDataCategory {
@@ -286,7 +286,7 @@ export interface StarterPreviewDataCategory {
  * Note: this controls the Spotter chat interface only. The starter prompts on
  * the Liveboard SpotterViz surface are configured separately through
  * {@link SpotterVizConfig.customStarterPrompts}.
- * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+ * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
  * @group Embed components
  */
 export interface StarterPromptsConfig {
@@ -367,7 +367,7 @@ export interface SpotterChatViewConfig {
      * `Action.DeepAnalysisPill` and `Action.DataLiteracyPill`.
      *
      * Supported embed types: `SpotterEmbed`, `LiveboardEmbed`, `AppEmbed`
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      * @example
      * ```js
      * const embed = new SpotterEmbed('#tsEmbed', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8724,7 +8724,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.QuickSearchPill]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     QuickSearchPill = 'quickSearchPill',
     /**
@@ -8739,7 +8739,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.DeepAnalysisPill]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     DeepAnalysisPill = 'deepAnalysisPill',
     /**
@@ -8754,7 +8754,7 @@ export enum Action {
      * ```js
      * hiddenActions: [Action.DataLiteracyPill]
      * ```
-     * @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
      */
     DataLiteracyPill = 'dataLiteracyPill',
     /**


### PR DESCRIPTION
The starter prompts configuration introduced in #601 was tagged @version SDK: 1.52.0 | ThoughtSpot Cloud: 26.9.0.cl. Update the eight tags on that surface to 1.53.0 | 26.10.0.cl, matching the lockstep convention where SDK 1.N pairs with ThoughtSpot Cloud 26.(N-43).0.cl and the 36 existing 1.53.0 tags in src.

Covers the StarterPromptQuestion, StarterPromptCategory, StarterPreviewDataCategory and StarterPromptsConfig interfaces, the SpotterChatViewConfig.starterPrompts field, and the QuickSearchPill, DeepAnalysisPill and DataLiteracyPill actions.

Doc comments only, no runtime or type changes. enableStarterPrompts is left at 1.51.0 | 26.8.0.cl, which is already correct for the release it shipped in.