### PR TITLE
[SCAL-327613] Add Spotter routes to fullHeight height-reset allowlist

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -2676,6 +2676,14 @@ describe('App embed tests', () => {
             testSetIframeHeightBehavior('/some/other/path/', true);
         });
 
+        test('should not call setIFrameHeight if currentPath is the bare Spotter landing route "/insights/conv-assist"', () => {
+            testSetIframeHeightBehavior('/insights/conv-assist', false);
+        });
+
+        test('should not call setIFrameHeight if currentPath starts with "/embed/insights/conv-assist/s/" (conversation id set mid-stream)', () => {
+            testSetIframeHeightBehavior('/embed/insights/conv-assist/s/abc123', false);
+        });
+
         test('should update iframe height correctly', async () => {
             const appEmbed = new AppEmbed(getRootEl(), {
                 ...defaultViewConfig,

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -1000,6 +1000,40 @@ describe('Liveboard/viz embed tests', () => {
         expect(spySetIFrameHeight).toHaveBeenCalled();
     });
 
+    test('should not call setIFrameHeight if currentPath is the bare Spotter landing route "/insights/conv-assist"', () => {
+        const myObject = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: true,
+            liveboardId,
+        } as LiveboardViewConfig) as any;
+        const spySetIFrameHeight = jest.spyOn(myObject, 'setIFrameHeight');
+
+        myObject.render();
+        myObject.fullHeightController.handleRouteChange({
+            data: { currentPath: '/insights/conv-assist' },
+            type: 'Route',
+        });
+
+        expect(spySetIFrameHeight).not.toHaveBeenCalled();
+    });
+
+    test('should not call setIFrameHeight if currentPath starts with "/embed/insights/conv-assist/s/" (conversation id set mid-stream)', () => {
+        const myObject = new LiveboardEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            fullHeight: true,
+            liveboardId,
+        } as LiveboardViewConfig) as any;
+        const spySetIFrameHeight = jest.spyOn(myObject, 'setIFrameHeight');
+
+        myObject.render();
+        myObject.fullHeightController.handleRouteChange({
+            data: { currentPath: '/embed/insights/conv-assist/s/abc123' },
+            type: 'Route',
+        });
+
+        expect(spySetIFrameHeight).not.toHaveBeenCalled();
+    });
+
     test('Should set the visible vizs', async () => {
         const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/full-height.ts
+++ b/src/full-height.ts
@@ -46,6 +46,14 @@ const LIVEBOARD_RELATED_ROUTES = [
     '/insights/liveboard/',
     '/tsl-editor/PINBOARD_ANSWER_BOOK/',
     '/import-tsl/PINBOARD_ANSWER_BOOK/',
+    // Spotter (conv-assist) routes. Without these, navigating into or within
+    // Spotter resets the frame to defaultHeight, clobbering the fullHeight
+    // layout both on initial route (the bare route has no trailing segment,
+    // e.g. "/insights/conv-assist") and again mid-stream, when the
+    // conversation gets a real id and the URL is updated to
+    // "/insights/conv-assist/s/{id}".
+    '/insights/conv-assist',
+    '/embed/insights/conv-assist',
 ];
 
 /**


### PR DESCRIPTION
Spotter (conv-assist) routes were missing from the RouteChange allowlist that skips the fullHeight iframe height reset, causing the embed to collapse to defaultHeight when navigating into or within Spotter.

- Add /insights/conv-assist and /embed/insights/conv-assist to liveboardRelatedRoutes in app.ts and liveboard.ts
- Add pinning tests for the bare landing route and the conversation-id URL variant