### PR TITLE
[SCAL-332931] Retag Liveboard gutter additions to SDK 1.51.1 / 26.8.0.cl

### DIFF
--- a/src/css-variables.ts
+++ b/src/css-variables.ts
@@ -538,7 +538,7 @@ export interface CustomCssVariables {
      * Left and right margin of the header and the tab/filter section of an
      * embedded Liveboard. Use alongside the `liveboardGutter` view config to
      * keep the header aligned with a custom tile-grid gutter.
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.51.1 | ThoughtSpot Cloud: 26.8.0.cl
      */
     '--ts-var-liveboard-header-horizontal-margin'?: string;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2039,7 +2039,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {boolean}
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.51.1 | ThoughtSpot Cloud: 26.8.0.cl
      * @default false
      * @example
      * ```js
@@ -2164,7 +2164,7 @@ export interface LiveboardAppEmbedViewConfig {
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`
      * @type {number}
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.51.1 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * // Replace <EmbedComponent> with embed component name. For example, AppEmbed or LiveboardEmbed
@@ -4676,7 +4676,7 @@ export enum HostEvent {
      *
      * Unlike {@link HostEvent.OpenFilter}, which opens the panel of an
      * existing filter, this event starts the creation of a new filter.
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.51.1 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddFilterModal);
@@ -4692,7 +4692,7 @@ export enum HostEvent {
      * Hiding the *Add parameter* button with `hiddenActions:
      * [Action.AddParameter]` does not block this event, but disabling it
      * with `disabledActions` does.
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @version SDK: 1.51.1 | ThoughtSpot Cloud: 26.8.0.cl
      * @example
      * ```js
      * liveboardEmbed.trigger(HostEvent.OpenAddParameterModal);


### PR DESCRIPTION
Move the @version tags for liveboardGutter, the related Liveboard view config flag, the --ts-var-liveboard-header-horizontal-margin CSS variable and the OpenAddFilterModal / OpenAddParameterModal host events from SDK 1.53.0 | ThoughtSpot Cloud 26.10.0.cl to SDK 1.51.1 | ThoughtSpot Cloud 26.8.0.cl to match the release they ship in.