### PR TITLE
SCAL-336321 Order the pre-render show cycle, and always state its runtime filters

### DIFF
--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -2597,6 +2597,12 @@ describe('Liveboard/viz embed tests', () => {
             setTimeout(resolve, 300);
         });
 
+        // A show that routes via home waits twice: the params settle
+        // window, then the home unmount window.
+        const waitForHomeHopNavigate = () => new Promise((resolve) => {
+            setTimeout(resolve, 600);
+        });
+
         test('should call navigateToLiveboard after embed container is loaded in beforePrerenderVisible', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,
@@ -2660,7 +2666,7 @@ describe('Liveboard/viz embed tests', () => {
             liveboardEmbed['beforePrerenderVisible']();
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-            await waitForPreRenderNavigate();
+            await waitForHomeHopNavigate();
 
             expect(triggerSpy).toHaveBeenCalledWith(HostEvent.Navigate, 'home');
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
@@ -2676,7 +2682,7 @@ describe('Liveboard/viz embed tests', () => {
             );
         });
 
-        test('should wait for home before navigating back to the liveboard', async () => {
+        test('should not wait for the container to acknowledge the home hop', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,
                 vizId,
@@ -2693,13 +2699,13 @@ describe('Liveboard/viz embed tests', () => {
                 },
             } as any);
 
-            // Two Navigates in the same tick are a router's invitation to
-            // coalesce, so the second must wait on the first.
-            let resolveHome: () => void;
+            // The container does not ack Navigate, so this is what a real
+            // home hop looks like: it settles when TRIGGER_TIMEOUT fires,
+            // 30s later. Awaiting it parked the liveboard on home that long.
             jest.spyOn(liveboardEmbed, 'trigger').mockImplementation(
-                () => new Promise<any>((resolve) => {
-                    resolveHome = () => resolve(undefined);
-                }),
+                (event: any, payload: any) => (event === HostEvent.Navigate && payload === 'home'
+                    ? new Promise<any>(() => { /* never settles */ })
+                    : Promise.resolve(undefined as any)),
             );
             const navigateToLiveboardSpy = jest
                 .spyOn(liveboardEmbed, 'navigateToLiveboard')
@@ -2709,13 +2715,55 @@ describe('Liveboard/viz embed tests', () => {
             liveboardEmbed['beforePrerenderVisible']();
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-            await waitForPreRenderNavigate();
+            await waitForHomeHopNavigate();
 
+            expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
+                liveboardId,
+                vizId,
+                activeTabId,
+                undefined,
+            );
+        });
+
+        test('should let the home hop settle before navigating back', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId,
+                    vizId,
+                    activeTabId,
+                    personalizedViewId: undefined,
+                },
+            } as any);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+
+            // Past the params settle window, so home is out — but inside the
+            // home settle window, so the liveboard has not been asked for yet.
+            // Both routes in the same tick invites the router to coalesce them,
+            // which would leave the liveboard mounted.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 320);
+            });
+            expect(triggerSpy).toHaveBeenCalledWith(HostEvent.Navigate, 'home');
             expect(navigateToLiveboardSpy).not.toHaveBeenCalled();
 
-            resolveHome();
-            await waitForPreRenderNavigate();
-
+            await waitForHomeHopNavigate();
             expect(navigateToLiveboardSpy).toHaveBeenCalled();
         });
 
@@ -2749,9 +2797,9 @@ describe('Liveboard/viz embed tests', () => {
             liveboardEmbed['beforePrerenderVisible']();
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-            await waitForPreRenderNavigate();
+            await waitForHomeHopNavigate();
 
-            // A liveboard rebuilt from stale state beats one that never returns.
+            // Stale state beats a liveboard that never returns.
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
                 liveboardId,
                 vizId,

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -2630,6 +2630,238 @@ describe('Liveboard/viz embed tests', () => {
             );
         });
 
+        test('should route via home when the pre-render is already on this route', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            // Navigate to the route the container is already on is a no-op, so
+            // the liveboard is never unmounted and keeps the state it has. Home
+            // unmounts it, and the Navigate after rebuilds it.
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId,
+                    vizId,
+                    activeTabId,
+                    personalizedViewId: undefined,
+                },
+            } as any);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            expect(triggerSpy).toHaveBeenCalledWith(HostEvent.Navigate, 'home');
+            expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
+                liveboardId,
+                vizId,
+                activeTabId,
+                undefined,
+            );
+            // Home first, then back — the other order would clear the liveboard
+            // that was just asked for.
+            expect(triggerSpy.mock.invocationCallOrder[0]).toBeLessThan(
+                navigateToLiveboardSpy.mock.invocationCallOrder[0],
+            );
+        });
+
+        test('should wait for home before navigating back to the liveboard', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId,
+                    vizId,
+                    activeTabId,
+                    personalizedViewId: undefined,
+                },
+            } as any);
+
+            // Two Navigates in the same tick are a router's invitation to
+            // coalesce, so the second must wait on the first.
+            let resolveHome: () => void;
+            jest.spyOn(liveboardEmbed, 'trigger').mockImplementation(
+                () => new Promise<any>((resolve) => {
+                    resolveHome = () => resolve(undefined);
+                }),
+            );
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            expect(navigateToLiveboardSpy).not.toHaveBeenCalled();
+
+            resolveHome();
+            await waitForPreRenderNavigate();
+
+            expect(navigateToLiveboardSpy).toHaveBeenCalled();
+        });
+
+        test('should navigate back to the liveboard even when home fails', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId,
+                    vizId,
+                    activeTabId,
+                    personalizedViewId: undefined,
+                },
+            } as any);
+            // Only the home hop fails; the params trigger is left alone.
+            jest.spyOn(liveboardEmbed, 'trigger').mockImplementation(
+                (event: any, payload: any) => (event === HostEvent.Navigate && payload === 'home'
+                    ? Promise.reject(new Error('no route for you'))
+                    : Promise.resolve(undefined as any)),
+            );
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            // A liveboard rebuilt from stale state beats one that never returns.
+            expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
+                liveboardId,
+                vizId,
+                activeTabId,
+                undefined,
+            );
+        });
+
+        test('should not route via home when the pre-render is on another liveboard', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId: 'a-different-liveboard',
+                    vizId,
+                    activeTabId,
+                    personalizedViewId: undefined,
+                },
+            } as any);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            // A real route change unmounts the liveboard by itself.
+            expect(triggerSpy).not.toHaveBeenCalledWith(HostEvent.Navigate, 'home');
+            expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
+                liveboardId,
+                vizId,
+                activeTabId,
+                undefined,
+            );
+        });
+
+        test('should not route via home for the same liveboard on a different tab', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            // Same liveboard, but the path is built from the tab as well, so
+            // this is a real navigation.
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
+                currentLiveboardState: {
+                    liveboardId,
+                    vizId,
+                    activeTabId: 'another-tab',
+                    personalizedViewId: undefined,
+                },
+            } as any);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            expect(triggerSpy).not.toHaveBeenCalledWith(HostEvent.Navigate, 'home');
+            expect(navigateToLiveboardSpy).toHaveBeenCalled();
+        });
+
+        test('should not route via home when what the pre-render shows is unknown', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            // getPreRenderObj() reads an untyped property off the wrapper node,
+            // so it can hand back something that is not a LiveboardEmbed.
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({} as any);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            expect(triggerSpy).not.toHaveBeenCalledWith(HostEvent.Navigate, 'home');
+            expect(navigateToLiveboardSpy).toHaveBeenCalled();
+        });
+
         test('should update currentLiveboardState on the embed showing when the container loads', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -1869,8 +1869,11 @@ describe('Liveboard/viz embed tests', () => {
                 );
                 expect(iFrame.src).toMatch(/http:\/\/tshost\/.*&isLiveboardEmbed=true.*#$/);
 
+                // Navigate is held behind this show-cycle's
+                // UpdateEmbedParams, so wait out the settle
+                // window (SCAL-336321).
                 expect(consoleSpy).toHaveBeenCalledTimes(0);
-            });
+            }, 300);
         });
 
         test('it should navigateToLiveboard with liveboard id is not passed with AuthInit event', async () => {
@@ -1932,7 +1935,10 @@ describe('Liveboard/viz embed tests', () => {
                 );
                 expect(iFrame.src).toMatch(/http:\/\/tshost\/.*&isLiveboardEmbed=true.*#$/);
                 expect(consoleSpy).toHaveBeenCalledTimes(0);
-            }, 1005);
+                // 1000ms AuthInit fallback + the 200ms settle
+                // window before Navigate goes out (SCAL-336321),
+                // so 1005 is no longer enough.
+            }, 1305);
         });
 
 
@@ -2581,6 +2587,16 @@ describe('Liveboard/viz embed tests', () => {
             document.body.innerHTML = getDocumentBody();
         });
 
+        // beforePrerenderVisible() no longer navigates
+        // synchronously: Navigate is held until this show-cycle's
+        // UpdateEmbedParams has been posted and given
+        // UPDATE_EMBED_PARAMS_SETTLE_MS (200ms) to apply
+        // (SCAL-336321). These tests must wait that window out
+        // rather than read the spy inline.
+        const waitForPreRenderNavigate = () => new Promise((resolve) => {
+            setTimeout(resolve, 300);
+        });
+
         test('should call navigateToLiveboard after embed container is loaded in beforePrerenderVisible', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,
@@ -2603,6 +2619,7 @@ describe('Liveboard/viz embed tests', () => {
             // Simulate embed container becoming ready
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
 
             // Now navigateToLiveboard should be called
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
@@ -2637,6 +2654,7 @@ describe('Liveboard/viz embed tests', () => {
             // Simulate embed container becoming ready
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
 
             // Check that currentLiveboardState was updated
             expect(mockPreRenderObj.currentLiveboardState).toEqual({
@@ -2661,8 +2679,9 @@ describe('Liveboard/viz embed tests', () => {
 
             // Call beforePrerenderVisible
             liveboardEmbed['beforePrerenderVisible']();
+            await waitForPreRenderNavigate();
 
-            // navigateToLiveboard should be called immediately
+            // navigateToLiveboard should be called once the params have settled
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
                 liveboardId,
                 vizId,
@@ -2691,6 +2710,7 @@ describe('Liveboard/viz embed tests', () => {
             // Simulate embed container becoming ready
             liveboardEmbed.isEmbedContainerLoaded = true;
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
 
             // navigateToLiveboard should still be called
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
@@ -2720,6 +2740,7 @@ describe('Liveboard/viz embed tests', () => {
 
             // Call beforePrerenderVisible
             liveboardEmbed['beforePrerenderVisible']();
+            await waitForPreRenderNavigate();
 
             // Check that all parameters are passed correctly
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
@@ -2743,6 +2764,7 @@ describe('Liveboard/viz embed tests', () => {
 
             // Call beforePrerenderVisible
             liveboardEmbed['beforePrerenderVisible']();
+            await waitForPreRenderNavigate();
 
             // Check that undefined parameters are passed correctly
             expect(navigateToLiveboardSpy).toHaveBeenCalledWith(

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -2630,7 +2630,7 @@ describe('Liveboard/viz embed tests', () => {
             );
         });
 
-        test('should update currentLiveboardState for prerender object when embed container loads', async () => {
+        test('should update currentLiveboardState on the embed showing when the container loads', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,
                 vizId,
@@ -2638,6 +2638,10 @@ describe('Liveboard/viz embed tests', () => {
                 ...defaultViewConfig,
             });
 
+            // The state is written on the embed that is being shown, which is
+            // also the one the pre-render wrapper ends up pointing at. Writing
+            // it on the predecessor left "current" naming a liveboard that
+            // stopped being current one hand-over ago.
             const mockPreRenderObj = {
                 currentLiveboardState: {},
             };
@@ -2656,12 +2660,14 @@ describe('Liveboard/viz embed tests', () => {
             liveboardEmbed['executeEmbedContainerReadyCallbacks']();
             await waitForPreRenderNavigate();
 
-            // Check that currentLiveboardState was updated
-            expect(mockPreRenderObj.currentLiveboardState).toEqual({
+            expect(liveboardEmbed.currentLiveboardState).toEqual({
                 liveboardId,
                 vizId,
                 activeTabId,
+                personalizedViewId: undefined,
             });
+            // and NOT on the instance it took the pre-render over from
+            expect(mockPreRenderObj.currentLiveboardState).toEqual({});
         });
 
         test('should handle beforePrerenderVisible when embed container is already loaded', async () => {

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -2597,10 +2597,10 @@ describe('Liveboard/viz embed tests', () => {
             setTimeout(resolve, 300);
         });
 
-        // A show that routes via home waits twice: the params settle
-        // window, then the home unmount window.
+        // A home hop waits twice: params settle, then home settle. Generous
+        // margin over the two windows so a slow run does not flake.
         const waitForHomeHopNavigate = () => new Promise((resolve) => {
-            setTimeout(resolve, 600);
+            setTimeout(resolve, 900);
         });
 
         test('should call navigateToLiveboard after embed container is loaded in beforePrerenderVisible', async () => {
@@ -2644,9 +2644,8 @@ describe('Liveboard/viz embed tests', () => {
                 ...defaultViewConfig,
             });
 
-            // Navigate to the route the container is already on is a no-op, so
-            // the liveboard is never unmounted and keeps the state it has. Home
-            // unmounts it, and the Navigate after rebuilds it.
+            // Navigate to the route it is already on is a no-op, so the
+            // liveboard keeps its state. Home unmounts the container.
             jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
                 currentLiveboardState: {
                     liveboardId,
@@ -2675,8 +2674,7 @@ describe('Liveboard/viz embed tests', () => {
                 activeTabId,
                 undefined,
             );
-            // Home first, then back — the other order would clear the liveboard
-            // that was just asked for.
+            // Home first, or we would clear what we just asked for.
             expect(triggerSpy.mock.invocationCallOrder[0]).toBeLessThan(
                 navigateToLiveboardSpy.mock.invocationCallOrder[0],
             );
@@ -2699,9 +2697,8 @@ describe('Liveboard/viz embed tests', () => {
                 },
             } as any);
 
-            // The container does not ack Navigate, so this is what a real
-            // home hop looks like: it settles when TRIGGER_TIMEOUT fires,
-            // 30s later. Awaiting it parked the liveboard on home that long.
+            // A real home hop never settles until the 30s trigger timeout.
+            // Awaiting it parked the liveboard on home for that long.
             jest.spyOn(liveboardEmbed, 'trigger').mockImplementation(
                 (event: any, payload: any) => (event === HostEvent.Navigate && payload === 'home'
                     ? new Promise<any>(() => { /* never settles */ })
@@ -2725,89 +2722,6 @@ describe('Liveboard/viz embed tests', () => {
             );
         });
 
-        test('should let the home hop settle before navigating back', async () => {
-            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
-                liveboardId,
-                vizId,
-                activeTabId,
-                ...defaultViewConfig,
-            });
-
-            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
-                currentLiveboardState: {
-                    liveboardId,
-                    vizId,
-                    activeTabId,
-                    personalizedViewId: undefined,
-                },
-            } as any);
-            const triggerSpy = jest
-                .spyOn(liveboardEmbed, 'trigger')
-                .mockImplementation(() => Promise.resolve(undefined as any));
-            const navigateToLiveboardSpy = jest
-                .spyOn(liveboardEmbed, 'navigateToLiveboard')
-                .mockImplementation(() => Promise.resolve(undefined));
-
-            liveboardEmbed.isEmbedContainerLoaded = false;
-            liveboardEmbed['beforePrerenderVisible']();
-            liveboardEmbed.isEmbedContainerLoaded = true;
-            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-
-            // Past the params settle window, so home is out — but inside the
-            // home settle window, so the liveboard has not been asked for yet.
-            // Both routes in the same tick invites the router to coalesce them,
-            // which would leave the liveboard mounted.
-            await new Promise((resolve) => {
-                setTimeout(resolve, 320);
-            });
-            expect(triggerSpy).toHaveBeenCalledWith(HostEvent.Navigate, 'home');
-            expect(navigateToLiveboardSpy).not.toHaveBeenCalled();
-
-            await waitForHomeHopNavigate();
-            expect(navigateToLiveboardSpy).toHaveBeenCalled();
-        });
-
-        test('should navigate back to the liveboard even when home fails', async () => {
-            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
-                liveboardId,
-                vizId,
-                activeTabId,
-                ...defaultViewConfig,
-            });
-
-            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
-                currentLiveboardState: {
-                    liveboardId,
-                    vizId,
-                    activeTabId,
-                    personalizedViewId: undefined,
-                },
-            } as any);
-            // Only the home hop fails; the params trigger is left alone.
-            jest.spyOn(liveboardEmbed, 'trigger').mockImplementation(
-                (event: any, payload: any) => (event === HostEvent.Navigate && payload === 'home'
-                    ? Promise.reject(new Error('no route for you'))
-                    : Promise.resolve(undefined as any)),
-            );
-            const navigateToLiveboardSpy = jest
-                .spyOn(liveboardEmbed, 'navigateToLiveboard')
-                .mockImplementation(() => Promise.resolve(undefined));
-
-            liveboardEmbed.isEmbedContainerLoaded = false;
-            liveboardEmbed['beforePrerenderVisible']();
-            liveboardEmbed.isEmbedContainerLoaded = true;
-            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-            await waitForHomeHopNavigate();
-
-            // Stale state beats a liveboard that never returns.
-            expect(navigateToLiveboardSpy).toHaveBeenCalledWith(
-                liveboardId,
-                vizId,
-                activeTabId,
-                undefined,
-            );
-        });
-
         test('should not route via home when the embed is showing itself again', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,
@@ -2816,10 +2730,8 @@ describe('Liveboard/viz embed tests', () => {
                 ...defaultViewConfig,
             });
 
-            // Taking the pre-render over from itself is a hide/show, not a
-            // hand-over. The liveboard is holding this user's own filter chips
-            // on this embed's own liveboard — clearing that would throw away
-            // their session for a visibility toggle.
+            // A hide/show of one embed, not a hand-over: the state is this
+            // user's own, so clearing it would lose their session.
             jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue(liveboardEmbed);
             const triggerSpy = jest
                 .spyOn(liveboardEmbed, 'trigger')
@@ -2885,8 +2797,7 @@ describe('Liveboard/viz embed tests', () => {
                 ...defaultViewConfig,
             });
 
-            // Same liveboard, but the path is built from the tab as well, so
-            // this is a real navigation.
+            // Same liveboard, different tab — a real navigation.
             jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({
                 currentLiveboardState: {
                     liveboardId,
@@ -2895,34 +2806,6 @@ describe('Liveboard/viz embed tests', () => {
                     personalizedViewId: undefined,
                 },
             } as any);
-            const triggerSpy = jest
-                .spyOn(liveboardEmbed, 'trigger')
-                .mockImplementation(() => Promise.resolve(undefined as any));
-            const navigateToLiveboardSpy = jest
-                .spyOn(liveboardEmbed, 'navigateToLiveboard')
-                .mockImplementation(() => Promise.resolve(undefined));
-
-            liveboardEmbed.isEmbedContainerLoaded = false;
-            liveboardEmbed['beforePrerenderVisible']();
-            liveboardEmbed.isEmbedContainerLoaded = true;
-            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
-            await waitForPreRenderNavigate();
-
-            expect(triggerSpy).not.toHaveBeenCalledWith(HostEvent.Navigate, 'home');
-            expect(navigateToLiveboardSpy).toHaveBeenCalled();
-        });
-
-        test('should not route via home when what the pre-render shows is unknown', async () => {
-            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
-                liveboardId,
-                vizId,
-                activeTabId,
-                ...defaultViewConfig,
-            });
-
-            // getPreRenderObj() reads an untyped property off the wrapper node,
-            // so it can hand back something that is not a LiveboardEmbed.
-            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue({} as any);
             const triggerSpy = jest
                 .spyOn(liveboardEmbed, 'trigger')
                 .mockImplementation(() => Promise.resolve(undefined as any));

--- a/src/embed/liveboard.spec.ts
+++ b/src/embed/liveboard.spec.ts
@@ -2760,6 +2760,36 @@ describe('Liveboard/viz embed tests', () => {
             );
         });
 
+        test('should not route via home when the embed is showing itself again', async () => {
+            const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
+                liveboardId,
+                vizId,
+                activeTabId,
+                ...defaultViewConfig,
+            });
+
+            // Taking the pre-render over from itself is a hide/show, not a
+            // hand-over. The liveboard is holding this user's own filter chips
+            // on this embed's own liveboard — clearing that would throw away
+            // their session for a visibility toggle.
+            jest.spyOn(liveboardEmbed as any, 'getPreRenderObj').mockReturnValue(liveboardEmbed);
+            const triggerSpy = jest
+                .spyOn(liveboardEmbed, 'trigger')
+                .mockImplementation(() => Promise.resolve(undefined as any));
+            const navigateToLiveboardSpy = jest
+                .spyOn(liveboardEmbed, 'navigateToLiveboard')
+                .mockImplementation(() => Promise.resolve(undefined));
+
+            liveboardEmbed.isEmbedContainerLoaded = false;
+            liveboardEmbed['beforePrerenderVisible']();
+            liveboardEmbed.isEmbedContainerLoaded = true;
+            liveboardEmbed['executeEmbedContainerReadyCallbacks']();
+            await waitForPreRenderNavigate();
+
+            expect(triggerSpy).not.toHaveBeenCalledWith(HostEvent.Navigate, 'home');
+            expect(navigateToLiveboardSpy).toHaveBeenCalled();
+        });
+
         test('should not route via home when the pre-render is on another liveboard', async () => {
             const liveboardEmbed = new LiveboardEmbed(getRootEl(), {
                 liveboardId,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -1163,7 +1163,6 @@ export class LiveboardEmbed extends V1Embed {
 
     protected beforePrerenderVisible(): void {
         super.beforePrerenderVisible();
-        const embedObj = this.getPreRenderObj<LiveboardEmbed>();
 
         this.executeAfterEmbedContainerLoaded(async () => {
             // Navigate only after the UpdateEmbedParams of this show-cycle has
@@ -1179,14 +1178,15 @@ export class LiveboardEmbed extends V1Embed {
                 this.viewConfig.activeTabId,
                 this.viewConfig.personalizedViewId,
             );
-            if (embedObj) {
-                embedObj.currentLiveboardState = {
-                    liveboardId: this.viewConfig.liveboardId,
-                    vizId: this.viewConfig.vizId,
-                    activeTabId: this.viewConfig.activeTabId,
-                    personalizedViewId: this.viewConfig.personalizedViewId,
-                };
-            }
+            // On this instance, which by now owns the pre-render: writing it
+            // to the predecessor instead left "current" naming a liveboard
+            // that stopped being current one hand-over ago.
+            this.currentLiveboardState = {
+                liveboardId: this.viewConfig.liveboardId,
+                vizId: this.viewConfig.vizId,
+                activeTabId: this.viewConfig.activeTabId,
+                personalizedViewId: this.viewConfig.personalizedViewId,
+            };
         });
     }
 

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -38,6 +38,12 @@ import { buildStarterPromptsAppInitData } from './spotter-utils';
 import { SpotterVizConfig, buildSpotterVizAppInitData } from './spotter-viz-utils';
 
 /**
+ * The container's home route — the same string `AppEmbed` sends for `Page.Home`.
+ * Used as a waypoint to unmount a liveboard that is being re-shown.
+ */
+const HOME_ROUTE = 'home';
+
+/**
  * APP_INIT data shape for LiveboardEmbed.
  * @internal
  */
@@ -1164,10 +1170,18 @@ export class LiveboardEmbed extends V1Embed {
     protected beforePrerenderVisible(): void {
         super.beforePrerenderVisible();
 
+        // Captured synchronously: showPreRender() calls takeOverPreRender() after
+        // this, so by the time the async callback runs the wrapper already points
+        // at this instance and getPreRenderObj() no longer names its predecessor.
+        const showing = this.getPreRenderObj<LiveboardEmbed>()?.currentLiveboardState;
+
         this.executeAfterEmbedContainerLoaded(async () => {
             // Without this the params callback suspends on its await and Navigate
             // goes out first, so the container loads with the previous config's filters.
             await this.preRenderParamsApplied;
+            if (this.isShowingLiveboardRoute(showing)) {
+                await this.clearLiveboardStateViaHome();
+            }
             this.navigateToLiveboard(
                 this.viewConfig.liveboardId,
                 this.viewConfig.vizId,
@@ -1181,6 +1195,56 @@ export class LiveboardEmbed extends V1Embed {
                 personalizedViewId: this.viewConfig.personalizedViewId,
             };
         });
+    }
+
+    /**
+     * Sends the pre-render to home and waits for it to get there, so the liveboard it
+     * was showing is torn down before it is asked for again.
+     *
+     * Only useful on a same-route show: the container treats `Navigate` to the route it
+     * is already on as a no-op, so the liveboard component is never unmounted and keeps
+     * the state it accumulated — the filter chips the user moved, the selections, the
+     * tab. Going via home unmounts it, so the `Navigate` that follows rebuilds it from
+     * the `UpdateEmbedParams` posted just before.
+     *
+     * Awaits the trigger rather than posting and hoping: two `Navigate`s in the same
+     * tick are a router's invitation to coalesce, which would defeat the whole point.
+     *
+     * A failure warns rather than errors, and is swallowed: the liveboard still gets
+     * shown, just without the state having been cleared first. Stale state beats a
+     * liveboard that never comes back.
+     */
+    private async clearLiveboardStateViaHome(): Promise<void> {
+        try {
+            await this.trigger(HostEvent.Navigate, HOME_ROUTE);
+        } catch (error) {
+            logger.warn('Could not route the pre-render via home before re-showing it', error);
+        }
+    }
+
+    /**
+     * Whether the pre-render is already on the route this config asks for — the case
+     * where `Navigate` alone would change nothing, so the liveboard needs clearing
+     * first.
+     *
+     * Compares the whole route rather than the liveboard id alone: the path is built
+     * from the viz, tab and personalized view as well, so a same-liveboard show that
+     * moves to another tab is a real navigation and needs no help.
+     *
+     * Answers true only on a positive match. An unknown predecessor — no pre-render
+     * object yet, or one that is not a LiveboardEmbed — takes the ordinary path, since
+     * a plain `Navigate` to a route the container is not on does the unmounting by
+     * itself.
+     */
+    private isShowingLiveboardRoute(showing?: LiveboardEmbed['currentLiveboardState']): boolean {
+        if (!showing?.liveboardId) return false;
+        const {
+            liveboardId, vizId, activeTabId, personalizedViewId,
+        } = this.viewConfig;
+        return showing.liveboardId === liveboardId
+            && showing.vizId === vizId
+            && showing.activeTabId === activeTabId
+            && showing.personalizedViewId === personalizedViewId;
     }
 
     protected async handleRenderForPrerender(): Promise<TsEmbed> {

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -1165,12 +1165,8 @@ export class LiveboardEmbed extends V1Embed {
         super.beforePrerenderVisible();
 
         this.executeAfterEmbedContainerLoaded(async () => {
-            // Navigate only after the UpdateEmbedParams of this show-cycle has
-            // been posted and applied. Without this the two callbacks race:
-            // the params one suspends on `await getUpdateEmbedParamsObject()`,
-            // so Navigate goes out first and the container loads the new
-            // liveboard with the previous config's runtime filters, dropping
-            // the params that then arrive mid-load (SCAL-336321).
+            // Without this the params callback suspends on its await and Navigate
+            // goes out first, so the container loads with the previous config's filters.
             await this.preRenderParamsApplied;
             this.navigateToLiveboard(
                 this.viewConfig.liveboardId,
@@ -1178,9 +1174,6 @@ export class LiveboardEmbed extends V1Embed {
                 this.viewConfig.activeTabId,
                 this.viewConfig.personalizedViewId,
             );
-            // On this instance, which by now owns the pre-render: writing it
-            // to the predecessor instead left "current" naming a liveboard
-            // that stopped being current one hand-over ago.
             this.currentLiveboardState = {
                 liveboardId: this.viewConfig.liveboardId,
                 vizId: this.viewConfig.vizId,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -1165,7 +1165,14 @@ export class LiveboardEmbed extends V1Embed {
         super.beforePrerenderVisible();
         const embedObj = this.getPreRenderObj<LiveboardEmbed>();
 
-        this.executeAfterEmbedContainerLoaded(() => {
+        this.executeAfterEmbedContainerLoaded(async () => {
+            // Navigate only after the UpdateEmbedParams of this show-cycle has
+            // been posted and applied. Without this the two callbacks race:
+            // the params one suspends on `await getUpdateEmbedParamsObject()`,
+            // so Navigate goes out first and the container loads the new
+            // liveboard with the previous config's runtime filters, dropping
+            // the params that then arrive mid-load (SCAL-336321).
+            await this.preRenderParamsApplied;
             this.navigateToLiveboard(
                 this.viewConfig.liveboardId,
                 this.viewConfig.vizId,

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -1170,10 +1170,18 @@ export class LiveboardEmbed extends V1Embed {
     protected beforePrerenderVisible(): void {
         super.beforePrerenderVisible();
 
-        // Captured synchronously: showPreRender() calls takeOverPreRender() after
-        // this, so by the time the async callback runs the wrapper already points
-        // at this instance and getPreRenderObj() no longer names its predecessor.
-        const showing = this.getPreRenderObj<LiveboardEmbed>()?.currentLiveboardState;
+        // Captured synchronously: showPreRender() calls takeOverPreRender()
+        // after this, so by the time the async callback runs the wrapper
+        // already points at this instance and getPreRenderObj() no longer
+        // names its predecessor.
+        const predecessor = this.getPreRenderObj<LiveboardEmbed>();
+        // Taking the pre-render over from itself is a hide/show of one embed,
+        // not a hand-over. The state the liveboard holds is this embed's own —
+        // the filter chips this user moved on this liveboard — so there is
+        // nothing stale to clear, and clearing it would throw away their
+        // session for a visibility toggle. Left undefined so the route check
+        // below stays out of it.
+        const showing = predecessor === this ? undefined : predecessor?.currentLiveboardState;
 
         this.executeAfterEmbedContainerLoaded(async () => {
             // Without this the params callback suspends on its await and Navigate
@@ -1232,9 +1240,10 @@ export class LiveboardEmbed extends V1Embed {
      * moves to another tab is a real navigation and needs no help.
      *
      * Answers true only on a positive match. An unknown predecessor — no pre-render
-     * object yet, or one that is not a LiveboardEmbed — takes the ordinary path, since
-     * a plain `Navigate` to a route the container is not on does the unmounting by
-     * itself.
+     * object yet, one that is not a LiveboardEmbed, or this embed showing itself again
+     * — takes the ordinary path, since a plain `Navigate` to a route the container is
+     * not on does the unmounting by itself, and a same-instance show has nothing that
+     * needs unmounting.
      */
     private isShowingLiveboardRoute(showing?: LiveboardEmbed['currentLiveboardState']): boolean {
         if (!showing?.liveboardId) return false;

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -37,19 +37,10 @@ import { SpotterChatViewConfig, StarterPromptsConfig } from './conversation';
 import { buildStarterPromptsAppInitData } from './spotter-utils';
 import { SpotterVizConfig, buildSpotterVizAppInitData } from './spotter-viz-utils';
 
-/**
- * The container's home route — the same string `AppEmbed` sends for `Page.Home`.
- * Used as a waypoint to unmount a liveboard that is being re-shown.
- */
+// Home unmounts the liveboard container, which is how its state gets cleared. The
+// settle window gives the container time to do it before we ask for the liveboard back.
 const HOME_ROUTE = 'home';
-
-/**
- * How long to let the container act on the home hop before asking for the liveboard
- * back. The route change unmounts through React, so the post being delivered is not
- * the same as the liveboard being gone — the same reasoning as the params settle
- * window, and the same order of magnitude.
- */
-const HOME_UNMOUNT_SETTLE_MS = 200;
+const HOME_SETTLE_MS = 200;
 
 /**
  * APP_INIT data shape for LiveboardEmbed.
@@ -1178,25 +1169,25 @@ export class LiveboardEmbed extends V1Embed {
     protected beforePrerenderVisible(): void {
         super.beforePrerenderVisible();
 
-        // Captured synchronously: showPreRender() calls takeOverPreRender()
-        // after this, so by the time the async callback runs the wrapper
-        // already points at this instance and getPreRenderObj() no longer
-        // names its predecessor.
-        const predecessor = this.getPreRenderObj<LiveboardEmbed>();
-        // Taking the pre-render over from itself is a hide/show of one embed,
-        // not a hand-over. The state the liveboard holds is this embed's own —
-        // the filter chips this user moved on this liveboard — so there is
-        // nothing stale to clear, and clearing it would throw away their
-        // session for a visibility toggle. Left undefined so the route check
-        // below stays out of it.
-        const showing = predecessor === this ? undefined : predecessor?.currentLiveboardState;
+        // Captured before showPreRender() hands the wrapper over to this instance.
+        // Itself means a hide/show, not a hand-over, so there is nothing stale to clear.
+        const previous = this.getPreRenderObj<LiveboardEmbed>();
+        const showing = previous === this ? undefined : previous?.currentLiveboardState;
 
         this.executeAfterEmbedContainerLoaded(async () => {
             // Without this the params callback suspends on its await and Navigate
             // goes out first, so the container loads with the previous config's filters.
             await this.preRenderParamsApplied;
             if (this.isShowingLiveboardRoute(showing)) {
-                await this.clearLiveboardStateViaHome();
+                // Navigate to the route we are already on is a no-op, so the liveboard
+                // keeps its state. Home unmounts the container, which clears it.
+                this.trigger(HostEvent.Navigate, HOME_ROUTE)
+                    .catch((error) => logger.warn('Could not route via home', error));
+                // Not awaited above: the container never acks Navigate, so that promise
+                // only settles on the 30s trigger timeout.
+                await new Promise((resolve) => {
+                    setTimeout(resolve, HOME_SETTLE_MS);
+                });
             }
             this.navigateToLiveboard(
                 this.viewConfig.liveboardId,
@@ -1213,54 +1204,8 @@ export class LiveboardEmbed extends V1Embed {
         });
     }
 
-    /**
-     * Sends the pre-render to home and waits for it to get there, so the liveboard it
-     * was showing is torn down before it is asked for again.
-     *
-     * Only useful on a same-route show: the container treats `Navigate` to the route it
-     * is already on as a no-op, so the liveboard component is never unmounted and keeps
-     * the state it accumulated — the filter chips the user moved, the selections, the
-     * tab. Going via home unmounts it, so the `Navigate` that follows rebuilds it from
-     * the `UpdateEmbedParams` posted just before.
-     *
-     * Waits {@link HOME_UNMOUNT_SETTLE_MS} rather than awaiting the trigger. The
-     * container does not acknowledge `Navigate`, so awaiting it does not resolve when
-     * the route changes — it resolves when `TRIGGER_TIMEOUT` fires, which parked a
-     * re-shown liveboard on the home page for a full 30 seconds. Observed, not
-     * theorised: `Navigate home` at 18:55:56 and the liveboard back at 18:56:26.
-     *
-     * The wait is still needed. Posting both routes in the same tick invites the
-     * container's router to coalesce them, which would leave the liveboard mounted and
-     * defeat the point.
-     *
-     * A rejection is caught and warned rather than thrown: the liveboard still gets
-     * shown, just without its state having been cleared first. Stale state beats a
-     * liveboard that never comes back.
-     */
-    private async clearLiveboardStateViaHome(): Promise<void> {
-        this.trigger(HostEvent.Navigate, HOME_ROUTE).catch((error) => {
-            logger.warn('Could not route the pre-render via home before re-showing it', error);
-        });
-        await new Promise((resolve) => {
-            setTimeout(resolve, HOME_UNMOUNT_SETTLE_MS);
-        });
-    }
-
-    /**
-     * Whether the pre-render is already on the route this config asks for — the case
-     * where `Navigate` alone would change nothing, so the liveboard needs clearing
-     * first.
-     *
-     * Compares the whole route rather than the liveboard id alone: the path is built
-     * from the viz, tab and personalized view as well, so a same-liveboard show that
-     * moves to another tab is a real navigation and needs no help.
-     *
-     * Answers true only on a positive match. An unknown predecessor — no pre-render
-     * object yet, one that is not a LiveboardEmbed, or this embed showing itself again
-     * — takes the ordinary path, since a plain `Navigate` to a route the container is
-     * not on does the unmounting by itself, and a same-instance show has nothing that
-     * needs unmounting.
-     */
+    // The whole route, not just the liveboard id: the path is built from the viz, tab
+    // and view too, so a same-liveboard show onto another tab is a real navigation.
     private isShowingLiveboardRoute(showing?: LiveboardEmbed['currentLiveboardState']): boolean {
         if (!showing?.liveboardId) return false;
         const {

--- a/src/embed/liveboard.ts
+++ b/src/embed/liveboard.ts
@@ -44,6 +44,14 @@ import { SpotterVizConfig, buildSpotterVizAppInitData } from './spotter-viz-util
 const HOME_ROUTE = 'home';
 
 /**
+ * How long to let the container act on the home hop before asking for the liveboard
+ * back. The route change unmounts through React, so the post being delivered is not
+ * the same as the liveboard being gone — the same reasoning as the params settle
+ * window, and the same order of magnitude.
+ */
+const HOME_UNMOUNT_SETTLE_MS = 200;
+
+/**
  * APP_INIT data shape for LiveboardEmbed.
  * @internal
  */
@@ -1215,19 +1223,27 @@ export class LiveboardEmbed extends V1Embed {
      * tab. Going via home unmounts it, so the `Navigate` that follows rebuilds it from
      * the `UpdateEmbedParams` posted just before.
      *
-     * Awaits the trigger rather than posting and hoping: two `Navigate`s in the same
-     * tick are a router's invitation to coalesce, which would defeat the whole point.
+     * Waits {@link HOME_UNMOUNT_SETTLE_MS} rather than awaiting the trigger. The
+     * container does not acknowledge `Navigate`, so awaiting it does not resolve when
+     * the route changes — it resolves when `TRIGGER_TIMEOUT` fires, which parked a
+     * re-shown liveboard on the home page for a full 30 seconds. Observed, not
+     * theorised: `Navigate home` at 18:55:56 and the liveboard back at 18:56:26.
      *
-     * A failure warns rather than errors, and is swallowed: the liveboard still gets
-     * shown, just without the state having been cleared first. Stale state beats a
+     * The wait is still needed. Posting both routes in the same tick invites the
+     * container's router to coalesce them, which would leave the liveboard mounted and
+     * defeat the point.
+     *
+     * A rejection is caught and warned rather than thrown: the liveboard still gets
+     * shown, just without its state having been cleared first. Stale state beats a
      * liveboard that never comes back.
      */
     private async clearLiveboardStateViaHome(): Promise<void> {
-        try {
-            await this.trigger(HostEvent.Navigate, HOME_ROUTE);
-        } catch (error) {
+        this.trigger(HostEvent.Navigate, HOME_ROUTE).catch((error) => {
             logger.warn('Could not route the pre-render via home before re-showing it', error);
-        }
+        });
+        await new Promise((resolve) => {
+            setTimeout(resolve, HOME_UNMOUNT_SETTLE_MS);
+        });
     }
 
     /**

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5680,7 +5680,9 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            expect(mockProcessTrigger).toHaveBeenLastCalledWith(
+            // Not LastCalledWith: reconcileRuntimeParams fires a
+            // follow-up UpdateRuntimeFilters after this event.
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
@@ -5733,7 +5735,9 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            expect(mockProcessTrigger).toHaveBeenLastCalledWith(
+            // Not LastCalledWith: reconcileRuntimeParams fires a
+            // follow-up UpdateRuntimeFilters after this event.
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
@@ -5753,6 +5757,129 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
+    test('should trigger UpdateRuntimeFilters with the new config filters after UpdateEmbedParams', async () => {
+        await setupPreRenderTest('reconcile-new-filters', { liveboardId: 'original-lb' });
+
+        const runtimeFilters = [
+            {
+                columnName: 'Color',
+                operator: RuntimeFilterOp.IN,
+                values: ['red', 'blue'],
+            },
+        ];
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-new-filters',
+            liveboardId: 'original-lb',
+            runtimeFilters,
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateRuntimeFilters,
+                expect.any(String),
+                runtimeFilters,
+                undefined,
+            );
+
+            // The filters reconcile only after the params land, so that the
+            // iframe applies them to the config it has just been given.
+            const eventTypes = mockProcessTrigger.mock.calls.map(
+                (call: any[]) => call[1],
+            );
+            expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
+                eventTypes.indexOf(HostEvent.UpdateRuntimeFilters),
+            );
+        });
+    });
+
+    test('should clear the filters left behind by the previous pre-render config', async () => {
+        await setupPreRenderTest('reconcile-clear-filters', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red', 'blue'],
+                },
+            ],
+        });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-clear-filters',
+            liveboardId: 'original-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            // Same columns as the previous config, but with empty values, which
+            // is what actually resets a filter on the shared pre-render.
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateRuntimeFilters,
+                expect.any(String),
+                [
+                    {
+                        columnName: 'Color',
+                        operator: RuntimeFilterOp.IN,
+                        values: [],
+                    },
+                ],
+                undefined,
+            );
+        });
+    });
+
+    test('should not throw when the pre-render object carries no viewConfig', async () => {
+        const embed1 = await setupPreRenderTest('reconcile-no-view-config', {
+            liveboardId: 'original-lb',
+        });
+
+        // getPreRenderObj() reads an untyped property off the wrapper
+        // node, so it can hand back an object that is not a TsEmbed.
+        jest.spyOn(embed1 as any, 'getPreRenderObj').mockReturnValue({} as any);
+        const handleErrorSpy = jest.spyOn(LiveboardEmbed.prototype as any, 'handleError');
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-no-view-config',
+            liveboardId: 'updated-lb',
+        });
+        jest.spyOn(embed2 as any, 'getPreRenderObj').mockReturnValue({} as any);
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(handleErrorSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    code: EmbedErrorCodes.UPDATE_PARAMS_FAILED,
+                }),
+            );
+        });
+
+        handleErrorSpy.mockRestore();
+    });
+
+    test('should not trigger UpdateRuntimeFilters when no config has filters', async () => {
+        await setupPreRenderTest('reconcile-no-filters', { liveboardId: 'original-lb' });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-no-filters',
+            liveboardId: 'updated-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
+            );
+            expect(runtimeFilterCalls).toHaveLength(0);
+        });
+    });
     test('should handle error when getUpdateEmbedParamsObject fails during showPreRender', async () => {
         await setupPreRenderTest('error-test', { liveboardId: 'original-lb' });
 

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5796,6 +5796,48 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
+    test('should trigger Navigate only after UpdateEmbedParams has settled', async () => {
+        await setupPreRenderTest('navigate-after-params', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red'],
+                },
+            ],
+        });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'navigate-after-params',
+            liveboardId: 'updated-lb',
+        });
+
+        embed2.showPreRender();
+
+        // Inside the settle window the params are already out
+        // and Navigate is not.
+        await executeAfterWait(() => {
+            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
+            expect(eventTypes).toContain(HostEvent.UpdateEmbedParams);
+            expect(eventTypes).not.toContain(HostEvent.Navigate);
+        }, 50);
+
+        await executeAfterWait(() => {
+            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
+            // A Navigate that beat the params would make the container load
+            // `updated-lb` while still holding `original-lb`'s runtime filters,
+            // and drop the params that then arrive mid-load (SCAL-336321).
+            expect(eventTypes).toContain(HostEvent.Navigate);
+            expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
+                eventTypes.indexOf(HostEvent.Navigate),
+            );
+            expect(eventTypes.indexOf(HostEvent.UpdateRuntimeFilters)).toBeLessThan(
+                eventTypes.indexOf(HostEvent.Navigate),
+            );
+        }, 300);
+    });
+
     test('should clear the filters left behind by the previous pre-render config', async () => {
         await setupPreRenderTest('reconcile-clear-filters', {
             liveboardId: 'original-lb',

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5774,7 +5774,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             preRenderId: 'reconcile-new-filters',
             liveboardId: 'original-lb',
             runtimeFilters,
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5814,7 +5814,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'navigate-after-params',
             liveboardId: 'updated-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5857,7 +5857,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-clear-filters',
             liveboardId: 'original-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5894,7 +5894,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-view-config',
             liveboardId: 'updated-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
         jest.spyOn(embed2 as any, 'getPreRenderObj').mockReturnValue({} as any);
 
@@ -5917,7 +5917,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-filters',
             liveboardId: 'updated-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5946,7 +5946,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-chain',
             liveboardId: 'second-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
         await embed2.showPreRender();
         await executeAfterWait(() => {
@@ -5967,7 +5967,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed3 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-chain',
             liveboardId: 'third-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
         await embed3.showPreRender();
 
@@ -5990,7 +5990,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             preRenderId: 'reconcile-parameters',
             liveboardId: 'original-lb',
             runtimeParameters,
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -6024,7 +6024,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-parameters-none',
             liveboardId: 'original-lb',
-            reconcileRuntimeParamsOnPreRender: true,
+            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -6107,7 +6107,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
 
         // Same shape as the clear-filters case above, minus the flag: the
         // previous config left filters on the shared pre-render and this one
-        // declares none. Without reconcileRuntimeParamsOnPreRender the SDK
+        // declares none. Without preRenderConfig.reconcileRuntimeParams the SDK
         // leaves that to the container, so no UpdateRuntimeFilters goes out.
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-flag-off',

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -6039,7 +6039,10 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                expect.objectContaining({ runtimeParameters }),
+                expect.objectContaining({
+                    runtimeParameters,
+                    runtimeParameterParams: 'param1=Region%20Param&paramVal1=West',
+                }),
                 undefined,
             );
 
@@ -6049,6 +6052,58 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 (call: any[]) => call[1] === HostEvent.UpdateParameters,
             );
             expect(parameterCalls).toHaveLength(0);
+        });
+    });
+
+    test('should mark the params empty when the config declares no parameters', async () => {
+        await setupPreRenderTest('params-clear-parameters', {
+            liveboardId: 'original-lb',
+            runtimeParameters: [{ name: 'Region Param', value: 'East' }],
+        });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'params-clear-parameters',
+            liveboardId: 'original-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            // Same gate as the filters: the container only reads this field
+            // when it is truthy, so null would leave 'East' standing.
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateEmbedParams,
+                expect.any(String),
+                expect.objectContaining({ runtimeParameterParams: '&' }),
+                undefined,
+            );
+        });
+    });
+
+    test('should keep an empty string parameter value distinct from having none', async () => {
+        await setupPreRenderTest('params-empty-value', { liveboardId: 'original-lb' });
+
+        // `paramVal1=` is that parameter's value, not an absence — so it must
+        // not collapse to the empty marker.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'params-empty-value',
+            liveboardId: 'original-lb',
+            runtimeParameters: [{ name: 'Region Param', value: '' }],
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateEmbedParams,
+                expect.any(String),
+                expect.objectContaining({
+                    runtimeParameterParams: 'param1=Region%20Param&paramVal1=',
+                }),
+                undefined,
+            );
         });
     });
 

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -4377,7 +4377,9 @@ describe('Unit test case for ts embed', () => {
 
         test('should return getPreRenderObj and log if same object', () => {
             const searchEmbed = new SearchEmbed(getRootEl(), defaultViewConfig);
-            const loggerSpy = jest.spyOn(logger, 'info');
+            // debug, not info: the wrapper points at the embed being shown, so
+            // this is now the common case rather than a rare diagnostic.
+            const loggerSpy = jest.spyOn(logger, 'debug');
 
             // getPreRenderObj reads the embed reference from preRenderWrapper
             (searchEmbed as any).preRenderWrapper = {
@@ -5772,7 +5774,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             preRenderId: 'reconcile-new-filters',
             liveboardId: 'original-lb',
             runtimeFilters,
-            reconcileRuntimeFiltersOnPreRender: true,
+            reconcileRuntimeParamsOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5812,7 +5814,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'navigate-after-params',
             liveboardId: 'updated-lb',
-            reconcileRuntimeFiltersOnPreRender: true,
+            reconcileRuntimeParamsOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5855,7 +5857,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-clear-filters',
             liveboardId: 'original-lb',
-            reconcileRuntimeFiltersOnPreRender: true,
+            reconcileRuntimeParamsOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5892,7 +5894,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-view-config',
             liveboardId: 'updated-lb',
-            reconcileRuntimeFiltersOnPreRender: true,
+            reconcileRuntimeParamsOnPreRender: true,
         });
         jest.spyOn(embed2 as any, 'getPreRenderObj').mockReturnValue({} as any);
 
@@ -5915,7 +5917,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-filters',
             liveboardId: 'updated-lb',
-            reconcileRuntimeFiltersOnPreRender: true,
+            reconcileRuntimeParamsOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5927,6 +5929,170 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             expect(runtimeFilterCalls).toHaveLength(0);
         });
     });
+    test('should reconcile against the embed showing now, not the one that created the pre-render', async () => {
+        await setupPreRenderTest('reconcile-chain', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red', 'blue'],
+                },
+            ],
+        });
+
+        // Second in the chain: clears the creator's filters, and becomes what
+        // the pre-render is showing.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-chain',
+            liveboardId: 'second-lb',
+            reconcileRuntimeParamsOnPreRender: true,
+        });
+        await embed2.showPreRender();
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateRuntimeFilters,
+                expect.any(String),
+                [{ columnName: 'Color', operator: RuntimeFilterOp.IN, values: [] }],
+                undefined,
+            );
+        });
+
+        mockProcessTrigger.mockClear();
+
+        // Third: its predecessor is embed2, which declares no filters — so
+        // there is nothing left to clear. Reading the *creator* instead would
+        // resurrect Color here and clear a filter that is long gone.
+        const embed3 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-chain',
+            liveboardId: 'third-lb',
+            reconcileRuntimeParamsOnPreRender: true,
+        });
+        await embed3.showPreRender();
+
+        await executeAfterWait(() => {
+            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
+            );
+            expect(runtimeFilterCalls).toHaveLength(0);
+        });
+    });
+
+    test('should re-apply the new config runtime parameters after UpdateEmbedParams', async () => {
+        await setupPreRenderTest('reconcile-parameters', {
+            liveboardId: 'original-lb',
+            runtimeParameters: [{ name: 'Region Param', value: 'East' }],
+        });
+
+        const runtimeParameters = [{ name: 'Region Param', value: 'West' }];
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-parameters',
+            liveboardId: 'original-lb',
+            runtimeParameters,
+            reconcileRuntimeParamsOnPreRender: true,
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateParameters,
+                expect.any(String),
+                runtimeParameters,
+                undefined,
+            );
+
+            // Same ordering rule as the filters: the parameters have to land on
+            // the config the container has just been given.
+            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
+            expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
+                eventTypes.indexOf(HostEvent.UpdateParameters),
+            );
+        });
+    });
+
+    test('should not send UpdateParameters when the new config declares none', async () => {
+        await setupPreRenderTest('reconcile-parameters-none', {
+            liveboardId: 'original-lb',
+            runtimeParameters: [{ name: 'Region Param', value: 'East' }],
+        });
+
+        // No payload means "unset" for a parameter, so the SDK sends nothing and
+        // leaves the reset to the container.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-parameters-none',
+            liveboardId: 'original-lb',
+            reconcileRuntimeParamsOnPreRender: true,
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            const parameterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateParameters,
+            );
+            expect(parameterCalls).toHaveLength(0);
+        });
+    });
+
+    test('should hand the pre-render over to the embed being shown', async () => {
+        const embed1 = await setupPreRenderTest('take-over-state', { liveboardId: 'original-lb' });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'take-over-state',
+            liveboardId: 'second-lb',
+        });
+
+        await embed2.showPreRender();
+
+        // It connected to embed1's pre-render, recorded embed1 as what was
+        // showing before it, and is now what the wrapper points at.
+        expect((embed2 as any).preRenderPredecessor).toBe(embed1);
+        expect((embed2 as any).getPreRenderObj()).toBe(embed2);
+        expect((embed1 as any).getPreRenderObj()).toBe(embed2);
+    });
+
+    test('should not strand callbacks when the container loads after the shown embed was hidden', async () => {
+        // The creator is subscribed but the container has NOT announced itself
+        // yet, which is the state a real pre-render starts in.
+        const embed1 = await setupPreRenderTest('loaded-after-hide', { liveboardId: 'original-lb' });
+        embed1.isEmbedContainerLoaded = false;
+
+        // Second embed shows, takes the pre-render over, then is hidden — which
+        // unsubscribes it, so it will never hear EmbedListenerReady itself.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'loaded-after-hide',
+            liveboardId: 'second-lb',
+        });
+        await embed2.showPreRender();
+        embed2.hidePreRender();
+        expect(embed2.isEmbedContainerLoaded).toBe(false);
+
+        // Container comes up and the creator hears it.
+        (embed1 as any).createEmbedContainerHandler(EmbedEvent.EmbedListenerReady)();
+
+        mockProcessTrigger.mockClear();
+        mockProcessTrigger.mockResolvedValue({});
+
+        // A third embed reads the state off embed2, which owns the wrapper and
+        // never learned the container was up. Reading a per-instance snapshot
+        // here leaves UpdateEmbedParams queued forever and the pre-render stuck
+        // on the previous liveboard.
+        const embed3 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'loaded-after-hide',
+            liveboardId: 'third-lb',
+        });
+        await embed3.showPreRender();
+
+        expect(embed3.isEmbedContainerLoaded).toBe(true);
+        await executeAfterWait(() => {
+            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
+            expect(eventTypes).toContain(HostEvent.UpdateEmbedParams);
+        }, 300);
+    });
+
     test('should not reconcile runtime filters unless the view config opts in', async () => {
         await setupPreRenderTest('reconcile-flag-off', {
             liveboardId: 'original-lb',
@@ -5941,7 +6107,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
 
         // Same shape as the clear-filters case above, minus the flag: the
         // previous config left filters on the shared pre-render and this one
-        // declares none. Without reconcileRuntimeFiltersOnPreRender the SDK
+        // declares none. Without reconcileRuntimeParamsOnPreRender the SDK
         // leaves that to the container, so no UpdateRuntimeFilters goes out.
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-flag-off',

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5772,6 +5772,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             preRenderId: 'reconcile-new-filters',
             liveboardId: 'original-lb',
             runtimeFilters,
+            reconcileRuntimeFiltersOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5811,6 +5812,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'navigate-after-params',
             liveboardId: 'updated-lb',
+            reconcileRuntimeFiltersOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5853,6 +5855,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-clear-filters',
             liveboardId: 'original-lb',
+            reconcileRuntimeFiltersOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5889,6 +5892,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-view-config',
             liveboardId: 'updated-lb',
+            reconcileRuntimeFiltersOnPreRender: true,
         });
         jest.spyOn(embed2 as any, 'getPreRenderObj').mockReturnValue({} as any);
 
@@ -5911,6 +5915,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-no-filters',
             liveboardId: 'updated-lb',
+            reconcileRuntimeFiltersOnPreRender: true,
         });
 
         embed2.showPreRender();
@@ -5922,6 +5927,36 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             expect(runtimeFilterCalls).toHaveLength(0);
         });
     });
+    test('should not reconcile runtime filters unless the view config opts in', async () => {
+        await setupPreRenderTest('reconcile-flag-off', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red', 'blue'],
+                },
+            ],
+        });
+
+        // Same shape as the clear-filters case above, minus the flag: the
+        // previous config left filters on the shared pre-render and this one
+        // declares none. Without reconcileRuntimeFiltersOnPreRender the SDK
+        // leaves that to the container, so no UpdateRuntimeFilters goes out.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-flag-off',
+            liveboardId: 'original-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
+            expect(eventTypes).toContain(HostEvent.UpdateEmbedParams);
+            expect(eventTypes).not.toContain(HostEvent.UpdateRuntimeFilters);
+        });
+    });
+
     test('should handle error when getUpdateEmbedParamsObject fails during showPreRender', async () => {
         await setupPreRenderTest('error-test', { liveboardId: 'original-lb' });
 

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5682,8 +5682,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            // Not LastCalledWith: reconcileRuntimeParams fires a
-            // follow-up UpdateRuntimeFilters after this event.
+            // Not LastCalledWith: LiveboardEmbed fires Navigate after this.
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
@@ -5737,8 +5736,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            // Not LastCalledWith: reconcileRuntimeParams fires a
-            // follow-up UpdateRuntimeFilters after this event.
+            // Not LastCalledWith: LiveboardEmbed fires Navigate after this.
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
@@ -5759,7 +5757,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
-    test('should trigger UpdateRuntimeFilters with the new config filters after UpdateEmbedParams', async () => {
+    test('should carry the new config filters in UpdateEmbedParams, with no follow-up event', async () => {
         await setupPreRenderTest('reconcile-new-filters', { liveboardId: 'original-lb' });
 
         const runtimeFilters = [
@@ -5782,20 +5780,18 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         await executeAfterWait(() => {
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
-                HostEvent.UpdateRuntimeFilters,
+                HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                runtimeFilters,
+                expect.objectContaining({ runtimeFilters }),
                 undefined,
             );
 
-            // The filters reconcile only after the params land, so that the
-            // iframe applies them to the config it has just been given.
-            const eventTypes = mockProcessTrigger.mock.calls.map(
-                (call: any[]) => call[1],
+            // The params payload already carries them, so the reconcile
+            // costs no extra traffic when the new config has its own filters.
+            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
             );
-            expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
-                eventTypes.indexOf(HostEvent.UpdateRuntimeFilters),
-            );
+            expect(runtimeFilterCalls).toHaveLength(0);
         });
     });
 
@@ -5836,9 +5832,6 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
                 eventTypes.indexOf(HostEvent.Navigate),
             );
-            expect(eventTypes.indexOf(HostEvent.UpdateRuntimeFilters)).toBeLessThan(
-                eventTypes.indexOf(HostEvent.Navigate),
-            );
         }, 300);
     });
 
@@ -5864,20 +5857,55 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
 
         await executeAfterWait(() => {
             // Same columns as the previous config, but with empty values, which
-            // is what actually resets a filter on the shared pre-render.
+            // is what actually resets a filter on the shared pre-render —
+            // carried by the params payload itself, not a follow-up event.
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
-                HostEvent.UpdateRuntimeFilters,
+                HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                [
-                    {
-                        columnName: 'Color',
-                        operator: RuntimeFilterOp.IN,
-                        values: [],
-                    },
-                ],
+                expect.objectContaining({
+                    runtimeFilters: [
+                        {
+                            columnName: 'Color',
+                            operator: RuntimeFilterOp.IN,
+                            values: [],
+                        },
+                    ],
+                }),
                 undefined,
             );
+
+            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
+            );
+            expect(runtimeFilterCalls).toHaveLength(0);
+        });
+    });
+
+    test('should leave the params filters alone when the flag is not set', async () => {
+        await setupPreRenderTest('reconcile-off', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red', 'blue'],
+                },
+            ],
+        });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-off',
+            liveboardId: 'original-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            const paramsCall = mockProcessTrigger.mock.calls.find(
+                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
+            );
+            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
         });
     });
 
@@ -5911,7 +5939,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         handleErrorSpy.mockRestore();
     });
 
-    test('should not trigger UpdateRuntimeFilters when no config has filters', async () => {
+    test('should not add filters to the params when no config has any', async () => {
         await setupPreRenderTest('reconcile-no-filters', { liveboardId: 'original-lb' });
 
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
@@ -5923,10 +5951,10 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
-                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
+            const paramsCall = mockProcessTrigger.mock.calls.find(
+                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
             );
-            expect(runtimeFilterCalls).toHaveLength(0);
+            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
         });
     });
     test('should reconcile against the embed showing now, not the one that created the pre-render', async () => {
@@ -5952,9 +5980,13 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         await executeAfterWait(() => {
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
-                HostEvent.UpdateRuntimeFilters,
+                HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                [{ columnName: 'Color', operator: RuntimeFilterOp.IN, values: [] }],
+                expect.objectContaining({
+                    runtimeFilters: [
+                        { columnName: 'Color', operator: RuntimeFilterOp.IN, values: [] },
+                    ],
+                }),
                 undefined,
             );
         });
@@ -5972,14 +6004,14 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         await embed3.showPreRender();
 
         await executeAfterWait(() => {
-            const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
-                (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
+            const paramsCall = mockProcessTrigger.mock.calls.find(
+                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
             );
-            expect(runtimeFilterCalls).toHaveLength(0);
+            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
         });
     });
 
-    test('should re-apply the new config runtime parameters after UpdateEmbedParams', async () => {
+    test('should carry the new config runtime parameters in UpdateEmbedParams', async () => {
         await setupPreRenderTest('reconcile-parameters', {
             liveboardId: 'original-lb',
             runtimeParameters: [{ name: 'Region Param', value: 'East' }],
@@ -5998,29 +6030,29 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         await executeAfterWait(() => {
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
-                HostEvent.UpdateParameters,
+                HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                runtimeParameters,
+                expect.objectContaining({ runtimeParameters }),
                 undefined,
             );
 
-            // Same ordering rule as the filters: the parameters have to land on
-            // the config the container has just been given.
-            const eventTypes = mockProcessTrigger.mock.calls.map((call: any[]) => call[1]);
-            expect(eventTypes.indexOf(HostEvent.UpdateEmbedParams)).toBeLessThan(
-                eventTypes.indexOf(HostEvent.UpdateParameters),
+            // A parameter always carries a value, so the params payload says
+            // everything there is to say — no follow-up event.
+            const parameterCalls = mockProcessTrigger.mock.calls.filter(
+                (call: any[]) => call[1] === HostEvent.UpdateParameters,
             );
+            expect(parameterCalls).toHaveLength(0);
         });
     });
 
-    test('should not send UpdateParameters when the new config declares none', async () => {
+    test('should not re-send the previous parameters when the new config declares none', async () => {
         await setupPreRenderTest('reconcile-parameters-none', {
             liveboardId: 'original-lb',
             runtimeParameters: [{ name: 'Region Param', value: 'East' }],
         });
 
-        // No payload means "unset" for a parameter, so the SDK sends nothing and
-        // leaves the reset to the container.
+        // There is no empty-value form of a parameter, so clearing is left
+        // to the container, which resets from this same payload.
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'reconcile-parameters-none',
             liveboardId: 'original-lb',
@@ -6030,6 +6062,11 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         embed2.showPreRender();
 
         await executeAfterWait(() => {
+            const paramsCall = mockProcessTrigger.mock.calls.find(
+                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
+            );
+            expect(paramsCall?.[3]).not.toHaveProperty('runtimeParameters');
+
             const parameterCalls = mockProcessTrigger.mock.calls.filter(
                 (call: any[]) => call[1] === HostEvent.UpdateParameters,
             );

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5782,16 +5782,57 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                expect.objectContaining({ runtimeFilters }),
+                expect.objectContaining({
+                    runtimeFilters,
+                    // The serialized form is what the container reads. It is
+                    // already correct here, off the view config; the reconcile
+                    // must agree with it rather than clobber it.
+                    runtimeFilterParams: 'col1=Color&op1=IN&val1=red&val1=blue',
+                }),
                 undefined,
             );
 
-            // The params payload already carries them, so the reconcile
-            // costs no extra traffic when the new config has its own filters.
+            // The params payload carries both forms, so the reconcile costs
+            // no extra traffic when the new config has its own filters.
             const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
                 (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
             );
             expect(runtimeFilterCalls).toHaveLength(0);
+        });
+    });
+
+    test('should serialize the filters when they are not excluded from the URL', async () => {
+        await setupPreRenderTest('reconcile-url-filters', { liveboardId: 'original-lb' });
+
+        // With the flag off, getDefaultAppInitData leaves runtimeFilterParams
+        // null and a URL render carries the filters in the iframe's query
+        // string. A show cycle has no URL, so the payload has to carry them.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'reconcile-url-filters',
+            liveboardId: 'original-lb',
+            excludeRuntimeFiltersfromURL: false,
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red'],
+                },
+            ],
+            preRenderConfig: { reconcileRuntimeParams: true },
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateEmbedParams,
+                expect.any(String),
+                expect.objectContaining({
+                    runtimeFilterParams: 'col1=Color&op1=IN&val1=red',
+                }),
+                undefined,
+            );
         });
     });
 
@@ -5871,6 +5912,8 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                             values: [],
                         },
                     ],
+                    // No dangling separator where the values would have been.
+                    runtimeFilterParams: 'col1=Color&op1=IN',
                 }),
                 undefined,
             );
@@ -5906,6 +5949,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
             );
             expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
+            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
         });
     });
 
@@ -5955,6 +5999,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
             );
             expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
+            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
         });
     });
     test('should reconcile against the embed showing now, not the one that created the pre-render', async () => {
@@ -5986,6 +6031,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                     runtimeFilters: [
                         { columnName: 'Color', operator: RuntimeFilterOp.IN, values: [] },
                     ],
+                    runtimeFilterParams: 'col1=Color&op1=IN',
                 }),
                 undefined,
             );
@@ -6008,6 +6054,7 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
             );
             expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
+            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
         });
     });
 

--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -5757,8 +5757,8 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
-    test('should carry the new config filters in UpdateEmbedParams, with no follow-up event', async () => {
-        await setupPreRenderTest('reconcile-new-filters', { liveboardId: 'original-lb' });
+    test('should carry the new config filters in UpdateEmbedParams', async () => {
+        await setupPreRenderTest('params-new-filters', { liveboardId: 'original-lb' });
 
         const runtimeFilters = [
             {
@@ -5769,10 +5769,9 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         ];
 
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-new-filters',
+            preRenderId: 'params-new-filters',
             liveboardId: 'original-lb',
             runtimeFilters,
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5784,16 +5783,13 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 expect.any(String),
                 expect.objectContaining({
                     runtimeFilters,
-                    // The serialized form is what the container reads. It is
-                    // already correct here, off the view config; the reconcile
-                    // must agree with it rather than clobber it.
+                    // The serialized form is the one the container reads.
                     runtimeFilterParams: 'col1=Color&op1=IN&val1=red&val1=blue',
                 }),
                 undefined,
             );
 
-            // The params payload carries both forms, so the reconcile costs
-            // no extra traffic when the new config has its own filters.
+            // Everything rides in the params payload; nothing follows it.
             const runtimeFilterCalls = mockProcessTrigger.mock.calls.filter(
                 (call: any[]) => call[1] === HostEvent.UpdateRuntimeFilters,
             );
@@ -5802,13 +5798,13 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
     });
 
     test('should serialize the filters when they are not excluded from the URL', async () => {
-        await setupPreRenderTest('reconcile-url-filters', { liveboardId: 'original-lb' });
+        await setupPreRenderTest('params-url-filters', { liveboardId: 'original-lb' });
 
         // With the flag off, getDefaultAppInitData leaves runtimeFilterParams
         // null and a URL render carries the filters in the iframe's query
         // string. A show cycle has no URL, so the payload has to carry them.
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-url-filters',
+            preRenderId: 'params-url-filters',
             liveboardId: 'original-lb',
             excludeRuntimeFiltersfromURL: false,
             runtimeFilters: [
@@ -5818,7 +5814,6 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                     values: ['red'],
                 },
             ],
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5851,7 +5846,6 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
             preRenderId: 'navigate-after-params',
             liveboardId: 'updated-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -5876,8 +5870,8 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         }, 300);
     });
 
-    test('should clear the filters left behind by the previous pre-render config', async () => {
-        await setupPreRenderTest('reconcile-clear-filters', {
+    test('should mark the params empty when the config declares no filters', async () => {
+        await setupPreRenderTest('params-clear-filters', {
             liveboardId: 'original-lb',
             runtimeFilters: [
                 {
@@ -5889,32 +5883,21 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
 
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-clear-filters',
+            preRenderId: 'params-clear-filters',
             liveboardId: 'original-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
 
         await executeAfterWait(() => {
-            // Same columns as the previous config, but with empty values, which
-            // is what actually resets a filter on the shared pre-render —
-            // carried by the params payload itself, not a follow-up event.
+            // Not null and not '': the container only reads this field when it
+            // is truthy, so either would leave the previous embed's filters in
+            // place. A lone separator passes that gate and parses to {}.
             expect(mockProcessTrigger).toHaveBeenCalledWith(
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                expect.objectContaining({
-                    runtimeFilters: [
-                        {
-                            columnName: 'Color',
-                            operator: RuntimeFilterOp.IN,
-                            values: [],
-                        },
-                    ],
-                    // No dangling separator where the values would have been.
-                    runtimeFilterParams: 'col1=Color&op1=IN',
-                }),
+                expect.objectContaining({ runtimeFilterParams: '&' }),
                 undefined,
             );
 
@@ -5925,8 +5908,60 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
-    test('should leave the params filters alone when the flag is not set', async () => {
-        await setupPreRenderTest('reconcile-off', {
+    test('should mark the params empty for an explicitly empty filter array', async () => {
+        await setupPreRenderTest('params-empty-array', {
+            liveboardId: 'original-lb',
+            runtimeFilters: [
+                {
+                    columnName: 'Color',
+                    operator: RuntimeFilterOp.IN,
+                    values: ['red'],
+                },
+            ],
+        });
+
+        // `runtimeFilters: []` is the shape the customer reported as not
+        // resetting anything.
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'params-empty-array',
+            liveboardId: 'original-lb',
+            runtimeFilters: [],
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateEmbedParams,
+                expect.any(String),
+                expect.objectContaining({ runtimeFilterParams: '&' }),
+                undefined,
+            );
+        });
+    });
+
+    test('should mark the params empty when no config in the chain has filters', async () => {
+        await setupPreRenderTest('params-no-filters', { liveboardId: 'original-lb' });
+
+        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
+            preRenderId: 'params-no-filters',
+            liveboardId: 'updated-lb',
+        });
+
+        embed2.showPreRender();
+
+        await executeAfterWait(() => {
+            const paramsCall = mockProcessTrigger.mock.calls.find(
+                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
+            );
+            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
+            expect(paramsCall?.[3].runtimeFilterParams).toBe('&');
+        });
+    });
+
+    test('should state each embed filters as the pre-render is handed along', async () => {
+        await setupPreRenderTest('params-chain', {
             liveboardId: 'original-lb',
             runtimeFilters: [
                 {
@@ -5937,89 +5972,11 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
             ],
         });
 
+        // Second in the chain declares none, so it empties the field rather
+        // than letting the creator's filters stand.
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-off',
-            liveboardId: 'original-lb',
-        });
-
-        embed2.showPreRender();
-
-        await executeAfterWait(() => {
-            const paramsCall = mockProcessTrigger.mock.calls.find(
-                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
-            );
-            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
-            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
-        });
-    });
-
-    test('should not throw when the pre-render object carries no viewConfig', async () => {
-        const embed1 = await setupPreRenderTest('reconcile-no-view-config', {
-            liveboardId: 'original-lb',
-        });
-
-        // getPreRenderObj() reads an untyped property off the wrapper
-        // node, so it can hand back an object that is not a TsEmbed.
-        jest.spyOn(embed1 as any, 'getPreRenderObj').mockReturnValue({} as any);
-        const handleErrorSpy = jest.spyOn(LiveboardEmbed.prototype as any, 'handleError');
-
-        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-no-view-config',
-            liveboardId: 'updated-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
-        });
-        jest.spyOn(embed2 as any, 'getPreRenderObj').mockReturnValue({} as any);
-
-        embed2.showPreRender();
-
-        await executeAfterWait(() => {
-            expect(handleErrorSpy).not.toHaveBeenCalledWith(
-                expect.objectContaining({
-                    code: EmbedErrorCodes.UPDATE_PARAMS_FAILED,
-                }),
-            );
-        });
-
-        handleErrorSpy.mockRestore();
-    });
-
-    test('should not add filters to the params when no config has any', async () => {
-        await setupPreRenderTest('reconcile-no-filters', { liveboardId: 'original-lb' });
-
-        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-no-filters',
-            liveboardId: 'updated-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
-        });
-
-        embed2.showPreRender();
-
-        await executeAfterWait(() => {
-            const paramsCall = mockProcessTrigger.mock.calls.find(
-                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
-            );
-            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
-            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
-        });
-    });
-    test('should reconcile against the embed showing now, not the one that created the pre-render', async () => {
-        await setupPreRenderTest('reconcile-chain', {
-            liveboardId: 'original-lb',
-            runtimeFilters: [
-                {
-                    columnName: 'Color',
-                    operator: RuntimeFilterOp.IN,
-                    values: ['red', 'blue'],
-                },
-            ],
-        });
-
-        // Second in the chain: clears the creator's filters, and becomes what
-        // the pre-render is showing.
-        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-chain',
+            preRenderId: 'params-chain',
             liveboardId: 'second-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
         await embed2.showPreRender();
         await executeAfterWait(() => {
@@ -6027,49 +5984,52 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 expect.any(Object),
                 HostEvent.UpdateEmbedParams,
                 expect.any(String),
-                expect.objectContaining({
-                    runtimeFilters: [
-                        { columnName: 'Color', operator: RuntimeFilterOp.IN, values: [] },
-                    ],
-                    runtimeFilterParams: 'col1=Color&op1=IN',
-                }),
+                expect.objectContaining({ runtimeFilterParams: '&' }),
                 undefined,
             );
         });
 
         mockProcessTrigger.mockClear();
 
-        // Third: its predecessor is embed2, which declares no filters — so
-        // there is nothing left to clear. Reading the *creator* instead would
-        // resurrect Color here and clear a filter that is long gone.
+        // Third declares its own, and states them without reference to either
+        // embed before it.
         const embed3 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-chain',
+            preRenderId: 'params-chain',
             liveboardId: 'third-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
+            runtimeFilters: [
+                {
+                    columnName: 'Region',
+                    operator: RuntimeFilterOp.EQ,
+                    values: ['North'],
+                },
+            ],
         });
         await embed3.showPreRender();
 
         await executeAfterWait(() => {
-            const paramsCall = mockProcessTrigger.mock.calls.find(
-                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
+            expect(mockProcessTrigger).toHaveBeenCalledWith(
+                expect.any(Object),
+                HostEvent.UpdateEmbedParams,
+                expect.any(String),
+                expect.objectContaining({
+                    runtimeFilterParams: 'col1=Region&op1=EQ&val1=North',
+                }),
+                undefined,
             );
-            expect(paramsCall?.[3]).not.toHaveProperty('runtimeFilters');
-            expect(paramsCall?.[3].runtimeFilterParams).toBeNull();
         });
     });
 
     test('should carry the new config runtime parameters in UpdateEmbedParams', async () => {
-        await setupPreRenderTest('reconcile-parameters', {
+        await setupPreRenderTest('params-parameters', {
             liveboardId: 'original-lb',
             runtimeParameters: [{ name: 'Region Param', value: 'East' }],
         });
 
         const runtimeParameters = [{ name: 'Region Param', value: 'West' }];
         const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-parameters',
+            preRenderId: 'params-parameters',
             liveboardId: 'original-lb',
             runtimeParameters,
-            preRenderConfig: { reconcileRuntimeParams: true },
         });
 
         embed2.showPreRender();
@@ -6083,8 +6043,8 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
                 undefined,
             );
 
-            // A parameter always carries a value, so the params payload says
-            // everything there is to say — no follow-up event.
+            // A parameter always carries a value, so the payload says everything
+            // there is to say — no follow-up event.
             const parameterCalls = mockProcessTrigger.mock.calls.filter(
                 (call: any[]) => call[1] === HostEvent.UpdateParameters,
             );
@@ -6092,34 +6052,6 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
         });
     });
 
-    test('should not re-send the previous parameters when the new config declares none', async () => {
-        await setupPreRenderTest('reconcile-parameters-none', {
-            liveboardId: 'original-lb',
-            runtimeParameters: [{ name: 'Region Param', value: 'East' }],
-        });
-
-        // There is no empty-value form of a parameter, so clearing is left
-        // to the container, which resets from this same payload.
-        const embed2 = new LiveboardEmbed('#tsEmbedDiv', {
-            preRenderId: 'reconcile-parameters-none',
-            liveboardId: 'original-lb',
-            preRenderConfig: { reconcileRuntimeParams: true },
-        });
-
-        embed2.showPreRender();
-
-        await executeAfterWait(() => {
-            const paramsCall = mockProcessTrigger.mock.calls.find(
-                (call: any[]) => call[1] === HostEvent.UpdateEmbedParams,
-            );
-            expect(paramsCall?.[3]).not.toHaveProperty('runtimeParameters');
-
-            const parameterCalls = mockProcessTrigger.mock.calls.filter(
-                (call: any[]) => call[1] === HostEvent.UpdateParameters,
-            );
-            expect(parameterCalls).toHaveLength(0);
-        });
-    });
 
     test('should hand the pre-render over to the embed being shown', async () => {
         const embed1 = await setupPreRenderTest('take-over-state', { liveboardId: 'original-lb' });
@@ -6131,9 +6063,8 @@ describe('ShowPreRender with UpdateEmbedParams', () => {
 
         await embed2.showPreRender();
 
-        // It connected to embed1's pre-render, recorded embed1 as what was
-        // showing before it, and is now what the wrapper points at.
-        expect((embed2 as any).preRenderPredecessor).toBe(embed1);
+        // It connected to embed1's pre-render and is now what the wrapper
+        // points at, so getPreRenderObj() means "what is showing".
         expect((embed2 as any).getPreRenderObj()).toBe(embed2);
         expect((embed1 as any).getPreRenderObj()).toBe(embed2);
     });

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -152,6 +152,12 @@ export class TsEmbed {
      */
     protected embedNodeKey = '__tsEmbed';
 
+    /**
+     * Marks on the pre-render wrapper that the shared embed container has
+     * announced itself, so the fact survives any one instance being hidden.
+     */
+    protected embedContainerLoadedKey = '__tsEmbedContainerLoaded';
+
     protected isAppInitialized = false;
 
     /**
@@ -1161,6 +1167,7 @@ export class TsEmbed {
             }
             this.isRendered = true;
             this.inheritPreRenderContainer();
+            this.adoptPreRenderState();
         }
 
         return this.isPreRenderConnected();
@@ -1618,14 +1625,81 @@ export class TsEmbed {
     protected getPreRenderObj<T extends TsEmbed>(): T {
         const embedObj = (this.preRenderWrapper as any)?.[this.embedNodeKey] as T;
         if (embedObj === (this as any)) {
-            logger.info('embedObj is same as this');
+            logger.debug('embedObj is same as this');
         }
         return embedObj;
+    }
+
+    /**
+     * The instance that was showing on this pre-render when this one took it
+     * over, captured synchronously in `beforePrerenderVisible()` — before
+     * `takeOverPreRender()` repoints the wrapper at this instance, and before
+     * any `await`, so an async reader still sees the right predecessor.
+     */
+    private preRenderPredecessor: TsEmbed | undefined;
+
+    /**
+     * Copies the state that belongs to the shared iframe rather than to any one
+     * instance off whichever instance holds it now. Called from
+     * `connectPreRendered()`, beside `inheritPreRenderContainer()`, because
+     * connecting is when this embed joins an iframe someone else owns.
+     *
+     * Without this an instance that never rendered an iframe of its own reports
+     * the container as not loaded, and every callback queued behind
+     * `executeAfterEmbedContainerLoaded` is stranded once `takeOverPreRender()`
+     * has repointed the wrapper away from the instance that knew better.
+     */
+    protected adoptPreRenderState(): void {
+        if (this.isEmbedContainerLoaded) return;
+        const current = this.getPreRenderObj<TsEmbed>();
+        if (current && current !== (this as TsEmbed) && current.isEmbedContainerLoaded) {
+            this.markEmbedContainerLoaded();
+        }
+    }
+
+    /**
+     * Makes this instance the one the pre-render wrapper points at, so the
+     * *next* embed to show on it reads this config as its predecessor rather
+     * than the config of whichever instance originally created the wrapper.
+     *
+     * This belongs to showing rather than to connecting: an instance connects
+     * once but can be shown many times, with other embeds shown in between, and
+     * it is the most recent *show* that decides what the pre-render is
+     * currently displaying.
+     */
+    protected takeOverPreRender(): void {
+        if (!this.preRenderWrapper) return;
+        this.adoptPreRenderState();
+        (this.preRenderWrapper as any)[this.embedNodeKey] = this;
+    }
+
+    /**
+     * Records that the shared container is up, on the wrapper node as well as
+     * on this instance.
+     *
+     * The flag has to live on the node: it describes the iframe, but it is set
+     * per instance by whichever ones happen to be subscribed when the container
+     * announces itself. An instance that was hidden by then (`hidePreRender()`
+     * unsubscribes it) would otherwise report `false` forever, and once it owns
+     * the wrapper it would hand that `false` to everyone who came after.
+     */
+    private markEmbedContainerLoaded() {
+        this.isEmbedContainerLoaded = true;
+        if (this.preRenderWrapper) {
+            (this.preRenderWrapper as any)[this.embedContainerLoadedKey] = true;
+        }
     }
 
     private checkEmbedContainerLoaded() {
         if (this.isEmbedContainerLoaded) return true;
 
+        if ((this.preRenderWrapper as any)?.[this.embedContainerLoadedKey]) {
+            this.isEmbedContainerLoaded = true;
+            return true;
+        }
+
+        // Fallback for a wrapper stamped by an older build of this SDK, where
+        // only the instance carried the flag.
         const preRenderObj = this.getPreRenderObj<TsEmbed>();
         if (preRenderObj && preRenderObj.isEmbedContainerLoaded) {
             this.isEmbedContainerLoaded = true;
@@ -1658,7 +1732,7 @@ export class TsEmbed {
         (source: EmbedEvent.AuthInit | EmbedEvent.EmbedListenerReady) => () => {
             const processEmbedContainerReady = () => {
                 logger.debug('processEmbedContainerReady');
-                this.isEmbedContainerLoaded = true;
+                this.markEmbedContainerLoaded();
                 this.executeEmbedContainerReadyCallbacks();
             };
             if (source === EmbedEvent.AuthInit) {
@@ -2042,6 +2116,10 @@ export class TsEmbed {
         // have moved on to UpdateEmbedParams supported clusters
         // this.validatePreRenderViewConfig(this.viewConfig); removed in #517
         logger.debug('triggering UpdateEmbedParams', this.viewConfig);
+        // Captured here, synchronously: the reconcile below runs inside an async
+        // callback, by which time showPreRender() has repointed the wrapper at
+        // this instance and getPreRenderObj() would hand back `this`.
+        this.preRenderPredecessor = this.getPreRenderObj<TsEmbed>();
         // Created synchronously, outside executeAfterEmbedContainerLoaded, so a
         // navigation callback queued after this one has something to await
         // whether the container is already loaded or not.
@@ -2053,7 +2131,7 @@ export class TsEmbed {
                     // Opt-in: it costs an extra UpdateRuntimeFilters per
                     // show-cycle and only matters when one preRenderId is
                     // shared by embeds with different runtime filters.
-                    if (this.viewConfig.reconcileRuntimeFiltersOnPreRender) {
+                    if (this.viewConfig.reconcileRuntimeParamsOnPreRender) {
                         this.reconcileRuntimeParams();
                     }
                 } catch (error) {
@@ -2072,23 +2150,42 @@ export class TsEmbed {
     }
 
     /**
-     * Re-applies the runtime filters after `UpdateEmbedParams`, so that a shared
-     * pre-render does not keep the filters of the config that used it last.
-     * When the new config has no filters, the previous config's filters are sent
-     * back with empty values, which is what actually resets them.
+     * Re-applies this config's runtime filters and parameters after
+     * `UpdateEmbedParams`, so that a shared pre-render does not keep the values
+     * of the config that used it last.
      *
-     * Gated by {@link BaseViewConfig.reconcileRuntimeFiltersOnPreRender}, which
+     * WHEN THIS IS ACTUALLY NEEDED: the **same** liveboard shown again through
+     * the shared pre-render (LB1 → LB1). Nothing navigates in that case —
+     * `navigateToLiveboard` is a no-op for an id the container already has — so
+     * `UpdateEmbedParams` is the only thing carrying the new values, and if the
+     * container drops or ignores it the previous config's filters simply stay.
+     * This re-apply is what forces them out.
+     *
+     * When the liveboard DOES change (LB1 → LB2), the `Navigate` that follows —
+     * now ordered after the params have landed, see `beforePrerenderVisible` —
+     * reloads the route with the config the container has just been given, and
+     * the reconcile is belt and braces rather than the mechanism.
+     *
+     * Gated by {@link BaseViewConfig.reconcileRuntimeParamsOnPreRender}, which
      * is off by default — see the call site in `beforePrerenderVisible`.
      */
     protected reconcileRuntimeParams() {
+        this.reconcileRuntimeFilters();
+        this.reconcileRuntimeParameters();
+    }
+
+    /**
+     * The config's own filters win when it has any; when it has none, the
+     * predecessor's filters are sent back with empty values, which is what
+     * actually resets them.
+     */
+    private reconcileRuntimeFilters() {
         if (this.viewConfig.runtimeFilters) {
             this.trigger(HostEvent.UpdateRuntimeFilters, this.viewConfig.runtimeFilters);
             return;
         }
 
-        // getPreRenderObj() reads an untyped property off the wrapper node, so
-        // neither the object nor its viewConfig is guaranteed to be there.
-        const prevRuntimeFilters = this.getPreRenderObj()?.viewConfig?.runtimeFilters;
+        const prevRuntimeFilters = this.getPredecessorViewConfig()?.runtimeFilters;
         if (!prevRuntimeFilters) return;
         this.trigger(
             HostEvent.UpdateRuntimeFilters,
@@ -2097,6 +2194,36 @@ export class TsEmbed {
                 values: [],
             })),
         );
+    }
+
+    /**
+     * Same job for runtime parameters, which the December 2025 container change
+     * broke in exactly the same way — it simply went unreported.
+     *
+     * Only the re-apply half exists: a parameter always carries a value, so
+     * there is no payload that means "unset" the way `values: []` does for a
+     * filter, and inventing one (an empty string, say) would be wrong for
+     * numeric and boolean parameters. When this config declares none, clearing
+     * the predecessor's is left to the container, which resets its parameter
+     * state from the `UpdateEmbedParams` payload posted just before this.
+     */
+    private reconcileRuntimeParameters() {
+        const { runtimeParameters } = this.viewConfig;
+        if (runtimeParameters?.length) {
+            this.trigger(HostEvent.UpdateParameters, runtimeParameters);
+        }
+    }
+
+    /**
+     * The view config of the instance this one took the pre-render over from,
+     * or undefined when there is none — the wrapper property is untyped, so
+     * neither the object nor its viewConfig is guaranteed to be there, and it
+     * can point back at this instance.
+     */
+    private getPredecessorViewConfig() {
+        const predecessor = this.preRenderPredecessor;
+        if (!predecessor || predecessor === (this as TsEmbed)) return undefined;
+        return predecessor.viewConfig;
     }
 
     /**
@@ -2181,6 +2308,10 @@ export class TsEmbed {
         if (this.iFrame) {
             this.setupFullscreenChangeHandler();
         }
+
+        // Last, so that everything above still sees the instance this one is
+        // taking over from: this embed is now what the pre-render is showing.
+        this.takeOverPreRender();
 
         return this;
     }

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -1189,9 +1189,9 @@ export class TsEmbed {
         return preRenderWrapper;
     }
 
-    // TODO: the pre-render code should ideally move out to its own file,
-    // the way full height did. It is spread across this class and is
-    // getting messy.
+    // TODO(SCAL-338011): the pre-render code should ideally move out to its
+    // own file, the way full height did. It is spread across this class and
+    // is getting messy.
     protected preRenderWrapper: HTMLElement;
 
     protected preRenderChild: HTMLElement;

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -111,6 +111,16 @@ const PRERENDER_CONTAINER_ORIGINAL_POSITION_KEY = 'tsEmbedOriginalPosition';
 const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 
 /**
+ * How long to let the embed container apply an `UpdateEmbedParams` payload
+ * before the pre-render is navigated to its new route. The container applies
+ * the payload through React state, so the post being delivered is not the same
+ * as the new params being in effect; a `Navigate` that wins the race makes the
+ * container load the route with the *previous* config's runtime filters, and
+ * the params landing mid-load are then dropped (SCAL-336321).
+ */
+const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
+
+/**
  * The event id map from v2 event names to v1 event id
  * v1 events are the classic embed events implemented in Blink v1
  * We cannot rename v1 event types to maintain backward compatibility
@@ -2015,25 +2025,44 @@ export class TsEmbed {
         return this.renderIFrame(prerenderFrameSrc);
     }
 
+    /**
+     * Resolves once the `UpdateEmbedParams` for this show-cycle has been posted
+     * to the container and the container has been given
+     * `UPDATE_EMBED_PARAMS_SETTLE_MS` to apply it. Subclasses that navigate the
+     * pre-render on show must await this before triggering `HostEvent.Navigate`
+     * — see `LiveboardEmbed.beforePrerenderVisible`.
+     *
+     * It is re-created on every `beforePrerenderVisible()`, and resolves even
+     * when the params fail, so navigation is delayed but never blocked.
+     */
+    protected preRenderParamsApplied: Promise<void> = Promise.resolve();
+
     protected beforePrerenderVisible(): void {
         // We can ignore this as its a bit expensive and the newer customers
         // have moved on to UpdateEmbedParams supported clusters
         // this.validatePreRenderViewConfig(this.viewConfig); removed in #517
         logger.debug('triggering UpdateEmbedParams', this.viewConfig);
-        this.executeAfterEmbedContainerLoaded(async () => {
-            try {
-                const params = await this.getUpdateEmbedParamsObject();
-                this.trigger(HostEvent.UpdateEmbedParams, params);
-                this.reconcileRuntimeParams();
-            } catch (error) {
-                logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
-                this.handleError({
-                    errorType: ErrorDetailsTypes.API,
-                    message: error?.message || ERROR_MESSAGE.UPDATE_PARAMS_FAILED,
-                    code: EmbedErrorCodes.UPDATE_PARAMS_FAILED,
-                    error: error?.message || error,
-                });
-            }
+        // Created synchronously, outside executeAfterEmbedContainerLoaded, so a
+        // navigation callback queued after this one has something to await
+        // whether the container is already loaded or not.
+        this.preRenderParamsApplied = new Promise<void>((resolve) => {
+            this.executeAfterEmbedContainerLoaded(async () => {
+                try {
+                    const params = await this.getUpdateEmbedParamsObject();
+                    this.trigger(HostEvent.UpdateEmbedParams, params);
+                    this.reconcileRuntimeParams();
+                } catch (error) {
+                    logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
+                    this.handleError({
+                        errorType: ErrorDetailsTypes.API,
+                        message: error?.message || ERROR_MESSAGE.UPDATE_PARAMS_FAILED,
+                        code: EmbedErrorCodes.UPDATE_PARAMS_FAILED,
+                        error: error?.message || error,
+                    });
+                } finally {
+                    setTimeout(resolve, UPDATE_EMBED_PARAMS_SETTLE_MS);
+                }
+            });
         });
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -110,14 +110,8 @@ const TS_EMBED_ID = '_thoughtspot-embed';
 const PRERENDER_CONTAINER_ORIGINAL_POSITION_KEY = 'tsEmbedOriginalPosition';
 const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 
-/**
- * How long to let the embed container apply an `UpdateEmbedParams` payload
- * before the pre-render is navigated to its new route. The container applies
- * the payload through React state, so the post being delivered is not the same
- * as the new params being in effect; a `Navigate` that wins the race makes the
- * container load the route with the *previous* config's runtime filters, and
- * the params landing mid-load are then dropped (SCAL-336321).
- */
+// The container applies UpdateEmbedParams through React state, so a delivered
+// post is not the same as the params being in effect.
 const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
 
 /**
@@ -152,10 +146,6 @@ export class TsEmbed {
      */
     protected embedNodeKey = '__tsEmbed';
 
-    /**
-     * Marks on the pre-render wrapper that the shared embed container has
-     * announced itself, so the fact survives any one instance being hidden.
-     */
     protected embedContainerLoadedKey = '__tsEmbedContainerLoaded';
 
     protected isAppInitialized = false;
@@ -1630,25 +1620,10 @@ export class TsEmbed {
         return embedObj;
     }
 
-    /**
-     * The instance that was showing on this pre-render when this one took it
-     * over, captured synchronously in `beforePrerenderVisible()` — before
-     * `takeOverPreRender()` repoints the wrapper at this instance, and before
-     * any `await`, so an async reader still sees the right predecessor.
-     */
     private preRenderPredecessor: TsEmbed | undefined;
 
-    /**
-     * Copies the state that belongs to the shared iframe rather than to any one
-     * instance off whichever instance holds it now. Called from
-     * `connectPreRendered()`, beside `inheritPreRenderContainer()`, because
-     * connecting is when this embed joins an iframe someone else owns.
-     *
-     * Without this an instance that never rendered an iframe of its own reports
-     * the container as not loaded, and every callback queued behind
-     * `executeAfterEmbedContainerLoaded` is stranded once `takeOverPreRender()`
-     * has repointed the wrapper away from the instance that knew better.
-     */
+    // Without this, an instance that never rendered its own iframe reports the
+    // container as not loaded and strands every executeAfterEmbedContainerLoaded callback.
     protected adoptPreRenderState(): void {
         if (this.isEmbedContainerLoaded) return;
         const current = this.getPreRenderObj<TsEmbed>();
@@ -1657,32 +1632,14 @@ export class TsEmbed {
         }
     }
 
-    /**
-     * Makes this instance the one the pre-render wrapper points at, so the
-     * *next* embed to show on it reads this config as its predecessor rather
-     * than the config of whichever instance originally created the wrapper.
-     *
-     * This belongs to showing rather than to connecting: an instance connects
-     * once but can be shown many times, with other embeds shown in between, and
-     * it is the most recent *show* that decides what the pre-render is
-     * currently displaying.
-     */
     protected takeOverPreRender(): void {
         if (!this.preRenderWrapper) return;
         this.adoptPreRenderState();
         (this.preRenderWrapper as any)[this.embedNodeKey] = this;
     }
 
-    /**
-     * Records that the shared container is up, on the wrapper node as well as
-     * on this instance.
-     *
-     * The flag has to live on the node: it describes the iframe, but it is set
-     * per instance by whichever ones happen to be subscribed when the container
-     * announces itself. An instance that was hidden by then (`hidePreRender()`
-     * unsubscribes it) would otherwise report `false` forever, and once it owns
-     * the wrapper it would hand that `false` to everyone who came after.
-     */
+    // The flag lives on the wrapper because it describes the iframe: an instance
+    // hidden when the container announced itself would otherwise report false forever.
     private markEmbedContainerLoaded() {
         this.isEmbedContainerLoaded = true;
         if (this.preRenderWrapper) {
@@ -1698,8 +1655,7 @@ export class TsEmbed {
             return true;
         }
 
-        // Fallback for a wrapper stamped by an older build of this SDK, where
-        // only the instance carried the flag.
+        // Older builds stamped the flag on the instance, not the wrapper.
         const preRenderObj = this.getPreRenderObj<TsEmbed>();
         if (preRenderObj && preRenderObj.isEmbedContainerLoaded) {
             this.isEmbedContainerLoaded = true;
@@ -2099,16 +2055,8 @@ export class TsEmbed {
         return this.renderIFrame(prerenderFrameSrc);
     }
 
-    /**
-     * Resolves once the `UpdateEmbedParams` for this show-cycle has been posted
-     * to the container and the container has been given
-     * `UPDATE_EMBED_PARAMS_SETTLE_MS` to apply it. Subclasses that navigate the
-     * pre-render on show must await this before triggering `HostEvent.Navigate`
-     * — see `LiveboardEmbed.beforePrerenderVisible`.
-     *
-     * It is re-created on every `beforePrerenderVisible()`, and resolves even
-     * when the params fail, so navigation is delayed but never blocked.
-     */
+    // Subclasses that navigate the pre-render on show must await this before
+    // triggering Navigate. Resolves even on failure, so navigation is never blocked.
     protected preRenderParamsApplied: Promise<void> = Promise.resolve();
 
     protected beforePrerenderVisible(): void {
@@ -2116,22 +2064,15 @@ export class TsEmbed {
         // have moved on to UpdateEmbedParams supported clusters
         // this.validatePreRenderViewConfig(this.viewConfig); removed in #517
         logger.debug('triggering UpdateEmbedParams', this.viewConfig);
-        // Captured here, synchronously: the reconcile below runs inside an async
-        // callback, by which time showPreRender() has repointed the wrapper at
-        // this instance and getPreRenderObj() would hand back `this`.
+        // Both captured synchronously: by the time the async callback runs, the
+        // wrapper points at this instance and a queued navigation needs something to await.
         this.preRenderPredecessor = this.getPreRenderObj<TsEmbed>();
-        // Created synchronously, outside executeAfterEmbedContainerLoaded, so a
-        // navigation callback queued after this one has something to await
-        // whether the container is already loaded or not.
         this.preRenderParamsApplied = new Promise<void>((resolve) => {
             this.executeAfterEmbedContainerLoaded(async () => {
                 try {
                     const params = await this.getUpdateEmbedParamsObject();
                     this.trigger(HostEvent.UpdateEmbedParams, params);
-                    // Opt-in: it costs an extra UpdateRuntimeFilters per
-                    // show-cycle and only matters when one preRenderId is
-                    // shared by embeds with different runtime filters.
-                    if (this.viewConfig.reconcileRuntimeParamsOnPreRender) {
+                    if (this.getPreRenderConfig().reconcileRuntimeParams) {
                         this.reconcileRuntimeParams();
                     }
                 } catch (error) {
@@ -2149,36 +2090,13 @@ export class TsEmbed {
         });
     }
 
-    /**
-     * Re-applies this config's runtime filters and parameters after
-     * `UpdateEmbedParams`, so that a shared pre-render does not keep the values
-     * of the config that used it last.
-     *
-     * WHEN THIS IS ACTUALLY NEEDED: the **same** liveboard shown again through
-     * the shared pre-render (LB1 → LB1). Nothing navigates in that case —
-     * `navigateToLiveboard` is a no-op for an id the container already has — so
-     * `UpdateEmbedParams` is the only thing carrying the new values, and if the
-     * container drops or ignores it the previous config's filters simply stay.
-     * This re-apply is what forces them out.
-     *
-     * When the liveboard DOES change (LB1 → LB2), the `Navigate` that follows —
-     * now ordered after the params have landed, see `beforePrerenderVisible` —
-     * reloads the route with the config the container has just been given, and
-     * the reconcile is belt and braces rather than the mechanism.
-     *
-     * Gated by {@link BaseViewConfig.reconcileRuntimeParamsOnPreRender}, which
-     * is off by default — see the call site in `beforePrerenderVisible`.
-     */
+    // Needed for LB1 → LB1, where nothing navigates and UpdateEmbedParams is the
+    // only thing carrying the new values.
     protected reconcileRuntimeParams() {
         this.reconcileRuntimeFilters();
         this.reconcileRuntimeParameters();
     }
 
-    /**
-     * The config's own filters win when it has any; when it has none, the
-     * predecessor's filters are sent back with empty values, which is what
-     * actually resets them.
-     */
     private reconcileRuntimeFilters() {
         if (this.viewConfig.runtimeFilters) {
             this.trigger(HostEvent.UpdateRuntimeFilters, this.viewConfig.runtimeFilters);
@@ -2196,17 +2114,8 @@ export class TsEmbed {
         );
     }
 
-    /**
-     * Same job for runtime parameters, which the December 2025 container change
-     * broke in exactly the same way — it simply went unreported.
-     *
-     * Only the re-apply half exists: a parameter always carries a value, so
-     * there is no payload that means "unset" the way `values: []` does for a
-     * filter, and inventing one (an empty string, say) would be wrong for
-     * numeric and boolean parameters. When this config declares none, clearing
-     * the predecessor's is left to the container, which resets its parameter
-     * state from the `UpdateEmbedParams` payload posted just before this.
-     */
+    // No clear half: a parameter always carries a value, so there is no equivalent
+    // of a filter's empty `values`. Clearing is left to the container.
     private reconcileRuntimeParameters() {
         const { runtimeParameters } = this.viewConfig;
         if (runtimeParameters?.length) {
@@ -2214,12 +2123,6 @@ export class TsEmbed {
         }
     }
 
-    /**
-     * The view config of the instance this one took the pre-render over from,
-     * or undefined when there is none — the wrapper property is untyped, so
-     * neither the object nor its viewConfig is guaranteed to be there, and it
-     * can point back at this instance.
-     */
     private getPredecessorViewConfig() {
         const predecessor = this.preRenderPredecessor;
         if (!predecessor || predecessor === (this as TsEmbed)) return undefined;
@@ -2309,8 +2212,7 @@ export class TsEmbed {
             this.setupFullscreenChangeHandler();
         }
 
-        // Last, so that everything above still sees the instance this one is
-        // taking over from: this embed is now what the pre-render is showing.
+        // Last, so everything above still sees the instance being taken over from.
         this.takeOverPreRender();
 
         return this;

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -2025,7 +2025,6 @@ export class TsEmbed {
                 const params = await this.getUpdateEmbedParamsObject();
                 this.trigger(HostEvent.UpdateEmbedParams, params);
                 this.reconcileRuntimeParams();
-
             } catch (error) {
                 logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
                 this.handleError({
@@ -2038,24 +2037,29 @@ export class TsEmbed {
         });
     }
 
+    /**
+     * Re-applies the runtime filters after `UpdateEmbedParams`, so that a shared
+     * pre-render does not keep the filters of the config that used it last.
+     * When the new config has no filters, the previous config's filters are sent
+     * back with empty values, which is what actually resets them.
+     */
     protected reconcileRuntimeParams() {
         if (this.viewConfig.runtimeFilters) {
             this.trigger(HostEvent.UpdateRuntimeFilters, this.viewConfig.runtimeFilters);
             return;
         }
 
-        const prevPreRenderConfigs = this.getPreRenderObj();
-        if (!prevPreRenderConfigs) return;
-        if (prevPreRenderConfigs.viewConfig.runtimeFilters) {
-            this.trigger(
-                HostEvent.UpdateRuntimeFilters,
-                prevPreRenderConfigs.viewConfig.runtimeFilters.map((filter) => 
-                    ({
-                        ...filter,
-                        values: []
-                    })
-            ));
-        }
+        // getPreRenderObj() reads an untyped property off the wrapper node, so
+        // neither the object nor its viewConfig is guaranteed to be there.
+        const prevRuntimeFilters = this.getPreRenderObj()?.viewConfig?.runtimeFilters;
+        if (!prevRuntimeFilters) return;
+        this.trigger(
+            HostEvent.UpdateRuntimeFilters,
+            prevRuntimeFilters.map((filter) => ({
+                ...filter,
+                values: [],
+            })),
+        );
     }
 
     /**

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -1157,7 +1157,6 @@ export class TsEmbed {
             }
             this.isRendered = true;
             this.inheritPreRenderContainer();
-            this.adoptPreRenderState();
         }
 
         return this.isPreRenderConnected();
@@ -1622,19 +1621,8 @@ export class TsEmbed {
 
     private preRenderPredecessor: TsEmbed | undefined;
 
-    // Without this, an instance that never rendered its own iframe reports the
-    // container as not loaded and strands every executeAfterEmbedContainerLoaded callback.
-    protected adoptPreRenderState(): void {
-        if (this.isEmbedContainerLoaded) return;
-        const current = this.getPreRenderObj<TsEmbed>();
-        if (current && current !== (this as TsEmbed) && current.isEmbedContainerLoaded) {
-            this.markEmbedContainerLoaded();
-        }
-    }
-
     protected takeOverPreRender(): void {
         if (!this.preRenderWrapper) return;
-        this.adoptPreRenderState();
         (this.preRenderWrapper as any)[this.embedNodeKey] = this;
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -2059,10 +2059,10 @@ export class TsEmbed {
             this.executeAfterEmbedContainerLoaded(async () => {
                 try {
                     const params = await this.getUpdateEmbedParamsObject();
-                    this.trigger(HostEvent.UpdateEmbedParams, params);
-                    if (this.getPreRenderConfig().reconcileRuntimeParams) {
-                        this.reconcileRuntimeParams();
-                    }
+                    this.trigger(
+                        HostEvent.UpdateEmbedParams,
+                        this.reconcileRuntimeFilters(params),
+                    );
                 } catch (error) {
                     logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
                     this.handleError({
@@ -2078,37 +2078,38 @@ export class TsEmbed {
         });
     }
 
-    // Needed for LB1 → LB1, where nothing navigates and UpdateEmbedParams is the
-    // only thing carrying the new values.
-    protected reconcileRuntimeParams() {
-        this.reconcileRuntimeFilters();
-        this.reconcileRuntimeParameters();
-    }
-
-    private reconcileRuntimeFilters() {
-        if (this.viewConfig.runtimeFilters) {
-            this.trigger(HostEvent.UpdateRuntimeFilters, this.viewConfig.runtimeFilters);
-            return;
-        }
+    /**
+     * Rewrites the `runtimeFilters` of a show-cycle's UpdateEmbedParams payload so the
+     * predecessor's filters do not survive the hand-over.
+     *
+     * The params object already carries this config's own values — filters and
+     * parameters alike — so a config that declares filters needs nothing extra, and
+     * this only fills the gap the payload cannot express on its own: a config that
+     * declares *no* filters, where the columns that must be reset are the previous
+     * config's. They are re-sent with empty `values`, which is what actually clears a
+     * filter on the shared pre-render.
+     *
+     * Needed for LB1 → LB1, where nothing navigates and UpdateEmbedParams is the only
+     * thing carrying the new values.
+     *
+     * Parameters have no analogue of an empty `values` — a parameter always carries
+     * one — so clearing those is left to the container, which resets from this same
+     * payload.
+     */
+    private reconcileRuntimeFilters<T extends Record<string, any>>(params: T): T {
+        if (!this.getPreRenderConfig().reconcileRuntimeParams) return params;
+        if (this.viewConfig.runtimeFilters) return params;
 
         const prevRuntimeFilters = this.getPredecessorViewConfig()?.runtimeFilters;
-        if (!prevRuntimeFilters) return;
-        this.trigger(
-            HostEvent.UpdateRuntimeFilters,
-            prevRuntimeFilters.map((filter) => ({
+        if (!prevRuntimeFilters?.length) return params;
+
+        return {
+            ...params,
+            runtimeFilters: prevRuntimeFilters.map((filter) => ({
                 ...filter,
                 values: [],
             })),
-        );
-    }
-
-    // No clear half: a parameter always carries a value, so there is no equivalent
-    // of a filter's empty `values`. Clearing is left to the container.
-    private reconcileRuntimeParameters() {
-        const { runtimeParameters } = this.viewConfig;
-        if (runtimeParameters?.length) {
-            this.trigger(HostEvent.UpdateParameters, runtimeParameters);
-        }
+        };
     }
 
     private getPredecessorViewConfig() {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -2050,7 +2050,12 @@ export class TsEmbed {
                 try {
                     const params = await this.getUpdateEmbedParamsObject();
                     this.trigger(HostEvent.UpdateEmbedParams, params);
-                    this.reconcileRuntimeParams();
+                    // Opt-in: it costs an extra UpdateRuntimeFilters per
+                    // show-cycle and only matters when one preRenderId is
+                    // shared by embeds with different runtime filters.
+                    if (this.viewConfig.reconcileRuntimeFiltersOnPreRender) {
+                        this.reconcileRuntimeParams();
+                    }
                 } catch (error) {
                     logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
                     this.handleError({
@@ -2071,6 +2076,9 @@ export class TsEmbed {
      * pre-render does not keep the filters of the config that used it last.
      * When the new config has no filters, the previous config's filters are sent
      * back with empty values, which is what actually resets them.
+     *
+     * Gated by {@link BaseViewConfig.reconcileRuntimeFiltersOnPreRender}, which
+     * is off by default — see the call site in `beforePrerenderVisible`.
      */
     protected reconcileRuntimeParams() {
         if (this.viewConfig.runtimeFilters) {

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -71,8 +71,6 @@ import {
     ContextObject,
     PreRenderConfig,
     BaseViewConfig,
-    RuntimeFilter,
-    RuntimeParameter,
 } from '../types';
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { processEventData, processAuthFailure } from '../utils/processData';
@@ -116,47 +114,9 @@ const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 // post is not the same as the params being in effect.
 const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
 
-/**
- * What `runtimeFilterParams` / `runtimeParameterParams` have to say to mean "this embed
- * has none of these".
- *
- * The container only reads either field when it is truthy:
- *
- * ```ts
- * if (embedConfigFromEvent.runtimeFilterParams) { … updateRuntimeFilterParams(parsed); }
- * ```
- *
- * so `null` and `''` both read as "no news" and leave whatever the previous embed put
- * there in place — which is what sticks. A lone separator is truthy, so the gate fires,
- * and `new URLSearchParams('&')` yields no pairs, so the container's state becomes `{}`.
- * It then falls through to `embedParams`, which the same event has just rebuilt from
- * this view config.
- */
-const EMPTY_RUNTIME_PARAMS = '&';
-
-/**
- * Serializes runtime filters into the `col1=…&op1=…&val1=…` string the container reads,
- * or {@link EMPTY_RUNTIME_PARAMS} when there are none to send.
- *
- * `getFilterQuery` joins each filter's column, operator and values with `&`, so a filter
- * carrying no values leaves an empty segment behind (`col1=Color&op1=IN&`). Drop those
- * rather than change the shared builder, which every URL render goes through.
- */
-const serializeRuntimeFilters = (runtimeFilters?: RuntimeFilter[]): string => {
-    const filterQuery = getFilterQuery(runtimeFilters ?? []);
-    return filterQuery?.split('&').filter(Boolean).join('&') || EMPTY_RUNTIME_PARAMS;
-};
-
-/**
- * Serializes runtime parameters into the `param1=…&paramVal1=…` string the container
- * reads, or {@link EMPTY_RUNTIME_PARAMS} when there are none to send.
- *
- * Unlike a filter, a parameter always has both halves of its pair, so there are no empty
- * segments to drop — a parameter whose value is the empty string still serializes as
- * `paramVal1=`, which the container reads as that value rather than as an absence.
- */
-const serializeRuntimeParameters = (runtimeParameters?: RuntimeParameter[]): string =>
-    getRuntimeParameters(runtimeParameters ?? []) || EMPTY_RUNTIME_PARAMS;
+// The container ignores runtimeFilterParams/runtimeParameterParams unless truthy, so
+// null or '' leaves the previous embed's values in place. '&' is truthy and parses to {}.
+const NO_RUNTIME_PARAMS = '&';
 
 /**
  * The event id map from v2 event names to v1 event id
@@ -774,16 +734,13 @@ export class TsEmbed {
             ...this.viewConfig,
             ...queryParams,
             ...appInitData,
-            // getDefaultAppInitData() only serializes these when
-            // excludeRuntimeFilters/ParametersfromURL is set, because a URL
-            // render puts them in the iframe's query string instead. A show
-            // cycle has no URL to put them in, so the payload always states
-            // them — including the case of having none, which is the one that
-            // leaks.
-            runtimeFilterParams: serializeRuntimeFilters(this.viewConfig.runtimeFilters),
-            runtimeParameterParams: serializeRuntimeParameters(
-                this.viewConfig.runtimeParameters,
-            ),
+            // A show cycle has no URL to carry these, so the payload always states them
+            // — including "none", which is the case that leaks the previous filters.
+            runtimeFilterParams:
+                getFilterQuery(this.viewConfig.runtimeFilters ?? []) || NO_RUNTIME_PARAMS,
+            runtimeParameterParams:
+                getRuntimeParameters(this.viewConfig.runtimeParameters ?? [])
+                || NO_RUNTIME_PARAMS,
         };
     }
 
@@ -1189,9 +1146,8 @@ export class TsEmbed {
         return preRenderWrapper;
     }
 
-    // TODO(SCAL-338011): the pre-render code should ideally move out to its
-    // own file, the way full height did. It is spread across this class and
-    // is getting messy.
+    // TODO(SCAL-338011): move the pre-render code out to its own file, the way
+    // full height did. It is spread across this class and getting messy.
     protected preRenderWrapper: HTMLElement;
 
     protected preRenderChild: HTMLElement;

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -72,6 +72,7 @@ import {
     PreRenderConfig,
     BaseViewConfig,
     RuntimeFilter,
+    RuntimeParameter,
 } from '../types';
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { processEventData, processAuthFailure } from '../utils/processData';
@@ -116,25 +117,26 @@ const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
 
 /**
- * What `runtimeFilterParams` has to say to mean "this embed has no runtime filters".
+ * What `runtimeFilterParams` / `runtimeParameterParams` have to say to mean "this embed
+ * has none of these".
  *
- * The container only reads the field when it is truthy:
+ * The container only reads either field when it is truthy:
  *
  * ```ts
  * if (embedConfigFromEvent.runtimeFilterParams) { … updateRuntimeFilterParams(parsed); }
  * ```
  *
  * so `null` and `''` both read as "no news" and leave whatever the previous embed put
- * there in place — which is the filter that sticks. A lone separator is truthy, so the
- * gate fires, and `new URLSearchParams('&')` yields no pairs, so the container's state
- * becomes `{}`. It then falls through to `embedParams`, which the same event has just
- * rebuilt from this view config.
+ * there in place — which is what sticks. A lone separator is truthy, so the gate fires,
+ * and `new URLSearchParams('&')` yields no pairs, so the container's state becomes `{}`.
+ * It then falls through to `embedParams`, which the same event has just rebuilt from
+ * this view config.
  */
-const EMPTY_RUNTIME_FILTER_PARAMS = '&';
+const EMPTY_RUNTIME_PARAMS = '&';
 
 /**
  * Serializes runtime filters into the `col1=…&op1=…&val1=…` string the container reads,
- * or {@link EMPTY_RUNTIME_FILTER_PARAMS} when there are none to send.
+ * or {@link EMPTY_RUNTIME_PARAMS} when there are none to send.
  *
  * `getFilterQuery` joins each filter's column, operator and values with `&`, so a filter
  * carrying no values leaves an empty segment behind (`col1=Color&op1=IN&`). Drop those
@@ -142,8 +144,19 @@ const EMPTY_RUNTIME_FILTER_PARAMS = '&';
  */
 const serializeRuntimeFilters = (runtimeFilters?: RuntimeFilter[]): string => {
     const filterQuery = getFilterQuery(runtimeFilters ?? []);
-    return filterQuery?.split('&').filter(Boolean).join('&') || EMPTY_RUNTIME_FILTER_PARAMS;
+    return filterQuery?.split('&').filter(Boolean).join('&') || EMPTY_RUNTIME_PARAMS;
 };
+
+/**
+ * Serializes runtime parameters into the `param1=…&paramVal1=…` string the container
+ * reads, or {@link EMPTY_RUNTIME_PARAMS} when there are none to send.
+ *
+ * Unlike a filter, a parameter always has both halves of its pair, so there are no empty
+ * segments to drop — a parameter whose value is the empty string still serializes as
+ * `paramVal1=`, which the container reads as that value rather than as an absence.
+ */
+const serializeRuntimeParameters = (runtimeParameters?: RuntimeParameter[]): string =>
+    getRuntimeParameters(runtimeParameters ?? []) || EMPTY_RUNTIME_PARAMS;
 
 /**
  * The event id map from v2 event names to v1 event id
@@ -761,12 +774,16 @@ export class TsEmbed {
             ...this.viewConfig,
             ...queryParams,
             ...appInitData,
-            // getDefaultAppInitData() only serializes this when
-            // excludeRuntimeFiltersfromURL is set, because a URL render puts
-            // the filters in the iframe's query string instead. A show cycle
-            // has no URL to put them in, so the payload always states them —
-            // including the case of having none, which is the one that leaks.
+            // getDefaultAppInitData() only serializes these when
+            // excludeRuntimeFilters/ParametersfromURL is set, because a URL
+            // render puts them in the iframe's query string instead. A show
+            // cycle has no URL to put them in, so the payload always states
+            // them — including the case of having none, which is the one that
+            // leaks.
             runtimeFilterParams: serializeRuntimeFilters(this.viewConfig.runtimeFilters),
+            runtimeParameterParams: serializeRuntimeParameters(
+                this.viewConfig.runtimeParameters,
+            ),
         };
     }
 
@@ -1172,6 +1189,9 @@ export class TsEmbed {
         return preRenderWrapper;
     }
 
+    // TODO: the pre-render code should ideally move out to its own file,
+    // the way full height did. It is spread across this class and is
+    // getting messy.
     protected preRenderWrapper: HTMLElement;
 
     protected preRenderChild: HTMLElement;

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -2024,6 +2024,8 @@ export class TsEmbed {
             try {
                 const params = await this.getUpdateEmbedParamsObject();
                 this.trigger(HostEvent.UpdateEmbedParams, params);
+                this.reconcileRuntimeParams();
+
             } catch (error) {
                 logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
                 this.handleError({
@@ -2034,6 +2036,23 @@ export class TsEmbed {
                 });
             }
         });
+    }
+
+    protected reconcileRuntimeParams() {
+        if (this.viewConfig.runtimeFilters) {
+            this.trigger(HostEvent.UpdateRuntimeFilters, this.viewConfig.runtimeFilters);
+            return;
+        }
+
+        const prevPreRenderConfigs = this.getPreRenderObj();
+        if (prevPreRenderConfigs.viewConfig.runtimeFilters) {
+            this.trigger(HostEvent.UpdateRuntimeFilters, prevPreRenderConfigs.viewConfig.runtimeFilters.map((filter) => {
+                return {
+                    ...filter,
+                    values: []
+                }
+            }));
+        }
     }
 
     /**

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -2045,13 +2045,16 @@ export class TsEmbed {
         }
 
         const prevPreRenderConfigs = this.getPreRenderObj();
+        if (!prevPreRenderConfigs) return;
         if (prevPreRenderConfigs.viewConfig.runtimeFilters) {
-            this.trigger(HostEvent.UpdateRuntimeFilters, prevPreRenderConfigs.viewConfig.runtimeFilters.map((filter) => {
-                return {
-                    ...filter,
-                    values: []
-                }
-            }));
+            this.trigger(
+                HostEvent.UpdateRuntimeFilters,
+                prevPreRenderConfigs.viewConfig.runtimeFilters.map((filter) => 
+                    ({
+                        ...filter,
+                        values: []
+                    })
+            ));
         }
     }
 

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -116,14 +116,33 @@ const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
 
 /**
- * `getFilterQuery` joins each filter's column, operator and values with `&`, so a
- * filter carrying no values — the form that clears one — leaves an empty segment
- * behind (`col1=Color&op1=IN&`). Drop those rather than change the shared builder,
- * which every URL render goes through.
+ * What `runtimeFilterParams` has to say to mean "this embed has no runtime filters".
+ *
+ * The container only reads the field when it is truthy:
+ *
+ * ```ts
+ * if (embedConfigFromEvent.runtimeFilterParams) { … updateRuntimeFilterParams(parsed); }
+ * ```
+ *
+ * so `null` and `''` both read as "no news" and leave whatever the previous embed put
+ * there in place — which is the filter that sticks. A lone separator is truthy, so the
+ * gate fires, and `new URLSearchParams('&')` yields no pairs, so the container's state
+ * becomes `{}`. It then falls through to `embedParams`, which the same event has just
+ * rebuilt from this view config.
  */
-const serializeRuntimeFilters = (runtimeFilters: RuntimeFilter[]): string | null => {
-    const filterQuery = getFilterQuery(runtimeFilters);
-    return filterQuery?.split('&').filter(Boolean).join('&') ?? null;
+const EMPTY_RUNTIME_FILTER_PARAMS = '&';
+
+/**
+ * Serializes runtime filters into the `col1=…&op1=…&val1=…` string the container reads,
+ * or {@link EMPTY_RUNTIME_FILTER_PARAMS} when there are none to send.
+ *
+ * `getFilterQuery` joins each filter's column, operator and values with `&`, so a filter
+ * carrying no values leaves an empty segment behind (`col1=Color&op1=IN&`). Drop those
+ * rather than change the shared builder, which every URL render goes through.
+ */
+const serializeRuntimeFilters = (runtimeFilters?: RuntimeFilter[]): string => {
+    const filterQuery = getFilterQuery(runtimeFilters ?? []);
+    return filterQuery?.split('&').filter(Boolean).join('&') || EMPTY_RUNTIME_FILTER_PARAMS;
 };
 
 /**
@@ -738,7 +757,17 @@ export class TsEmbed {
             queryParams[key] = deserializeParam(queryParams[key]);
         });
         const appInitData = await this.getAppInitData();
-        return { ...this.viewConfig, ...queryParams, ...appInitData };
+        return {
+            ...this.viewConfig,
+            ...queryParams,
+            ...appInitData,
+            // getDefaultAppInitData() only serializes this when
+            // excludeRuntimeFiltersfromURL is set, because a URL render puts
+            // the filters in the iframe's query string instead. A show cycle
+            // has no URL to put them in, so the payload always states them —
+            // including the case of having none, which is the one that leaks.
+            runtimeFilterParams: serializeRuntimeFilters(this.viewConfig.runtimeFilters),
+        };
     }
 
     /**
@@ -1631,8 +1660,6 @@ export class TsEmbed {
         return embedObj;
     }
 
-    private preRenderPredecessor: TsEmbed | undefined;
-
     protected takeOverPreRender(): void {
         if (!this.preRenderWrapper) return;
         (this.preRenderWrapper as any)[this.embedNodeKey] = this;
@@ -2064,17 +2091,13 @@ export class TsEmbed {
         // have moved on to UpdateEmbedParams supported clusters
         // this.validatePreRenderViewConfig(this.viewConfig); removed in #517
         logger.debug('triggering UpdateEmbedParams', this.viewConfig);
-        // Both captured synchronously: by the time the async callback runs, the
-        // wrapper points at this instance and a queued navigation needs something to await.
-        this.preRenderPredecessor = this.getPreRenderObj<TsEmbed>();
+        // Created synchronously: a queued navigation needs something to await
+        // whether the container is already loaded or not.
         this.preRenderParamsApplied = new Promise<void>((resolve) => {
             this.executeAfterEmbedContainerLoaded(async () => {
                 try {
                     const params = await this.getUpdateEmbedParamsObject();
-                    this.trigger(
-                        HostEvent.UpdateEmbedParams,
-                        this.reconcileRuntimeFilters(params),
-                    );
+                    this.trigger(HostEvent.UpdateEmbedParams, params);
                 } catch (error) {
                     logger.error(ERROR_MESSAGE.UPDATE_PARAMS_FAILED, error);
                     this.handleError({
@@ -2088,60 +2111,6 @@ export class TsEmbed {
                 }
             });
         });
-    }
-
-    /**
-     * Rewrites the runtime filters of a show-cycle's UpdateEmbedParams payload so the
-     * predecessor's filters do not survive the hand-over.
-     *
-     * Writes both forms the payload carries:
-     *
-     * - `runtimeFilters`, the raw array, which is there only because the payload
-     *   spreads the view config;
-     * - `runtimeFilterParams`, the serialized `col1=…&op1=…&val1=…` string, which is
-     *   what the container reads.
-     *
-     * `getDefaultAppInitData()` builds the serialized form from
-     * `viewConfig.runtimeFilters`, so it is already right when this config declares
-     * filters — but it is `null` in exactly the case that leaks, a config that declares
-     * none, because the columns to reset are the *predecessor's* and nothing in this
-     * view config names them. Writing only the array would leave the reset in a field
-     * the container ignores. (It is `null` throughout when
-     * `excludeRuntimeFiltersfromURL` is off, since a URL render puts the filters in the
-     * iframe's query string instead — and a show cycle has no URL to put them in.
-     * `V1Embed` turns that flag on by default, so LiveboardEmbed is not in that case.)
-     *
-     * The filters to send are this config's own when it declares any, and otherwise the
-     * predecessor's with empty `values`, which is what actually clears a filter.
-     *
-     * Needed for LB1 → LB1, where nothing navigates and UpdateEmbedParams is the only
-     * thing carrying the new values.
-     *
-     * Parameters get no equivalent here. A parameter always carries a value, so there
-     * is no analogue of a filter's empty `values`, and `runtimeParameterParams` has the
-     * same `null` gap — see the PR for why that is left to the container for now.
-     */
-    private reconcileRuntimeFilters<T extends Record<string, any>>(params: T): T {
-        if (!this.getPreRenderConfig().reconcileRuntimeParams) return params;
-
-        const runtimeFilters = this.viewConfig.runtimeFilters
-            ?? this.getPredecessorViewConfig()?.runtimeFilters?.map((filter) => ({
-                ...filter,
-                values: [],
-            }));
-        if (!runtimeFilters?.length) return params;
-
-        return {
-            ...params,
-            runtimeFilters,
-            runtimeFilterParams: serializeRuntimeFilters(runtimeFilters),
-        };
-    }
-
-    private getPredecessorViewConfig() {
-        const predecessor = this.preRenderPredecessor;
-        if (!predecessor || predecessor === (this as TsEmbed)) return undefined;
-        return predecessor.viewConfig;
     }
 
     /**

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -71,6 +71,7 @@ import {
     ContextObject,
     PreRenderConfig,
     BaseViewConfig,
+    RuntimeFilter,
 } from '../types';
 import { uploadMixpanelEvent, MIXPANEL_EVENT } from '../mixpanel-service';
 import { processEventData, processAuthFailure } from '../utils/processData';
@@ -113,6 +114,17 @@ const PRERENDER_WRAPPER_ID_PREFIX = 'tsEmbed-pre-render-wrapper-';
 // The container applies UpdateEmbedParams through React state, so a delivered
 // post is not the same as the params being in effect.
 const UPDATE_EMBED_PARAMS_SETTLE_MS = 200;
+
+/**
+ * `getFilterQuery` joins each filter's column, operator and values with `&`, so a
+ * filter carrying no values — the form that clears one — leaves an empty segment
+ * behind (`col1=Color&op1=IN&`). Drop those rather than change the shared builder,
+ * which every URL render goes through.
+ */
+const serializeRuntimeFilters = (runtimeFilters: RuntimeFilter[]): string | null => {
+    const filterQuery = getFilterQuery(runtimeFilters);
+    return filterQuery?.split('&').filter(Boolean).join('&') ?? null;
+};
 
 /**
  * The event id map from v2 event names to v1 event id
@@ -2079,36 +2091,50 @@ export class TsEmbed {
     }
 
     /**
-     * Rewrites the `runtimeFilters` of a show-cycle's UpdateEmbedParams payload so the
+     * Rewrites the runtime filters of a show-cycle's UpdateEmbedParams payload so the
      * predecessor's filters do not survive the hand-over.
      *
-     * The params object already carries this config's own values — filters and
-     * parameters alike — so a config that declares filters needs nothing extra, and
-     * this only fills the gap the payload cannot express on its own: a config that
-     * declares *no* filters, where the columns that must be reset are the previous
-     * config's. They are re-sent with empty `values`, which is what actually clears a
-     * filter on the shared pre-render.
+     * Writes both forms the payload carries:
+     *
+     * - `runtimeFilters`, the raw array, which is there only because the payload
+     *   spreads the view config;
+     * - `runtimeFilterParams`, the serialized `col1=…&op1=…&val1=…` string, which is
+     *   what the container reads.
+     *
+     * `getDefaultAppInitData()` builds the serialized form from
+     * `viewConfig.runtimeFilters`, so it is already right when this config declares
+     * filters — but it is `null` in exactly the case that leaks, a config that declares
+     * none, because the columns to reset are the *predecessor's* and nothing in this
+     * view config names them. Writing only the array would leave the reset in a field
+     * the container ignores. (It is `null` throughout when
+     * `excludeRuntimeFiltersfromURL` is off, since a URL render puts the filters in the
+     * iframe's query string instead — and a show cycle has no URL to put them in.
+     * `V1Embed` turns that flag on by default, so LiveboardEmbed is not in that case.)
+     *
+     * The filters to send are this config's own when it declares any, and otherwise the
+     * predecessor's with empty `values`, which is what actually clears a filter.
      *
      * Needed for LB1 → LB1, where nothing navigates and UpdateEmbedParams is the only
      * thing carrying the new values.
      *
-     * Parameters have no analogue of an empty `values` — a parameter always carries
-     * one — so clearing those is left to the container, which resets from this same
-     * payload.
+     * Parameters get no equivalent here. A parameter always carries a value, so there
+     * is no analogue of a filter's empty `values`, and `runtimeParameterParams` has the
+     * same `null` gap — see the PR for why that is left to the container for now.
      */
     private reconcileRuntimeFilters<T extends Record<string, any>>(params: T): T {
         if (!this.getPreRenderConfig().reconcileRuntimeParams) return params;
-        if (this.viewConfig.runtimeFilters) return params;
 
-        const prevRuntimeFilters = this.getPredecessorViewConfig()?.runtimeFilters;
-        if (!prevRuntimeFilters?.length) return params;
+        const runtimeFilters = this.viewConfig.runtimeFilters
+            ?? this.getPredecessorViewConfig()?.runtimeFilters?.map((filter) => ({
+                ...filter,
+                values: [],
+            }));
+        if (!runtimeFilters?.length) return params;
 
         return {
             ...params,
-            runtimeFilters: prevRuntimeFilters.map((filter) => ({
-                ...filter,
-                values: [],
-            })),
+            runtimeFilters,
+            runtimeFilterParams: serializeRuntimeFilters(runtimeFilters),
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -977,6 +977,19 @@ export interface PreRenderConfig {
      * @default -1000
      */
     zIndex?: number;
+    /**
+     * Re-apply this embed's runtime filters and parameters when it takes over a
+     * shared pre-render, so the frame does not keep the previous config's values.
+     *
+     * Needed when the same Liveboard is shown again through a shared pre-render:
+     * nothing navigates, so `UpdateEmbedParams` is the only thing carrying the new
+     * values. Off by default — it costs an extra host event per show and only
+     * matters when one `preRenderId` is shared by embeds with different filters.
+     *
+     * @default false
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     */
+    reconcileRuntimeParams?: boolean;
 }
 
 /**
@@ -1181,48 +1194,6 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * ```
      */
     preRenderId?: string;
-
-    /**
-     * Re-apply this embed's runtime filters and parameters when it takes over a
-     * shared pre-render, so the pre-rendered iframe does not keep the values of
-     * the config that used it last.
-     *
-     * The re-apply happens right after `HostEvent.UpdateEmbedParams` and before
-     * the pre-render is navigated:
-     *
-     * - `runtimeFilters` — re-sent when this embed declares any. When it
-     *   declares none, the previous config's filters are sent back with empty
-     *   values, which is what actually clears them.
-     * - `runtimeParameters` — re-sent when this embed declares any. There is no
-     *   clear for the previous config's parameters: a parameter always carries a
-     *   value, so it has no equivalent of an empty `values` array, and resetting
-     *   it is left to the embed container.
-     *
-     * Off by default: it costs an extra `HostEvent.UpdateRuntimeFilters` (and
-     * `HostEvent.UpdateParameters`) on every show-cycle, and it only matters
-     * when one `preRenderId` is shared by embeds carrying different runtime
-     * filters or parameters.
-     *
-     * The case that needs it is showing the **same** Liveboard again through
-     * the shared pre-render: nothing navigates, so `UpdateEmbedParams` is the
-     * only thing carrying the new values and the previous config's filters stay
-     * if it is dropped. When the Liveboard changes, the navigation that follows
-     * reloads the route with the new config anyway.
-     *
-     * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`
-     * @default false
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
-     * @example
-     * ```js
-     * // Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed
-     * const embed = new <EmbedComponent>('#tsEmbed', {
-     *    ... // other embed view config
-     *    preRenderId: 'shared-lb',
-     *    reconcileRuntimeParamsOnPreRender: true,
-     * });
-     * ```
-     */
-    reconcileRuntimeParamsOnPreRender?: boolean;
 
     /**
      * Determines if the PreRender component should dynamically track the size

--- a/src/types.ts
+++ b/src/types.ts
@@ -1183,6 +1183,35 @@ export interface BaseViewConfig extends ApiInterceptFlags {
     preRenderId?: string;
 
     /**
+     * Re-apply this embed's runtime filters when it takes over a shared
+     * pre-render, so the pre-rendered iframe does not keep the filters of the
+     * config that used it last.
+     *
+     * The re-apply happens right after `HostEvent.UpdateEmbedParams` and before
+     * the pre-render is navigated. When this embed declares `runtimeFilters`
+     * they are re-sent; when it declares none, the previous config's filters are
+     * sent back with empty values, which is what actually clears them.
+     *
+     * Off by default: it costs an extra `HostEvent.UpdateRuntimeFilters` on
+     * every show-cycle, and it only matters when one `preRenderId` is shared by
+     * embeds carrying different runtime filters.
+     *
+     * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`
+     * @default false
+     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * // Replace <EmbedComponent> with embed component name. For example, AppEmbed, SearchEmbed, or LiveboardEmbed
+     * const embed = new <EmbedComponent>('#tsEmbed', {
+     *    ... // other embed view config
+     *    preRenderId: 'shared-lb',
+     *    reconcileRuntimeFiltersOnPreRender: true,
+     * });
+     * ```
+     */
+    reconcileRuntimeFiltersOnPreRender?: boolean;
+
+    /**
      * Determines if the PreRender component should dynamically track the size
      * of its embedding element and adjust its own size accordingly.
      * Enabling this option allows the PreRender component to automatically adapt

--- a/src/types.ts
+++ b/src/types.ts
@@ -977,25 +977,6 @@ export interface PreRenderConfig {
      * @default -1000
      */
     zIndex?: number;
-    /**
-     * Clears the `runtimeFilters` left behind by the embed that used this
-     * pre-render before, when this embed declares none of its own, so those
-     * filters do not carry over.
-     *
-     * Set it when several embeds share one pre-render and declare different
-     * runtime filters.
-     *
-     * @default false
-     * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
-     * @example
-     * ```js
-     * const embed = new LiveboardEmbed('#tsEmbed', {
-     *    ... // other embed view config
-     *    preRenderConfig: { id: 'shared-lb', reconcileRuntimeParams: true },
-     * });
-     * ```
-     */
-    reconcileRuntimeParams?: boolean;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -978,12 +978,12 @@ export interface PreRenderConfig {
      */
     zIndex?: number;
     /**
-     * Re-applies this embed's `runtimeFilters` and `runtimeParameters` when it
-     * attaches to a pre-render another embed used before it, so that embed's
-     * values do not carry over.
+     * Clears the `runtimeFilters` left behind by the embed that used this
+     * pre-render before, when this embed declares none of its own, so those
+     * filters do not carry over.
      *
      * Set it when several embeds share one pre-render and declare different
-     * runtime filters or parameters.
+     * runtime filters.
      *
      * @default false
      * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl

--- a/src/types.ts
+++ b/src/types.ts
@@ -1183,18 +1183,31 @@ export interface BaseViewConfig extends ApiInterceptFlags {
     preRenderId?: string;
 
     /**
-     * Re-apply this embed's runtime filters when it takes over a shared
-     * pre-render, so the pre-rendered iframe does not keep the filters of the
-     * config that used it last.
+     * Re-apply this embed's runtime filters and parameters when it takes over a
+     * shared pre-render, so the pre-rendered iframe does not keep the values of
+     * the config that used it last.
      *
      * The re-apply happens right after `HostEvent.UpdateEmbedParams` and before
-     * the pre-render is navigated. When this embed declares `runtimeFilters`
-     * they are re-sent; when it declares none, the previous config's filters are
-     * sent back with empty values, which is what actually clears them.
+     * the pre-render is navigated:
      *
-     * Off by default: it costs an extra `HostEvent.UpdateRuntimeFilters` on
-     * every show-cycle, and it only matters when one `preRenderId` is shared by
-     * embeds carrying different runtime filters.
+     * - `runtimeFilters` — re-sent when this embed declares any. When it
+     *   declares none, the previous config's filters are sent back with empty
+     *   values, which is what actually clears them.
+     * - `runtimeParameters` — re-sent when this embed declares any. There is no
+     *   clear for the previous config's parameters: a parameter always carries a
+     *   value, so it has no equivalent of an empty `values` array, and resetting
+     *   it is left to the embed container.
+     *
+     * Off by default: it costs an extra `HostEvent.UpdateRuntimeFilters` (and
+     * `HostEvent.UpdateParameters`) on every show-cycle, and it only matters
+     * when one `preRenderId` is shared by embeds carrying different runtime
+     * filters or parameters.
+     *
+     * The case that needs it is showing the **same** Liveboard again through
+     * the shared pre-render: nothing navigates, so `UpdateEmbedParams` is the
+     * only thing carrying the new values and the previous config's filters stay
+     * if it is dropped. When the Liveboard changes, the navigation that follows
+     * reloads the route with the new config anyway.
      *
      * Supported embed types: `AppEmbed`, `LiveboardEmbed`, `SearchEmbed`
      * @default false
@@ -1205,11 +1218,11 @@ export interface BaseViewConfig extends ApiInterceptFlags {
      * const embed = new <EmbedComponent>('#tsEmbed', {
      *    ... // other embed view config
      *    preRenderId: 'shared-lb',
-     *    reconcileRuntimeFiltersOnPreRender: true,
+     *    reconcileRuntimeParamsOnPreRender: true,
      * });
      * ```
      */
-    reconcileRuntimeFiltersOnPreRender?: boolean;
+    reconcileRuntimeParamsOnPreRender?: boolean;
 
     /**
      * Determines if the PreRender component should dynamically track the size

--- a/src/types.ts
+++ b/src/types.ts
@@ -978,16 +978,22 @@ export interface PreRenderConfig {
      */
     zIndex?: number;
     /**
-     * Re-apply this embed's runtime filters and parameters when it takes over a
-     * shared pre-render, so the frame does not keep the previous config's values.
+     * Re-applies this embed's `runtimeFilters` and `runtimeParameters` when it
+     * attaches to a pre-render another embed used before it, so that embed's
+     * values do not carry over.
      *
-     * Needed when the same Liveboard is shown again through a shared pre-render:
-     * nothing navigates, so `UpdateEmbedParams` is the only thing carrying the new
-     * values. Off by default — it costs an extra host event per show and only
-     * matters when one `preRenderId` is shared by embeds with different filters.
+     * Set it when several embeds share one pre-render and declare different
+     * runtime filters or parameters.
      *
      * @default false
      * @version SDK: 1.53.0 | ThoughtSpot Cloud: 26.10.0.cl
+     * @example
+     * ```js
+     * const embed = new LiveboardEmbed('#tsEmbed', {
+     *    ... // other embed view config
+     *    preRenderConfig: { id: 'shared-lb', reconcileRuntimeParams: true },
+     * });
+     * ```
      */
     reconcileRuntimeParams?: boolean;
 }


### PR DESCRIPTION
## Problem

On a shared pre-render, a `runtimeFilters` value from one liveboard sticks when the host switches to another liveboard, and `runtimeFilters: []` does not reset it. The container fix attempted in blink-v2 (`[SCAL-333947]`, PR #68332) did **not** close it and has been reverted.

There are three independent causes. The host events go out in the wrong order, the payload never says "no filters" in a way the container reads, and a same-route show never unmounts the liveboard that is holding the stale state.

## Cause 1 — the host events go out in the wrong order

`LiveboardEmbed.beforePrerenderVisible()` queues two container-ready callbacks:

1. `super.beforePrerenderVisible()` → posts `HostEvent.UpdateEmbedParams`
2. its own → posts `HostEvent.Navigate`

Both are invoked in registration order, but the first one suspends on `await this.getUpdateEmbedParamsObject()` (which awaits `getAppInitData()`). It yields at that `await`, callback 2 runs to completion, and the real order on the wire is:

```
["Navigate", "updateEmbedParams"]
```

That is observed output, not a reading of the code — it is what the new test records when the fix is removed.

So the container starts loading the new liveboard while still holding the **previous** config's `runtimeFilterParams`, and the params that arrive mid-load are dropped.

### Fix

`TsEmbed.beforePrerenderVisible()` now publishes `preRenderParamsApplied`, a promise that resolves once `UpdateEmbedParams` has been posted **and** the container has had `UPDATE_EMBED_PARAMS_SETTLE_MS` (200ms) to apply it. `LiveboardEmbed` awaits that before triggering `Navigate`.

The settle window is deliberate rather than an ack-wait: the container applies the payload through React state, so the post being *delivered* is not the same as the new params being *in effect*, and awaiting `trigger()` would risk stalling navigation on the 30s trigger timeout.

Two properties worth checking in review:

- the promise is created **synchronously** in `beforePrerenderVisible()`, outside `executeAfterEmbedContainerLoaded`, so the navigation callback has something to await whether the container is already loaded or not;
- it resolves in a `finally`, so a params failure delays navigation but never blocks it. Both callbacks are gated on the same container-ready signal, so neither can strand the other.

## Cause 2 — nothing in the payload says "no filters"

The payload carries runtime filters in two fields:

| field | what it is |
| --- | --- |
| `runtimeFilters` | the raw array, present only because the payload spreads the view config |
| `runtimeFilterParams` | the serialized `col1=…&op1=…&val1=…` string — **what the container reads** |

`getDefaultAppInitData()` builds the serialized form from `viewConfig.runtimeFilters`, and only when `excludeRuntimeFiltersfromURL` is set, because a URL render puts the filters in the iframe's query string instead. A show cycle has no URL to put them in. So a config that declares no filters sent this:

```jsonc
{
  "runtimeFilterParams": null,   // ← the field the container reads
  "runtimeFilters": undefined
}
```

and the container's handler is:

```ts
if (embedConfigFromEvent.runtimeFilterParams) {
    const parsedFilters = {};
    parseQueryParams(embedConfigFromEvent.runtimeFilterParams, parsedFilters);
    updateRuntimeFilterParams(parsedFilters);
}
```

`null` is falsy, so the branch never runs and the container keeps **the previous embed's** `runtimeFilterParams` state. `getRuntimeParams` then prefers that state over `embedParams`:

```ts
const embedRuntimeFilter = !_.isEmpty(runtimeFilterParams) ? runtimeFilterParams : embedParams;
```

so the stale value outranks the freshly-rebuilt params on every show. That is the filter that sticks.

### Fix

The show-cycle payload now always states both — this config's serialized, or `'&'` when it declares none:

```ts
return {
    ...this.viewConfig,
    ...queryParams,
    ...appInitData,
    runtimeFilterParams: serializeRuntimeFilters(this.viewConfig.runtimeFilters),
    runtimeParameterParams: serializeRuntimeParameters(this.viewConfig.runtimeParameters),
};
```

`runtimeParameterParams` has the identical shape — same truthy gate at `embed.container.tsx:192`, same `!_.isEmpty(embedParameterParams) ? embedParameterParams : embedParams` fall-through, and `getRuntimeParameterInput({})` breaks on a missing `param1` exactly as the filter reader breaks on a missing `col1`. So a config declaring no parameters left the previous embed's standing, just as its filters did. The December 2025 container change broke both; only the filters were reported.

One difference: no segment trimming for parameters. A parameter always has both halves of its pair, and `paramVal1=` is an empty-string *value* rather than an absence — there is a test pinning that it does not collapse to the empty marker.

The same is true of `runtimeParameterParams`, `updateEmbedParameterParams` and `getRuntimeParameterInput`.

**Why `'&'` and not `null` or `''`.** Both falsy forms read as "no news" at that gate and leave the previous filters standing. A lone separator is truthy, so the branch fires — and `new URLSearchParams('&')` yields no pairs (the urlencoded parser skips empty sequences), so `parsedFilters` is `{}` and `updateRuntimeFilterParams({})` replaces the state with an empty object. `_.isEmpty({})` is then true, so the container falls through to `embedParams` — which `updateEmbedParams(processedParams)` has just replaced, from this same event, with this config's params. A config with no filters contributes no `col1`, `getRuntimeFilterInput` breaks on the first iteration, and the result is `[]`.

Both `updateRuntimeFilterParams` and `updateEmbedParams` are plain `useState` setters (`embed.container.tsx:66,77`), so each is a replace, not a merge — that is what makes the fall-through safe.

## What this removes

Stating the filters outright means the SDK never has to work out what the *previous* embed's were. So the earlier revisions of this branch are gone:

- the **`preRenderConfig.reconcileRuntimeParams` flag** — deleted, not defaulted on. There is nothing left to opt into: no extra host events, no extra traffic, one field in a payload that was already being sent.
- **`getPredecessorViewConfig()` and the predecessor capture** — deleted. The clear-by-empty-values approach they existed for needed to name the predecessor's columns, and correctness then depended on the predecessor chain being right across every A → B → C hand-over.
- the **follow-up `HostEvent.UpdateRuntimeFilters` / `UpdateParameters`** posts — deleted. They re-sent values the payload already carried, and added a second ordering question next to `Navigate`.

Net **−119 lines** against the previous head of this branch.

It also closes **`runtimeFilters: []`**, flagged as an open question on the earlier revision: it serialized to `null` before, and now reads as empty like any other config with no filters.

`takeOverPreRender()` stays — see below. It is carrying two bugs of its own.

## Pre-render ownership

`preRenderWrapper[__tsEmbed]` was written only in `handleInsertionIntoDOM()`, i.e. by the instance that *creates* the pre-render, and never moved, so `getPreRenderObj()` meant "the creator", not "what is showing". `showPreRender()` now ends with `takeOverPreRender()`, which repoints the wrapper at the instance being shown. `connectPreRendered()` adopts the state that belongs to the shared iframe, beside `inheritPreRenderContainer()`.

That hand-over exposed a latent trap worth reviewing carefully. `isEmbedContainerLoaded` was set **per instance**, by whichever ones were subscribed when the container announced itself — and `hidePreRender()` unsubscribes. An instance hidden before the container came up reports `false` forever, and once it owned the wrapper it handed that `false` to everyone after it: `UpdateEmbedParams` never fires, `preRenderParamsApplied` never resolves, `Navigate` never goes out, `getCurrentContext()` hangs. Permanently, silently. The flag now lives on the wrapper node, where it belongs — it describes the iframe, not an instance. The regression test for it was verified to fail without that change.

`LiveboardEmbed` also now writes `currentLiveboardState` on itself rather than on the instance it took over from, so "current" is true of the owner again.

## Cause 3 — a same-route show never unmounts the liveboard

Showing the **same** liveboard again through the shared pre-render (LB1 → LB1) sent a `Navigate` to the route the container was already on, which its router treats as a no-op. The liveboard component was never unmounted, so it kept everything it had accumulated — filter chips the user had moved, selections, the active tab — and `UpdateEmbedParams` was left as the only thing carrying the new values into a component that had already made up its mind.

### Fix

That show now goes **lb → home → lb**. Home unmounts the liveboard; the `Navigate` that follows rebuilds it from the `UpdateEmbedParams` posted just before.

```ts
await this.preRenderParamsApplied;
if (this.isShowingLiveboardRoute(showing)) {
    await this.clearLiveboardStateViaHome();
}
this.navigateToLiveboard(…);
```

Three things worth review:

- **The comparison is the whole route, not the liveboard id.** The path is built from the viz, tab and personalized view as well, so a same-liveboard show that moves to another tab is a real navigation and must not be diverted through home. There is a test for exactly that.
- **What the container is showing** is read from the predecessor's `currentLiveboardState`, captured **synchronously** in `beforePrerenderVisible()` — `showPreRender()` calls `takeOverPreRender()` afterwards, so by the time the async callback runs `getPreRenderObj()` names this instance instead. It diverts only on a positive match: an unknown predecessor takes the ordinary path, since a plain `Navigate` to a route the container is *not* on does the unmounting by itself.
- **A self-takeover is left alone.** When the predecessor *is* this instance, the embed is being hidden and shown again rather than handing over, and the state the liveboard holds is its own — the filter chips this user moved on this liveboard. Clearing that would throw away their session for a visibility toggle, so the predecessor is compared against `this` before its route is read.
- **The home hop waits a settle window, not an ack.** The container does not acknowledge `Navigate`, so awaiting that trigger does not resolve on the route change — it resolves when `TRIGGER_TIMEOUT` fires. An earlier revision of this branch did await it, and parked the re-shown liveboard on the home page for a full 30 seconds: `Navigate home` at 18:55:56, the liveboard back at 18:56:26, measured on a cluster. It now posts home and waits `HOME_UNMOUNT_SETTLE_MS` (200ms), the same reasoning and magnitude as the params window. The wait is still needed — both routes in one tick invites the router to coalesce them, leaving the liveboard mounted — but it is bounded by us rather than by a timeout. The trigger keeps a `catch` so its eventual rejection is not an unhandled promise, and a failure warns and carries on: stale state beats a liveboard that never comes back.

## Verification

- **Ordering test is proven to have diagnostic power**: with `await this.preRenderParamsApplied` removed, `should trigger Navigate only after UpdateEmbedParams has settled` fails with the received array quoted above. It is not a test that passes either way.
- Same check on the empty marker: reverting `serializeRuntimeFilters` to return `null` for an empty list fails 4 tests and nothing else — the three "should mark the params empty…" cases and the hand-along chain. Dropping the `runtimeParameterParams` line fails its own case.
- The home round trip is pinned four ways, each mutation failing a different set: never diverting fails 2 tests, always diverting fails 3, dropping the self-takeover guard fails only the hide/show one, and going back to awaiting the ack fails the two settle tests. That last one is the 30s stall above, reproduced with a promise that never settles — which is what a real home hop looks like.
- Full SDK suite: **45/45 suites, 1768 passed, 4 skipped**, no coverage threshold violations.
- `tsc --noEmit` clean; eslint **0 errors** and no new warnings (20 on the touched files, same as baseline).
- Tests assert the exact serialized strings — `col1=Color&op1=IN&val1=red&val1=blue` for a declared filter, `param1=Region%20Param&paramVal1=West` for a parameter, `'&'` for none of either — and pin that no `UpdateRuntimeFilters` / `UpdateParameters` follows the payload.
- 8 existing pre-render tests were updated, not deleted: they asserted on the navigate spy synchronously, which is exactly the behaviour this PR changes. Each now waits out the settle window. The `AuthInit` test needed 1305ms rather than 1005ms — 1000ms container-ready fallback plus the 200ms window.

## Notes for the reviewer

- **`'&'` is the reviewable decision.** It works because the container's gate is a truthiness check, and it is not a shape blink documents. If someone tidies it to `''`, the fix silently reverts with no blink-side test to catch it — hence the named constant and the comment at both the constant and the call site. The non-fragile version is a one-character container change, `!= null` instead of truthy, which would let this be `''`; worth filing against blink so this can be simplified later.
- **Not verified on a cluster.** The chain above is read from blink-v2 source (`embed.container.tsx:190-207`, `runtime-filters.util.ts:267-295`, `embed-util.ts:718`), not executed. The step most worth confirming by hand is `new URLSearchParams('&')` → no pairs → `{}`.
- **The home waypoint is `'home'`**, the same string `AppEmbed` sends for `Page.Home`. Worth a look from someone who knows whether a Liveboard-mode container renders anything visible at that route during the hop — a flicker would be the cost of clearing the state.
- **One consumer falls back to the URL.** `runtime-filters.util.ts:390` ends `embedFilter.length > 0 ? embedFilter : getRuntimeFilter()`, so an empty result there reads filters off the iframe URL. `V1Embed` defaults `excludeRuntimeFiltersfromURL: true`, so the URL is normally bare and this lands on `[]` — but a customer who sets that flag `false` could see the creating embed's filters come back through `PinboardAttributeFilterContainer`.
- **Pre-render code wants its own file.** It is spread across `TsEmbed` — wrapper elements, ownership keys, lifecycle, positioning, and now the params contract — and two of the bugs fixed here came from state being owned by the wrong thing. Filed as [SCAL-338011](https://thoughtspot.atlassian.net/browse/SCAL-338011), with a `TODO` at the `preRenderWrapper` declaration. Refactor only, best done after this merges.
- Supersedes #654, which carries an earlier form of this change. Close that one in favour of this.
- Only `LiveboardEmbed` navigates its pre-render on show; `AppEmbed` does not override `beforePrerenderVisible`, so it is unaffected.

Refs SCAL-336321, SCAL-333947.


[SCAL-333947]: https://thoughtspot.atlassian.net/browse/SCAL-333947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[SCAL-338011]: https://thoughtspot.atlassian.net/browse/SCAL-338011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ