### PR TITLE
[SCAL-337374] Add showAnswerEditPanel config option to show/hide Answ…

### DIFF
--- a/src/embed/app.spec.ts
+++ b/src/embed/app.spec.ts
@@ -2756,6 +2756,43 @@ describe('AppEmbed uncovered branch tests', () => {
         });
     });
 
+    test('should set showAnswerEditPanel=false when hideAnswerEditPanel is true', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            hideAnswerEditPanel: true,
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+                showAnswerEditPanel: 'false',
+            });
+        });
+    });
+
+    test('should set showAnswerEditPanel=true when hideAnswerEditPanel is false', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            hideAnswerEditPanel: false,
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlToHaveParamsWithValues(getIFrameSrc(), {
+                showAnswerEditPanel: 'true',
+            });
+        });
+    });
+
+    test('should not set showAnswerEditPanel param when hideAnswerEditPanel is not provided', async () => {
+        const appEmbed = new AppEmbed(getRootEl(), {
+            ...defaultViewConfig,
+        } as AppViewConfig);
+        appEmbed.render();
+        await executeAfterWait(() => {
+            const url = new URL(getIFrameSrc());
+            expect(url.searchParams.has('showAnswerEditPanel')).toBe(false);
+        });
+    });
+
     test('should set hideObjects param when non-empty array is provided', async () => {
         const appEmbed = new AppEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -1022,6 +1022,21 @@ export interface AppViewConfig extends AllEmbedViewConfig {
      * ```
      */
     updatedSpotterExperience?: boolean;
+
+    /**
+     * If set to true, the answer edit panel is hidden.
+     *
+     * Supported embed types: `AppEmbed`
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * const embed = new AppEmbed('#tsEmbed', {
+     *    ... // other embed view config
+     *    hideAnswerEditPanel:true,
+     * })
+     * ```
+     */
+    hideAnswerEditPanel?: boolean;
 }
 
 /**
@@ -1170,6 +1185,7 @@ export class AppEmbed extends V1Embed {
             enableHomepageAnnouncement = false,
             isContinuousLiveboardPDFEnabled,
             enableLiveboardDataCache,
+            hideAnswerEditPanel,
         } = this.viewConfig;
 
         let params: any = {};
@@ -1206,6 +1222,9 @@ export class AppEmbed extends V1Embed {
         }
         if (!isUndefined(coverAndFilterOptionInPDF)) {
             params[Param.CoverAndFilterOptionInPDF] = !!coverAndFilterOptionInPDF;
+        }
+        if (!isUndefined(hideAnswerEditPanel)) {
+            params[Param.ShowAnswerEditPanel] = !hideAnswerEditPanel;
         }
 
         params = this.getBaseQueryParams(params);

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -584,6 +584,34 @@ describe('Search embed tests', () => {
         });
     });
 
+    test('Should add showAnswerEditPanel flag set to true to the iframe src', async () => {
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showAnswerEditPanel: true,
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&showAnswerEditPanel=true&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
+            );
+        });
+    });
+
+    test('Should add showAnswerEditPanel flag set to false to the iframe src', async () => {
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            showAnswerEditPanel: false,
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&showAnswerEditPanel=false&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
+            );
+        });
+    });
+
     test('should set dataPanelCustomGroupsAccordionInitialState to EXPAND_FIRST when passed', async () => {
         const searchEmbed = new SearchBarEmbed(getRootEl() as any, {
             ...defaultViewConfig,

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -584,30 +584,30 @@ describe('Search embed tests', () => {
         });
     });
 
-    test('Should add showAnswerEditPanel flag set to true to the iframe src', async () => {
+    test('Should add showAnswerEditPanel flag set to false to the iframe src when hideAnswerEditPanel is true', async () => {
         const searchEmbed = new SearchEmbed(getRootEl(), {
             ...defaultViewConfig,
-            showAnswerEditPanel: true,
-        });
-        searchEmbed.render();
-        await executeAfterWait(() => {
-            expectUrlMatchesWithParams(
-                getIFrameSrc(),
-                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&showAnswerEditPanel=true&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
-            );
-        });
-    });
-
-    test('Should add showAnswerEditPanel flag set to false to the iframe src', async () => {
-        const searchEmbed = new SearchEmbed(getRootEl(), {
-            ...defaultViewConfig,
-            showAnswerEditPanel: false,
+            hideAnswerEditPanel: true,
         });
         searchEmbed.render();
         await executeAfterWait(() => {
             expectUrlMatchesWithParams(
                 getIFrameSrc(),
                 `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&showAnswerEditPanel=false&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
+            );
+        });
+    });
+
+    test('Should add showAnswerEditPanel flag set to true to the iframe src when hideAnswerEditPanel is false', async () => {
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            ...defaultViewConfig,
+            hideAnswerEditPanel: false,
+        });
+        searchEmbed.render();
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParamsWithHiddenActions}&showAnswerEditPanel=true&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/answer`,
             );
         });
     });

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -197,7 +197,7 @@ export interface SearchViewConfig
      * Show or hide answer edit panel.
      *
      * Supported embed types: `SearchEmbed`
-     * @version SDK: 1.26.0 | ThoughtSpot: 9.7.0.cl
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
      * const embed = new SearchEmbed('#tsEmbed', {

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -192,6 +192,22 @@ export interface SearchViewConfig
      * ```
      */
     dataSource?: string;
+
+    /**
+     * Show or hide answer edit panel.
+     *
+     * Supported embed types: `SearchEmbed`
+     * @version SDK: 1.26.0 | ThoughtSpot: 9.7.0.cl
+     * @example
+     * ```js
+     * const embed = new SearchEmbed('#tsEmbed', {
+     *    ... // other embed view config
+     *    showAnswerEditPanel:true,
+     * })
+     * ```
+     */
+    showAnswerEditPanel?: boolean;
+
     /**
      * The initial search query to load the answer with.
      * Use {@link searchOptions} instead.
@@ -443,6 +459,7 @@ export class SearchEmbed extends TsEmbed {
             collapseSearchBar = true,
             isThisPeriodInDateFiltersEnabled,
             newChartsLibrary,
+            showAnswerEditPanel,
         } = this.viewConfig;
         const queryParams = this.getBaseQueryParams();
 
@@ -469,6 +486,9 @@ export class SearchEmbed extends TsEmbed {
         }
         if (enableSearchAssist) {
             queryParams[Param.EnableSearchAssist] = true;
+        }
+        if (showAnswerEditPanel !== undefined) {
+            queryParams[Param.ShowAnswerEditPanel] = showAnswerEditPanel;
         }
         if (hideResults) {
             queryParams[Param.HideResult] = true;

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -194,7 +194,7 @@ export interface SearchViewConfig
     dataSource?: string;
 
     /**
-     * Show or hide answer edit panel.
+     * If set to true, the answer edit panel is hidden.
      *
      * Supported embed types: `SearchEmbed`
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
@@ -202,11 +202,11 @@ export interface SearchViewConfig
      * ```js
      * const embed = new SearchEmbed('#tsEmbed', {
      *    ... // other embed view config
-     *    showAnswerEditPanel:true,
+     *    hideAnswerEditPanel:true,
      * })
      * ```
      */
-    showAnswerEditPanel?: boolean;
+    hideAnswerEditPanel?: boolean;
 
     /**
      * The initial search query to load the answer with.
@@ -459,7 +459,7 @@ export class SearchEmbed extends TsEmbed {
             collapseSearchBar = true,
             isThisPeriodInDateFiltersEnabled,
             newChartsLibrary,
-            showAnswerEditPanel,
+            hideAnswerEditPanel,
         } = this.viewConfig;
         const queryParams = this.getBaseQueryParams();
 
@@ -487,8 +487,8 @@ export class SearchEmbed extends TsEmbed {
         if (enableSearchAssist) {
             queryParams[Param.EnableSearchAssist] = true;
         }
-        if (showAnswerEditPanel !== undefined) {
-            queryParams[Param.ShowAnswerEditPanel] = showAnswerEditPanel;
+        if (hideAnswerEditPanel !== undefined) {
+            queryParams[Param.ShowAnswerEditPanel] = !hideAnswerEditPanel;
         }
         if (hideResults) {
             queryParams[Param.HideResult] = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6904,6 +6904,7 @@ export enum Param {
     SpotterDataSources = 'spotterDataSources',
     AnalystId = 'analystId',
     OpenSpotterOnLiveboardByDefault = 'openSpotterOnLiveboardByDefault',
+    ShowAnswerEditPanel = 'showAnswerEditPanel',
 }
 
 /**


### PR DESCRIPTION
…erEditPanel in SearchEmbed

# Hide Answer Edit Panel Configuration

## Summary

Adds a new `hideAnswerEditPanel` option to `SearchViewConfig` and `AppViewConfig`,
mapped to the existing `Param.ShowAnswerEditPanel` (`showAnswerEditPanel`) query
parameter, inverted.

This allows consumers to explicitly show or hide the answer edit panel in
`SearchEmbed` and `AppEmbed`.

The value is forwarded to the iframe URL only when it is explicitly set
(`!== undefined`), and inverted before being sent. This ensures:

- `hideAnswerEditPanel: true` sends `showAnswerEditPanel=false`, reliably
  hiding the answer edit panel.
- `hideAnswerEditPanel: false` sends `showAnswerEditPanel=true`, reliably
  showing the answer edit panel.
- Leaving `hideAnswerEditPanel` unset omits the param entirely, preserving the
  existing/default application behavior.

## Test Plan

Updated unit tests in `search.spec.ts` covering both explicitly configured
values:

- `hideAnswerEditPanel: true` correctly adds `showAnswerEditPanel=false` to
  the resulting iframe URL.
- `hideAnswerEditPanel: false` correctly adds `showAnswerEditPanel=true` to
  the resulting iframe URL.

These tests ensure that both boolean values are inverted and forwarded
correctly.

when showAnswerEditPanel flag is true and isChartSettingsV2Enabled is true
<img width="1471" height="998" alt="Screenshot 2026-09-09 at 12 51 40 PM" src="https://github.com/user-attachments/assets/459e73a9-12b3-4ff1-9887-af2c0fd5d46a" />

when showAnswerEditPanel flag is false and isChartSettingsV2Enabled is true/false
<img width="1472" height="996" alt="Screenshot 2026-09-09 at 1 39 53 PM" src="https://github.com/user-attachments/assets/9074c19a-1958-46cb-9106-608c5a2c2a08" />

when showAnswerEditPanel flag is true and isChartSettingsV2Enabled is false
<img width="1474" height="995" alt="Screenshot 2026-09-09 at 1 42 03 PM" src="https://github.com/user-attachments/assets/b315279e-b632-4332-8ec8-67629199ae92" />

