### PR TITLE
SCAL-337722 Add preRenderConfig.inFlow to mount the pre-render in-flow

### DIFF
--- a/src/embed/ts-embed.spec.ts
+++ b/src/embed/ts-embed.spec.ts
@@ -2714,6 +2714,112 @@ describe('Unit test case for ts embed', () => {
             expect(preRenderWrapper.style.opacity).toBe('0');
         });
 
+        describe('preRenderConfig.inFlow', () => {
+            const stubResizeObserver = () => {
+                (window as any).ResizeObserver =
+                    window.ResizeObserver ||
+                    jest.fn().mockImplementation(() => ({
+                        disconnect: jest.fn(),
+                        observe: jest.fn(),
+                        unobserve: jest.fn(),
+                    }));
+            };
+
+            const withMoveBefore = (impl?: (node: Node, ref: Node | null) => void) => {
+                (Element.prototype as any).moveBefore =
+                    impl ??
+                    function moveBefore(this: Element, node: Node, ref: Node | null) {
+                        this.insertBefore(node, ref);
+                    };
+            };
+
+            afterEach(() => {
+                delete (Element.prototype as any).moveBefore;
+            });
+
+            const preRenderInFlow = async (inFlow: boolean, id: string) => {
+                createRootEleForEmbed();
+                stubResizeObserver();
+                const embed = new LiveboardEmbed('#tsEmbedDiv', {
+                    liveboardId: 'myLiveboardId',
+                    preRenderConfig: { id, inFlow },
+                });
+                await embed.preRender();
+                await waitFor(() => !!getIFrameEl());
+                return embed;
+            };
+
+            it('moves the wrapper into the host element and drops the overlay', async () => {
+                withMoveBefore();
+                const embed = await preRenderInFlow(true, 'in-flow-on');
+                const ids = embed.getPreRenderIds();
+
+                await embed.showPreRender();
+
+                const wrapper = document.getElementById(ids.wrapper);
+                const host = document.getElementById('tsEmbedDiv');
+                expect(wrapper.parentElement).toBe(host);
+                expect(document.getElementById(ids.placeHolder)).toBe(null);
+                expect(wrapper.style.position).toBe('');
+                expect(wrapper.style.top).toBe('');
+                expect(wrapper.style.left).toBe('');
+            });
+
+            it('keeps the overlay when moveBefore is unavailable', async () => {
+                const embed = await preRenderInFlow(true, 'in-flow-unsupported');
+                const ids = embed.getPreRenderIds();
+
+                await embed.showPreRender();
+
+                const wrapper = document.getElementById(ids.wrapper);
+                expect(wrapper.parentElement).toBe(document.body);
+                expect(document.getElementById(ids.placeHolder)).not.toBe(null);
+            });
+
+            it('falls back to the overlay when moveBefore throws', async () => {
+                withMoveBefore(() => {
+                    throw new Error('HierarchyRequestError');
+                });
+                const embed = await preRenderInFlow(true, 'in-flow-throws');
+                const ids = embed.getPreRenderIds();
+
+                await embed.showPreRender();
+
+                const wrapper = document.getElementById(ids.wrapper);
+                expect(wrapper.parentElement).toBe(document.body);
+                expect(document.getElementById(ids.placeHolder)).not.toBe(null);
+            });
+
+            it('keeps the overlay when inFlow is not set', async () => {
+                withMoveBefore();
+                const embed = await preRenderInFlow(false, 'in-flow-off');
+                const ids = embed.getPreRenderIds();
+
+                await embed.showPreRender();
+
+                expect(document.getElementById(ids.wrapper).parentElement).toBe(document.body);
+                expect(document.getElementById(ids.placeHolder)).not.toBe(null);
+            });
+
+            it('moves the wrapper back out of the host on hide', async () => {
+                withMoveBefore();
+                const embed = await preRenderInFlow(true, 'in-flow-hide');
+                const ids = embed.getPreRenderIds();
+
+                await embed.showPreRender();
+                expect(document.getElementById(ids.wrapper).parentElement).toBe(
+                    document.getElementById('tsEmbedDiv'),
+                );
+
+                embed.hidePreRender();
+
+                const wrapper = document.getElementById(ids.wrapper);
+                expect(wrapper.parentElement).toBe(document.body);
+                expect(wrapper.style.position).toBe('absolute');
+                expect(wrapper.style.opacity).toBe('0');
+            });
+        });
+
         it('it should connect with another object', async () => {
             createRootEleForEmbed();
             mockMessageChannel();

--- a/src/embed/ts-embed.ts
+++ b/src/embed/ts-embed.ts
@@ -1128,6 +1128,30 @@ export class TsEmbed {
 
     protected preRenderChild: HTMLElement;
 
+    private isInFlow = false;
+
+    private canMoveInFlow(): boolean {
+        return (
+            !!this.getPreRenderConfig().inFlow
+            && typeof (Element.prototype as any).moveBefore === 'function'
+        );
+    }
+
+    /**
+     * Reparents the pre-render wrapper without reloading the frame. Returns false
+     * when the move is not possible, so callers fall back to the overlay path.
+     */
+    private movePreRenderWrapperTo(parent: HTMLElement): boolean {
+        if (!parent?.isConnected || !this.preRenderWrapper?.isConnected) return false;
+        try {
+            (parent as any).moveBefore(this.preRenderWrapper, null);
+            return true;
+        } catch (error) {
+            logger.warn(`preRender in-flow move failed, using overlay instead: ${error}`);
+            return false;
+        }
+    }
+
     /**
      * Checks for an existing pre-rendered component and connects to it.
      *
@@ -2026,7 +2050,15 @@ export class TsEmbed {
         this.isRendered = true;
         this.beforePrerenderVisible();
 
-        if (this.hostElement) {
+        if (this.hostElement && this.canMoveInFlow() && this.movePreRenderWrapperTo(this.hostElement)) {
+            this.isInFlow = true;
+            const { width: inFlowWidth, height: inFlowHeight } = this.viewConfig.frameParams || {};
+            removeStyleProperties(this.preRenderWrapper, ['position', 'top', 'left']);
+            setStyleProperties(this.preRenderWrapper, {
+                width: getCssDimension(inFlowWidth || DEFAULT_EMBED_WIDTH),
+                height: getCssDimension(inFlowHeight || DEFAULT_EMBED_HEIGHT),
+            });
+        } else if (this.hostElement) {
             this.insertedDomEl = this.createPreRenderPlaceholder();
             if ((this.viewConfig as { fullHeight: boolean }).fullHeight) {
                 // If fullHeight has already sized the wrapper, seed the placeholder
@@ -2099,6 +2131,7 @@ export class TsEmbed {
      * is not defined or not found.
      */
     public syncPreRenderStyle(): void {
+        if (this.isInFlow) return;
         if (!this.isPreRenderConnected() || !this.getPreRenderPlaceHolderElement()) {
             logger.error(ERROR_MESSAGE.SYNC_STYLE_CALLED_BEFORE_RENDER);
             return;
@@ -2142,6 +2175,11 @@ export class TsEmbed {
             logger.warn('PreRender should be called before hiding it using hidePreRender.');
             return;
         }
+        if (this.isInFlow) {
+            this.movePreRenderWrapperTo(this.preRenderContainerEl ?? document.body);
+            this.isInFlow = false;
+        }
+
         const { zIndex } = this.getPreRenderConfig();
         const preRenderHideStyles = {
             opacity: '0',

--- a/src/types.ts
+++ b/src/types.ts
@@ -977,6 +977,24 @@ export interface PreRenderConfig {
      * @default -1000
      */
     zIndex?: number;
+    /**
+     * Moves the pre-rendered frame into the host element on `showPreRender()`
+     * instead of overlaying it, so the browser lays it out like a normal embed.
+     *
+     * The default pre-render parks its wrapper outside the host's layout flow and
+     * keeps it aligned in JavaScript, which means position, size, stacking, clipping
+     * and scrolling are emulated rather than owned by the browser. With this on, the
+     * frame becomes a real child of the host element and all of that behaves as it
+     * does for a non-pre-rendered embed — so an ancestor with `overflow: hidden`
+     * clips it, `z-index` resolves normally, and nested scroll containers work.
+     *
+     * Requires `Element.moveBefore()`, which preserves the frame's state across the
+     * move. Where it is unavailable (notably Safari) or the move is rejected, this
+     * silently falls back to the overlay behaviour, so it is always safe to set.
+     *
+     * @default false
+     */
+    inFlow?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What

Adds `preRenderConfig.inFlow`. When set, `showPreRender()` moves the pre-rendered frame **into the host element** with [`Element.moveBefore()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) instead of overlaying it, so the browser lays it out like a normal embed.

[SCAL-337722](https://thoughtspot.atlassian.net/browse/SCAL-337722)

## Why

Today the wrapper is parked on `document.body`, absolutely positioned, and aligned to an in-flow placeholder by `syncPreRenderStyle()` + a `ResizeObserver` + a container scroll listener. Because it sits outside the host's layout flow, the SDK emulates what the browser does for free — position, size, stacking, clipping, scrolling.

That emulation is the source of a recurring class of defects: SCAL-235696, SCAL-270176 (P0), SCAL-287671, SCAL-307017, SCAL-325118, SCAL-331221, and SCAL-265112 which is still open — six sizing/stacking bugs in 21 months, each from a different host layout, none predicted by the last.

`moveBefore()` is a state-preserving atomic move: the frame keeps its browsing context, so it can be reparented without reloading. That removes the reason the wrapper had to live out of flow.

## How

- `showPreRender()` — move the wrapper into `hostElement`, clear `position/top/left`, size it from `frameParams`. The placeholder, `syncPreRenderStyle()`, the `ResizeObserver` and the scroll listener are all skipped.
- `hidePreRender()` — move it back to the parking container before restoring the hidden styles.
- `syncPreRenderStyle()` is a no-op while in-flow, so a host calling it directly cannot fight the browser.

Guarded end to end: off unless opted in, feature-detected on `Element.prototype.moveBefore`, and `try`/`catch` around the move. Any of those failing takes the existing overlay path, so it is safe to set unconditionally.

## Not in scope

- **Reuse defects** — filter leak, config bleed, residual screen state, memory retention on `navigateToLiveboard`. `moveBefore` preserves state by design, so these are unaffected.
- **Background-load behaviour** — the instance still loads and runs while parked (SCAL-337430 unchanged).
- **`fullHeight`** — the height negotiation over postMessage is untouched. This removes the wrapper sync, not the protocol.

## Browser support

Chrome 133+, Firefox 144+. Safari has not shipped `moveBefore`, so WebKit keeps the overlay path and both placement models remain supported.

## Testing

`tsc --noEmit` clean. Full `ts-embed.spec.ts` green: 1257 passed, nothing existing changed.

Five new cases under `preRenderConfig.inFlow`:

| Case | Expected |
|---|---|
| `inFlow` + `moveBefore` available | wrapper is a child of the host, no placeholder, `position/top/left` cleared |
| `inFlow`, `moveBefore` missing | overlay path, placeholder present |
| `inFlow`, `moveBefore` throws | overlay path, placeholder present |
| `inFlow` not set | overlay path |
| hide after an in-flow show | wrapper back in the parking container, hidden styles restored |

Worth noting there is no e2e harness that can park and show a pre-render separately (see SCAL-336321's notes on the embed test bed), so real-browser verification across host layouts — ancestor `transform`, clipping `overflow: hidden`, inner scroll container, sticky header, high `z-index` sibling, two co-located embeds — is still manual.


[SCAL-337722]: https://thoughtspot.atlassian.net/browse/SCAL-337722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ