### PR TITLE
[SCAL-336968] Add embed support for Spotter conversation search

### DIFF
--- a/src/embed/conversation.ts
+++ b/src/embed/conversation.ts
@@ -68,6 +68,15 @@ export interface SpotterSidebarViewConfig {
      */
     enablePastConversationsSidebar?: boolean;
     /**
+     * Controls the visibility of the conversation search button in the
+     * sidebar header. The search page itself stays reachable through
+     * {@link HostEvent.OpenSpotterConversationSearch} even when the
+     * button is hidden.
+     * @default false
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     */
+    enableConversationSearch?: boolean;
+    /**
      * Custom title text for the sidebar header.
      * Defaults to translated "Spotter" text.
      * @version SDK: 1.47.0 | ThoughtSpot: 26.4.0.cl

--- a/src/embed/spotter-utils.spec.ts
+++ b/src/embed/spotter-utils.spec.ts
@@ -57,6 +57,16 @@ describe('buildSpotterSidebarAppInitData', () => {
             .toEqual(spotterChatPinConfig);
     });
 
+    it('forwards enableConversationSearch through embedParams.spotterSidebarConfig', () => {
+        const result = buildSpotterSidebarAppInitData(base, {
+            spotterSidebarConfig: {
+                enablePastConversationsSidebar: true,
+                enableConversationSearch: true,
+            },
+        }, noopError);
+        expect(result.embedParams?.spotterSidebarConfig?.enableConversationSearch).toBe(true);
+    });
+
     it('promotes standalone flag into spotterSidebarConfig.enablePastConversationsSidebar', () => {
         const result = buildSpotterSidebarAppInitData(base, { enablePastConversationsSidebar: true }, noopError);
         expect(result.embedParams?.spotterSidebarConfig?.enablePastConversationsSidebar).toBe(true);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4131,6 +4131,20 @@ export enum EmbedEvent {
      * @version SDK: 1.46.0 | ThoughtSpot: 26.3.0.cl
      */
     SpotterConversationSelected = 'spotterConversationSelected',
+    /**
+     * Emitted when the Spotter conversation search page is opened or closed,
+     * regardless of how the change happened (search button, host events, or
+     * in-app navigation).
+     * @example
+     * ```js
+     * spotterEmbed.on(EmbedEvent.SpotterConversationSearchToggled, (payload) => {
+     *     console.log('Conversation search toggled', payload);
+     *     // payload: { open: boolean }
+     * })
+     * ```
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     */
+    SpotterConversationSearchToggled = 'spotterConversationSearchToggled',
 
     /**
      * Emitted when the Spotter agent finishes streaming/rendering a response.
@@ -6661,6 +6675,34 @@ export enum HostEvent {
      * ```
      */
     UnpinSpotterConversation = 'UnpinSpotterConversation',
+
+    /**
+     * Opens the conversation search page in Spotter embed. Works even when
+     * the search button is hidden (`spotterSidebarConfig.enableConversationSearch`
+     * not set), so hosts can provide their own search entry point.
+     *
+     * This feature is available only when conversation search is enabled on your
+     * ThoughtSpot instance. Contact your admin or ThoughtSpot Support to enable
+     * it on your instance.
+     *
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * spotterEmbed.trigger(HostEvent.OpenSpotterConversationSearch);
+     * ```
+     */
+    OpenSpotterConversationSearch = 'OpenSpotterConversationSearch',
+
+    /**
+     * Closes the conversation search page in Spotter embed if it is open.
+     *
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * spotterEmbed.trigger(HostEvent.CloseSpotterConversationSearch);
+     * ```
+     */
+    CloseSpotterConversationSearch = 'CloseSpotterConversationSearch',
 
     /**
      * @hidden


### PR DESCRIPTION
- spotterSidebarConfig.enableConversationSearch view-config flag to show the search button in the sidebar (embed-only, off by default; forwarded via APP_INIT like the rest of the sidebar config)
- HostEvent.OpenSpotterConversationSearch / CloseSpotterConversationSearch to open/close the search page (open works even with the button hidden)
- EmbedEvent.SpotterConversationSearchToggled ({ open: boolean }) emitted on every open/close of the search page