### PR TITLE
[SCAL-337804] Add Chart Settings V2 menu item actions

### DIFF
--- a/src/embed/app.ts
+++ b/src/embed/app.ts
@@ -907,7 +907,7 @@ export interface AppViewConfig extends AllEmbedViewConfig, FullHeightViewConfig 
     updatedSpotterExperience?: boolean;
 
     /**
-     * If set to true, the answer edit panel is hidden.
+     * If set to `true`, the answer edit panel is hidden.
      *
      * Supported embed types: `AppEmbed`
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
@@ -915,7 +915,7 @@ export interface AppViewConfig extends AllEmbedViewConfig, FullHeightViewConfig 
      * ```js
      * const embed = new AppEmbed('#tsEmbed', {
      *    ... // other embed view config
-     *    hideAnswerEditPanel:true,
+     *    hideAnswerEditPanel: true,
      * })
      * ```
      */

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -438,6 +438,56 @@ describe('Search embed tests', () => {
         });
     });
 
+    test('should set visibility and disable state for Chart Settings V2 menu items', async () => {
+        expect(Action.ChartTypeSettings).toBe('CHART_TYPE');
+        expect(Action.LayoutSettings).toBe('LAYOUT');
+        expect(Action.ColumnSettings).toBe('COLUMN');
+        expect(Action.AxisSettings).toBe('AXIS');
+        expect(Action.DataLabelSettings).toBe('DATA_LABEL');
+        expect(Action.TooltipSettings).toBe('TOOLTIP');
+        expect(Action.LegendSettings).toBe('LEGEND');
+        expect(Action.DisplaySettings).toBe('DISPLAY');
+        expect(Action.QuerySettings).toBe('QUERY_DETAILS');
+        expect(Action.CustomSettings).toBe('CUSTOM_ACTION');
+        expect(Action.MuzeAiSettings).toBe('MUZE_AI');
+
+        const chartSettingsActions = [
+            Action.ChartTypeSettings,
+            Action.LayoutSettings,
+            Action.ColumnSettings,
+            Action.AxisSettings,
+            Action.DataLabelSettings,
+            Action.TooltipSettings,
+            Action.LegendSettings,
+            Action.DisplaySettings,
+            Action.QuerySettings,
+            Action.CustomSettings,
+            Action.MuzeAiSettings,
+        ];
+        const searchEmbed = new SearchEmbed(getRootEl(), {
+            hiddenActions: chartSettingsActions,
+            disabledActions: chartSettingsActions,
+            disabledActionReason: 'Access denied',
+            ...defaultViewConfig,
+            answerId,
+        });
+        searchEmbed.render();
+        const hideActionUrl = fixedEncodeURI(
+            JSON.stringify([
+                Action.ReportError,
+                ...chartSettingsActions,
+                ...HiddenActionItemByDefaultForSearchEmbed,
+            ]),
+        );
+        const disableActionUrl = fixedEncodeURI(JSON.stringify(chartSettingsActions));
+        await executeAfterWait(() => {
+            expectUrlMatchesWithParams(
+                getIFrameSrc(),
+                `http://${thoughtSpotHost}/v2/?${defaultParams}&disableAction=${disableActionUrl}&disableHint=Access%20denied&hideAction=${hideActionUrl}&dataSourceMode=expand&useLastSelectedSources=false${prefixParams}#/embed/saved-answer/${answerId}`,
+            );
+        });
+    });
+
     test('should load saved answer', async () => {
         const searchEmbed = new SearchEmbed(getRootEl(), {
             ...defaultViewConfig,

--- a/src/embed/search.spec.ts
+++ b/src/embed/search.spec.ts
@@ -450,6 +450,7 @@ describe('Search embed tests', () => {
         expect(Action.QuerySettings).toBe('QUERY_DETAILS');
         expect(Action.CustomSettings).toBe('CUSTOM_ACTION');
         expect(Action.MuzeAiSettings).toBe('MUZE_AI');
+        expect(Action.RAnalysisSettings).toBe('R_ANALYSIS');
 
         const chartSettingsActions = [
             Action.ChartTypeSettings,
@@ -463,6 +464,7 @@ describe('Search embed tests', () => {
             Action.QuerySettings,
             Action.CustomSettings,
             Action.MuzeAiSettings,
+            Action.RAnalysisSettings,
         ];
         const searchEmbed = new SearchEmbed(getRootEl(), {
             hiddenActions: chartSettingsActions,

--- a/src/embed/search.ts
+++ b/src/embed/search.ts
@@ -194,7 +194,7 @@ export interface SearchViewConfig
     dataSource?: string;
 
     /**
-     * If set to true, the answer edit panel is hidden.
+     * If set to `true`, the answer edit panel is hidden.
      *
      * Supported embed types: `SearchEmbed`
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
@@ -202,7 +202,7 @@ export interface SearchViewConfig
      * ```js
      * const embed = new SearchEmbed('#tsEmbed', {
      *    ... // other embed view config
-     *    hideAnswerEditPanel:true,
+     *    hideAnswerEditPanel: true,
      * })
      * ```
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -8976,6 +8976,127 @@ export enum Action {
      * ```
      */
     SpotterOnLiveboard = 'spotterOnLiveboard',
+    /**
+     * Controls visibility and disable state of the "Chart Type" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.ChartTypeSettings]
+     * disabledActions: [Action.ChartTypeSettings]
+     * ```
+     */
+    ChartTypeSettings = 'CHART_TYPE',
+    /**
+     * Controls visibility and disable state of the "Layout" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.LayoutSettings]
+     * disabledActions: [Action.LayoutSettings]
+     * ```
+     */
+    LayoutSettings = 'LAYOUT',
+    /**
+     * Controls visibility and disable state of the "Column" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.ColumnSettings]
+     * disabledActions: [Action.ColumnSettings]
+     * ```
+     */
+    ColumnSettings = 'COLUMN',
+    /**
+     * Controls visibility and disable state of the "Axis" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.AxisSettings]
+     * disabledActions: [Action.AxisSettings]
+     * ```
+     */
+    AxisSettings = 'AXIS',
+    /**
+     * Controls visibility and disable state of the "Data Label" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.DataLabelSettings]
+     * disabledActions: [Action.DataLabelSettings]
+     * ```
+     */
+    DataLabelSettings = 'DATA_LABEL',
+    /**
+     * Controls visibility and disable state of the "Tooltip" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.TooltipSettings]
+     * disabledActions: [Action.TooltipSettings]
+     * ```
+     */
+    TooltipSettings = 'TOOLTIP',
+    /**
+     * Controls visibility and disable state of the "Legend" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.LegendSettings]
+     * disabledActions: [Action.LegendSettings]
+     * ```
+     */
+    LegendSettings = 'LEGEND',
+    /**
+     * Controls visibility and disable state of the "Display" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.DisplaySettings]
+     * disabledActions: [Action.DisplaySettings]
+     * ```
+     */
+    DisplaySettings = 'DISPLAY',
+    /**
+     * Controls visibility and disable state of the "Query Details" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.QuerySettings]
+     * disabledActions: [Action.QuerySettings]
+     * ```
+     */
+    QuerySettings = 'QUERY_DETAILS',
+    /**
+     * Controls visibility and disable state of the "Custom Action" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.CustomSettings]
+     * disabledActions: [Action.CustomSettings]
+     * ```
+     */
+    CustomSettings = 'CUSTOM_ACTION',
+    /**
+     * Controls visibility and disable state of the "Muze AI" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.MuzeAiSettings]
+     * disabledActions: [Action.MuzeAiSettings]
+     * ```
+     */
+    MuzeAiSettings = 'MUZE_AI',
 }
 export interface AnswerServiceType {
     getAnswer?: (offset: number, batchSize: number) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9097,6 +9097,17 @@ export enum Action {
      * ```
      */
     MuzeAiSettings = 'MUZE_AI',
+    /**
+     * Controls visibility and disable state of the "R Analysis" menu item
+     * in Chart Settings V2.
+     * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
+     * @example
+     * ```js
+     * hiddenActions: [Action.RAnalysisSettings]
+     * disabledActions: [Action.RAnalysisSettings]
+     * ```
+     */
+    RAnalysisSettings = 'R_ANALYSIS',
 }
 export interface AnswerServiceType {
     getAnswer?: (offset: number, batchSize: number) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8977,134 +8977,158 @@ export enum Action {
      */
     SpotterOnLiveboard = 'spotterOnLiveboard',
     /**
-     * Controls visibility and disable state of the "Chart Type" menu item
+     * Controls the visibility and disabled state of the "Chart Type" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.ChartTypeSettings]
-     * disabledActions: [Action.ChartTypeSettings]
+     * {
+     *     hiddenActions: [Action.ChartTypeSettings],
+     *     disabledActions: [Action.ChartTypeSettings],
+     * }
      * ```
      */
     ChartTypeSettings = 'CHART_TYPE',
     /**
-     * Controls visibility and disable state of the "Layout" menu item
+     * Controls the visibility and disabled state of the "Layout" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.LayoutSettings]
-     * disabledActions: [Action.LayoutSettings]
+     * {
+     *     hiddenActions: [Action.LayoutSettings],
+     *     disabledActions: [Action.LayoutSettings],
+     * }
      * ```
      */
     LayoutSettings = 'LAYOUT',
     /**
-     * Controls visibility and disable state of the "Column" menu item
+     * Controls the visibility and disabled state of the "Column" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.ColumnSettings]
-     * disabledActions: [Action.ColumnSettings]
+     * {
+     *     hiddenActions: [Action.ColumnSettings],
+     *     disabledActions: [Action.ColumnSettings],
+     * }
      * ```
      */
     ColumnSettings = 'COLUMN',
     /**
-     * Controls visibility and disable state of the "Axis" menu item
+     * Controls the visibility and disabled state of the "Axis" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.AxisSettings]
-     * disabledActions: [Action.AxisSettings]
+     * {
+     *     hiddenActions: [Action.AxisSettings],
+     *     disabledActions: [Action.AxisSettings],
+     * }
      * ```
      */
     AxisSettings = 'AXIS',
     /**
-     * Controls visibility and disable state of the "Data Label" menu item
+     * Controls the visibility and disabled state of the "Data Label" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.DataLabelSettings]
-     * disabledActions: [Action.DataLabelSettings]
+     * {
+     *     hiddenActions: [Action.DataLabelSettings],
+     *     disabledActions: [Action.DataLabelSettings],
+     * }
      * ```
      */
     DataLabelSettings = 'DATA_LABEL',
     /**
-     * Controls visibility and disable state of the "Tooltip" menu item
+     * Controls the visibility and disabled state of the "Tooltip" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.TooltipSettings]
-     * disabledActions: [Action.TooltipSettings]
+     * {
+     *     hiddenActions: [Action.TooltipSettings],
+     *     disabledActions: [Action.TooltipSettings],
+     * }
      * ```
      */
     TooltipSettings = 'TOOLTIP',
     /**
-     * Controls visibility and disable state of the "Legend" menu item
+     * Controls the visibility and disabled state of the "Legend" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.LegendSettings]
-     * disabledActions: [Action.LegendSettings]
+     * {
+     *     hiddenActions: [Action.LegendSettings],
+     *     disabledActions: [Action.LegendSettings],
+     * }
      * ```
      */
     LegendSettings = 'LEGEND',
     /**
-     * Controls visibility and disable state of the "Display" menu item
+     * Controls the visibility and disabled state of the "Display" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.DisplaySettings]
-     * disabledActions: [Action.DisplaySettings]
+     * {
+     *     hiddenActions: [Action.DisplaySettings],
+     *     disabledActions: [Action.DisplaySettings],
+     * }
      * ```
      */
     DisplaySettings = 'DISPLAY',
     /**
-     * Controls visibility and disable state of the "Query Details" menu item
-     * in Chart Settings V2.
+     * Controls the visibility and disabled state of the "Query Details" menu
+     * item in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.QuerySettings]
-     * disabledActions: [Action.QuerySettings]
+     * {
+     *     hiddenActions: [Action.QuerySettings],
+     *     disabledActions: [Action.QuerySettings],
+     * }
      * ```
      */
     QuerySettings = 'QUERY_DETAILS',
     /**
-     * Controls visibility and disable state of the "Custom Action" menu item
-     * in Chart Settings V2.
+     * Controls the visibility and disabled state of the "Custom Action" menu
+     * item in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.CustomSettings]
-     * disabledActions: [Action.CustomSettings]
+     * {
+     *     hiddenActions: [Action.CustomSettings],
+     *     disabledActions: [Action.CustomSettings],
+     * }
      * ```
      */
     CustomSettings = 'CUSTOM_ACTION',
     /**
-     * Controls visibility and disable state of the "Muze AI" menu item
+     * Controls the visibility and disabled state of the "Muze AI" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.MuzeAiSettings]
-     * disabledActions: [Action.MuzeAiSettings]
+     * {
+     *     hiddenActions: [Action.MuzeAiSettings],
+     *     disabledActions: [Action.MuzeAiSettings],
+     * }
      * ```
      */
     MuzeAiSettings = 'MUZE_AI',
     /**
-     * Controls visibility and disable state of the "R Analysis" menu item
+     * Controls the visibility and disabled state of the "R Analysis" menu item
      * in Chart Settings V2.
      * @version SDK: 1.54.0 | ThoughtSpot Cloud: 26.11.0.cl
      * @example
      * ```js
-     * hiddenActions: [Action.RAnalysisSettings]
-     * disabledActions: [Action.RAnalysisSettings]
+     * {
+     *     hiddenActions: [Action.RAnalysisSettings],
+     *     disabledActions: [Action.RAnalysisSettings],
+     * }
      * ```
      */
     RAnalysisSettings = 'R_ANALYSIS',


### PR DESCRIPTION
# Summary

Adds 12 new `Action` enum members to support granular control over individual menu items in the new **Chart Settings V2** panel.

The new actions can be used with `hiddenActions` and `disabledActions` to allow customers to hide or disable specific Chart Settings V2 menu items.

## New Action Enum Members

* `ChartTypeSettings`
* `LayoutSettings`
* `ColumnSettings`
* `AxisSettings`
* `DataLabelSettings`
* `TooltipSettings`
* `LegendSettings`
* `DisplaySettings`
* `QuerySettings`
* `CustomSettings`
* `MuzeAiSettings`
* `RAnalysisSettings`

## Implementation

* Added the 12 new action enum members.
* Enables customers to control the visibility and enabled state of individual Chart Settings V2 menu items through:

  * `hiddenActions`
  * `disabledActions`
* Ensures `hiddenActions` and `disabledActions` are correctly serialized and passed to the embedded iframe URL.

## Test Plan

Added test coverage in `search.spec.ts` to:

* Pin the expected string value for each of the 12 new actions.
* Verify `hiddenActions` are correctly serialized into the iframe URL.
* Verify `disabledActions` are correctly serialized into the iframe URL.
* Ensure the action values remain stable and do not change unexpectedly.
